### PR TITLE
fix: handle lntxbot lndhub empty strings.

### DIFF
--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -94,7 +94,7 @@ export default class SendingLightning extends React.Component<
                             {localeString('views.SendingLightning.sending')}
                         </Text>
                     )}
-                    {(error || payment_error) && (
+                    {(!!error || !!payment_error) && (
                         <Text
                             style={{
                                 color: 'white',
@@ -110,7 +110,7 @@ export default class SendingLightning extends React.Component<
                             {payment_error || error_msg}
                         </Text>
                     )}
-                    {success && !error && (
+                    {!!success && !error && (
                         <Text
                             style={{
                                 color: 'white',
@@ -121,7 +121,7 @@ export default class SendingLightning extends React.Component<
                             {localeString('views.SendingLightning.success')}
                         </Text>
                     )}
-                    {payment_preimage &&
+                    {!!payment_preimage &&
                         payment_hash === LnurlPayStore.paymentHash &&
                         LnurlPayStore.successAction && (
                             <LnurlPaySuccess
@@ -132,7 +132,7 @@ export default class SendingLightning extends React.Component<
                                 SettingsStore={SettingsStore}
                             />
                         )}
-                    {payment_hash && (
+                    {!!payment_hash && (
                         <Text
                             style={{
                                 color: 'white',
@@ -143,7 +143,7 @@ export default class SendingLightning extends React.Component<
                             'views.SendingLightning.paymentHash'
                         )}: ${payment_hash}`}</Text>
                     )}
-                    {success && !error && (
+                    {!!success && !error && (
                         <Button
                             title=""
                             icon={{
@@ -158,7 +158,7 @@ export default class SendingLightning extends React.Component<
                             }}
                         />
                     )}
-                    {error && (
+                    {!!error && (
                         <Button
                             title=""
                             icon={{
@@ -174,7 +174,7 @@ export default class SendingLightning extends React.Component<
                         />
                     )}
 
-                    {(error || payment_error || success) && (
+                    {(!!error || !!payment_error || !!success) && (
                         <Button
                             title={localeString(
                                 'views.SendingLightning.goToWallet'


### PR DESCRIPTION
# Description

The issue is the same old "text must be rendered inside <Text> components".
lntxbot returns empty strings for some fields that other lndHub servers return null, that causes glitches in some condition checks.

Reported by Hamish MacEwan.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [x] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
