### PR TITLE
Send: fix padding of transction type label

### DIFF
--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -377,7 +377,8 @@ export default class Send extends React.Component<SendProps, SendState> {
                     {transactionType && (
                         <Text
                             style={{
-                                paddingTop: 10,
+                                paddingBottom: 10,
+                                marginBottom: 10,
                                 color: themeColor('text'),
                                 ...styles.text
                             }}


### PR DESCRIPTION
Before:
<img width="406" alt="Screen Shot 2022-02-05 at 19 49 55" src="https://user-images.githubusercontent.com/1878621/152664021-0728a8ee-83e9-48a5-9d93-905bc31e82b9.png">

After:
<img width="410" alt="Screen Shot 2022-02-05 at 19 51 05" src="https://user-images.githubusercontent.com/1878621/152664024-16202cab-0cbb-45cc-b70d-bbc5d61c1d65.png">

