### PR TITLE
Bug fix: Locale gets reset on node config changes

### DIFF
--- a/views/Settings/AddEditNode.tsx
+++ b/views/Settings/AddEditNode.tsx
@@ -220,7 +220,7 @@ export default class AddEditNode extends React.Component<
             index
         } = this.state;
         const { setSettings, settings } = SettingsStore;
-        const { lurkerMode, passphrase, fiat } = settings;
+        const { lurkerMode, passphrase, fiat, locale } = settings;
 
         if (
             implementation === 'lndhub' &&
@@ -258,6 +258,7 @@ export default class AddEditNode extends React.Component<
                 selectedNode: settings.selectedNode,
                 onChainAddress: settings.onChainAddress,
                 fiat,
+                locale,
                 lurkerMode,
                 passphrase
             })
@@ -278,7 +279,7 @@ export default class AddEditNode extends React.Component<
         const { SettingsStore, navigation } = this.props;
         const { setSettings, settings } = SettingsStore;
         const { index } = this.state;
-        const { nodes, lurkerMode, passphrase, fiat } = settings;
+        const { nodes, lurkerMode, passphrase, fiat, locale } = settings;
 
         let newNodes: any = [];
         for (let i = 0; nodes && i < nodes.length; i++) {
@@ -295,6 +296,7 @@ export default class AddEditNode extends React.Component<
                     index === settings.selectedNode ? 0 : settings.selectedNode,
                 onChainAddress: settings.onChainAddress,
                 fiat,
+                locale,
                 lurkerMode,
                 passphrase
             })
@@ -307,7 +309,7 @@ export default class AddEditNode extends React.Component<
         const { SettingsStore, navigation } = this.props;
         const { setSettings, settings } = SettingsStore;
         const { index } = this.state;
-        const { nodes, lurkerMode, passphrase, fiat } = settings;
+        const { nodes, lurkerMode, passphrase, fiat, locale } = settings;
 
         setSettings(
             JSON.stringify({
@@ -316,6 +318,7 @@ export default class AddEditNode extends React.Component<
                 selectedNode: index,
                 onChainAddress: settings.onChainAddress,
                 fiat,
+                locale,
                 lurkerMode,
                 passphrase
             })


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-373**

Locale setting was resetting to English when changing/saving node configs.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [x] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [x] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
