### PR TITLE
Eclair balances in sats instead of millisats.

### DIFF
--- a/backends/Eclair.ts
+++ b/backends/Eclair.ts
@@ -31,7 +31,7 @@ export default class Eclair {
                 },
                 querystring.stringify(params)
             )
-            .then(response => {
+            .then((response) => {
                 delete calls[id];
 
                 const status = response.info().status;
@@ -78,15 +78,16 @@ export default class Eclair {
                     remote_pubkey: chan.data.commitments.remoteParams.nodeId,
                     channel_point: null,
                     chan_id: chan.channelId,
-                    capacity: Number(
-                        chan.data.commitments.localCommit.spec.toLocal +
-                            chan.data.commitments.localCommit.spec.toRemote
+                    capacity: Math.round(
+                        (chan.data.commitments.localCommit.spec.toLocal +
+                            chan.data.commitments.localCommit.spec.toRemote) /
+                            1000
                     ).toString(),
-                    local_balance: Number(
-                        chan.data.commitments.localCommit.spec.toLocal
+                    local_balance: Math.round(
+                        chan.data.commitments.localCommit.spec.toLocal / 1000
                     ).toString(),
-                    remote_balance: Number(
-                        chan.data.commitments.localCommit.spec.toRemote
+                    remote_balance: Math.round(
+                        chan.data.commitments.localCommit.spec.toRemote / 1000
                     ).toString(),
                     total_satoshis_sent: null,
                     total_satoshis_received: null,
@@ -109,25 +110,30 @@ export default class Eclair {
         });
     getLightningBalance = () =>
         this.api('channels').then((channels: any) => ({
-            balance: channels
-                .filter(
-                    (chan: any) =>
-                        chan.state === 'NORMAL' || chan.state == 'OFFLINE'
-                )
-                .reduce(
-                    (acc: any, o: any) =>
-                        acc + o.data.commitments.localCommit.spec.toLocal,
-                    0
-                ),
-            pending_open_balance: channels
-                .filter(
-                    (chan: any) => chan.state === 'WAIT_FOR_FUNDING_CONFIRMED'
-                )
-                .reduce(
-                    (acc: any, o: any) =>
-                        acc + o.data.commitments.localCommit.spec.toLocal,
-                    0
-                )
+            balance: Math.round(
+                channels
+                    .filter(
+                        (chan: any) =>
+                            chan.state === 'NORMAL' || chan.state == 'OFFLINE'
+                    )
+                    .reduce(
+                        (acc: any, o: any) =>
+                            acc + o.data.commitments.localCommit.spec.toLocal,
+                        0
+                    ) / 1000
+            ),
+            pending_open_balance: Math.round(
+                channels
+                    .filter(
+                        (chan: any) =>
+                            chan.state === 'WAIT_FOR_FUNDING_CONFIRMED'
+                    )
+                    .reduce(
+                        (acc: any, o: any) =>
+                            acc + o.data.commitments.localCommit.spec.toLocal,
+                        0
+                    ) / 1000
+            )
         }));
     sendCoins = (data: TransactionRequest) =>
         this.api('sendonchain', {
@@ -340,10 +346,11 @@ export default class Eclair {
     setFees = async (data: any) => {
         const params: any = {};
         if (data.global) {
-            params.channelIds = (await this.api('channels').then(
-                (channels: any) =>
+            params.channelIds = (
+                await this.api('channels').then((channels: any) =>
                     channels.map((channel: any) => channel.channelId)
-            )).join(',');
+                )
+            ).join(',');
         } else {
             params.channelId = data.channelId;
         }


### PR DESCRIPTION
# Description

Relates to issue: https://t.me/zeusLN/15514

When I was testing Eclair on regtest I had so many satoshis I didn't notice Zeus was showing 1000x more than I should.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [ ] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [x] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [x] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
