### PR TITLE
Adding amp toggle for keysends

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -327,6 +327,7 @@
     "views.Send.editNetworkFees": "Edit network fees",
     "views.Send.keysendNotSupported": "does not support sending keysend payments at the moment.",
     "views.Send.lookup": "Look Up Payment Request",
+    "views.Send.amp": "Attempt atomic multi-path payment",
     "views.SendingLightning.sending": "Sending Transaction",
     "views.SendingLightning.success": "Transaction successfully sent",
     "views.SendingLightning.paymentHash": "Payment Hash",

--- a/locales/en.json
+++ b/locales/en.json
@@ -327,7 +327,6 @@
     "views.Send.editNetworkFees": "Edit network fees",
     "views.Send.keysendNotSupported": "does not support sending keysend payments at the moment.",
     "views.Send.lookup": "Look Up Payment Request",
-    "views.Send.amp": "Attempt atomic multi-path payment",
     "views.SendingLightning.sending": "Sending Transaction",
     "views.SendingLightning.success": "Transaction successfully sent",
     "views.SendingLightning.paymentHash": "Payment Hash",

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -6,7 +6,8 @@ import {
     View,
     ScrollView,
     TouchableOpacity,
-    TouchableWithoutFeedback
+    TouchableWithoutFeedback,
+    Switch
 } from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { inject, observer } from 'mobx-react';
@@ -63,6 +64,7 @@ interface SendState {
     maxShardAmt: string;
     feeLimitSat: string;
     message: string;
+    enableAtomicMultiPathPayment: boolean;
 }
 
 @inject(
@@ -98,7 +100,8 @@ export default class Send extends React.Component<SendProps, SendState> {
             maxParts: '16',
             maxShardAmt: '',
             feeLimitSat: '',
-            message: ''
+            message: '',
+            enableAtomicMultiPathPayment: false
         };
     }
 
@@ -227,10 +230,16 @@ export default class Send extends React.Component<SendProps, SendState> {
 
     sendKeySendPayment = (satAmount: string | number) => {
         const { TransactionsStore, navigation } = this.props;
-        const { destination, maxParts, maxShardAmt, feeLimitSat, message } =
-            this.state;
+        const {
+            destination,
+            maxParts,
+            maxShardAmt,
+            feeLimitSat,
+            message,
+            enableAtomicMultiPathPayment
+        } = this.state;
 
-        if (RESTUtils.supportsAMP()) {
+        if (enableAtomicMultiPathPayment) {
             TransactionsStore.sendPayment({
                 amount: satAmount.toString(),
                 pubkey: destination,
@@ -282,7 +291,8 @@ export default class Send extends React.Component<SendProps, SendState> {
             maxParts,
             maxShardAmt,
             feeLimitSat,
-            message
+            message,
+            enableAtomicMultiPathPayment
         } = this.state;
         const { confirmedBlockchainBalance } = BalanceStore;
         const { implementation, settings } = SettingsStore;
@@ -626,97 +636,148 @@ export default class Send extends React.Component<SendProps, SendState> {
                                             }
                                             style={styles.textInput}
                                         />
+                                    </React.Fragment>
+                                )}
+                                {RESTUtils.supportsAMP() &&
+                                    enableAtomicMultiPathPayment && (
+                                        <React.Fragment>
+                                            <Text
+                                                style={{
+                                                    ...styles.secondaryText,
+                                                    color: themeColor(
+                                                        'secondaryText'
+                                                    )
+                                                }}
+                                            >
+                                                {`${localeString(
+                                                    'views.PaymentRequest.maxParts'
+                                                )} (${localeString(
+                                                    'general.optional'
+                                                )})`}
+                                                :
+                                            </Text>
+                                            <TextInput
+                                                keyboardType="numeric"
+                                                value={maxParts}
+                                                onChangeText={(text: string) =>
+                                                    this.setState({
+                                                        maxParts: text
+                                                    })
+                                                }
+                                                style={styles.textInput}
+                                            />
+                                            <Text
+                                                style={{
+                                                    ...styles.text,
+                                                    color: themeColor('text'),
+                                                    paddingBottom: 15
+                                                }}
+                                            >
+                                                {localeString(
+                                                    'views.PaymentRequest.maxPartsDescription'
+                                                )}
+                                            </Text>
+                                            <Text
+                                                style={{
+                                                    ...styles.secondaryText,
+                                                    color: themeColor(
+                                                        'secondaryText'
+                                                    )
+                                                }}
+                                            >
+                                                {`${localeString(
+                                                    'views.PaymentRequest.feeLimit'
+                                                )} (${localeString(
+                                                    'general.sats'
+                                                )}) (${localeString(
+                                                    'general.optional'
+                                                )})`}
+                                                :
+                                            </Text>
+                                            <TextInput
+                                                keyboardType="numeric"
+                                                placeholder="100"
+                                                value={feeLimitSat}
+                                                onChangeText={(text: string) =>
+                                                    this.setState({
+                                                        feeLimitSat: text
+                                                    })
+                                                }
+                                                style={styles.textInput}
+                                            />
+                                            <Text
+                                                style={{
+                                                    ...styles.secondaryText,
+                                                    color: themeColor(
+                                                        'secondaryText'
+                                                    )
+                                                }}
+                                            >
+                                                {`${localeString(
+                                                    'views.PaymentRequest.maxShardAmt'
+                                                )} (${localeString(
+                                                    'general.sats'
+                                                )}) (${localeString(
+                                                    'general.optional'
+                                                )})`}
+                                                :
+                                            </Text>
+                                            <TextInput
+                                                keyboardType="numeric"
+                                                value={maxShardAmt}
+                                                onChangeText={(text: string) =>
+                                                    this.setState({
+                                                        maxShardAmt: text
+                                                    })
+                                                }
+                                                style={styles.textInput}
+                                            />
+                                        </React.Fragment>
+                                    )}
+                                {RESTUtils.supportsAMP() && (
+                                    <React.Fragment>
                                         <Text
                                             style={{
-                                                ...styles.secondaryText,
-                                                color: themeColor(
-                                                    'secondaryText'
-                                                )
-                                            }}
-                                        >
-                                            {`${localeString(
-                                                'views.PaymentRequest.maxParts'
-                                            )} (${localeString(
-                                                'general.optional'
-                                            )})`}
-                                            :
-                                        </Text>
-                                        <TextInput
-                                            keyboardType="numeric"
-                                            value={maxParts}
-                                            onChangeText={(text: string) =>
-                                                this.setState({
-                                                    maxParts: text
-                                                })
-                                            }
-                                            style={styles.textInput}
-                                        />
-                                        <Text
-                                            style={{
-                                                ...styles.text,
+                                                ...styles.label,
                                                 color: themeColor('text'),
-                                                paddingBottom: 15
+                                                top: 25
                                             }}
                                         >
-                                            {localeString(
-                                                'views.PaymentRequest.maxPartsDescription'
-                                            )}
+                                            {localeString('views.Send.amp')}
                                         </Text>
-                                        <Text
+                                        <View
                                             style={{
-                                                ...styles.secondaryText,
-                                                color: themeColor(
-                                                    'secondaryText'
-                                                )
+                                                flex: 1,
+                                                flexDirection: 'row',
+                                                justifyContent: 'flex-end'
                                             }}
                                         >
-                                            {`${localeString(
-                                                'views.PaymentRequest.feeLimit'
-                                            )} (${localeString(
-                                                'general.sats'
-                                            )}) (${localeString(
-                                                'general.optional'
-                                            )})`}
-                                            :
-                                        </Text>
-                                        <TextInput
-                                            keyboardType="numeric"
-                                            placeholder="100"
-                                            value={feeLimitSat}
-                                            onChangeText={(text: string) =>
-                                                this.setState({
-                                                    feeLimitSat: text
-                                                })
-                                            }
-                                            style={styles.textInput}
-                                        />
-                                        <Text
-                                            style={{
-                                                ...styles.secondaryText,
-                                                color: themeColor(
-                                                    'secondaryText'
-                                                )
-                                            }}
-                                        >
-                                            {`${localeString(
-                                                'views.PaymentRequest.maxShardAmt'
-                                            )} (${localeString(
-                                                'general.sats'
-                                            )}) (${localeString(
-                                                'general.optional'
-                                            )})`}
-                                            :
-                                        </Text>
-                                        <TextInput
-                                            keyboardType="numeric"
-                                            value={maxShardAmt}
-                                            onChangeText={(text: string) =>
-                                                this.setState({
-                                                    maxShardAmt: text
-                                                })
-                                            }
-                                            style={styles.textInput}
-                                        />
+                                            <View
+                                                style={{
+                                                    flex: 1,
+                                                    flexDirection: 'row',
+                                                    justifyContent: 'flex-end'
+                                                }}
+                                            >
+                                                <Switch
+                                                    value={
+                                                        enableAtomicMultiPathPayment
+                                                    }
+                                                    onValueChange={() =>
+                                                        this.setState({
+                                                            enableAtomicMultiPathPayment:
+                                                                !enableAtomicMultiPathPayment
+                                                        })
+                                                    }
+                                                    trackColor={{
+                                                        false: '#767577',
+                                                        true: themeColor(
+                                                            'highlight'
+                                                        )
+                                                    }}
+                                                />
+                                            </View>
+                                        </View>
                                     </React.Fragment>
                                 )}
                                 <View style={styles.button}>
@@ -848,5 +909,9 @@ const styles = StyleSheet.create({
     editFeeButton: {
         paddingTop: 15,
         alignItems: 'center'
+    },
+    label: {
+        fontFamily: 'Lato-Regular',
+        paddingTop: 5
     }
 });

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -743,7 +743,7 @@ export default class Send extends React.Component<SendProps, SendState> {
                                                 top: 25
                                             }}
                                         >
-                                            {localeString('views.Send.amp')}
+                                            {localeString('views.PaymentRequest.amp')}
                                         </Text>
                                         <View
                                             style={{

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -636,6 +636,50 @@ export default class Send extends React.Component<SendProps, SendState> {
                                             }
                                             style={styles.textInput}
                                         />
+                                        <Text
+                                            style={{
+                                                ...styles.label,
+                                                color: themeColor('text'),
+                                                top: 25
+                                            }}
+                                        >
+                                            {localeString(
+                                                'views.PaymentRequest.amp'
+                                            )}
+                                        </Text>
+                                        <View
+                                            style={{
+                                                flex: 1,
+                                                flexDirection: 'row',
+                                                justifyContent: 'flex-end'
+                                            }}
+                                        >
+                                            <View
+                                                style={{
+                                                    flex: 1,
+                                                    flexDirection: 'row',
+                                                    justifyContent: 'flex-end'
+                                                }}
+                                            >
+                                                <Switch
+                                                    value={
+                                                        enableAtomicMultiPathPayment
+                                                    }
+                                                    onValueChange={() =>
+                                                        this.setState({
+                                                            enableAtomicMultiPathPayment:
+                                                                !enableAtomicMultiPathPayment
+                                                        })
+                                                    }
+                                                    trackColor={{
+                                                        false: '#767577',
+                                                        true: themeColor(
+                                                            'highlight'
+                                                        )
+                                                    }}
+                                                />
+                                            </View>
+                                        </View>
                                     </React.Fragment>
                                 )}
                                 {RESTUtils.supportsAMP() &&
@@ -734,52 +778,6 @@ export default class Send extends React.Component<SendProps, SendState> {
                                             />
                                         </React.Fragment>
                                     )}
-                                {RESTUtils.supportsAMP() && (
-                                    <React.Fragment>
-                                        <Text
-                                            style={{
-                                                ...styles.label,
-                                                color: themeColor('text'),
-                                                top: 25
-                                            }}
-                                        >
-                                            {localeString('views.PaymentRequest.amp')}
-                                        </Text>
-                                        <View
-                                            style={{
-                                                flex: 1,
-                                                flexDirection: 'row',
-                                                justifyContent: 'flex-end'
-                                            }}
-                                        >
-                                            <View
-                                                style={{
-                                                    flex: 1,
-                                                    flexDirection: 'row',
-                                                    justifyContent: 'flex-end'
-                                                }}
-                                            >
-                                                <Switch
-                                                    value={
-                                                        enableAtomicMultiPathPayment
-                                                    }
-                                                    onValueChange={() =>
-                                                        this.setState({
-                                                            enableAtomicMultiPathPayment:
-                                                                !enableAtomicMultiPathPayment
-                                                        })
-                                                    }
-                                                    trackColor={{
-                                                        false: '#767577',
-                                                        true: themeColor(
-                                                            'highlight'
-                                                        )
-                                                    }}
-                                                />
-                                            </View>
-                                        </View>
-                                    </React.Fragment>
-                                )}
                                 <View style={styles.button}>
                                     <Button
                                         title={localeString('general.send')}


### PR DESCRIPTION
# Description

Relates to issue: **[ZEUS-832](https://github.com/ZeusLN/zeus/issues/832)**

Previously, for LND 0.13 and 0.14 nodes, the keysend page would default to sending an amp payment. This could potentially cause issues, because amp payments will fail unless they're being sent to another LND 0.13 / 0.14 node with accept-amp turned on.

This change introduces an amp toggle for keysends. The toggle will only appear if the node supports amp (meaning it's an LND 0.13 / 0.14 node).

Screenshot when toggle is disabling amp payment:

<img width="398" alt="Screen Shot 2022-02-16 at 9 07 33 PM" src="https://user-images.githubusercontent.com/93104057/154390960-6920f0ea-aaa2-40ce-b533-bee6dffdf878.png">

Screenshot when toggle is enabling amp payment:

<img width="397" alt="Screen Shot 2022-02-16 at 9 08 13 PM" src="https://user-images.githubusercontent.com/93104057/154391016-88fcd441-2a7c-435f-a024-832c82b58e32.png">


