### PR TITLE
Add color prop to Amount and use in Activity view

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -20,8 +20,7 @@ interface AmountDisplayProps {
     rtl?: boolean;
     space?: boolean;
     jumboText?: boolean;
-    credit?: boolean;
-    debit?: boolean;
+    color?: 'text' | 'success' | 'warning' | 'highlight' | 'secondaryText';
 }
 
 function AmountDisplay({
@@ -33,8 +32,7 @@ function AmountDisplay({
     rtl = false,
     space = false,
     jumboText = false,
-    credit = false,
-    debit = false
+    color = undefined
 }: AmountDisplayProps) {
     if (unit === 'fiat' && !symbol) {
         console.error('Must include a symbol when rendering fiat');
@@ -42,21 +40,17 @@ function AmountDisplay({
 
     const actualSymbol = unit === 'btc' ? '₿' : symbol;
 
+    // TODO this could probably be made more readable by componentizing the repeat bits
     switch (unit) {
         case 'sats':
             return (
                 <Row align="flex-end">
-                    <Body jumbo={jumboText} credit={credit} debit={debit}>
+                    <Body jumbo={jumboText} color={color}>
                         {amount}
                     </Body>
                     <Spacer width={2} />
                     <View style={{ paddingBottom: jumboText ? 8 : 1.5 }}>
-                        <Body
-                            secondary
-                            small={!jumboText}
-                            credit={credit}
-                            debit={debit}
-                        >
+                        <Body secondary small={!jumboText} color={color}>
                             {plural ? 'sats' : 'sat'}
                         </Body>
                     </View>
@@ -67,27 +61,18 @@ function AmountDisplay({
             if (rtl) {
                 return (
                     <Row align="flex-end">
-                        <Body jumbo={jumboText} credit={credit} debit={debit}>
+                        <Body jumbo={jumboText} color={color}>
                             {negative ? '-' : ''}
                             {amount}
                         </Body>
                         {space ? (
-                            <Body
-                                jumbo={jumboText}
-                                credit={credit}
-                                debit={debit}
-                            >
+                            <Body jumbo={jumboText} color={color}>
                                 {' '}
                             </Body>
                         ) : (
                             <Spacer width={1} />
                         )}
-                        <Body
-                            secondary
-                            jumbo={jumboText}
-                            credit={credit}
-                            debit={debit}
-                        >
+                        <Body secondary jumbo={jumboText} color={color}>
                             {actualSymbol}
                         </Body>
                     </Row>
@@ -95,26 +80,17 @@ function AmountDisplay({
             } else {
                 return (
                     <Row align="flex-end">
-                        <Body
-                            secondary
-                            jumbo={jumboText}
-                            credit={credit}
-                            debit={debit}
-                        >
+                        <Body secondary jumbo={jumboText} color={color}>
                             {actualSymbol}
                         </Body>
                         {space ? (
-                            <Body
-                                jumbo={jumboText}
-                                credit={credit}
-                                debit={debit}
-                            >
+                            <Body jumbo={jumboText} color={color}>
                                 {' '}
                             </Body>
                         ) : (
                             <Spacer width={1} />
                         )}
-                        <Body jumbo={jumboText} credit={credit} debit={debit}>
+                        <Body jumbo={jumboText} color={color}>
                             {negative ? '-' : ''}
                             {amount.toString()}
                         </Body>
@@ -133,6 +109,8 @@ interface AmountProps {
     jumboText?: boolean;
     credit?: boolean;
     debit?: boolean;
+    // If credit or debit doesn't cover the use case
+    color?: 'text' | 'success' | 'warning' | 'highlight' | 'secondaryText';
     toggleable?: boolean;
 }
 
@@ -148,7 +126,8 @@ export class Amount extends React.Component<AmountProps, {}> {
             jumboText = false,
             credit = false,
             debit = false,
-            toggleable = false
+            toggleable = false,
+            color = undefined
         } = this.props;
         const UnitsStore = this.props.UnitsStore!;
 
@@ -156,6 +135,14 @@ export class Amount extends React.Component<AmountProps, {}> {
         const units = fixedUnits ? fixedUnits : UnitsStore.units;
 
         let unformattedAmount = UnitsStore.getUnformattedAmount(value, units);
+
+        const textColor = debit
+            ? 'warning'
+            : credit
+            ? 'success'
+            : color
+            ? color
+            : undefined;
 
         if (sensitive) {
             let amount = unformattedAmount.amount;
@@ -174,20 +161,22 @@ export class Amount extends React.Component<AmountProps, {}> {
                 <TouchableOpacity onPress={() => UnitsStore.changeUnits()}>
                     <AmountDisplay
                         {...unformattedAmount}
+                        negative={false}
                         jumboText={jumboText}
-                        credit={credit}
-                        debit={debit}
+                        color={textColor}
                     />
                 </TouchableOpacity>
             );
         }
 
+        // TODO negative is hardcoded to false because we're inconsistent
+        // an on-chain debit is a negative number, but a lightning debit isn't
         return (
             <AmountDisplay
                 {...unformattedAmount}
+                negative={false}
                 jumboText={jumboText}
-                credit={credit}
-                debit={debit}
+                color={textColor}
             />
         );
     }

--- a/components/text/Body.tsx
+++ b/components/text/Body.tsx
@@ -9,8 +9,7 @@ export function Body({
     small = false,
     big = false,
     jumbo = false,
-    credit = false,
-    debit = false,
+    color = undefined,
     children
 }: {
     secondary?: boolean;
@@ -18,23 +17,19 @@ export function Body({
     small?: boolean;
     big?: boolean;
     jumbo?: boolean;
-    credit?: boolean;
-    debit?: boolean;
+    // These should only be keys available on the theme
+    // TODO: enforce this with some global ThemeKey enum?
+    color?: 'text' | 'success' | 'warning' | 'highlight' | 'secondaryText';
     children: React.ReactNode;
 }) {
     return (
         <Text
             style={{
-                color: secondary
-                    ? credit
-                        ? 'darkgreen'
-                        : debit
-                        ? 'darkred'
-                        : themeColor('secondaryText')
-                    : credit
-                    ? 'lightgreen'
-                    : debit
-                    ? 'red'
+                // If there's a color prop, use that directly, otherwise check if secondary text
+                color: color
+                    ? themeColor(color)
+                    : secondary
+                    ? themeColor('secondaryText')
                     : themeColor('text'),
                 fontWeight: bold ? 'bold' : 'normal',
                 fontSize: small ? 12 : big ? 20 : jumbo ? 40 : 16

--- a/utils/ThemeUtils.ts
+++ b/utils/ThemeUtils.ts
@@ -23,19 +23,23 @@ export function themeColor(themeString: string): any {
         ],
         separator: '#CED0CE'
         // TODO: pick outbound and inbound colors for light and junkie themes
+        // TODO: success / warning / bitcoin colors for light and junkie (are they just the same?)
     };
 
     const Dark: { [key: string]: any } = {
         background: '#1f2328',
         secondary: '#2b3037',
         text: 'white',
-        secondaryText: 'gray',
+        secondaryText: '#A7A9AC',
         highlight: '#ffd24b',
         error: '#992600',
         gradient: ['black', '#1f2328', '#1f2328', '#1f2328'],
-        separator: 'darkgray',
+        separator: '#31363F',
         outbound: '#FFD93F',
-        inbound: '#FFF0CA'
+        inbound: '#FFF0CA',
+        success: '#46BE43',
+        warning: '#E14C4C',
+        bitcoin: '#FFB040'
     };
 
     const Junkie: { [key: string]: any } = {

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -9,7 +9,6 @@ import {
 import { Button, Header, Icon, ListItem } from 'react-native-elements';
 import { inject, observer } from 'mobx-react';
 import DateTimeUtils from './../../utils/DateTimeUtils';
-import PrivacyUtils from './../../utils/PrivacyUtils';
 import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
 
@@ -24,7 +23,7 @@ interface ActivityProps {
     ActivityStore: ActivityStore;
 }
 
-@inject('ActivityStore', 'UnitsStore')
+@inject('ActivityStore')
 @observer
 export default class Activity extends React.Component<ActivityProps, {}> {
     async UNSAFE_componentWillMount() {

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -13,15 +13,15 @@ import PrivacyUtils from './../../utils/PrivacyUtils';
 import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
 
+import { Amount } from '../../components/Amount';
+
 import ActivityStore from './../../stores/ActivityStore';
-import UnitsStore from './../../stores/UnitsStore';
 
 import Filter from './../../images/SVG/Filter On.svg';
 
 interface ActivityProps {
     navigation: any;
     ActivityStore: ActivityStore;
-    UnitsStore: UnitsStore;
 }
 
 @inject('ActivityStore', 'UnitsStore')
@@ -36,24 +36,35 @@ export default class Activity extends React.Component<ActivityProps, {}> {
 
     renderSeparator = () => <View style={styles.separator} />;
 
-    getRightTitleStyle = (item: any) => {
-        if (item.getAmount == 0) return 'gray';
+    // TODO this feels like an odd place to do all this deciding
+    // TODO on-chain has "-" sign but lightning doesn't?
+    getRightTitleTheme = (item: any) => {
+        console.log(`${item.getAmount} : ${typeof item.getAmount}`);
+        if (item.getAmount == 0) return 'secondaryText';
 
         if (item.model === localeString('general.transaction')) {
-            if (item.getAmount.includes('-')) return 'red';
-            return 'green';
+            if (item.getAmount.includes('-')) return 'warning';
+            return 'success';
         }
 
-        if (item.model === localeString('views.Payment.title')) return 'red';
+        if (item.model === localeString('views.Payment.title'))
+            return 'warning';
 
-        if (item.isPaid) return 'green';
+        if (item.model === localeString('views.Invoice.title')) {
+            if (item.isExpired && !item.isPaid) {
+                return 'text';
+            } else if (!item.isPaid) {
+                return 'highlight';
+            }
+        }
 
-        return themeColor('secondaryText');
+        if (item.isPaid) return 'success';
+
+        return 'secondaryText';
     };
 
     render() {
-        const { navigation, ActivityStore, UnitsStore } = this.props;
-        const { getAmount } = UnitsStore;
+        const { navigation, ActivityStore } = this.props;
         const {
             loading,
             filteredActivity,
@@ -98,7 +109,6 @@ export default class Activity extends React.Component<ActivityProps, {}> {
                         renderItem={({ item }: { item: any }) => {
                             let displayName = item.model;
                             let subTitle = item.model;
-                            let rightTitle: any = ' ';
                             if (
                                 item.model ===
                                 localeString('views.Invoice.title')
@@ -119,11 +129,6 @@ export default class Activity extends React.Component<ActivityProps, {}> {
                                                 )
                                               : item.expirationDate
                                       }`;
-                                rightTitle = PrivacyUtils.sensitiveValue(
-                                    getAmount(item.getAmount),
-                                    null,
-                                    true
-                                );
                             }
 
                             if (
@@ -134,11 +139,6 @@ export default class Activity extends React.Component<ActivityProps, {}> {
                                     'views.Activity.youSent'
                                 );
                                 subTitle = localeString('general.lightning');
-                                rightTitle = PrivacyUtils.sensitiveValue(
-                                    getAmount(item.getAmount),
-                                    null,
-                                    true
-                                );
                             }
 
                             if (
@@ -165,14 +165,6 @@ export default class Activity extends React.Component<ActivityProps, {}> {
                                               'general.unconfirmed'
                                           )}`
                                         : localeString('general.onchain');
-                                rightTitle =
-                                    item.getAmount == 0
-                                        ? '-'
-                                        : PrivacyUtils.sensitiveValue(
-                                              getAmount(item.getAmount),
-                                              null,
-                                              true
-                                          );
                             }
 
                             return (
@@ -244,17 +236,13 @@ export default class Activity extends React.Component<ActivityProps, {}> {
                                             </ListItem.Subtitle>
                                         </ListItem.Content>
                                         <ListItem.Content right>
-                                            <ListItem.Title
-                                                right
-                                                style={{
-                                                    fontWeight: '600',
-                                                    color: this.getRightTitleStyle(
-                                                        item
-                                                    )
-                                                }}
-                                            >
-                                                {rightTitle}
-                                            </ListItem.Title>
+                                            <Amount
+                                                sats={item.getAmount}
+                                                sensitive
+                                                color={this.getRightTitleTheme(
+                                                    item
+                                                )}
+                                            />
                                             <ListItem.Subtitle
                                                 right
                                                 style={


### PR DESCRIPTION
# Description

Relates to issue: Follow up to #509 

`Amount` component can now take a "color" prop in addition to the debit / credit options. Testing this out by putting it in the `Activity` view.

I changed up the underlying `AmountDisplay` component to just take a color and removed the debit / credit options from `Body` and just added a color prop to keep it more logic agnostic.

I'm also using the semantic "warning" / "success" color names instead of "red" / "green" because that seems to offer the most flexibility to future theme authors.

Speaking of colors, we don't have all of these colors for the non-Dark themes. What's a good solution to that? I also had an idea to create an enum for all the keys in the theme which we could to typecheck anyone using this `Amount` or `Body` component to make sure they're passing a valid key and not some random string.

Next obvious step would be to use `KeyValue` component to refactor this `Activity` view but wanted to keep this pr focused.

![image](https://user-images.githubusercontent.com/543668/131271881-67ac8a74-31fa-4ac1-aabc-5bd29f97c942.png)

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [x] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [x] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS
