### PR TITLE
LNDHub: Tor support (Umbrel)

### DIFF
--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -248,7 +248,11 @@ export default class LND {
     getForwardingHistory = (data: any) => this.postRequest('/v1/switch', data);
 
     // LndHub
-    createAccount = (host: string, certVerification: boolean) => {
+    createAccount = (
+        host: string,
+        certVerification: boolean,
+        useTor?: boolean
+    ) => {
         const url: string = `${host}/create`;
         return this.restReq(
             {
@@ -261,7 +265,8 @@ export default class LND {
                 partnerid: 'bluewallet',
                 accounttype: 'common'
             },
-            certVerification
+            certVerification,
+            useTor
         );
     };
 

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -193,11 +193,15 @@ export default class SettingsStore {
 
     // LNDHub
     @action
-    public createAccount = (host: string, certVerification: boolean) => {
+    public createAccount = (
+        host: string,
+        certVerification: boolean,
+        enableTor?: boolean
+    ) => {
         this.createAccountSuccess = '';
         this.createAccountError = '';
         this.loading = true;
-        return RESTUtils.createAccount(host, certVerification)
+        return RESTUtils.createAccount(host, certVerification, enableTor)
             .then((data: any) => {
                 this.loading = false;
                 this.createAccountSuccess =

--- a/utils/AddressUtils.test.ts
+++ b/utils/AddressUtils.test.ts
@@ -212,6 +212,11 @@ describe('AddressUtils', () => {
                         'lndhub://9a1e4e972f732352c75e:4a1e4e172f732352c75e@https://test-domain.org:4324'
                     )
                 ).toBeTruthy();
+                expect(
+                    AddressUtils.isValidLNDHubAddress(
+                        'bluewallet:setlndhuburl?url=http%3A%2F%2Fnaf3121nfadoxnwer1s5x2rkirdqbmvuws2ojvgood.onion'
+                    )
+                ).toBeTruthy();
             });
             it('processes all BECH32 send address variations', () => {
                 // with fee
@@ -298,6 +303,16 @@ describe('AddressUtils', () => {
                     username: '9a1e4e972f732352c75e',
                     password: '4a1e4e172f732352c75e',
                     host: 'https://test-domain.org:4324'
+                });
+            });
+            it('processes hosts from Umbrel', () => {
+                expect(
+                    AddressUtils.processLNDHubAddress(
+                        'bluewallet:setlndhuburl?url=http%3A%2F%2Fnaf3121nfadoxnwer1s5x2rkirdqbmvuws2ojvgood.onion'
+                    )
+                ).toEqual({
+                    host:
+                        'http://naf3121nfadoxnwer1s5x2rkirdqbmvuws2ojvgood.onion'
                 });
             });
         });

--- a/utils/LndConnectUtils.ts
+++ b/utils/LndConnectUtils.ts
@@ -34,7 +34,9 @@ class LndConnectUtils {
         // prepend https by default
         host = 'https://' + host;
 
-        return { host, port, macaroonHex };
+        const enableTor: boolean = host.includes('.onion');
+
+        return { host, port, macaroonHex, enableTor };
     };
 }
 

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -43,6 +43,9 @@ export default async function(data: string): Promise<any> {
         const { username, password, host } = AddressUtils.processLNDHubAddress(
             value
         );
+
+        const existingAccount: boolean = !!username;
+
         let node;
         if (host) {
             node = {
@@ -51,7 +54,7 @@ export default async function(data: string): Promise<any> {
                 password,
                 lndhubUrl: host,
                 certVerification: true,
-                existingAccount: true
+                existingAccount
             };
         } else {
             node = {
@@ -59,7 +62,7 @@ export default async function(data: string): Promise<any> {
                 username,
                 password,
                 certVerification: true,
-                existingAccount: true
+                existingAccount
             };
         }
         return [

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -54,6 +54,7 @@ export default async function(data: string): Promise<any> {
                 password,
                 lndhubUrl: host,
                 certVerification: true,
+                enableTor: host.includes('.onion'),
                 existingAccount
             };
         } else {

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -37,7 +37,7 @@ export default class SendingLightning extends React.Component<
             error
         } = TransactionsStore;
 
-        if (error && error !== '') {
+        if (!!error) {
             return 'darkred';
         } else if (
             payment_route ||

--- a/views/Settings/AddEditNode.tsx
+++ b/views/Settings/AddEditNode.tsx
@@ -33,8 +33,8 @@ interface AddEditNodeState {
     url: string; // spark, eclair
     accessKey: string; // spark
     lndhubUrl: string; // lndhub
-    username: string; // lndhub
-    password: string; // lndhub, eclair
+    username: string | undefined; // lndhub
+    password: string | undefined; // lndhub, eclair
     existingAccount: boolean; // lndhub
     implementation: string;
     certVerification: boolean;
@@ -83,7 +83,8 @@ export default class AddEditNode extends React.Component<
 
         if (
             clipboard.includes('lndconnect://') ||
-            clipboard.includes('lndhub://')
+            clipboard.includes('lndhub://') ||
+            clipboard.includes('bluewallet:')
         ) {
             this.setState({
                 suggestImport: clipboard
@@ -105,14 +106,20 @@ export default class AddEditNode extends React.Component<
                 host,
                 port,
                 macaroonHex,
-                suggestImport: ''
+                suggestImport: '',
+                enableTor: host.includes('.onion')
             });
-        } else if (suggestImport.includes('lndhub://')) {
+        } else if (
+            suggestImport.includes('lndhub://') ||
+            suggestImport.includes('bluewallet:')
+        ) {
             const {
                 username,
                 password,
                 host
             } = AddressUtils.processLNDHubAddress(suggestImport);
+
+            const existingAccount: boolean = !!username;
 
             if (host) {
                 this.setState({
@@ -120,14 +127,17 @@ export default class AddEditNode extends React.Component<
                     password,
                     lndhubUrl: host,
                     implementation: 'lndhub',
-                    suggestImport: ''
+                    suggestImport: '',
+                    enableTor: host.includes('.onion'),
+                    existingAccount
                 });
             } else {
                 this.setState({
                     username,
                     password,
                     implementation: 'lndhub',
-                    suggestImport: ''
+                    suggestImport: '',
+                    existingAccount
                 });
             }
         }
@@ -150,14 +160,6 @@ export default class AddEditNode extends React.Component<
         this.isComponentMounted = false;
     }
 
-    componentDidUpdate() {
-        // auto set tor enabled if onion
-        if (this.state.host && this.state.host.endsWith('.onion')) {
-            if (this.state.enableTor === false) {
-                this.setState(state => ({ ...state, enableTor: true }));
-            }
-        }
-    }
     UNSAFE_componentWillReceiveProps(nextProps: any) {
         this.initFromProps(nextProps);
     }
@@ -1161,7 +1163,8 @@ export default class AddEditNode extends React.Component<
                                 } else {
                                     createAccount(
                                         lndhubUrl,
-                                        certVerification
+                                        certVerification,
+                                        enableTor
                                     ).then((data: any) => {
                                         if (data) {
                                             this.setState({


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-452**](https://github.com/ZeusLN/zeus/issues/452)

BlueWallet QR code from Umbrel was incompatible with Zeus. Furthermore, connecting to an LNDHub instance over Tor wasn't possible unless you already had an existing account.

This PR also makes sure people connecting to .onion hosts can untoggle the `Enable Tor` button so they can continue to use Orbot if they so please.

This pull request is categorized as a:

- [x] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [x] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
