### PR TITLE
Update TextInput padding

### DIFF
--- a/components/DropdownSetting.tsx
+++ b/components/DropdownSetting.tsx
@@ -117,6 +117,7 @@ const styles = StyleSheet.create({
         borderRadius: 6,
         borderBottomWidth: 20,
         marginBottom: 20,
-        paddingLeft: 5
+        paddingLeft: 10,
+        overflow: 'hidden'
     }
 });

--- a/components/TextInput.tsx
+++ b/components/TextInput.tsx
@@ -40,7 +40,8 @@ function TextInput(props: TextInputProps) {
               backgroundColor: themeColor('secondary'),
               borderRadius: 6,
               marginBottom: 20,
-              paddingLeft: 5
+              padding: 10,
+              paddingTop: 10
           }
         : {
               color: themeColor('text'),
@@ -51,7 +52,7 @@ function TextInput(props: TextInputProps) {
               backgroundColor: themeColor('secondary'),
               borderRadius: 6,
               marginBottom: 20,
-              paddingLeft: 5
+              padding: 10
           };
 
     return (


### PR DESCRIPTION
Text forms without placeholders on iOS were looking funky. Also rounded the corners on the `DropdownSetting` component on iOS