### PR TITLE
add scan button to MainPane.

### DIFF
--- a/views/Wallet/MainPane.tsx
+++ b/views/Wallet/MainPane.tsx
@@ -235,12 +235,36 @@ export default class MainPane extends React.Component<
                                     borderRadius: 30
                                 }}
                                 containerStyle={{
-                                    marginLeft: 10
+                                    marginLeft: 10,
+                                    marginRight: 10
                                 }}
                                 titleStyle={{
                                     color: theme === 'dark' ? 'white' : 'black'
                                 }}
                                 onPress={() => navigation.navigate('Receive')}
+                                raised={theme !== 'dark'}
+                            />
+                            <Button
+                                title="Scan"
+                                icon={{
+                                    name: 'crop-free',
+                                    size: 25,
+                                    color: '#f1a58c'
+                                }}
+                                buttonStyle={{
+                                    backgroundColor:
+                                        theme === 'dark' ? 'black' : 'white',
+                                    borderRadius: 20
+                                }}
+                                containerStyle={{
+                                    marginLeft: 10
+                                }}
+                                titleStyle={{
+                                    color: theme === 'dark' ? 'white' : 'black'
+                                }}
+                                onPress={() =>
+                                    navigation.navigate('AddressQRCodeScanner')
+                                }
                                 raised={theme !== 'dark'}
                             />
                         </View>


### PR DESCRIPTION
The idea is to make `AddressQRCodeScanner` a scanner for both invoices and lnurl things, so even if you're in the Pay screen and click scan you'll be able to scan an lnurl. So why not have a scanner button in the main app pane?

This is useful because after lnurl-withdraw we can introduce lnurl-pay, lnurl-auth and lnurl-channel reusing the same basic lnurl interface and scanning everything from the same place, without having to make a custom scanner for each and add buttons whoknowswhere for all these kinds of lnurls.

Even if you're not interested in adding all the bizarre lnurl types, I still think having the scanner in the front of the app is a good idea.

I also like the idea of swiping to the right to scan, instead of clicking. Is that an addition I should investigate?