### PR TITLE
Eclair: Fix timestamps

### DIFF
--- a/backends/Eclair.ts
+++ b/backends/Eclair.ts
@@ -437,6 +437,7 @@ const mapInvoice = (isPending: any) => ({
     serialized,
     paymentHash,
     expiry,
+    timestamp,
     amount
 }: any) => {
     if (!isPending) isPending = { [paymentHash]: true };
@@ -449,6 +450,7 @@ const mapInvoice = (isPending: any) => ({
         creation_date: null,
         settle_date: null,
         payment_request: serialized,
+        timestamp,
         expiry,
         amt_paid: isPending[paymentHash] ? 0 : amount / 1000,
         amt_paid_sat: isPending[paymentHash] ? 0 : amount / 1000,

--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -99,7 +99,6 @@ export default class Invoice extends BaseModel {
         return Number(this.num_satoshis || 0);
     }
 
-    // return amount in satoshis
     @computed public get listDate(): string {
         return this.isPaid
             ? this.settleDate


### PR DESCRIPTION
# Description


We weren't returning timestamps in our mapping function causing the display to be Dec 31 1969 for each invoice


This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [ ] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [ ] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [X] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
