### PR TITLE
Added copy node config button

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -112,6 +112,7 @@
     "views.Settings.AddEditNode.scanBtcpay": "Scan BTCPay config",
     "views.Settings.AddEditNode.scanLndhub": "Scan LNDHub QR",
     "views.Settings.AddEditNode.deleteNode": "Delete Node config",
+    "views.Settings.AddEditNode.copyNode": "Copy Node config",
     "views.Settings.AddEditNode.nodeInterface": "Node interface",
     "views.Settings.AddEditNode.useTor": "Use Tor",
     "views.Settings.CertInstallInstructions.title": "Certificate Installation Instructions",

--- a/views/Settings/AddEditNode.tsx
+++ b/views/Settings/AddEditNode.tsx
@@ -321,7 +321,7 @@ export default class AddEditNode extends React.Component<
         const { nodes, lurkerMode, passphrase, fiat, locale } = settings;
 
         const node = {
-            nickname: nickname + ' copy',
+            nickname: `${nickname} copy`,
             host,
             port,
             url,
@@ -1297,6 +1297,11 @@ export default class AddEditNode extends React.Component<
                                     'views.Settings.AddEditNode.copyNode'
                                 )}
                                 onPress={() => {
+                                    /**
+                                     * Scrolls to the top of the screen when going to the node config
+                                     * page for the copied node. Without this, the user would have to
+                                     * manually scroll to the top to edit the copied node properties.
+                                     */
                                     this.refs._scrollView.scrollTo({
                                         x: 0,
                                         y: 0,

--- a/views/Settings/AddEditNode.tsx
+++ b/views/Settings/AddEditNode.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useRef } from 'react';
 import {
     Modal,
     StyleSheet,
@@ -356,7 +355,7 @@ export default class AddEditNode extends React.Component<
                 index: Number(nodes.length)
             });
         });
-    }
+    };
 
     deleteNodeConfig = () => {
         const { SettingsStore, navigation } = this.props;
@@ -761,7 +760,7 @@ export default class AddEditNode extends React.Component<
                 )}
 
                 <ScrollView
-                    ref='_scrollView'
+                    ref="_scrollView"
                     style={{ flex: 1, paddingLeft: 15, paddingRight: 15 }}
                 >
                     <View style={styles.form}>
@@ -1298,9 +1297,12 @@ export default class AddEditNode extends React.Component<
                                     'views.Settings.AddEditNode.copyNode'
                                 )}
                                 onPress={() => {
-                                    this.refs._scrollView.scrollTo({x: 0, y: 0, animated: true});
+                                    this.refs._scrollView.scrollTo({
+                                        x: 0,
+                                        y: 0,
+                                        animated: true
+                                    });
                                     this.copyNodeConfig();
-
                                 }}
                                 secondary
                             />

--- a/views/Settings/AddEditNode.tsx
+++ b/views/Settings/AddEditNode.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useRef } from 'react';
 import {
     Modal,
     StyleSheet,
@@ -299,6 +300,63 @@ export default class AddEditNode extends React.Component<
             }
         });
     };
+
+    copyNodeConfig = () => {
+        const { SettingsStore, navigation } = this.props;
+        const { setSettings, settings } = SettingsStore;
+        const {
+            nickname,
+            host,
+            port,
+            url,
+            enableTor,
+            lndhubUrl,
+            existingAccount,
+            macaroonHex,
+            accessKey,
+            username,
+            password,
+            implementation,
+            certVerification
+        } = this.state;
+        const { nodes, lurkerMode, passphrase, fiat, locale } = settings;
+
+        const node = {
+            nickname: nickname + ' copy',
+            host,
+            port,
+            url,
+            lndhubUrl,
+            existingAccount,
+            macaroonHex,
+            accessKey,
+            username,
+            password,
+            implementation,
+            certVerification,
+            enableTor
+        };
+
+        setSettings(
+            JSON.stringify({
+                nodes,
+                theme: settings.theme,
+                selectedNode: settings.selectedNode,
+                fiat,
+                locale,
+                lurkerMode,
+                passphrase,
+                privacy: settings.privacy
+            })
+        ).then(() => {
+            navigation.navigate('AddEditNode', {
+                node,
+                newEntry: true,
+                saved: false,
+                index: Number(nodes.length)
+            });
+        });
+    }
 
     deleteNodeConfig = () => {
         const { SettingsStore, navigation } = this.props;
@@ -703,6 +761,7 @@ export default class AddEditNode extends React.Component<
                 )}
 
                 <ScrollView
+                    ref='_scrollView'
                     style={{ flex: 1, paddingLeft: 15, paddingRight: 15 }}
                 >
                     <View style={styles.form}>
@@ -1227,6 +1286,22 @@ export default class AddEditNode extends React.Component<
                                     'views.Settings.AddEditNode.deleteNode'
                                 )}
                                 onPress={() => this.deleteNodeConfig()}
+                                secondary
+                            />
+                        </View>
+                    )}
+
+                    {saved && (
+                        <View style={styles.button}>
+                            <Button
+                                title={localeString(
+                                    'views.Settings.AddEditNode.copyNode'
+                                )}
+                                onPress={() => {
+                                    this.refs._scrollView.scrollTo({x: 0, y: 0, animated: true});
+                                    this.copyNodeConfig();
+
+                                }}
                                 secondary
                             />
                         </View>

--- a/views/Settings/AddEditNode.tsx
+++ b/views/Settings/AddEditNode.tsx
@@ -1282,18 +1282,6 @@ export default class AddEditNode extends React.Component<
                         <View style={styles.button}>
                             <Button
                                 title={localeString(
-                                    'views.Settings.AddEditNode.deleteNode'
-                                )}
-                                onPress={() => this.deleteNodeConfig()}
-                                secondary
-                            />
-                        </View>
-                    )}
-
-                    {saved && (
-                        <View style={styles.button}>
-                            <Button
-                                title={localeString(
                                     'views.Settings.AddEditNode.copyNode'
                                 )}
                                 onPress={() => {
@@ -1309,6 +1297,18 @@ export default class AddEditNode extends React.Component<
                                     });
                                     this.copyNodeConfig();
                                 }}
+                                secondary
+                            />
+                        </View>
+                    )}
+
+                    {saved && (
+                        <View style={styles.button}>
+                            <Button
+                                title={localeString(
+                                    'views.Settings.AddEditNode.deleteNode'
+                                )}
+                                onPress={() => this.deleteNodeConfig()}
                                 secondary
                             />
                         </View>


### PR DESCRIPTION
# Description

Relates to issue: **[226](https://github.com/ZeusLN/zeus/issues/226)**

Added copy node config button below delete node config. Brings user to a new Node Configuration page with all of the same properties, except for ' copy' added to the end of the Nickname. 

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [x] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS iphone 11 Pro iOS 13.7

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND
- [x] c-lightning-REST
- [x] spark
- [x] Eclair
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
