### PR TITLE
LND: let users set Min and Max HTLC channel rates

### DIFF
--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -246,9 +246,13 @@ export default class LND {
                 base_fee_msat: data.base_fee_msat,
                 fee_rate: `${Number(data.fee_rate) / 100}`,
                 global: true,
-                time_lock_delta: data.time_lock_delta,
-                min_htlc_msat: `${Number(data.min_htlc) * 1000}`,
-                max_htlc_msat: `${Number(data.max_htlc) * 1000}`,
+                time_lock_delta: Number(data.time_lock_delta),
+                min_htlc_msat: data.min_htlc
+                    ? `${Number(data.min_htlc) * 1000}`
+                    : null,
+                max_htlc_msat: data.max_htlc
+                    ? `${Number(data.max_htlc) * 1000}`
+                    : null,
                 min_htlc_msat_specified: data.min_htlc ? true : false
             });
         }
@@ -259,9 +263,13 @@ export default class LND {
                 funding_txid_str: data.chan_point.funding_txid_str,
                 output_index: data.chan_point.output_index
             },
-            time_lock_delta: data.time_lock_delta,
-            min_htlc_msat: `${Number(data.min_htlc) * 1000}`,
-            max_htlc_msat: `${Number(data.max_htlc) * 1000}`,
+            time_lock_delta: Number(data.time_lock_delta),
+            min_htlc_msat: data.min_htlc
+                ? `${Number(data.min_htlc) * 1000}`
+                : null,
+            max_htlc_msat: data.max_htlc
+                ? `${Number(data.max_htlc) * 1000}`
+                : null,
             min_htlc_msat_specified: data.min_htlc ? true : false
         });
     };

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -240,16 +240,31 @@ export default class LND {
     getNodeInfo = (urlParams?: Array<string>) =>
         this.getRequest(`/v1/graph/node/${urlParams && urlParams[0]}`);
     getFees = () => this.getRequest('/v1/fees');
-    setFees = (data: any) =>
-        this.postRequest('/v1/chanpolicy', {
+    setFees = (data: any) => {
+        if (data.global) {
+            return this.postRequest('/v1/chanpolicy', {
+                base_fee_msat: data.base_fee_msat,
+                fee_rate: `${Number(data.fee_rate) / 100}`,
+                global: true,
+                time_lock_delta: data.time_lock_delta,
+                min_htlc_msat: `${Number(data.min_htlc) * 1000}`,
+                max_htlc_msat: `${Number(data.max_htlc) * 1000}`,
+                min_htlc_msat_specified: data.min_htlc ? true : false
+            });
+        }
+        return this.postRequest('/v1/chanpolicy', {
             base_fee_msat: data.base_fee_msat,
             fee_rate: `${Number(data.fee_rate) / 100}`,
             chan_point: {
                 funding_txid_str: data.chan_point.funding_txid_str,
                 output_index: data.chan_point.output_index
             },
-            time_lock_delta: data.time_lock_delta
+            time_lock_delta: data.time_lock_delta,
+            min_htlc_msat: `${Number(data.min_htlc) * 1000}`,
+            max_htlc_msat: `${Number(data.max_htlc) * 1000}`,
+            min_htlc_msat_specified: data.min_htlc ? true : false
         });
+    };
     getRoutes = (urlParams?: Array<string>) =>
         this.getRequest(
             `/v1/graph/routes/${urlParams && urlParams[0]}/${

--- a/components/FeeBreakdown.tsx
+++ b/components/FeeBreakdown.tsx
@@ -106,10 +106,10 @@ export default class FeeBreakdown extends React.Component<
                             keyValue={localeString('views.Channel.minHTLC')}
                             value={
                                 <Amount
-                                    sats={
+                                    sats={Number(
                                         chanInfo[channelId].node1_policy
-                                            .min_htlc
-                                    }
+                                            .min_htlc / 1000
+                                    )}
                                     toggleable
                                     sensitive
                                 />

--- a/components/FeeBreakdown.tsx
+++ b/components/FeeBreakdown.tsx
@@ -262,10 +262,12 @@ export default class FeeBreakdown extends React.Component<
                                 keyValue={localeString('views.Channel.minHTLC')}
                                 value={
                                     <Amount
-                                        sats={
-                                            chanInfo[channelId].node2_policy
-                                                .min_htlc
-                                        }
+                                        sats={`${
+                                            Number(
+                                                chanInfo[channelId].node2_policy
+                                                    .min_htlc
+                                            ) / 1000
+                                        }`}
                                         toggleable
                                         sensitive
                                     />
@@ -320,6 +322,18 @@ export default class FeeBreakdown extends React.Component<
                                     timeLockDelta={chanInfo[
                                         channelId
                                     ].node2_policy.time_lock_delta.toString()}
+                                    minHtlc={`${
+                                        Number(
+                                            chanInfo[channelId].node2_policy
+                                                .min_htlc
+                                        ) / 1000
+                                    }`}
+                                    maxHtlc={`${
+                                        Number(
+                                            chanInfo[channelId].node2_policy
+                                                .max_htlc_msat
+                                        ) / 1000
+                                    }`}
                                     channelPoint={channelPoint}
                                     channelId={channelId}
                                     FeeStore={FeeStore}

--- a/components/FeeBreakdown.tsx
+++ b/components/FeeBreakdown.tsx
@@ -106,10 +106,12 @@ export default class FeeBreakdown extends React.Component<
                             keyValue={localeString('views.Channel.minHTLC')}
                             value={
                                 <Amount
-                                    sats={Number(
-                                        chanInfo[channelId].node1_policy
-                                            .min_htlc / 1000
-                                    )}
+                                    sats={
+                                        Number(
+                                            chanInfo[channelId].node1_policy
+                                                .min_htlc
+                                        ) / 1000
+                                    }
                                     toggleable
                                     sensitive
                                 />
@@ -161,6 +163,18 @@ export default class FeeBreakdown extends React.Component<
                                 timeLockDelta={chanInfo[
                                     channelId
                                 ].node1_policy.time_lock_delta.toString()}
+                                minHtlc={`${
+                                    Number(
+                                        chanInfo[channelId].node1_policy
+                                            .min_htlc
+                                    ) / 1000
+                                }`}
+                                maxHtlc={`${
+                                    Number(
+                                        chanInfo[channelId].node1_policy
+                                            .max_htlc_msat
+                                    ) / 1000
+                                }`}
                                 channelPoint={channelPoint}
                                 channelId={channelId}
                                 FeeStore={FeeStore}

--- a/components/SetFeesForm.tsx
+++ b/components/SetFeesForm.tsx
@@ -20,6 +20,8 @@ interface SetFeesFormProps {
     channelPoint?: string;
     channelId?: string;
     expanded?: boolean;
+    minHtlc?: string;
+    maxHtlc?: string;
 }
 
 interface SetFeesFormState {
@@ -28,6 +30,8 @@ interface SetFeesFormState {
     newBaseFee: string;
     newFeeRate: string;
     newTimeLockDelta: string;
+    newMinHtlc: string;
+    newMaxHtlc: string;
 }
 
 @inject('FeeStore', 'ChannelsStore', 'SettingsStore')
@@ -50,7 +54,9 @@ export default class SetFeesForm extends React.Component<
                 props.feeRate || implementation === 'c-lightning-REST'
                     ? '1'
                     : '0.001',
-            newTimeLockDelta: props.timeLockDelta || '144'
+            newTimeLockDelta: props.timeLockDelta || '144',
+            newMinHtlc: props.minHtlc || '1',
+            newMaxHtlc: props.maxHtlc || '250000'
         };
     }
 
@@ -60,7 +66,9 @@ export default class SetFeesForm extends React.Component<
             feesSubmitted,
             newBaseFee,
             newFeeRate,
-            newTimeLockDelta
+            newTimeLockDelta,
+            newMinHtlc,
+            newMaxHtlc
         } = this.state;
         const {
             FeeStore,
@@ -71,7 +79,9 @@ export default class SetFeesForm extends React.Component<
             timeLockDelta,
             channelPoint,
             channelId,
-            expanded
+            expanded,
+            minHTLC,
+            maxHTLC
         } = this.props;
         const {
             setFees,
@@ -195,6 +205,46 @@ export default class SetFeesForm extends React.Component<
                             autoCorrect={false}
                         />
 
+                        {implementation === 'lnd' && (
+                            <>
+                                <Text style={{ color: themeColor('text') }}>
+                                    {localeString(
+                                        'components.SetFeesForm.minHtlc'
+                                    )}
+                                </Text>
+                                <TextInput
+                                    keyboardType="numeric"
+                                    placeholder={minHTLC}
+                                    value={newMinHtlc}
+                                    onChangeText={(text: string) =>
+                                        this.setState({
+                                            newMinHtlc: text
+                                        })
+                                    }
+                                    autoCapitalize="none"
+                                    autoCorrect={false}
+                                />
+
+                                <Text style={{ color: themeColor('text') }}>
+                                    {localeString(
+                                        'components.SetFeesForm.maxHtlc'
+                                    )}
+                                </Text>
+                                <TextInput
+                                    keyboardType="numeric"
+                                    placeholder={maxHTLC}
+                                    value={newMaxHtlc}
+                                    onChangeText={(text: string) =>
+                                        this.setState({
+                                            newMaxHtlc: text
+                                        })
+                                    }
+                                    autoCapitalize="none"
+                                    autoCorrect={false}
+                                />
+                            </>
+                        )}
+
                         <View style={styles.button}>
                             <Button
                                 title={localeString(
@@ -206,7 +256,9 @@ export default class SetFeesForm extends React.Component<
                                         newFeeRate,
                                         Number(newTimeLockDelta),
                                         channelPoint,
-                                        channelId
+                                        channelId,
+                                        newMinHtlc,
+                                        newMaxHtlc
                                     ).then(() => {
                                         if (
                                             channelId &&

--- a/components/SetFeesForm.tsx
+++ b/components/SetFeesForm.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { inject, observer } from 'mobx-react';
 
 import Button from './../components/Button';
+import LoadingIndicator from './../components/LoadingIndicator';
 import {
     SuccessMessage,
     ErrorMessage
@@ -56,10 +57,11 @@ export default class SetFeesForm extends React.Component<
             showNewFeesForm: false,
             feesSubmitted: false,
             newBaseFee: props.baseFee || '1',
-            newFeeRate:
-                props.feeRate || implementation === 'c-lightning-REST'
-                    ? '1'
-                    : '0.001',
+            newFeeRate: props.feeRate
+                ? props.feeRate
+                : implementation === 'c-lightning-REST'
+                ? '1'
+                : '0.001',
             newTimeLockDelta: props.timeLockDelta || '144',
             newMinHtlc: props.minHtlc,
             newMaxHtlc: props.maxHtlc
@@ -123,11 +125,7 @@ export default class SetFeesForm extends React.Component<
 
                 {(expanded || showNewFeesForm) && (
                     <React.Fragment>
-                        {loading && (
-                            <Text style={{ color: themeColor('text') }}>
-                                {localeString('components.SetFeesForm.setting')}
-                            </Text>
-                        )}
+                        {loading && <LoadingIndicator />}
                         {feesSubmitted && setFeesSuccess && (
                             <SuccessMessage
                                 message={localeString(

--- a/components/SetFeesForm.tsx
+++ b/components/SetFeesForm.tsx
@@ -55,8 +55,8 @@ export default class SetFeesForm extends React.Component<
                     ? '1'
                     : '0.001',
             newTimeLockDelta: props.timeLockDelta || '144',
-            newMinHtlc: props.minHtlc || '1',
-            newMaxHtlc: props.maxHtlc || '250000'
+            newMinHtlc: props.minHtlc,
+            newMaxHtlc: props.maxHtlc
         };
     }
 
@@ -214,7 +214,7 @@ export default class SetFeesForm extends React.Component<
                                 </Text>
                                 <TextInput
                                     keyboardType="numeric"
-                                    placeholder={minHTLC}
+                                    placeholder={minHTLC || '1'}
                                     value={newMinHtlc}
                                     onChangeText={(text: string) =>
                                         this.setState({
@@ -232,7 +232,7 @@ export default class SetFeesForm extends React.Component<
                                 </Text>
                                 <TextInput
                                     keyboardType="numeric"
-                                    placeholder={maxHTLC}
+                                    placeholder={maxHTLC || '250000'}
                                     value={newMaxHtlc}
                                     onChangeText={(text: string) =>
                                         this.setState({

--- a/components/SetFeesForm.tsx
+++ b/components/SetFeesForm.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { inject, observer } from 'mobx-react';
+
 import Button from './../components/Button';
+import {
+    SuccessMessage,
+    ErrorMessage
+} from './../components/SuccessErrorMessage';
 import TextInput from './../components/TextInput';
+
 import { localeString } from './../utils/LocaleUtils';
 import { themeColor } from './../utils/ThemeUtils';
 
@@ -123,26 +129,22 @@ export default class SetFeesForm extends React.Component<
                             </Text>
                         )}
                         {feesSubmitted && setFeesSuccess && (
-                            <Text
-                                style={{
-                                    color: 'green'
-                                }}
-                            >
-                                {localeString('components.SetFeesForm.success')}
-                            </Text>
+                            <SuccessMessage
+                                message={localeString(
+                                    'components.SetFeesForm.success'
+                                )}
+                            />
                         )}
                         {feesSubmitted && setFeesError && (
-                            <Text
-                                style={{
-                                    color: 'red'
-                                }}
-                            >
-                                {setFeesErrorMsg
-                                    ? setFeesErrorMsg
-                                    : localeString(
-                                          'components.SetFeesForm.error'
-                                      )}
-                            </Text>
+                            <ErrorMessage
+                                message={
+                                    setFeesErrorMsg
+                                        ? setFeesErrorMsg
+                                        : localeString(
+                                              'components.SetFeesForm.error'
+                                          )
+                                }
+                            />
                         )}
 
                         <Text style={{ color: themeColor('text') }}>

--- a/locales/en.json
+++ b/locales/en.json
@@ -50,6 +50,8 @@
     "components.SetFeesForm.ppm": "PPM (Parts Per Million)",
     "components.SetFeesForm.ppmMilliMsat": "PPM rate in milli msat",
     "components.SetFeesForm.timeLockDelta": "Timelock Delta (blocks)",
+    "components.SetFeesForm.minHtlc": "Min HTLC (sats)",
+    "components.SetFeesForm.maxHtlc": "Max HTLC (sats)",
     "components.SetFeesForm.submit": "Submit New Fees",
     "components.UTXOPicker.defaultTitle": "UTXOs to use",
     "components.UTXOPicker.selectUTXOs": "Select UTXOs to use",

--- a/stores/FeeStore.ts
+++ b/stores/FeeStore.ts
@@ -120,7 +120,9 @@ export default class FeeStore {
         newFeeRate: string,
         timeLockDelta = 4,
         channelPoint?: string,
-        channelId?: string
+        channelId?: string,
+        minHtlc?: string,
+        maxHtlc?: string
     ) => {
         this.loading = true;
         this.setFeesError = false;
@@ -149,6 +151,13 @@ export default class FeeStore {
 
         if (!channelId && !channelPoint) {
             data.global = true;
+        }
+
+        if (minHtlc) {
+            data.min_htlc = minHtlc;
+        }
+        if (maxHtlc) {
+            data.max_htlc = maxHtlc;
         }
 
         return RESTUtils.setFees(data)


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-705**](https://github.com/ZeusLN/zeus/issues/705)

- Lets LND users set Min and Max HTLC channel rates
- Properly display min HTLC in sats instead of msats
- Add `LoadingIndicator` and `SuccessErrorMessage` components to `SetFeesForm`

This pull request is categorized as a:

- [x] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND
- [x] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
