### PR TITLE
LNURL-auth: don't base64 enc messages for LND twice

### DIFF
--- a/views/LnurlAuth.tsx
+++ b/views/LnurlAuth.tsx
@@ -89,7 +89,7 @@ export default class LnurlAuth extends React.Component<
     triggerSign() {
         this.setState({ preparingSignature: true });
 
-        const body = Base64Utils.btoa(LNURLAUTH_CANONICAL_PHRASE);
+        const body = LNURLAUTH_CANONICAL_PHRASE;
 
         RESTUtils.signMessage(body)
             .then((signature: any) => {


### PR DESCRIPTION
# Description

While refactoring things for Verify Message support, we added Base64 encoding for messages in LND in the backend definitions. This removes the need to Base64 encode in the LNURL-auth process.

Commit: https://github.com/ZeusLN/zeus/commit/97edc4bfbf1806d51b0f79777d3220f239b2e84d

Verify Message PR: https://github.com/ZeusLN/zeus/pull/649

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [ ] I’ve run `npm run tsc` and made sure my code compiles correctly
- [ ] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
