### PR TITLE
Nodes: Fix implementation display

### DIFF
--- a/views/Settings/Nodes.tsx
+++ b/views/Settings/Nodes.tsx
@@ -143,8 +143,8 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                                     subtitle={
                                         selectedNode === index ||
                                         (!selectedNode && index === 0)
-                                            ? `Active | ${implementation}`
-                                            : `${implementation}`
+                                            ? `Active | ${item.implementation}`
+                                            : `${item.implementation}`
                                     }
                                     containerStyle={{
                                         borderBottomWidth: 0,


### PR DESCRIPTION
We were previously displaying the implementation of the `Active` node for all saved nodes.