### PR TITLE
Add support for LNURL withdraws

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "0.19.0",
     "base-64": "0.1.0",
+    "bech32": "1.1.3",
     "dateformat": "3.0.3",
     "identicon.js": "2.3.3",
     "lodash": "4.17.11",

--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -71,7 +71,7 @@ export default class InvoicesStore {
     }
 
     @action
-    public createInvoice = (memo: string, value: string, expiry: string = "3600") => {
+    public createInvoice = (memo: string, value: string, expiry: string = "3600", lnurlCallback: string | null = null) => {
         const { host, port, macaroonHex } = this.settingsStore;
 
         this.payment_request = null;
@@ -95,6 +95,14 @@ export default class InvoicesStore {
             const data = response.data;
             this.payment_request = data.payment_request;
             this.creatingInvoice = false;
+
+            // submit payment_request to lnurlCallback
+            if (lnurlCallback) {
+                axios.request({
+                    method: 'get',
+                    url: lnurlCallback + '&pr=' + data.payment_request
+                });
+            }
         })
         .catch((error: any) => {
             // handle error

--- a/utils/AddressUtils.ts
+++ b/utils/AddressUtils.ts
@@ -2,6 +2,7 @@ const btcNonBech = /^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/;
 const btcBech = /^(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}$/;
 
 const lnInvoice = /^(lnbcrt|lntb|lnbc|LNBCRT|LNTB|LNBC)([0-9]{1,}[a-zA-Z0-9]+){1}$/;
+const lnUrl = /^(lnurl|LNURL)([0-9]{1,}[a-zA-Z0-9]+){1}$/;
 
 /* testnet */
 const btcNonBechTestnet = /^[2][a-km-zA-HJ-NP-Z1-9]{25,34}$/;
@@ -17,6 +18,8 @@ class AddressUtils {
     };
 
     isValidLightningPaymentRequest = (input: string) => lnInvoice.test(input);
+
+    isValidLNURL = (input: string) => lnUrl.test(input);
 };
 
 const addressUtils = new AddressUtils();

--- a/views/AddressQRScanner.tsx
+++ b/views/AddressQRScanner.tsx
@@ -22,12 +22,11 @@ export default class AddressQRScanner extends React.Component<AddressQRProps, {}
 
         // handle addresses prefixed with 'bitcoin:' and
         // payment requests prefixed with 'lightning:'
+        data = data.toLowerCase();
         if (data.includes('bitcoin:')) {
             processedValue = data.split('bitcoin:')[1];
         } else if (data.includes('lightning:')) {
             processedValue = data.split('lightning:')[1];
-        } else if (data.includes('LIGHTNING:')) {
-            processedValue = data.split('LIGHTNING:')[1];
         } else {
             processedValue = data;
         }
@@ -36,6 +35,8 @@ export default class AddressQRScanner extends React.Component<AddressQRProps, {}
             navigation.navigate('Send', { destination: processedValue, transactionType: 'On-chain' });
         } else if (AddressUtils.isValidLightningPaymentRequest(processedValue)) {
             navigation.navigate('Send', { destination: processedValue, transactionType: 'Lightning' });
+        } else if (AddressUtils.isValidLNURL(processedValue)) {
+            navigation.navigate('Receive', { lnurl: processedValue });
         } else {
             Alert.alert(
                 'Error',

--- a/views/AddressQRScanner.tsx
+++ b/views/AddressQRScanner.tsx
@@ -20,13 +20,17 @@ export default class AddressQRScanner extends React.Component<AddressQRProps, {}
         const { testnet } = NodeInfoStore;
         let processedValue;
 
-        // handle addresses prefixed with 'bitcoin:' and
-        // payment requests prefixed with 'lightning:'
         data = data.toLowerCase();
+
+        // handle addresses prefixed with 'bitcoin:',
+        // payment requests prefixed with 'lightning:', and
+        // lnurls either prefixed with 'lightning:' or sent as a querystring fallback at '?lightning='
         if (data.includes('bitcoin:')) {
             processedValue = data.split('bitcoin:')[1];
         } else if (data.includes('lightning:')) {
             processedValue = data.split('lightning:')[1];
+        } else if (data.includes('lightning=')) {
+            processedValue = data.split('lightning=')[1].split('&')[0];
         } else {
             processedValue = data;
         }

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -212,6 +212,22 @@ export default class Receive extends React.Component<ReceiveProps, ReceiveState>
                                 }}
                             />
                         </View>
+
+                        <View style={styles.button}>
+                            <Button
+                                title="Scan LNURL"
+                                icon={{
+                                    name: "crop-free",
+                                    size: 25,
+                                    color: "white"
+                                }}
+                                onPress={() => navigation.navigate('AddressQRCodeScanner')}
+                                buttonStyle={{
+                                    backgroundColor: theme === "dark" ? "#261339" : "rgba(92, 99,216, 1)",
+                                    borderRadius: 30
+                                }}
+                            />
+                        </View>
                     </View>}
                 </View>
             </View>

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -30,6 +30,7 @@ export default class Receive extends React.Component<ReceiveProps, ReceiveState>
         selectedIndex: 0,
         memo: '',
         value: '',
+        valueFixed: false,
         expiry: '3600',
         lnurlCallback: null,
     }
@@ -54,6 +55,7 @@ export default class Receive extends React.Component<ReceiveProps, ReceiveState>
                     selectedIndex: 1,
                     memo: response.defaultDescription,
                     value: (response.maxWithdrawable / 1000).toString(),
+                    valueFixed: response.amountIsFixed || false,
                     lnurlCallback: response.callback + '?k1=' + response.k1
                 })
             })
@@ -78,6 +80,7 @@ export default class Receive extends React.Component<ReceiveProps, ReceiveState>
             // reset LN invoice values so old invoices don't linger
             memo: '',
             value: '',
+            valueFixed: false,
             expiry: '3600',
             lnurlCallback: null
         });
@@ -179,7 +182,11 @@ export default class Receive extends React.Component<ReceiveProps, ReceiveState>
                         <TextInput
                             placeholder={"100"}
                             value={value}
-                            onChangeText={(text: string) => this.setState({ value: text })}
+                            onChangeText={(text: string) => {
+                                if (!this.state.valueFixed) {
+                                    this.setState({ value: text });
+                                }
+                            }}
                             numberOfLines={1}
                             editable={true}
                             style={theme === 'dark' ? styles.textInputDark : styles.textInput}


### PR DESCRIPTION
See #118.

---

This pull request

* Adds a new scanning match for `AddressQRScanner`, `lnurl...` strings.
* When found, shows the `Receive` view prefilled with values taken from the URL (decoded as bech32).
* After confirmation by the user, the invoice is generated as normal, but automatically sent to the callback URL provided by the first lnurl call -- so the third-party service can proceed to pay the invoice.

---

Now I'm hitting a ton of bugs when trying to build it locally so I'm not sure it works. I'll wait for feedback before trying to build it locally again.