### PR TITLE
Remove barcode frame from scanner

### DIFF
--- a/components/QRCodeScanner.tsx
+++ b/components/QRCodeScanner.tsx
@@ -128,15 +128,11 @@ export default class QRCodeScanner extends React.Component<QRProps, QRState> {
           <Text>{text}</Text>
         </View>
         <CameraKitCameraScreen
-          laserColor={'orange'}
-          frameColor={'yellow'}
+          laserColor={"orange"}
           scanBarcode={true}
-          onReadCode={(event: any) =>
-            handleQRScanned(event.nativeEvent.codeStringValue)
-          }
-          hideControls={false}
-          showFrame={true}
-          heightForScannerFrame={250}
+          onReadCode={(event: any) => handleQRScanned(event.nativeEvent.codeStringValue)}
+          hideControls={true}
+          showFrame={false}
           style={{
             flex: 1
           }}

--- a/components/QRCodeScanner.tsx
+++ b/components/QRCodeScanner.tsx
@@ -60,12 +60,10 @@ export default class QRCodeScanner extends React.Component<QRProps, QRState> {
                 </View>
                 <CameraKitCameraScreen
                     laserColor={"orange"}
-                    frameColor={"yellow"}
                     scanBarcode={true}
                     onReadCode={(event: any) => handleQRScanned(event.nativeEvent.codeStringValue)}
-                    hideControls={false}
-                    showFrame={true}
-                    heightForScannerFrame={250}
+                    hideControls={true}
+                    showFrame={false}
                     style={{
                         flex: 1
                     }}


### PR DESCRIPTION
This change improves QR code scanning success rate on smaller Android phones by removing the limited scan area and using the whole camera image to scan.

Needs to be tested across other phones and iOS.

A styled overlay can be added later to imply some kind of scanning frame.