### PR TITLE
Bug fix: Mobx index issue

### DIFF
--- a/views/Settings/AddEditNode.tsx
+++ b/views/Settings/AddEditNode.tsx
@@ -255,9 +255,13 @@ export default class AddEditNode extends React.Component<
             certVerification
         };
 
-        let nodes: any = settings.nodes || [];
-
-        nodes[index] = node;
+        let nodes: any;
+        if (settings.nodes) {
+            nodes = settings.nodes;
+            nodes[index] = node;
+        } else {
+            nodes = [node];
+        }
 
         setSettings(
             JSON.stringify({


### PR DESCRIPTION
When saving your first account, Mobx would hit an error when you attempted to read nodes[0] when settings was undefined