### PR TITLE
Update the link path for the RaspiBolt installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You must provide Zeus with your node's hostname, port number, and the macaroon y
 
 On Android Zeus has support for connecting to you node entirely over the Tor network. You can refer to these guides to set up a Tor hidden service on your lnd node. The instructions are generally interchangable and typically only require you to change your Tor path.
 
-* [Zeus over Tor guide for RaspiBolt](https://stadicus.github.io/RaspiBolt/raspibolt_72_zeus-over-tor.html)
+* [Zeus over Tor guide for RaspiBolt](https://raspibolt.org/mobile-app.html)
 * [Zeus over Tor guide for FreeNAS by Seth586](https://github.com/seth586/guides/blob/master/FreeNAS/wallets/zeusln.md)
 * [Zeus over Tor guide for RaspiBlitz by openoms](https://github.com/openoms/bitcoin-tutorials/blob/master/Zeus_to_RaspiBlitz_through_Tor.md)
 * [Tor-Only Bitcoin & Lightning Guide by Lopp](https://blog.lopp.net/tor-only-bitcoin-lightning-guide/)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You must provide Zeus with your node's hostname, port number, and the macaroon y
 
 ### Tor Connection Guides
 
-On Android Zeus has support for connecting to you node entirely over the Tor network. You can refer to these guides to set up a Tor hidden service on your lnd node. The instructions are generally interchangable and typically only require you to change your Tor path.
+Zeus has support for connecting to you node entirely over the Tor network. You can refer to these guides to set up a Tor hidden service on your lnd node. The instructions are generally interchangable and typically only require you to change your Tor path.
 
 * [Zeus over Tor guide for RaspiBolt](https://raspibolt.org/mobile-app.html)
 * [Zeus over Tor guide for FreeNAS by Seth586](https://github.com/seth586/guides/blob/master/FreeNAS/wallets/zeusln.md)


### PR DESCRIPTION
# Description

An updated version of the RaspiBolt Zeus guide is now part of the main guide! (it was part of the bonus section before,). And the overall guide has also now its own domain name.

This PR updates the link path of the RaspiBolt entry in the `README.md`

PS: in the comment just above the list of installation guide, it is stated 

> On Android Zeus has support for connecting to you node entirely over the Tor network.

Is the "On Android" still relevant these days? or can Zeus be used over Tor on iOS as well?

This pull request is categorized as a:

### Other:

- [x] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

![image](https://user-images.githubusercontent.com/86242283/156133216-bc62a498-1418-4346-95ec-6b9f6ff45315.png)
