### PR TITLE
Update default settings

### DIFF
--- a/stores/FeeStore.ts
+++ b/stores/FeeStore.ts
@@ -1,10 +1,11 @@
 import { action, observable } from 'mobx';
 import ReactNativeBlobUtil from 'react-native-blob-util';
+import BigNumber from 'bignumber.js';
+
 import RESTUtils from './../utils/RESTUtils';
 import Base64Utils from './../utils/Base64Utils';
 import ForwardEvent from './../models/ForwardEvent';
 import SettingsStore from './SettingsStore';
-import BigNumber from 'bignumber.js';
 
 export default class FeeStore {
     @observable public fees: any = {};

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -130,9 +130,9 @@ export default class SettingsStore {
         privacy: {
             defaultBlockExplorer: 'mempool.space',
             customBlockExplorer: '',
-            clipboard: false,
+            clipboard: true,
             lurkerMode: false,
-            enableMempoolRates: false
+            enableMempoolRates: true
         }
     };
     @observable public loading = false;
@@ -301,7 +301,6 @@ export default class SettingsStore {
                     this.certVerification = node.certVerification || false;
                     this.enableTor = node.enableTor;
                 }
-                return this.settings;
             } else {
                 console.log('No credentials stored');
             }
@@ -310,6 +309,8 @@ export default class SettingsStore {
         } finally {
             this.loading = false;
         }
+
+        return this.settings;
     }
 
     @action


### PR DESCRIPTION
# Description

Updates the default settings so that `Read Clipboard` and `Fetch rates from Mempool.space` are on by default. This update will preserve settings on existing installations.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
