### PR TITLE
Fix channels count in header

### DIFF
--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -102,12 +102,12 @@ export default class ChannelsStore {
 
     @action
     public getChannels = () => {
+        this.loading = true;
         this.channels = [];
         this.largestChannelSats = 0;
         this.totalOutbound = 0;
         this.totalInbound = 0;
         this.totalOffline = 0;
-        this.loading = true;
         RESTUtils.getChannels()
             .then((data: any) => {
                 const channels = data.channels.map(

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -32,9 +32,6 @@ export default class ChannelsPane extends React.PureComponent<
     ChannelsProps,
     {}
 > {
-    headerString = `${localeString('views.Wallet.Wallet.channels')} (${
-        this.props.ChannelsStore.channels.length
-    })`;
 
     renderItem = ({ item }) => {
         const { ChannelsStore, navigation } = this.props;
@@ -73,12 +70,15 @@ export default class ChannelsPane extends React.PureComponent<
             totalOffline,
             channels
         } = ChannelsStore;
+        const headerString = `${localeString('views.Wallet.Wallet.channels')} (${
+            channels.length
+        })`;
 
         return (
             <View style={{ flex: 1 }}>
                 <WalletHeader
                     navigation={navigation}
-                    title={this.headerString}
+                    title={headerString}
                     SettingsStore={SettingsStore}
                     channels
                 />

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -32,7 +32,6 @@ export default class ChannelsPane extends React.PureComponent<
     ChannelsProps,
     {}
 > {
-
     renderItem = ({ item }) => {
         const { ChannelsStore, navigation } = this.props;
         const { nodes, largestChannelSats } = ChannelsStore;
@@ -70,9 +69,9 @@ export default class ChannelsPane extends React.PureComponent<
             totalOffline,
             channels
         } = ChannelsStore;
-        const headerString = `${localeString('views.Wallet.Wallet.channels')} (${
-            channels.length
-        })`;
+        const headerString = `${localeString(
+            'views.Wallet.Wallet.channels'
+        )} (${channels.length})`;
 
         return (
             <View style={{ flex: 1 }}>


### PR DESCRIPTION
Relates to #874

Sequence of events causing this issue:
Open wallet > go to channels page > settings > back

When back is selected, `getChannels` method is called from several places (`getChannels` getting called multiple times is a more complicated issue that I'll log, but it's not actually causing the count to be wrong)

In the beginning of the `getChannels` method, `channels` is set to empty, so `channels.length` is set to zero. At the same time, `ChannelsPane` gets the number of channels from `this.props.ChannelsStore.channels.length`, so that's why it's displaying zero.

With this fix, we display `channels.length` after the call to `getChannels`, so we don't end up setting it to zero.