### PR TITLE
Receive: Fix fiat conversion

### DIFF
--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -16,6 +16,15 @@ export default class FiatStore {
     }
 
     @action
+    public getRate = () => {
+        const { settings } = this.settingsStore;
+        const { fiat } = settings;
+        const rate = this.fiatRates[fiat]['15m'];
+        const symbol = this.fiatRates[fiat].symbol;
+        return `${symbol}${rate} BTC/${fiat}`;
+    };
+
+    @action
     public getFiatRates = () => {
         this.loading = true;
         RNFetchBlob.fetch('get', 'https://blockchain.info/ticker')

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -19,9 +19,12 @@ export default class FiatStore {
     public getRate = () => {
         const { settings } = this.settingsStore;
         const { fiat } = settings;
-        const rate = this.fiatRates[fiat]['15m'];
-        const symbol = this.fiatRates[fiat].symbol;
-        return `${symbol}${rate} BTC/${fiat}`;
+        if (fiat) {
+            const rate = this.fiatRates[fiat]['15m'];
+            const symbol = this.fiatRates[fiat].symbol;
+            return `${symbol}${rate} BTC/${fiat}`;
+        }
+        return 'N/A';
     };
 
     @action

--- a/stores/UnitsStore.ts
+++ b/stores/UnitsStore.ts
@@ -48,37 +48,38 @@ export default class UnitsStore {
         x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
     @action
-    public getAmount = (value: string | number = 0) => {
+    public getAmount = (value: string | number = 0, fixedUnits?: string) => {
         const { settings } = this.settingsStore;
         const { fiat } = settings;
+        const units = fixedUnits || this.units;
 
         const wholeSats = value.toString().split('.')[0];
-        if (this.units === 'btc') {
+        if (units === 'btc') {
             // handle negative values
             const valueToProcess = (wholeSats && wholeSats.toString()) || '0';
             if (valueToProcess.includes('-')) {
                 let processedValue = valueToProcess.split('-')[1];
-                return `- ₿ ${FeeUtils.toFixed(
+                return `-₿${FeeUtils.toFixed(
                     Number(processedValue) / satoshisPerBTC
                 )}`;
             }
 
-            return `₿ ${FeeUtils.toFixed(
+            return `₿${FeeUtils.toFixed(
                 Number(wholeSats || 0) / satoshisPerBTC
             )}`;
-        } else if (this.units === 'sats') {
+        } else if (units === 'sats') {
             const sats = `${value || 0} ${
                 Number(value) === 1 || Number(value) === -1 ? 'sat' : 'sats'
             }`;
             return this.numberWithCommas(sats);
-        } else if (this.units === 'fiat' && fiat) {
+        } else if (units === 'fiat' && fiat) {
             const rate = this.fiatStore.fiatRates[fiat]['15m'];
             const symbol = this.fiatStore.fiatRates[fiat].symbol;
 
             const valueToProcess = (wholeSats && wholeSats.toString()) || '0';
             if (valueToProcess.includes('-')) {
                 let processedValue = valueToProcess.split('-')[1];
-                return `- ${symbol} ${(
+                return `-${symbol}${(
                     FeeUtils.toFixed(Number(processedValue) / satoshisPerBTC) *
                     rate
                 ).toFixed(2)}`;

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -126,7 +126,7 @@ export default class Receive extends React.Component<
                 satAmount = Number(value) * satoshisPerBTC;
                 break;
             case 'fiat':
-                satAmount = Number(Number(value) * rate).toFixed(0);
+                satAmount = Number(Number(value) / Number(rate) * Number(satoshisPerBTC)).toFixed(0);
                 break;
         }
 
@@ -313,8 +313,36 @@ export default class Receive extends React.Component<
                                                     : 'black'
                                         }}
                                     >
-                                        {satAmount}{' '}
-                                        {localeString('views.Receive.satoshis')}
+                                        {UnitsStore.getAmount(satAmount, 'sats')}{' '}
+                                    </Text>
+                                </TouchableOpacity>
+                            )}
+                            {units !== 'btc' && (
+                                <TouchableOpacity onPress={() => changeUnits()}>
+                                    <Text
+                                        style={{
+                                            color:
+                                                theme === 'dark'
+                                                    ? 'white'
+                                                    : 'black'
+                                        }}
+                                    >
+                                        {UnitsStore.getAmount(satAmount, 'btc')}{' '}
+                                    </Text>
+                                </TouchableOpacity>
+                            )}
+
+                            {units === 'fiat' && (
+                                <TouchableOpacity onPress={() => changeUnits()}>
+                                    <Text
+                                        style={{
+                                            color:
+                                                theme === 'dark'
+                                                    ? 'white'
+                                                    : 'black'
+                                        }}
+                                    >
+                                        {FiatStore.getRate()}{' '}
                                     </Text>
                                 </TouchableOpacity>
                             )}

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -126,7 +126,9 @@ export default class Receive extends React.Component<
                 satAmount = Number(value) * satoshisPerBTC;
                 break;
             case 'fiat':
-                satAmount = Number(Number(value) / Number(rate) * Number(satoshisPerBTC)).toFixed(0);
+                satAmount = Number(
+                    (Number(value) / Number(rate)) * Number(satoshisPerBTC)
+                ).toFixed(0);
                 break;
         }
 
@@ -313,7 +315,10 @@ export default class Receive extends React.Component<
                                                     : 'black'
                                         }}
                                     >
-                                        {UnitsStore.getAmount(satAmount, 'sats')}{' '}
+                                        {UnitsStore.getAmount(
+                                            satAmount,
+                                            'sats'
+                                        )}{' '}
                                     </Text>
                                 </TouchableOpacity>
                             )}


### PR DESCRIPTION
# Description

Fiat conversion rate was broken on the receive view, when viewing sats amount when user is entering in fiat. Also added a rates display.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [ ] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [ ] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
