### PR TITLE
Improved Node Switching Workflow

### DIFF
--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -50,6 +50,7 @@ export default class InvoicesStore {
             .catch(() => {
                 // handle error
                 this.invoices = [];
+                this.invoicesCount = 0;
                 this.loading = false;
             });
     };

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -99,6 +99,7 @@ export default class SettingsStore {
         // Store the credentials
         await Keychain.setGenericPassword('settings', settings).then(() => {
             this.loading = false;
+            return settings;
         });
     }
 

--- a/views/Settings.tsx
+++ b/views/Settings.tsx
@@ -203,6 +203,7 @@ export default class Settings extends React.Component<
                         theme={theme}
                         loading={loading}
                         selectedNode={selectedNode}
+                        SettingsStore={SettingsStore}
                     />
                 </View>
 

--- a/views/Settings/AddEditNode.tsx
+++ b/views/Settings/AddEditNode.tsx
@@ -138,17 +138,17 @@ export default class AddEditNode extends React.Component<
                 selectedNode: settings.selectedNode,
                 onChainAddress: settings.onChainAddress
             })
-        );
+        ).then(() => {
+            this.setState({
+                saved: true
+            });
 
-        this.setState({
-            saved: true
+            if (nodes.length === 1) {
+                navigation.navigate('Wallet', { refresh: true });
+            } else {
+                navigation.navigate('Settings', { refresh: true });
+            }
         });
-
-        if (nodes.length === 1) {
-            navigation.navigate('Wallet', { refresh: true });
-        } else {
-            navigation.navigate('Settings', { refresh: true });
-        }
     };
 
     deleteNodeConfig = () => {

--- a/views/Settings/Nodes.tsx
+++ b/views/Settings/Nodes.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { FlatList, StyleSheet, View } from 'react-native';
 import { Avatar, Button, ListItem } from 'react-native-elements';
+import SettingsStore from './../../stores/SettingsStore';
 import Identicon from 'identicon.js';
 const hash = require('object-hash');
 
@@ -11,6 +12,7 @@ interface NodesProps {
     loading?: boolean;
     theme?: string;
     selectedNode?: number;
+    SettingsStore: SettingsStore;
 }
 
 export default class Nodes extends React.Component<NodesProps, {}> {
@@ -28,7 +30,16 @@ export default class Nodes extends React.Component<NodesProps, {}> {
     };
 
     render() {
-        const { navigation, nodes, theme, loading, selectedNode } = this.props;
+        const {
+            navigation,
+            nodes,
+            theme,
+            loading,
+            selectedNode,
+            SettingsStore
+        } = this.props;
+        const { setSettings, settings } = SettingsStore;
+
         const Node = (balanceImage: string) => (
             <Avatar
                 source={{
@@ -59,6 +70,37 @@ export default class Nodes extends React.Component<NodesProps, {}> {
                                         leftElement={Node(
                                             `data:image/png;base64,${data}`
                                         )}
+                                        rightElement={
+                                            <Button
+                                                title=""
+                                                icon={{
+                                                    name: 'settings',
+                                                    size: 25,
+                                                    color:
+                                                        theme === 'dark'
+                                                            ? 'white'
+                                                            : 'black'
+                                                }}
+                                                buttonStyle={{
+                                                    backgroundColor:
+                                                        'transparent',
+                                                    marginRight: -10
+                                                }}
+                                                onPress={() =>
+                                                    navigation.navigate(
+                                                        'AddEditNode',
+                                                        {
+                                                            node: item,
+                                                            index: index,
+                                                            active:
+                                                                selectedNode ===
+                                                                index,
+                                                            saved: true
+                                                        }
+                                                    )
+                                                }
+                                            />
+                                        }
                                         subtitle={
                                             selectedNode === index ||
                                             (!selectedNode && index === 0)
@@ -72,14 +114,21 @@ export default class Nodes extends React.Component<NodesProps, {}> {
                                                     ? 'black'
                                                     : 'white'
                                         }}
-                                        onPress={() =>
-                                            navigation.navigate('AddEditNode', {
-                                                node: item,
-                                                index: index,
-                                                active: selectedNode === index,
-                                                saved: true
-                                            })
-                                        }
+                                        onPress={() => {
+                                            setSettings(
+                                                JSON.stringify({
+                                                    nodes,
+                                                    theme: settings.theme,
+                                                    selectedNode: index,
+                                                    onChainAddress:
+                                                        settings.onChainAddress
+                                                })
+                                            ).then(() => {
+                                                navigation.navigate('Wallet', {
+                                                    refresh: true
+                                                });
+                                            });
+                                        }}
                                         titleStyle={{
                                             color:
                                                 theme === 'dark'

--- a/views/Settings/Nodes.tsx
+++ b/views/Settings/Nodes.tsx
@@ -50,7 +50,7 @@ export default class Nodes extends React.Component<NodesProps, {}> {
 
         return (
             <View>
-                {!!nodes && !loading && nodes.length > 0 && (
+                {!!nodes && nodes.length > 0 && (
                     <FlatList
                         data={nodes}
                         renderItem={({ item, index }) => {


### PR DESCRIPTION
It's annoying to have to go into the node configuration to make it the active node. Now on the Settings page, clicking the node entry will make it active and take you back to the Wallet view. To change the configuration of the node you will now tap the settings gear to its right.

![Simulator Screen Shot - iPhone 11 - 2020-01-20 at 00 51 09](https://user-images.githubusercontent.com/1878621/72702018-4112d680-3b1f-11ea-8abf-c7c31709c975.png)
