### PR TITLE
Adding zeusln deep link and fixing iOS deep link handling

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -94,6 +94,12 @@
             <data android:scheme="lndconnect" />
         </intent-filter>
         <intent-filter>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="zeusln" />
+        </intent-filter>
+        <intent-filter>
             <action android:name="android.nfc.action.NDEF_DISCOVERED" />
             <category android:name="android.intent.category.DEFAULT" />
             <data android:mimeType="text/plain" />

--- a/ios/zeus/AppDelegate.m
+++ b/ios/zeus/AppDelegate.m
@@ -3,6 +3,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
 
 #ifdef FB_SONARKIT_ENABLED
 #import <FlipperKit/FlipperClient.h>
@@ -24,6 +25,13 @@ static void InitializeFlipper(UIApplication *application) {
 #endif
 
 @implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application
+   openURL:(NSURL *)url
+   options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {

--- a/ios/zeus/Info.plist
+++ b/ios/zeus/Info.plist
@@ -35,6 +35,7 @@
 				<string>lnurlp</string>
 				<string>lnurlc</string>
 				<string>lndconnect</string>
+				<string>zeusln</string>
 			</array>
 		</dict>
 	</array>

--- a/utils/AddressUtils.ts
+++ b/utils/AddressUtils.ts
@@ -75,6 +75,8 @@ class AddressUtils {
             value = input.split('lightning:')[1];
         } else if (input.includes('LIGHTNING:')) {
             value = input.split('LIGHTNING:')[1];
+        } else if (input.includes('zeusln:')) {
+            value = input.split('zeusln:')[1];
         } else {
             value = input;
         }

--- a/utils/LinkingUtils.ts
+++ b/utils/LinkingUtils.ts
@@ -3,12 +3,12 @@ import { localeString } from './LocaleUtils';
 import handleAnything from './handleAnything';
 
 class LinkingUtils {
-    handleInitialUrl = (navigation: any) => 
+    handleInitialUrl = (navigation: any) =>
         Linking.getInitialURL().then(
             (url) => url && this.handleDeepLink(url, navigation)
         );
 
-    handleDeepLink = (url: string, navigation: any) => 
+    handleDeepLink = (url: string, navigation: any) =>
         handleAnything(url)
             .then(([route, props]) => {
                 navigation.navigate(route, props);
@@ -17,7 +17,6 @@ class LinkingUtils {
                 console.error(localeString('views.Wallet.Wallet.error'), err)
             );
 }
-
 
 const linkingUtils = new LinkingUtils();
 export default linkingUtils;

--- a/utils/LinkingUtils.ts
+++ b/utils/LinkingUtils.ts
@@ -3,12 +3,12 @@ import { localeString } from './LocaleUtils';
 import handleAnything from './handleAnything';
 
 class LinkingUtils {
-    handleInitialUrl = (navigation: any) =>
+    handleInitialUrl = (navigation: any) => 
         Linking.getInitialURL().then(
             (url) => url && this.handleDeepLink(url, navigation)
         );
 
-    handleDeepLink = (url: string, navigation: any) =>
+    handleDeepLink = (url: string, navigation: any) => 
         handleAnything(url)
             .then(([route, props]) => {
                 navigation.navigate(route, props);
@@ -16,19 +16,8 @@ class LinkingUtils {
             .catch((err) =>
                 console.error(localeString('views.Wallet.Wallet.error'), err)
             );
-
-    handleOpenURL = (event: any) => {
-        if (event.url) {
-            this.handleDeepLink(event.url);
-        }
-    };
-
-    addEventListener = () =>
-        Linking.addEventListener('url', this.handleOpenURL);
-
-    removeEventListener = () =>
-        Linking.removeEventListener('url', this.handleOpenURL);
 }
+
 
 const linkingUtils = new LinkingUtils();
 export default linkingUtils;

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -4,7 +4,8 @@ import {
     PanResponder,
     Text,
     TouchableOpacity,
-    View
+    View,
+    Linking
 } from 'react-native';
 
 import { inject, observer } from 'mobx-react';
@@ -89,7 +90,7 @@ export default class Wallet extends React.Component<WalletProps, {}> {
     }
 
     componentWillUnmount() {
-        LinkingUtils.removeEventListener();
+        Linking.removeEventListener('url', this.handleOpenURL);
     }
 
     async getSettingsAndNavigate() {
@@ -146,7 +147,7 @@ export default class Wallet extends React.Component<WalletProps, {}> {
             setConnectingStatus
         } = SettingsStore;
         const { fiat } = settings;
-
+        
         if (!!fiat && fiat !== 'Disabled') {
             FiatStore.getFiatRates();
         }
@@ -171,10 +172,17 @@ export default class Wallet extends React.Component<WalletProps, {}> {
 
         if (connecting) {
             setConnectingStatus(false);
-            LinkingUtils.addEventListener();
+            Linking.addEventListener('url', this.handleOpenURL);
             LinkingUtils.handleInitialUrl(navigation);
         }
     }
+
+    handleOpenURL = (event: any) => {
+        const {navigation} = this.props;
+        if (event.url) {
+            LinkingUtils.handleDeepLink(event.url, navigation);
+        }
+    };
 
     render() {
         const Tab = createBottomTabNavigator();

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -147,7 +147,7 @@ export default class Wallet extends React.Component<WalletProps, {}> {
             setConnectingStatus
         } = SettingsStore;
         const { fiat } = settings;
-        
+
         if (!!fiat && fiat !== 'Disabled') {
             FiatStore.getFiatRates();
         }
@@ -178,7 +178,7 @@ export default class Wallet extends React.Component<WalletProps, {}> {
     }
 
     handleOpenURL = (event: any) => {
-        const {navigation} = this.props;
+        const { navigation } = this.props;
         if (event.url) {
             LinkingUtils.handleDeepLink(event.url, navigation);
         }


### PR DESCRIPTION
Relates to issue #888 

Adding the following for deep links:
1. Adding 'zeusln' scheme for deep links because iOS opens up the last installed wallet with the scheme 'lightning'.

2. There was a bug on iOS where deep links were not being handled, and it was only happening when Zeus was already running in the background. If Zeus is completely closed, an LNURL deep link works fine - it will open up the app and bring up the Send page. However, if Zeus was running in the background, the deep link would just open up the app to the Wallet page and do nothing. This is happening because iOS Zeus was not configured for deep links as specified [here](https://reactnative.dev/docs/linking). Also, once it was configured correctly, there was a bug where `handleOpenURL` calls `handleDeepLink`, but does not pass in `navigation`.
