### PR TITLE
Tor: HTTPS fix

### DIFF
--- a/backends/Eclair.ts
+++ b/backends/Eclair.ts
@@ -465,8 +465,6 @@ export default class Eclair {
     supportsOnchainSends = () => true;
     supportsKeysend = () => false;
     supportsChannelManagement = () => true;
-    supportsCustomHostProtocol = () =>
-        stores.settingsStore.enableTor ? true : false;
     supportsMPP = () => false;
     supportsCoinControl = () => false;
 }

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -144,9 +144,7 @@ export default class LND {
         route: string,
         ws?: boolean
     ) => {
-        let baseUrl = this.supportsCustomHostProtocol()
-            ? `${host}${port ? ':' + port : ''}`
-            : `https://${host}${port ? ':' + port : ''}`;
+        let baseUrl = `${host}${port ? ':' + port : ''}`;
 
         if (ws) {
             baseUrl = baseUrl.replace('https', 'wss');
@@ -262,8 +260,6 @@ export default class LND {
     supportsOnchainSends = () => true;
     supportsKeysend = () => true;
     supportsChannelManagement = () => true;
-    supportsCustomHostProtocol = () =>
-        stores.settingsStore.enableTor ? true : false;
     supportsMPP = () => this.supports('v0.11.0');
     supportsCoinControl = () => false;
 }

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -72,6 +72,5 @@ export default class LndHub extends LND {
     supportsOnchainSends = () => false;
     supportsKeysend = () => false;
     supportsChannelManagement = () => false;
-    supportsCustomHostProtocol = () => true;
     supportsMPP = () => false;
 }

--- a/backends/Spark.ts
+++ b/backends/Spark.ts
@@ -312,8 +312,6 @@ export default class Spark {
     supportsOnchainSends = () => true;
     supportsKeysend = () => false;
     supportsChannelManagement = () => true;
-    supportsCustomHostProtocol = () =>
-        stores.settingsStore.enableTor ? true : false;
     supportsMPP = () => false;
     supportsCoinControl = () => false;
 }

--- a/utils/LndConnectUtils.test.ts
+++ b/utils/LndConnectUtils.test.ts
@@ -8,7 +8,7 @@ describe('LndConnectUtils', () => {
                     'lndconnect://8.8.0.0:2056?&macaroon=Z28gc2hvcnR5'
                 )
             ).toEqual({
-                host: '8.8.0.0',
+                host: 'https://8.8.0.0',
                 macaroonHex: '676F2073686F727479',
                 port: '2056'
             });
@@ -20,7 +20,7 @@ describe('LndConnectUtils', () => {
                     'lndconnect://[2604:2000::]:2056?&macaroon=Z28gc2hvcnR5'
                 )
             ).toEqual({
-                host: '[2604:2000::]',
+                host: 'https://[2604:2000::]',
                 macaroonHex: '676F2073686F727479',
                 port: '2056'
             });
@@ -32,7 +32,7 @@ describe('LndConnectUtils', () => {
                     'lndconnect://[2604:2000::]:2058?macaroon=Z28gc2hvcnR5&cert=a&otherParam=B'
                 )
             ).toEqual({
-                host: '[2604:2000::]',
+                host: 'https://[2604:2000::]',
                 macaroonHex: '676F2073686F727479',
                 port: '2058'
             });
@@ -44,7 +44,7 @@ describe('LndConnectUtils', () => {
                     'lndconnect://8.8.8.8:2059?otherParam=B&macaroon=Z28gc2hvcnR5&cert=asfdaa'
                 )
             ).toEqual({
-                host: '8.8.8.8',
+                host: 'https://8.8.8.8',
                 macaroonHex: '676F2073686F727479',
                 port: '2059'
             });

--- a/utils/LndConnectUtils.ts
+++ b/utils/LndConnectUtils.ts
@@ -31,6 +31,9 @@ class LndConnectUtils {
         macaroonHex =
             result.macaroon && MacaroonUtils.base64UrlToHex(result.macaroon);
 
+        // prepend https by default
+        host = 'https://' + host;
+
         return { host, port, macaroonHex };
     };
 }

--- a/utils/RESTUtils.ts
+++ b/utils/RESTUtils.ts
@@ -78,8 +78,6 @@ class RESTUtils {
     supportsOnchainSends = () => this.call('supportsOnchainSends');
     supportsKeysend = () => this.call('supportsKeysend');
     supportsChannelManagement = () => this.call('supportsChannelManagement');
-    // let users specify http/https
-    supportsCustomHostProtocol = () => this.call('supportsCustomHostProtocol');
     supportsMPP = () => this.call('supportsMPP');
     supportsCoinControl = () => this.call('supportsCoinControl');
 }


### PR DESCRIPTION
# Description

All backends whether using Tor or not will now be configured similarly. Protocols must be specified in the host field. LNDConnect import now also appends https:// to the host field.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [ ] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [x] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
