### PR TITLE
Zero amount invoices

### DIFF
--- a/components/CollapsedQR.tsx
+++ b/components/CollapsedQR.tsx
@@ -112,8 +112,7 @@ export default class CollapsedQR extends React.Component<
                         color: '#fff'
                     }}
                     containerStyle={{
-                        marginTop: 10,
-                        marginBottom: Platform.OS === 'android' ? 10 : 20
+                        margin: 20
                     }}
                     onPress={() => this.toggleCollapse()}
                 />
@@ -128,7 +127,7 @@ export default class CollapsedQR extends React.Component<
                                   )
                         }
                         containerStyle={{
-                            marginBottom: 20
+                            margin: 20
                         }}
                         onPress={() => this.toggleNfc()}
                         tertiary
@@ -149,6 +148,6 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         alignSelf: 'center',
         padding: 5,
-        marginBottom: 10
+        margin: 10
     }
 });

--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -63,7 +63,7 @@ export default class CopyButton extends React.Component<
                     size: 25
                 }}
                 containerStyle={{
-                    marginBottom: 10
+                    margin: 10
                 }}
                 onPress={() => this.copyToClipboard()}
                 secondary

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -207,7 +207,7 @@ export default class TransactionsStore {
             data.payment_request = payment_request;
         }
         if (amount) {
-            data.amt = amount;
+            data.amt = Number(amount);
         }
 
         if (pubkey) {

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -104,7 +104,7 @@ export default async function (data: string): Promise<any> {
         return [
             'OpenChannel',
             {
-                pubkey,
+                node_pubkey_string: pubkey,
                 host
             }
         ];

--- a/views/NodeQRScanner.tsx
+++ b/views/NodeQRScanner.tsx
@@ -22,7 +22,7 @@ function NodeQRScanner(props: NodeQRProps) {
             Alert.alert(
                 localeString('general.error'),
                 localeString('views.NodeQRScanner.error'),
-                [{ text: 'OK', onPress: () => void 0 }],
+                [{ text: localeString('general.ok'), onPress: () => void 0 }],
                 { cancelable: false }
             );
 

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -30,6 +30,7 @@ interface InvoiceProps {
 }
 
 interface InvoiceState {
+    customAmount: string;
     enableMultiPathPayment: boolean;
     enableAtomicMultiPathPayment: boolean;
     maxParts: string;
@@ -53,6 +54,7 @@ export default class PaymentRequest extends React.Component<
     InvoiceState
 > {
     state = {
+        customAmount: '',
         enableMultiPathPayment: false,
         enableAtomicMultiPathPayment: false,
         maxParts: '16',
@@ -80,7 +82,8 @@ export default class PaymentRequest extends React.Component<
             timeoutSeconds,
             feeLimitSat,
             outgoingChanId,
-            lastHopPubkey
+            lastHopPubkey,
+            customAmount
         } = this.state;
         const {
             pay_req,
@@ -118,6 +121,9 @@ export default class PaymentRequest extends React.Component<
 
         const { enableTor } = SettingsStore;
 
+        const isNoAmountInvoice: boolean =
+            !requestAmount || requestAmount === 0;
+
         const BackButton = () => (
             <Icon
                 name="arrow-back"
@@ -148,12 +154,7 @@ export default class PaymentRequest extends React.Component<
                 <ScrollView>
                     {!!getPayReqError && (
                         <View style={styles.content}>
-                            <Text
-                                style={{
-                                    ...styles.label,
-                                    color: themeColor('text')
-                                }}
-                            >
+                            <Text style={styles.label}>
                                 {localeString('views.PaymentRequest.error')}:{' '}
                                 {getPayReqError}
                             </Text>
@@ -163,11 +164,45 @@ export default class PaymentRequest extends React.Component<
                     {!!pay_req && (
                         <View style={styles.content}>
                             <View style={styles.center}>
-                                <Amount
-                                    sats={requestAmount || 0}
-                                    jumboText
-                                    toggleable
-                                />
+                                {isNoAmountInvoice ? (
+                                    <>
+                                        <Text
+                                            style={{
+                                                color: themeColor('text')
+                                            }}
+                                        >
+                                            {localeString(
+                                                'views.PaymentRequest.customAmt'
+                                            )}
+                                        </Text>
+                                        <TextInput
+                                            keyboardType="numeric"
+                                            placeholder={
+                                                requestAmount
+                                                    ? requestAmount.toString()
+                                                    : '0'
+                                            }
+                                            value={customAmount}
+                                            onChangeText={(text: string) =>
+                                                this.setState({
+                                                    customAmount: text
+                                                })
+                                            }
+                                            numberOfLines={1}
+                                            style={{
+                                                ...styles.textInput,
+                                                color: themeColor('text')
+                                            }}
+                                            placeholderTextColor="gray"
+                                        />
+                                    </>
+                                ) : (
+                                    <Amount
+                                        sats={requestAmount}
+                                        jumboText
+                                        toggleable
+                                    />
+                                )}
                             </View>
 
                             {(!!feeEstimate || feeEstimate === 0) && (
@@ -289,7 +324,6 @@ export default class PaymentRequest extends React.Component<
                                     <Text
                                         style={{
                                             ...styles.label,
-                                            color: themeColor('text'),
                                             top: 25
                                         }}
                                     >
@@ -344,12 +378,7 @@ export default class PaymentRequest extends React.Component<
 
                             {ampOrMppEnabled && (
                                 <React.Fragment>
-                                    <Text
-                                        style={{
-                                            ...styles.label,
-                                            color: themeColor('text')
-                                        }}
-                                    >
+                                    <Text style={styles.label}>
                                         {localeString(
                                             'views.PaymentRequest.timeout'
                                         )}
@@ -365,12 +394,7 @@ export default class PaymentRequest extends React.Component<
                                             })
                                         }
                                     />
-                                    <Text
-                                        style={{
-                                            ...styles.label,
-                                            color: themeColor('text')
-                                        }}
-                                    >
+                                    <Text style={styles.label}>
                                         {enableMultiPathPayment
                                             ? localeString(
                                                   'views.PaymentRequest.maxParts'
@@ -391,22 +415,12 @@ export default class PaymentRequest extends React.Component<
                                             })
                                         }
                                     />
-                                    <Text
-                                        style={{
-                                            ...styles.label,
-                                            color: themeColor('text')
-                                        }}
-                                    >
+                                    <Text style={styles.label}>
                                         {localeString(
                                             'views.PaymentRequest.maxPartsDescription'
                                         )}
                                     </Text>
-                                    <Text
-                                        style={{
-                                            ...styles.label,
-                                            color: themeColor('text')
-                                        }}
-                                    >
+                                    <Text style={styles.label}>
                                         {`${localeString(
                                             'views.PaymentRequest.feeLimit'
                                         )} (${localeString(
@@ -431,12 +445,7 @@ export default class PaymentRequest extends React.Component<
 
                             {enableAmp && (
                                 <React.Fragment>
-                                    <Text
-                                        style={{
-                                            ...styles.label,
-                                            color: themeColor('text')
-                                        }}
-                                    >
+                                    <Text style={styles.label}>
                                         {`${localeString(
                                             'views.PaymentRequest.maxShardAmt'
                                         )} (${localeString(
@@ -470,6 +479,7 @@ export default class PaymentRequest extends React.Component<
                                         onPress={() => {
                                             TransactionsStore.sendPayment({
                                                 payment_request: paymentRequest,
+                                                amount: customAmount,
                                                 max_parts: ampOrMppEnabled
                                                     ? maxParts
                                                     : null,
@@ -509,6 +519,7 @@ const styles = StyleSheet.create({
         padding: 20
     },
     label: {
+        color: themeColor('text'),
         fontFamily: 'Lato-Regular',
         paddingTop: 5
     },

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image, StyleSheet, Text, View } from 'react-native';
+import { Image, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import LnurlPaySuccess from './LnurlPay/Success';
 
@@ -65,7 +65,7 @@ export default class SendingLightning extends React.Component<
             payment_route || status === 'complete' || status === 'SUCCEEDED';
 
         return (
-            <View
+            <ScrollView
                 style={{
                     ...styles.container,
                     backgroundColor
@@ -175,7 +175,7 @@ export default class SendingLightning extends React.Component<
 
                     <View style={styles.buttons}>
                         {payment_hash && (
-                            <View style={{ marginBottom: 10, width: '100%' }}>
+                            <View style={{ margin: 10, width: '100%' }}>
                                 <CopyButton
                                     title={localeString(
                                         'views.SendingLightning.copyPaymentHash'
@@ -208,7 +208,7 @@ export default class SendingLightning extends React.Component<
                         )}
                     </View>
                 </View>
-            </View>
+            </ScrollView>
         );
     }
 }


### PR DESCRIPTION
This PR allows users to specify amounts for zero amount invoices. We previously had functionality to set custom amounts for LND users when overpaying was allowed, but now let's just support zero amount invoices.

This PR also allows success screens to scroll when dealing with LNURL data.