### PR TITLE
C-Lightning-REST: fix display of payments

### DIFF
--- a/backends/CLightningREST.ts
+++ b/backends/CLightningREST.ts
@@ -80,7 +80,7 @@ export default class CLightningREST extends LND {
             expiry: data.expiry,
             private: true
         });
-    getPayments = () => this.getRequest('/v1/pay/listPayments');
+    getPayments = () => this.getRequest('/v1/pay/listPays');
     getNewAddress = () => this.getRequest('/v1/newaddr');
     openChannel = (data: OpenChannelRequest) => {
         let request: any;

--- a/models/Payment.ts
+++ b/models/Payment.ts
@@ -22,13 +22,13 @@ export default class Payment extends BaseModel {
     // payment_hash: string;
     destination?: string;
     amount_msat?: string;
+    // amount_sent_msat?: string;
     msatoshi_sent?: string;
     msatoshi?: string;
-    // amount_sent_msat?: string;
     created_at?: string;
     timestamp?: string;
     // status: string;
-    // payment_preimage: string;
+    preimage: string;
     bolt11?: string;
     htlcs?: Array<any>;
     nodes?: any;
@@ -40,6 +40,10 @@ export default class Payment extends BaseModel {
 
     @computed public get model(): string {
         return localeString('views.Payment.title');
+    }
+
+    @computed public get getPreimage(): string {
+        return this.preimage || this.payment_preimage;
     }
 
     @computed public get getTimestamp(): string | number {
@@ -59,7 +63,9 @@ export default class Payment extends BaseModel {
     }
 
     @computed public get getAmount(): number | string {
-        return this.value || Number(this.msatoshi_sent) / 1000 || 0;
+        return this.amount_msat
+            ? Number(this.amount_msat.replace('msat', '')) / 1000
+            : this.value || Number(this.msatoshi_sent) / 1000 || 0;
     }
 
     @computed public get getFee(): string {
@@ -68,10 +74,12 @@ export default class Payment extends BaseModel {
             return this.fee_sat || (Number(this.fee_msat) / 1000).toString();
         }
 
-        // c-lightning
-        if (this.msatoshi && this.msatoshi_sent) {
-            const msatoshi_sent: any = this.msatoshi_sent;
-            const msatoshi: any = this.msatoshi;
+        // c-lightning-REST
+        if (this.amount_msat && this.amount_sent_msat) {
+            const msatoshi_sent: any = Number(
+                this.amount_sent_msat.replace('msat', '')
+            );
+            const msatoshi: any = Number(this.amount_msat.replace('msat', ''));
             const fee = Number(msatoshi_sent - msatoshi) / 1000;
             return fee.toString();
         }

--- a/stores/PaymentsStore.ts
+++ b/stores/PaymentsStore.ts
@@ -33,7 +33,8 @@ export default class PaymentsStore {
         this.loading = true;
         await RESTUtils.getPayments()
             .then((data: any) => {
-                const payments = data.transaction || data.payments || data;
+                const payments =
+                    data.transaction || data.payments || data.pays || data;
                 this.payments = payments
                     .slice()
                     .reverse()

--- a/views/Payment.tsx
+++ b/views/Payment.tsx
@@ -70,7 +70,7 @@ export default class PaymentView extends React.Component<PaymentProps> {
             getDisplayTime,
             getFee,
             payment_hash,
-            payment_preimage,
+            getPreimage,
             enhancedPath
         } = payment;
         const date = getDisplayTime;
@@ -127,7 +127,7 @@ export default class PaymentView extends React.Component<PaymentProps> {
                         <LnurlPayHistorical
                             navigation={navigation}
                             lnurlpaytx={lnurlpaytx}
-                            preimage={payment_preimage}
+                            preimage={getPreimage}
                         />
                     </View>
                 )}
@@ -185,7 +185,7 @@ export default class PaymentView extends React.Component<PaymentProps> {
                     <Text
                         style={{ ...styles.value, color: themeColor('text') }}
                     >
-                        {PrivacyUtils.sensitiveValue(payment_preimage)}
+                        {PrivacyUtils.sensitiveValue(getPreimage)}
                     </Text>
 
                     <Text


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-597**](https://github.com/ZeusLN/zeus/issues/597)

C-Lightning-REST was using a the endpoint that lists all individual routes as payments, causing user confusion.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [x] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
