### PR TITLE
ZEUS-600: Fix fiat conversion for keysend payments

### DIFF
--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -188,11 +188,10 @@ export default class Send extends React.Component<SendProps, SendState> {
         navigation.navigate('SendingOnChain');
     };
 
-    sendKeySendPayment = () => {
+    sendKeySendPayment = (satAmount: string | number) => {
         const { TransactionsStore, navigation } = this.props;
         const {
             destination,
-            amount,
             maxParts,
             maxShardAmt,
             timeoutSeconds,
@@ -201,7 +200,7 @@ export default class Send extends React.Component<SendProps, SendState> {
 
         if (RESTUtils.supportsAMP()) {
             TransactionsStore.sendPayment({
-                amount,
+                amount: satAmount.toString(),
                 pubkey: destination,
                 max_parts: maxParts,
                 max_shard_amt: maxShardAmt,
@@ -210,7 +209,10 @@ export default class Send extends React.Component<SendProps, SendState> {
                 amp: true
             });
         } else {
-            TransactionsStore.sendPayment({ amount, pubkey: destination });
+            TransactionsStore.sendPayment({
+                amount: satAmount.toString(),
+                pubkey: destination
+            });
         }
 
         navigation.navigate('SendingLightning');
@@ -657,7 +659,7 @@ export default class Send extends React.Component<SendProps, SendState> {
                                             color: 'white'
                                         }}
                                         onPress={() =>
-                                            this.sendKeySendPayment()
+                                            this.sendKeySendPayment(satAmount)
                                         }
                                     />
                                 </View>


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-600**](https://github.com/ZeusLN/zeus/issues/600)

Keysend payments were always sending the amount specified denominated in sats

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND
- [x] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
