### PR TITLE
add pending to Amount component and fix some SVGs

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -6,6 +6,8 @@ import { Spacer } from './layout/Spacer';
 import { inject, observer } from 'mobx-react';
 import UnitsStore from '../stores/UnitsStore';
 import PrivacyUtils from '../utils/PrivacyUtils';
+import ClockIcon from '../images/SVG/Clock.svg';
+import { themeColor } from '../utils/ThemeUtils';
 
 export const satoshisPerBTC = 100000000;
 
@@ -21,6 +23,7 @@ interface AmountDisplayProps {
     space?: boolean;
     jumboText?: boolean;
     color?: 'text' | 'success' | 'warning' | 'highlight' | 'secondaryText';
+    pending?: boolean;
 }
 
 function AmountDisplay({
@@ -32,7 +35,8 @@ function AmountDisplay({
     rtl = false,
     space = false,
     jumboText = false,
-    color = undefined
+    color = undefined,
+    pending = false
 }: AmountDisplayProps) {
     if (unit === 'fiat' && !symbol) {
         console.error('Must include a symbol when rendering fiat');
@@ -40,11 +44,39 @@ function AmountDisplay({
 
     const actualSymbol = unit === 'btc' ? '₿' : symbol;
 
+    const Pending = () => (
+        <View
+            style={{
+                paddingBottom: jumboText ? 8 : 2,
+                paddingHorizontal: jumboText ? 0 : 1
+            }}
+        >
+            <ClockIcon
+                color={themeColor('bitcoin')}
+                width={jumboText ? 30 : 15}
+                height={jumboText ? 30 : 15}
+            />
+        </View>
+    );
+
+    const FiatSymbol = () => (
+        <Body secondary jumbo={jumboText} color={color}>
+            {actualSymbol}
+        </Body>
+    );
+
+    const TextSpace = () => (
+        <Body jumbo={jumboText} color={color}>
+            {' '}
+        </Body>
+    );
+
     // TODO this could probably be made more readable by componentizing the repeat bits
     switch (unit) {
         case 'sats':
             return (
                 <Row align="flex-end">
+                    {pending ? <Pending /> : null}
                     <Body jumbo={jumboText} color={color}>
                         {amount}
                     </Body>
@@ -65,31 +97,17 @@ function AmountDisplay({
                             {negative ? '-' : ''}
                             {amount}
                         </Body>
-                        {space ? (
-                            <Body jumbo={jumboText} color={color}>
-                                {' '}
-                            </Body>
-                        ) : (
-                            <Spacer width={1} />
-                        )}
-                        <Body secondary jumbo={jumboText} color={color}>
-                            {actualSymbol}
-                        </Body>
+                        {space ? <TextSpace /> : <Spacer width={1} />}
+                        <FiatSymbol />
+                        {pending ? <Pending /> : null}
                     </Row>
                 );
             } else {
                 return (
                     <Row align="flex-end">
-                        <Body secondary jumbo={jumboText} color={color}>
-                            {actualSymbol}
-                        </Body>
-                        {space ? (
-                            <Body jumbo={jumboText} color={color}>
-                                {' '}
-                            </Body>
-                        ) : (
-                            <Spacer width={1} />
-                        )}
+                        {pending ? <Pending /> : null}
+                        <FiatSymbol />
+                        {space ? <TextSpace /> : <Spacer width={1} />}
                         <Body jumbo={jumboText} color={color}>
                             {negative ? '-' : ''}
                             {amount.toString()}
@@ -112,6 +130,7 @@ interface AmountProps {
     // If credit or debit doesn't cover the use case
     color?: 'text' | 'success' | 'warning' | 'highlight' | 'secondaryText';
     toggleable?: boolean;
+    pending?: boolean;
 }
 
 @inject('UnitsStore')
@@ -127,7 +146,8 @@ export class Amount extends React.Component<AmountProps, {}> {
             credit = false,
             debit = false,
             toggleable = false,
-            color = undefined
+            color = undefined,
+            pending = false
         } = this.props;
         const UnitsStore = this.props.UnitsStore!;
 
@@ -164,6 +184,7 @@ export class Amount extends React.Component<AmountProps, {}> {
                         negative={false}
                         jumboText={jumboText}
                         color={textColor}
+                        pending={pending}
                     />
                 </TouchableOpacity>
             );
@@ -177,6 +198,7 @@ export class Amount extends React.Component<AmountProps, {}> {
                 negative={false}
                 jumboText={jumboText}
                 color={textColor}
+                pending={pending}
             />
         );
     }

--- a/components/WalletHeader.tsx
+++ b/components/WalletHeader.tsx
@@ -40,7 +40,7 @@ const OpenChannelButton = ({ navigation }: { navigation: any }) => (
 
 const NodeInfoBadge = ({ navigation }: { navigation: any }) => (
     <TouchableOpacity onPress={() => navigation.navigate('NodeInfo')}>
-        <NodeOn stroke={themeColor('text')} />
+        <NodeOn color={themeColor('text')} />
     </TouchableOpacity>
 );
 

--- a/images/SVG/Clock.svg
+++ b/images/SVG/Clock.svg
@@ -1,4 +1,4 @@
-<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="15" cy="15" r="11" stroke="white" stroke-width="2"/>
-<path d="M14 7V16.1538L20 21" stroke="white" stroke-width="2"/>
+<svg width="30" height="30" viewBox="0 0 30 30" stroke="white" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="15" cy="15" r="11" stroke="currentColor" stroke-width="2"/>
+<path d="M14 7V16.1538L20 21" stroke="currentColor" stroke-width="2"/>
 </svg>

--- a/images/SVG/Node On.svg
+++ b/images/SVG/Node On.svg
@@ -1,7 +1,7 @@
 <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="6.3252" y="15" width="12.2688" height="12.2688" transform="rotate(-45 6.3252 15)" stroke="#000" stroke-width="1.73808"/>
-<circle cx="15" cy="6.5" r="3" fill="#000" stroke="#000"/>
-<circle cx="15" cy="23.5" r="3" fill="#000" stroke="#000"/>
-<circle cx="6.5" cy="15" r="3" fill="#000" stroke="#000"/>
-<circle cx="23.5" cy="15" r="3" fill="#000" stroke="#000"/>
+<rect x="6.3252" y="15" width="12.2688" height="12.2688" transform="rotate(-45 6.3252 15)" stroke="currentColor" stroke-width="1.73808"/>
+<circle cx="15" cy="6.5" r="3" fill="currentColor" />
+<circle cx="15" cy="23.5" r="3" fill="currentColor" />
+<circle cx="6.5" cy="15" r="3" fill="currentColor" />
+<circle cx="23.5" cy="15" r="3" fill="currentColor" />
 </svg>

--- a/images/SVG/Wallet.svg
+++ b/images/SVG/Wallet.svg
@@ -1,4 +1,4 @@
-<svg width="30" height="30" viewBox="0 0 30 30" fill="#000" xmlns="http://www.w3.org/2000/svg">
-<rect x="14" y="8.5" width="11.5" height="13" rx="1.5" stroke="none" />
-<path fill-rule="evenodd" clip-rule="evenodd" d="M6 8.00001C4.89543 8.00001 4 8.89544 4 10V20C4 21.1046 4.89543 22 6 22H20C21.1046 22 22 21.1046 22 20V10C22 8.89544 21.1046 8.00001 20 8.00001H6ZM9 17C10.1046 17 11 16.1046 11 15C11 13.8954 10.1046 13 9 13C7.89543 13 7 13.8954 7 15C7 16.1046 7.89543 17 9 17Z" fill="#000"/>
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="14" y="8.5" width="11.5" height="13" rx="1.5" stroke="currentColor" />
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6 8.00001C4.89543 8.00001 4 8.89544 4 10V20C4 21.1046 4.89543 22 6 22H20C21.1046 22 22 21.1046 22 20V10C22 8.89544 21.1046 8.00001 20 8.00001H6ZM9 17C10.1046 17 11 16.1046 11 15C11 13.8954 10.1046 13 9 13C7.89543 13 7 13.8954 7 15C7 16.1046 7.89543 17 9 17Z" fill="currentColor"/>
 </svg>

--- a/views/UTXOs/UTXO.tsx
+++ b/views/UTXOs/UTXO.tsx
@@ -83,15 +83,32 @@ export default class UTXO extends React.Component<UTXOProps> {
 
                 <View style={styles.content}>
                     <View>
-                        <Text style={{ ...styles.label, color: themeColor('text') }}>
+                        <Text
+                            style={{
+                                ...styles.label,
+                                color: themeColor('text')
+                            }}
+                        >
                             {localeString('general.outpoint')}:
                         </Text>
-                        <Text style={{ ...styles.value, color: themeColor('text') }}>{getOutpoint}</Text>
+                        <Text
+                            style={{
+                                ...styles.value,
+                                color: themeColor('text')
+                            }}
+                        >
+                            {getOutpoint}
+                        </Text>
                     </View>
 
                     {!!address && (
                         <View>
-                            <Text style={{ ...styles.label, color: themeColor('text') }}>
+                            <Text
+                                style={{
+                                    ...styles.label,
+                                    color: themeColor('text')
+                                }}
+                            >
                                 {localeString('general.address')}:
                             </Text>
                             <TouchableOpacity
@@ -109,7 +126,9 @@ export default class UTXO extends React.Component<UTXOProps> {
                         </View>
                     )}
 
-                    <Text style={{ ...styles.label, color: themeColor('text') }}>
+                    <Text
+                        style={{ ...styles.label, color: themeColor('text') }}
+                    >
                         {localeString('views.Transaction.transactionHash')}:
                     </Text>
                     <TouchableOpacity
@@ -123,7 +142,12 @@ export default class UTXO extends React.Component<UTXOProps> {
                     </TouchableOpacity>
 
                     <View>
-                        <Text style={{ ...styles.label, color: themeColor('text') }}>
+                        <Text
+                            style={{
+                                ...styles.label,
+                                color: themeColor('text')
+                            }}
+                        >
                             {localeString('views.Transaction.numConf')}:
                         </Text>
                         <Text

--- a/views/Wallet/MainPane.tsx
+++ b/views/Wallet/MainPane.tsx
@@ -28,7 +28,6 @@ export default class MainPane extends React.PureComponent<MainPaneProps, {}> {
     render() {
         const {
             NodeInfoStore,
-            UnitsStore,
             BalanceStore,
             SettingsStore,
             navigation
@@ -62,6 +61,7 @@ export default class MainPane extends React.PureComponent<MainPaneProps, {}> {
                         sensitive
                         jumboText
                         toggleable
+                        pending
                     />
                 ) : null}
             </>
@@ -80,6 +80,7 @@ export default class MainPane extends React.PureComponent<MainPaneProps, {}> {
                         sensitive
                         jumboText
                         toggleable
+                        pending
                     />
                 ) : null}
             </>

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -271,7 +271,7 @@ export default class Wallet extends React.Component<WalletProps, {}> {
                                         let iconName;
 
                                         if (route.name === 'Wallet') {
-                                            return <WalletIcon fill={color} />;
+                                            return <WalletIcon color={color} />;
                                         }
                                         if (route.name === scanAndSend) {
                                             return (


### PR DESCRIPTION
# Description

closes #560 

Sorry for the oversight on pending label before. I added the pending icon from the Figma... there doesn't really seem to be room for text like before.

Since I was playing with SVGs I took the chance to fix the wallet and node icons (they weren't filled quite right).

I didn't touch UTXO.tsx I guess it just got caught in in the prettier hype.

![Screenshot_20210911-112029655](https://user-images.githubusercontent.com/543668/132955038-b4baedbf-bc71-4244-b115-57f5f07570a4.png)

This pull request is categorized as a:

- [x] Bug fix



## Checklist
- [x] I’ve run `npm run tsc` and make sure my code didn’t produce errors 
- [x] I’ve run `npm run prettier` and formatted my code correctly

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [x] No, I’m a fool

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub