### PR TITLE
lnurl-auth signedmsg should be strict DER

### DIFF
--- a/views/LnurlAuth.tsx
+++ b/views/LnurlAuth.tsx
@@ -116,7 +116,7 @@ export default class LnurlAuth extends React.Component<
                 const signedMessage = ec.sign(
                     Base64Utils.hexToUint8Array(this.state.k1),
                     linkingKeyPriv,
-                    {canonical: true}
+                    { canonical: true }
                 );
                 const signedMessageDER = signedMessage.toDER();
 

--- a/views/LnurlAuth.tsx
+++ b/views/LnurlAuth.tsx
@@ -115,7 +115,8 @@ export default class LnurlAuth extends React.Component<
 
                 const signedMessage = ec.sign(
                     Base64Utils.hexToUint8Array(this.state.k1),
-                    linkingKeyPriv
+                    linkingKeyPriv,
+                    {canonical: true}
                 );
                 const signedMessageDER = signedMessage.toDER();
 


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0550**

Fixes https://github.com/ZeusLN/zeus/issues/550
elliptic requires additional parameter `{canonical: true}` to ensure strict DER for the signed message required for lnurl-auth. If this is not set, in some cases the secp256k1 library would give `invalid signature` error.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [X] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [X] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [X] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [X] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
