### PR TITLE
Fix issues with LNbits LndHub support

### DIFF
--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -137,6 +137,11 @@ export default class LND {
         if (ws) {
             baseUrl = baseUrl.replace('https', 'wss');
         }
+
+        if (baseUrl[baseUrl.length - 1] === '/') {
+            baseUrl = baseUrl.slice(0, -1);
+        }
+
         return `${baseUrl}${route}`;
     };
 

--- a/utils/AddressUtils.test.ts
+++ b/utils/AddressUtils.test.ts
@@ -190,14 +190,14 @@ describe('AddressUtils', () => {
                 ).toBeTruthy();
                 expect(
                     AddressUtils.isValidLNDHubAddress(
-                        'lndhub://123:9b9537fe3de0dc2a9c6b5b6475dd4047d5a4cf16e531fd4a3e37efb68c99b5d6@https://lntxbot.bigsun.xyz'
+                        'lndhub://admin:99b46a0892f7404e8a6e3a5e41d095cf@https://lnbits.local.domain.url:16507/lndhub/ext/'
                     )
                 ).toBeTruthy();
                 expect(
                     AddressUtils.isValidLNDHubAddress(
-                        'lndhub://9ae:9a1e4e972f732352c75e'
+                        'lndhub://123:9b9537fe3de0dc2a9c6b5b6475dd4047d5a4cf16e531fd4a3e37efb68c99b5d6@https://lntxbot.bigsun.xyz'
                     )
-                ).toBeFalsy();
+                ).toBeTruthy();
             });
         });
 

--- a/utils/AddressUtils.ts
+++ b/utils/AddressUtils.ts
@@ -13,7 +13,7 @@ const btcBechTestnet = /^(bc1|bcrt1|[2])[a-zA-HJ-NP-Z0-9]{25,89}$/;
 const btcBechPubkeyScriptHashTestnet = /^(tb1|[2])[a-zA-HJ-NP-Z0-9]{25,89}$/;
 
 /* lndhub */
-const lndHubAddress = /^(lndhub:\/\/)[a-hA-H-0-9]{1,24}(:)[a-hA-H-0-9]{18,64}(@https?:\/\/[\w\.]+)?$/;
+const lndHubAddress = /^(lndhub:\/\/)\w+(:)\w+(@https?:\/\/[\w\.]+(:\d{1,5})?([\/\w]+)?)?$/;
 
 class AddressUtils {
     processSendAddress = (input: string) => {


### PR DESCRIPTION
# Description

This PR fixes two issues:

* Add node QR code scans were failing with LndHub URLs from the new LNbits LndHub extension.
* lnbits LndHub extension was showing an URL with an ending slash. Although this could be fixed on the LNbits side it is a good measure to always remove the ending slash before adding our route path that will contain an starting slash.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [ ] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [x] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
