### PR TITLE
Fiat rate enhancements

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -156,7 +156,7 @@ export class Amount extends React.Component<AmountProps, {}> {
 
         const unformattedAmount = UnitsStore.getUnformattedAmount(value, units);
 
-        // display failed fiat fetches as N/A
+        // display fiat amounts when rate fetch fails as $N/A
         if (unformattedAmount.error) {
             const amount = 'N/A';
             const unit = 'fiat';

--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -156,6 +156,39 @@ export class Amount extends React.Component<AmountProps, {}> {
 
         const unformattedAmount = UnitsStore.getUnformattedAmount(value, units);
 
+        // display failed fiat fetches as N/A
+        if (unformattedAmount.error) {
+            const amount = 'N/A';
+            const unit = 'fiat';
+            const symbol = '$';
+
+            if (toggleable) {
+                return (
+                    <TouchableOpacity onPress={() => UnitsStore.changeUnits()}>
+                        <AmountDisplay
+                            amount={amount}
+                            unit={unit}
+                            symbol={symbol}
+                            negative={false}
+                            jumboText={jumboText}
+                            pending={pending}
+                        />
+                    </TouchableOpacity>
+                );
+            }
+
+            return (
+                <AmountDisplay
+                    amount={amount}
+                    unit={unit}
+                    symbol={symbol}
+                    negative={false}
+                    jumboText={jumboText}
+                    pending={pending}
+                />
+            );
+        }
+
         const textColor = debit
             ? 'warning'
             : credit

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -181,13 +181,10 @@ export default class FiatStore {
     @action
     public getFiatRates = () => {
         this.loading = true;
-        RNFetchBlob.config({
-            trusty: true
-        })
-            .fetch(
-                'GET',
-                'https://pay.zeusln.app/api/rates?storeId=Fjt7gLnGpg4UeBMFccLquy3GTTEz4cHU4PZMU63zqMBo'
-            )
+        RNFetchBlob.fetch(
+            'GET',
+            'https://pay.zeusln.app/api/rates?storeId=Fjt7gLnGpg4UeBMFccLquy3GTTEz4cHU4PZMU63zqMBo'
+        )
             .then((response: any) => {
                 const status = response.info().status;
                 if (status == 200) {

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -20,6 +20,12 @@ export default class FiatStore {
         this.settingsStore = settingsStore;
     }
 
+    numberWithCommas = (x: string | number) =>
+        new Intl.NumberFormat('en-EN').format(x);
+
+    numberWithDecimals = (x: string | number) =>
+        new Intl.NumberFormat('de-DE').format(x);
+
     private symbolLookup = (symbol: string): CurrencyDisplayRules => {
         const symbolPairs: any = {
             USD: {
@@ -145,8 +151,13 @@ export default class FiatStore {
                 (entry: any) => entry.code === fiat
             )[0];
             const rate = fiatEntry.rate;
-            // TODO: handle rtl etc
-            const symbol = this.symbolLookup(fiatEntry.code).symbol;
+            const { symbol, space, rtl, separatorSwap } = this.symbolLookup(
+                fiatEntry.code
+            );
+
+            const formattedRate = separatorSwap
+                ? this.numberWithDecimals(rate)
+                : this.numberWithCommas(rate);
             return `${symbol}${rate} BTC/${fiat}`;
         }
         return '$N/A';

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -132,7 +132,7 @@ export default class FiatStore {
             return this.symbolLookup(fiatEntry.code);
         } else {
             return {
-                symbol: '⸮',
+                symbol: fiat,
                 space: true,
                 rtl: true,
                 separatorSwap: false

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -178,7 +178,6 @@ export default class FiatStore {
         })
             .fetch(
                 'GET',
-                // TODO replace host or edit firewall
                 'https://pay.zeusln.app/api/rates?storeId=Fjt7gLnGpg4UeBMFccLquy3GTTEz4cHU4PZMU63zqMBo'
             )
             .then((response: any) => {

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -119,7 +119,7 @@ export default class FiatStore {
     @action getSymbol = () => {
         const { settings } = this.settingsStore;
         const { fiat } = settings;
-        if (fiat) {
+        if (fiat && this.fiatRates.filter) {
             const fiatEntry = this.fiatRates.filter(
                 (entry: any) => entry.code === fiat
             )[0];
@@ -140,16 +140,16 @@ export default class FiatStore {
     public getRate = () => {
         const { settings } = this.settingsStore;
         const { fiat } = settings;
-        if (fiat) {
+        if (fiat && this.fiatRates.filter) {
             const fiatEntry = this.fiatRates.filter(
                 (entry: any) => entry.code === fiat
             )[0];
             const rate = fiatEntry.rate;
-            // TODO: fix rate display
+            // TODO: handle rtl etc
             const symbol = this.symbolLookup(fiatEntry.code).symbol;
             return `${symbol}${rate} BTC/${fiat}`;
         }
-        return 'N/A';
+        return '$N/A';
     };
 
     @action
@@ -160,6 +160,7 @@ export default class FiatStore {
         })
             .fetch(
                 'GET',
+                // TODO replace host or edit firewall
                 'https://pay.zeusln.app/api/rates?storeId=Fjt7gLnGpg4UeBMFccLquy3GTTEz4cHU4PZMU63zqMBo'
             )
             .then((response: any) => {

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -158,7 +158,16 @@ export default class FiatStore {
             const formattedRate = separatorSwap
                 ? this.numberWithDecimals(rate)
                 : this.numberWithCommas(rate);
-            return `${symbol}${rate} BTC/${fiat}`;
+
+            if (rtl) {
+                return `${formattedRate}${
+                    space ? ' ' : ''
+                }${symbol} BTC/${fiat}`;
+            } else {
+                return `${symbol}${
+                    space ? ' ' : ''
+                }${formattedRate} BTC/${fiat}`;
+            }
         }
         return '$N/A';
     };

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -34,6 +34,7 @@ export default class FiatStore {
                 rtl: false,
                 separatorSwap: false
             },
+            ARS: { symbol: '$', space: true, rtl: false, separatorSwap: true },
             AUD: { symbol: '$', space: true, rtl: false, separatorSwap: false },
             BRL: {
                 symbol: 'R$',
@@ -86,9 +87,16 @@ export default class FiatStore {
                 rtl: true,
                 separatorSwap: true
             },
+            ILS: { symbol: '₪', space: true, rtl: false, separatorSwap: true },
             INR: { symbol: '₹', space: true, rtl: false, separatorSwap: false },
             JPY: { symbol: '¥', space: true, rtl: false, separatorSwap: false },
             KRW: { symbol: '₩', space: true, rtl: false, separatorSwap: false },
+            NGN: {
+                symbol: '₦',
+                space: false,
+                rtl: false,
+                separatorSwap: false
+            },
             NZD: { symbol: '$', space: true, rtl: false, separatorSwap: false },
             PLN: { symbol: 'zł', space: true, rtl: true, separatorSwap: false },
             RUB: {

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -131,10 +131,8 @@ export default class FiatStore {
             )[0];
             return this.symbolLookup(fiatEntry.code);
         } else {
-            console.log('no fiat?');
-            // TODO: what do we do in this case?
             return {
-                symbol: '???',
+                symbol: '⸮',
                 space: true,
                 rtl: true,
                 separatorSwap: false

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -104,7 +104,10 @@ export const CURRENCY_KEYS = [
     { key: '🇨🇿 Czech Koruna (CZK)', value: 'CZK' },
     { key: '🇭🇺 Hungarian Forint (HUF)', value: 'HUF' },
     { key: '🇮🇳 Indian Rupee (INR)', value: 'INR' },
-    { key: '🇹🇷 Turkish Lira (TRY)', value: 'TRY' }
+    { key: '🇹🇷 Turkish Lira (TRY)', value: 'TRY' },
+    { key: '🇳🇬 Nigerian Naira (NGN)', value: 'NGN' },
+    { key: '🇦🇷 Argentine Peso (ARS)', value: 'ARS' },
+    { key: '🇮🇱 Israeli New Shekel (ILS)', value: 'ILS' }
 ];
 
 export const THEME_KEYS = [

--- a/stores/UnitsStore.ts
+++ b/stores/UnitsStore.ts
@@ -100,28 +100,32 @@ export default class UnitsStore {
             }
 
             // TODO: what should we do when this is undefined?
-            const fiatEntry = this.fiatStore.fiatRates.filter(
-                (entry: any) => entry.code === fiat
-            )[0];
-            const rate = fiatEntry.rate;
-            const { symbol, space, rtl, separatorSwap } =
-                this.fiatStore.getSymbol();
+            if (this.fiatStore.fiatRates && this.fiatStore.fiatRates.filter) {
+                const fiatEntry = this.fiatStore.fiatRates.filter(
+                    (entry: any) => entry.code === fiat
+                )[0];
+                const rate = fiatEntry.rate;
+                const { symbol, space, rtl, separatorSwap } =
+                    this.fiatStore.getSymbol();
 
-            const amount = (
-                FeeUtils.toFixed(absValueSats / satoshisPerBTC) * rate
-            ).toFixed(2);
+                const amount = (
+                    FeeUtils.toFixed(absValueSats / satoshisPerBTC) * rate
+                ).toFixed(2);
 
-            return {
-                amount: separatorSwap
-                    ? this.numberWithDecimals(amount)
-                    : this.numberWithCommas(amount),
-                unit: 'fiat',
-                symbol,
-                negative,
-                plural: false,
-                rtl,
-                space
-            };
+                return {
+                    amount: separatorSwap
+                        ? this.numberWithDecimals(amount)
+                        : this.numberWithCommas(amount),
+                    unit: 'fiat',
+                    symbol,
+                    negative,
+                    plural: false,
+                    rtl,
+                    space
+                };
+            } else {
+                return { error: 'Error fetching fiat rates' };
+            }
         }
     };
 
@@ -151,24 +155,32 @@ export default class UnitsStore {
             }`;
             return sats;
         } else if (units === 'fiat' && fiat) {
-            const fiatEntry = this.fiatStore.fiatRates.filter(
-                (entry: any) => entry.code === fiat
-            )[0];
-            const rate = fiatEntry.rate;
-            const symbol = this.fiatStore.symbolLookup(fiatEntry.code);
+            if (this.fiatStore.fiatRates && this.fiatStore.fiatRates.filter) {
+                const fiatEntry = this.fiatStore.fiatRates.filter(
+                    (entry: any) => entry.code === fiat
+                )[0];
+                const rate = fiatEntry.rate;
+                const symbol = this.fiatStore.symbolLookup(fiatEntry.code);
 
-            const valueToProcess = (wholeSats && wholeSats.toString()) || '0';
-            if (valueToProcess.includes('-')) {
-                const processedValue = valueToProcess.split('-')[1];
-                return `-${symbol}${(
-                    FeeUtils.toFixed(Number(processedValue) / satoshisPerBTC) *
+                const valueToProcess =
+                    (wholeSats && wholeSats.toString()) || '0';
+                if (valueToProcess.includes('-')) {
+                    const processedValue = valueToProcess.split('-')[1];
+                    return `-${symbol}${(
+                        FeeUtils.toFixed(
+                            Number(processedValue) / satoshisPerBTC
+                        ) * rate
+                    ).toFixed(2)}`;
+                }
+
+                // TODO: handle rtl etc
+                return `${symbol}${(
+                    FeeUtils.toFixed(Number(wholeSats || 0) / satoshisPerBTC) *
                     rate
                 ).toFixed(2)}`;
+            } else {
+                return '$N/A';
             }
-
-            return `${symbol}${(
-                FeeUtils.toFixed(Number(wholeSats || 0) / satoshisPerBTC) * rate
-            ).toFixed(2)}`;
         }
     };
 }

--- a/stores/UnitsStore.ts
+++ b/stores/UnitsStore.ts
@@ -54,12 +54,6 @@ export default class UnitsStore {
         this.units = 'sats';
     };
 
-    numberWithCommas = (x: string | number) =>
-        new Intl.NumberFormat('en-EN').format(x);
-
-    numberWithDecimals = (x: string | number) =>
-        new Intl.NumberFormat('de-DE').format(x);
-
     @action getUnformattedAmount = (
         value: string | number = 0,
         fixedUnits?: string
@@ -82,7 +76,7 @@ export default class UnitsStore {
             };
         } else if (units === 'sats') {
             return {
-                amount: this.numberWithCommas(absValueSats),
+                amount: this.fiatStore.numberWithCommas(absValueSats),
                 unit: 'sats',
                 negative,
                 plural: !(Number(value) === 1 || Number(value) === -1)
@@ -99,7 +93,6 @@ export default class UnitsStore {
                 };
             }
 
-            // TODO: what should we do when this is undefined?
             if (this.fiatStore.fiatRates && this.fiatStore.fiatRates.filter) {
                 const fiatEntry = this.fiatStore.fiatRates.filter(
                     (entry: any) => entry.code === fiat
@@ -114,8 +107,8 @@ export default class UnitsStore {
 
                 return {
                     amount: separatorSwap
-                        ? this.numberWithDecimals(amount)
-                        : this.numberWithCommas(amount),
+                        ? this.fiatStore.numberWithDecimals(amount)
+                        : this.fiatStore.numberWithCommas(amount),
                     unit: 'fiat',
                     symbol,
                     negative,
@@ -150,7 +143,7 @@ export default class UnitsStore {
                 Number(wholeSats || 0) / satoshisPerBTC
             )}`;
         } else if (units === 'sats') {
-            const sats = `${this.numberWithCommas(value) || 0} ${
+            const sats = `${this.fiatStore.numberWithCommas(value) || 0} ${
                 Number(value) === 1 || Number(value) === -1 ? 'sat' : 'sats'
             }`;
             return sats;
@@ -160,24 +153,26 @@ export default class UnitsStore {
                     (entry: any) => entry.code === fiat
                 )[0];
                 const rate = fiatEntry.rate;
-                const symbol = this.fiatStore.symbolLookup(fiatEntry.code);
+                const { symbol, space, rtl, separatorSwap } =
+                    this.fiatStore.symbolLookup(fiatEntry.code);
 
                 const valueToProcess =
                     (wholeSats && wholeSats.toString()) || '0';
-                if (valueToProcess.includes('-')) {
-                    const processedValue = valueToProcess.split('-')[1];
-                    return `-${symbol}${(
-                        FeeUtils.toFixed(
-                            Number(processedValue) / satoshisPerBTC
-                        ) * rate
-                    ).toFixed(2)}`;
-                }
 
-                // TODO: handle rtl etc
-                return `${symbol}${(
+                const amount = (
                     FeeUtils.toFixed(Number(wholeSats || 0) / satoshisPerBTC) *
                     rate
-                ).toFixed(2)}`;
+                ).toFixed(2);
+
+                const formattedAmount = separatorSwap
+                    ? this.fiatStore.numberWithDecimals(amount)
+                    : this.fiatStore.numberWithCommas(amount);
+
+                if (rtl) {
+                    return `${formattedAmount}${space ? ' ' : ''}${symbol}`;
+                } else {
+                    return `${symbol}${space ? ' ' : ''}${formattedAmount}`;
+                }
             } else {
                 return '$N/A';
             }

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -132,9 +132,10 @@ export default class Receive extends React.Component<
         const { fiat } = settings;
         const address = onChainAddress;
 
-        const fiatEntry = fiat
-            ? fiatRates.filter((entry: any) => entry.code === fiat)[0]
-            : null;
+        const fiatEntry =
+            fiat && fiatRates && fiatRates.filter
+                ? fiatRates.filter((entry: any) => entry.code === fiat)[0]
+                : null;
 
         const rate =
             fiat && fiat !== 'Disabled' && fiatRates && fiatEntry

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -293,9 +293,10 @@ export default class Send extends React.Component<SendProps, SendState> {
         const { units, changeUnits } = UnitsStore;
         const { fiatRates }: any = FiatStore;
 
-        const fiatEntry = fiat
-            ? fiatRates.filter((entry: any) => entry.code === fiat)[0]
-            : null;
+        const fiatEntry =
+            fiat && fiatRates && fiatRates.filter
+                ? fiatRates.filter((entry: any) => entry.code === fiat)[0]
+                : null;
 
         const rate =
             fiat && fiat !== 'Disabled' && fiatRates && fiatEntry


### PR DESCRIPTION
- [x] Fail fiat rate fetch gracefully
- [x] Display fiat rates as '$N/A' when not available
- [x] Apply display fix all instances that call `getSymbol`
- [x] When symbol is not found, have display default to use currency code
- [x] Handle host config issue for `pay.zeusln.app`
- [x] New currencies
   - Nigerian Naira (NGN) 🇳🇬
   - Argentine Peso (ARS) 🇦🇷
   - Israeli New Shekel (ILS) 🇮🇱