### PR TITLE
Fix host bug

### DIFF
--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -148,10 +148,11 @@ export default class LND {
         route: string,
         ws?: boolean
     ) => {
-        let baseUrl = `${host}${port ? ':' + port : ''}`;
+        const hostPath = host.includes('://') ? host : `https://${host}`;
+        let baseUrl = `${hostPath}${port ? ':' + port : ''}`;
 
         if (ws) {
-            baseUrl = baseUrl.replace('https', 'wss');
+            baseUrl = baseUrl.replace('https', 'wss').replace('http', 'wss');
         }
 
         if (baseUrl[baseUrl.length - 1] === '/') {

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -155,7 +155,7 @@ export default class LND {
         let baseUrl = `${hostPath}${port ? ':' + port : ''}`;
 
         if (ws) {
-            baseUrl = baseUrl.replace('https', 'wss').replace('http', 'wss');
+            baseUrl = baseUrl.replace('https', 'wss').replace('http', 'ws');
         }
 
         if (baseUrl[baseUrl.length - 1] === '/') {


### PR DESCRIPTION
# Description

v0.5.0 required users to enter in https:// or http:// before their host name in node settings. This PR removes that requirement and allows entry from either of the three formats.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [ ] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [ ] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
