### PR TITLE
Fix fill on Channels icon

### DIFF
--- a/images/SVG/Channels.svg
+++ b/images/SVG/Channels.svg
@@ -1,8 +1,8 @@
 <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="3" y="6.99999" width="24" height="2" rx="1" fill="gray"/>
-<rect x="3" y="14" width="24" height="2" rx="1" fill="gray"/>
-<ellipse cx="21" cy="15" rx="3" ry="3" fill="gray"/>
-<ellipse cx="9" cy="8" rx="3" ry="3" fill="gray"/>
-<rect x="3" y="21" width="24" height="2" rx="1" fill="gray"/>
-<ellipse cx="9" cy="22" rx="3" ry="3" fill="gray"/>
+<rect x="3" y="6.99999" width="24" height="2" rx="1" fill="#000"/>
+<rect x="3" y="14" width="24" height="2" rx="1" fill="#000"/>
+<ellipse cx="21" cy="15" rx="3" ry="3" fill="#000"/>
+<ellipse cx="9" cy="8" rx="3" ry="3" fill="#000"/>
+<rect x="3" y="21" width="24" height="2" rx="1" fill="#000"/>
+<ellipse cx="9" cy="22" rx="3" ry="3" fill="#000"/>
 </svg>


### PR DESCRIPTION
# Description

Icon had grey fill fixed - modified to use the color assigned to it.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [ ] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [ ] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
