### PR TITLE
Fix toFixed utility function

### DIFF
--- a/utils/FeeUtils.test.ts
+++ b/utils/FeeUtils.test.ts
@@ -16,7 +16,9 @@ describe('FeeUtils', () => {
             expect(FeeUtils.toFixed(1000 / satoshisPerBTC)).toEqual('0.00001');
             expect(FeeUtils.toFixed(10000 / satoshisPerBTC)).toEqual('0.0001');
             // was returning "0.00000009999999999999999" in original version
-            expect(FeeUtils.toFixed(10 / satoshisPerBTC)).toEqual('0.0000001');
+            expect(
+                FeeUtils.toFixed(Number('10') / satoshisPerBTC).toString()
+            ).toBe('0.0000001');
             expect(FeeUtils.toFixed(1 / satoshisPerBTC)).toEqual('0.00000001');
             expect(FeeUtils.toFixed(283190 / satoshisPerBTC)).toEqual(
                 '0.0028319'

--- a/utils/FeeUtils.ts
+++ b/utils/FeeUtils.ts
@@ -59,10 +59,7 @@ class FeeUtils {
         return final;
     };
     toFixed = (x: any) => {
-        return x.toLocaleString('fullwide', {
-            useGrouping: false,
-            maximumSignificantDigits: 8
-        });
+        return x.toFixed(8).replace(/\.?0+$/, '');
     };
 }
 


### PR DESCRIPTION
make sure small values denominated in bitcoin are never collapsed to exponential notation