### PR TITLE
Don't prompt a second QR scan when an error happens on handleQRScanned

### DIFF
--- a/components/QRCodeScanner.tsx
+++ b/components/QRCodeScanner.tsx
@@ -41,9 +41,10 @@ export default class QRCodeScanner extends React.Component<QRProps, QRState> {
             return;
         }
 
+        let response;
         try {
             const uniqueId = 0;
-            const response = await ActivityResult.startActivityForResult(
+            response = await ActivityResult.startActivityForResult(
                 uniqueId,
                 QRINTENT,
                 { SCAN_MODE: 'QR_CODE_MODE' }
@@ -60,13 +61,13 @@ export default class QRCodeScanner extends React.Component<QRProps, QRState> {
                 this.setState({ useInternalScanner: true });
                 return;
             }
-
-            this.props.handleQRScanned(response.data.SCAN_RESULT);
         } catch (e) {
             // it seems this will never happen
             this.setState({ useInternalScanner: true });
             return;
         }
+
+        this.props.handleQRScanned(response.data.SCAN_RESULT);
     }
 
     async componentDidMount() {


### PR DESCRIPTION
# Description

Currently we are catching _every possible error that may happen on `handleQRScanned`_ and handling it by just sending telling the user to scan again. This is wrong and unnecessary. At the point we call `handleQRScanned` the scan part has already ended, so it should be done outside of the `catch {}` block.

Now specific errors related to `handleQRScanned` should be dealt with separately.

This PR saves users from the burden of having to scan the same QR twice before seeing an inevitable crash.

Reported by Hamish.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [x] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
