### PR TITLE
c-lightning-REST: OpenChannel: make feerate options clear

### DIFF
--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -59,18 +59,21 @@ export default class OpenChannel extends React.Component<
 > {
     constructor(props: any) {
         super(props);
-        const { navigation } = props;
+        const { navigation, SettingsStore } = props;
+        const { implementation } = SettingsStore;
         const node_pubkey_string = navigation.getParam(
             'node_pubkey_string',
             null
         );
         const host = navigation.getParam('host', null);
+        const sat_per_byte =
+            implementation === 'c-lightning-REST' ? 'normal' : '2';
 
         this.state = {
             node_pubkey_string: node_pubkey_string || '',
             local_funding_amount: '',
             min_confs: 1,
-            sat_per_byte: '2',
+            sat_per_byte,
             private: false,
             host: host || '',
             suggestImport: '',
@@ -164,7 +167,7 @@ export default class OpenChannel extends React.Component<
             channelSuccess
         } = ChannelsStore;
         const { confirmedBlockchainBalance } = BalanceStore;
-        const { settings } = SettingsStore;
+        const { implementation, settings } = SettingsStore;
         const { theme } = settings;
 
         const BackButton = () => (
@@ -380,7 +383,11 @@ export default class OpenChannel extends React.Component<
                     </Text>
                     <TextInput
                         keyboardType="numeric"
-                        placeholder="2"
+                        placeholder={
+                            implementation === 'c-lightning-REST'
+                                ? 'urgent / normal / slow'
+                                : '2'
+                        }
                         value={sat_per_byte}
                         onChangeText={(text: string) => this.setFee(text)}
                         numberOfLines={1}


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-460**](https://github.com/ZeusLN/zeus/issues/460)

Fee options when opening channel for c-lightning-REST are `urgent`, `normal`, and `slow`. We must make this clear to the user. Future iterations will use a GUI component, such as radio buttons.

https://github.com/Ride-The-Lightning/c-lightning-REST/blob/master/docs/channelmgmt.md

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [x] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
