### PR TITLE
README: remove first step in Android setup to remove confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,13 @@ for setting up a configuration profile. You want to add your LND cert to the sec
 **Don't trust, verify** the code with your own two eyes. Then when ready proceed to the steps below based on your platform.
 
 ### Android
-1. download the
-[Android Studio SDK package](https://developer.android.com/studio/#downloads).
-You only need the Command line tools to use `adb` with your phone.
-2. install and setup react-native and its related dependencies under **"Building Projects with Native Code"** on
+1. install and setup react-native and its related dependencies under **"Building Projects with Native Code"** on
 [react-native's Getting Started page](https://facebook.github.io/react-native/docs/getting-started.html) 
-3. if using your phone,
+2. if using your phone,
 [enable Developer mode and USB Debugging](https://developer.android.com/studio/debug/dev-options)
 , then make sure it is connected to your computer by running `adb devices`
 3. install node dependencies with `npm i`
-5. open up your Android simulator or connect your phone and run `react-native run-android`
+4. open up your Android simulator or connect your phone and run `react-native run-android`
 
 ### iOS
 1. if using a self-signed lnd cert with iOS, please read the section above titled


### PR DESCRIPTION
Users should go to the react-native getting started page in step one so they make sure they download the right version