### PR TITLE
Bug fix: retain settings on node change

### DIFF
--- a/views/Settings/Nodes.tsx
+++ b/views/Settings/Nodes.tsx
@@ -130,7 +130,12 @@ export default class Nodes extends React.Component<NodesProps, {}> {
                                                     theme: settings.theme,
                                                     selectedNode: index,
                                                     onChainAddress:
-                                                        settings.onChainAddress
+                                                        settings.onChainAddress,
+                                                    fiat: settings.fiat,
+                                                    lurkerMode:
+                                                        settings.lurkerMode,
+                                                    passphrase:
+                                                        settings.passphrase
                                                 })
                                             ).then(() => {
                                                 navigation.navigate('Wallet', {


### PR DESCRIPTION
users were losing fiat, lurker mode, and passphrase settings upon switching between nodes