### PR TITLE
Update style of Main Pane

### DIFF
--- a/components/text/Body.tsx
+++ b/components/text/Body.tsx
@@ -36,9 +36,8 @@ export function Body({
                     : secondary
                     ? themeColor('secondaryText')
                     : themeColor('text'),
-                fontWeight: bold ? 'bold' : 'normal',
                 fontSize: small ? 12 : big ? 20 : jumbo ? 40 : 16,
-                fontFamily: 'Lato-Regular'
+                fontFamily: bold || jumbo ? 'Lato-Bold' : 'Lato-Regular'
             }}
         >
             {children}

--- a/views/Wallet/MainPane.tsx
+++ b/views/Wallet/MainPane.tsx
@@ -123,7 +123,7 @@ export default class MainPane extends React.PureComponent<MainPaneProps, {}> {
                     style={{
                         height: 220,
                         alignItems: 'center',
-                        backgroundColor: themeColor('secondary')
+                        backgroundColor: themeColor('background')
                     }}
                 >
                     <WalletHeader
@@ -132,14 +132,23 @@ export default class MainPane extends React.PureComponent<MainPaneProps, {}> {
                     />
                     {!BalanceStore.loadingLightningBalance &&
                         !BalanceStore.loadingBlockchainBalance && (
-                            <>
+                            <View style={{ marginTop: 20 }}>
                                 {implementation === 'lndhub' ? (
                                     <LightningBalance />
                                 ) : (
                                     <BalanceViewCombined />
                                 )}
-                                {infoValue !== 'ⓘ' && <NetworkBadge />}
-                            </>
+                                {infoValue !== 'ⓘ' && (
+                                    <View
+                                        style={{
+                                            marginTop: 5,
+                                            alignItems: 'center'
+                                        }}
+                                    >
+                                        <NetworkBadge />
+                                    </View>
+                                )}
+                            </View>
                         )}
                 </View>
             );


### PR DESCRIPTION
Main Pane should now take the main background style instead of the secondary color used for balance sliders.

This also makes jumbo amounts bold and fixes some spacing within the main pane.