### PR TITLE
unify pasted/scanned content.

### DIFF
--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -1,0 +1,55 @@
+import stores from '../stores/Stores';
+import AddressUtils from './../utils/AddressUtils';
+import { getParams as getlnurlParams, findlnurl } from 'js-lnurl';
+
+const { nodeInfoStore, invoicesStore } = stores;
+
+export default async function(data: string): Promise<[string, any]> {
+    const { testnet } = nodeInfoStore;
+    const { value, amount } = AddressUtils.processSendAddress(data);
+
+    if (AddressUtils.isValidBitcoinAddress(value, testnet)) {
+        return [
+            'Send',
+            {
+                destination: value,
+                amount,
+                transactionType: 'On-chain'
+            }
+        ];
+    } else if (AddressUtils.isValidLightningPaymentRequest(value)) {
+        invoicesStore.getPayReq(value);
+        return ['PaymentRequest', {}];
+    } else if (findlnurl(value) !== null) {
+        const raw = findlnurl(value);
+        return getlnurlParams(raw).then(params => {
+            switch (params.tag) {
+                case 'withdrawRequest':
+                    return [
+                        'Receive',
+                        {
+                            lnurlParams: params
+                        }
+                    ];
+                    break;
+                case 'payRequest':
+                    params.lnurlText = raw;
+                    return [
+                        'LnurlPay',
+                        {
+                            lnurlParams: params
+                        }
+                    ];
+                    break;
+                default:
+                    throw new Error(
+                        params.reason || `Unsupported lnurl type: ${params.tag}`
+                    );
+            }
+        });
+    } else {
+        throw new Error(
+            'Scanned QR code was not a valid Bitcoin address or Lightning Invoice'
+        );
+    }
+}

--- a/views/AddressQRScanner.tsx
+++ b/views/AddressQRScanner.tsx
@@ -1,20 +1,13 @@
 import * as React from 'react';
 import { Alert } from 'react-native';
-import AddressUtils from './../utils/AddressUtils';
-import QRCodeScanner from './../components/QRCodeScanner';
 import { inject, observer } from 'mobx-react';
-import { getParams as getlnurlParams, findlnurl } from 'js-lnurl';
-
-import NodeInfoStore from './../stores/NodeInfoStore';
-import InvoicesStore from './../stores/InvoicesStore';
+import QRCodeScanner from './../components/QRCodeScanner';
+import handleAnything from './../utils/handleAnything';
 
 interface AddressQRProps {
     navigation: any;
-    InvoicesStore: InvoicesStore;
-    NodeInfoStore: NodeInfoStore;
 }
 
-@inject('InvoicesStore', 'NodeInfoStore')
 @observer
 export default class AddressQRScanner extends React.Component<
     AddressQRProps,
@@ -29,61 +22,21 @@ export default class AddressQRScanner extends React.Component<
     }
 
     handleAddressInvoiceScanned = (data: string) => {
-        const { InvoicesStore, NodeInfoStore, navigation } = this.props;
-        const { testnet } = NodeInfoStore;
+        const { navigation } = this.props;
+        handleAnything(data)
+            .then(([route, props]) => {
+                navigation.navigate(route, props);
+            })
+            .catch(err => {
+                Alert.alert(
+                    'Error',
+                    err.message,
+                    [{ text: 'OK', onPress: () => void 0 }],
+                    { cancelable: false }
+                );
 
-        const { value, amount } = AddressUtils.processSendAddress(data);
-
-        if (AddressUtils.isValidBitcoinAddress(value, testnet)) {
-            navigation.navigate('Send', {
-                destination: value,
-                amount,
-                transactionType: 'On-chain'
+                navigation.navigate('Send');
             });
-        } else if (AddressUtils.isValidLightningPaymentRequest(value)) {
-            navigation.navigate('Send', {
-                destination: value,
-                transactionType: 'Lightning'
-            });
-
-            InvoicesStore.getPayReq(value);
-            navigation.navigate('PaymentRequest');
-        } else if (findlnurl(value) !== null) {
-            const raw = findlnurl(value);
-            getlnurlParams(raw)
-                .then(params => {
-                    switch (params.tag) {
-                        case 'withdrawRequest':
-                            navigation.navigate('Receive', {
-                                lnurlParams: params
-                            });
-                            break;
-                        case 'payRequest':
-                            params.lnurlText = raw;
-                            navigation.navigate('LnurlPay', {
-                                lnurlParams: params
-                            });
-                            break;
-                        default:
-                            throw new Error(
-                                params.reason ||
-                                    `Unsupported lnurl type: ${params.tag}`
-                            );
-                    }
-                })
-                .catch(err => {
-                    Alert.alert(err.message);
-                });
-        } else {
-            Alert.alert(
-                'Error',
-                'Scanned QR code was not a valid Bitcoin address or Lightning Invoice',
-                [{ text: 'OK', onPress: () => void 0 }],
-                { cancelable: false }
-            );
-
-            navigation.navigate('Send');
-        }
     };
 
     render() {

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -46,7 +46,7 @@ export default class Send extends React.Component<SendProps, SendState> {
     }
 
     componentDidMount() {
-        Clipboard.getString().then(text => this.validateAddress(text));
+        Clipboard.getString().then(text => this.validateAddress(text, false));
     }
 
     componentWillReceiveProps(nextProps: any) {
@@ -67,7 +67,7 @@ export default class Send extends React.Component<SendProps, SendState> {
         });
     }
 
-    validateAddress = (text: string) => {
+    validateAddress = (text: string, apply: boolean = true) => {
         const { navigation } = this.props;
         handleAnything(text)
             .then(([route, props]) => {
@@ -77,7 +77,7 @@ export default class Send extends React.Component<SendProps, SendState> {
                 this.setState({
                     transactionType: null,
                     isValid: false,
-                    destination: text
+                    destination: apply ? text : this.state.destination
                 });
             });
     };

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { StyleSheet, Text, TextInput, View } from 'react-native';
+import { StyleSheet, Text, TextInput, View, Clipboard } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { Button, Header, Icon } from 'react-native-elements';
-import AddressUtils from './../utils/AddressUtils';
+import handleAnything from './../utils/handleAnything';
 
 import InvoicesStore from './../stores/InvoicesStore';
 import NodeInfoStore from './../stores/NodeInfoStore';
@@ -45,6 +45,10 @@ export default class Send extends React.Component<SendProps, SendState> {
         };
     }
 
+    componentDidMount() {
+        Clipboard.getString().then(text => this.validateAddress(text));
+    }
+
     componentWillReceiveProps(nextProps: any) {
         const { navigation } = nextProps;
         const destination = navigation.getParam('destination', null);
@@ -64,41 +68,18 @@ export default class Send extends React.Component<SendProps, SendState> {
     }
 
     validateAddress = (text: string) => {
-        const { NodeInfoStore, InvoicesStore } = this.props;
-        const { testnet } = NodeInfoStore;
-
-        const { value, amount } = AddressUtils.processSendAddress(text);
-
-        if (AddressUtils.isValidBitcoinAddress(value, testnet)) {
-            if (amount) {
+        const { navigation } = this.props;
+        handleAnything(text)
+            .then(([route, props]) => {
+                navigation.navigate(route, props);
+            })
+            .catch(err => {
                 this.setState({
-                    transactionType: 'On-chain',
-                    isValid: true,
-                    destination: value,
-                    amount
+                    transactionType: null,
+                    isValid: false,
+                    destination: text
                 });
-            } else {
-                this.setState({
-                    transactionType: 'On-chain',
-                    isValid: true,
-                    destination: value
-                });
-            }
-        } else if (AddressUtils.isValidLightningPaymentRequest(value)) {
-            this.setState({
-                transactionType: 'Lightning',
-                isValid: true,
-                destination: value
             });
-
-            InvoicesStore.getPayReq(value);
-        } else {
-            this.setState({
-                transactionType: null,
-                isValid: false,
-                destination: value
-            });
-        }
     };
 
     sendCoins = () => {


### PR DESCRIPTION
This PR moves logic from `Send.tsx` and `AddressQRScanner.tsx` to `utils/handleAnything.tsx`. There lives a function that takes a Bitcoin address, a Lightning invoice or any kind of LNURL and returns the route to which the user must be directed with parameters.

Also included in this PR is the usage of react-native's `Clipboard` at `Send.tsx`. If anything is copied at the user clipboard when that component is mounted it is automatically checked with `handleAnything()`, no need to click in the field, then click "paste", then click "Lookup payment request".