### PR TITLE
Eclair: Fix my node info view

### DIFF
--- a/backends/Eclair.ts
+++ b/backends/Eclair.ts
@@ -143,10 +143,18 @@ export default class Eclair {
         }).then((txid: any) => ({ txid }));
     getMyNodeInfo = () =>
         this.api('getinfo').then(
-            ({ version, nodeId, alias, network, publicAddresses }: any) => ({
+            ({
+                version,
+                nodeId,
+                alias,
+                network,
+                publicAddresses,
+                blockHeight
+            }: any) => ({
                 uris: publicAddresses.map((addr: any) => nodeId + '@' + addr),
                 alias,
                 version,
+                block_height: blockHeight,
                 identity_pubkey: nodeId,
                 testnet: network === 'testnet',
                 regtest: network === 'regtest'

--- a/views/NodeInfo.tsx
+++ b/views/NodeInfo.tsx
@@ -223,18 +223,33 @@ export default class NodeInfo extends React.Component<
                         : nodeInfo.alias}
                 </Text>
 
-                <Text
-                    style={theme === 'dark' ? styles.labelDark : styles.label}
-                >
-                    {localeString('views.NodeInfo.implementationVersion')}:
-                </Text>
-                <Text
-                    style={theme === 'dark' ? styles.valueDark : styles.value}
-                >
-                    {lurkerMode
-                        ? PrivacyUtils.hideValue(nodeInfo.version, 12)
-                        : nodeInfo.version}
-                </Text>
+                {nodeInfo.version && (
+                    <>
+                        <Text
+                            style={
+                                theme === 'dark'
+                                    ? styles.labelDark
+                                    : styles.label
+                            }
+                        >
+                            {localeString(
+                                'views.NodeInfo.implementationVersion'
+                            )}
+                            :
+                        </Text>
+                        <Text
+                            style={
+                                theme === 'dark'
+                                    ? styles.valueDark
+                                    : styles.value
+                            }
+                        >
+                            {lurkerMode
+                                ? PrivacyUtils.hideValue(nodeInfo.version, 12)
+                                : nodeInfo.version}
+                        </Text>
+                    </>
+                )}
 
                 <Text
                     style={theme === 'dark' ? styles.labelDark : styles.label}

--- a/views/Wallet/MainPane.tsx
+++ b/views/Wallet/MainPane.tsx
@@ -53,7 +53,7 @@ export default class MainPane extends React.Component<
             lightningBalance,
             pendingOpenBalance
         } = BalanceStore;
-        const { host, settings, implementation } = SettingsStore;
+        const { host, url, settings, implementation } = SettingsStore;
         const { theme, lurkerMode } = settings;
         const loading = NodeInfoStore.loading || BalanceStore.loading;
 
@@ -201,7 +201,8 @@ export default class MainPane extends React.Component<
 
         const NodeInfoBadge = () => (
             <View style={styles.nodeInfo}>
-                {host && host.includes('.onion') ? (
+                {(host && host.includes('.onion')) ||
+                (url && url.includes('.onion')) ? (
                     <TouchableOpacity
                         onPress={() => navigation.navigate('NodeInfo')}
                     >
@@ -211,7 +212,8 @@ export default class MainPane extends React.Component<
                         />
                     </TouchableOpacity>
                 ) : null}
-                {host && !host.includes('.onion') ? (
+                {(host && !host.includes('.onion')) ||
+                (url && !url.includes('.onion')) ? (
                     <Badge
                         onPress={() => navigation.navigate('NodeInfo')}
                         value={infoValue}


### PR DESCRIPTION
# Description

The button to go to the my node info view was not rendering + other fixes on that view

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [ ] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [ ] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [x] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
