### PR TITLE
Tighten up login process

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -157,6 +157,7 @@
     "views.Wallet.Wallet.invoices": "Invoices",
     "views.Wallet.Wallet.onchain": "On-chain",
     "views.Wallet.Wallet.channels": "Channels",
+    "views.Wallet.Wallet.startingUp": "Zeus is starting up.",
     "views.Wallet.Wallet.connecting": "Zeus is connecting to your node.",
     "views.Wallet.restart": "Restart",
     "views.BTCPayConfigQRScanner.text": "Scan a BTCPay Config under Settings > Services > LND Rest",

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -205,7 +205,8 @@ export default class Wallet extends React.Component<WalletProps, {}> {
         const { implementation, settings, loggedIn, connecting } =
             SettingsStore;
         const loginRequired =
-            !settings || (settings && settings.passphrase && !loggedIn);
+            !settings ||
+            (settings && (settings.passphrase || settings.pin) && !loggedIn);
         const dataAvailable = implementation === 'lndhub' || nodeInfo.version;
 
         const WalletScreen = () => {
@@ -384,32 +385,40 @@ export default class Wallet extends React.Component<WalletProps, {}> {
                                         padding: 8
                                     }}
                                 >
-                                    {localeString(
-                                        'views.Wallet.Wallet.connecting'
-                                    )}
+                                    {settings.nodes
+                                        ? localeString(
+                                              'views.Wallet.Wallet.connecting'
+                                          )
+                                        : localeString(
+                                              'views.Wallet.Wallet.startingUp'
+                                          )}
                                 </Text>
                                 <LoadingIndicator size={120} />
                             </View>
-                            <View
-                                style={{
-                                    bottom: 56
-                                }}
-                            >
-                                <Button
-                                    title={localeString('views.Settings.title')}
-                                    containerStyle={{
-                                        width: 320
+                            {settings.nodes && (
+                                <View
+                                    style={{
+                                        bottom: 56
                                     }}
-                                    titleStyle={{
-                                        color: 'white'
-                                    }}
-                                    onPress={() =>
-                                        navigation.navigate('Settings')
-                                    }
-                                    adaptiveWidth
-                                    iconOnly
-                                />
-                            </View>
+                                >
+                                    <Button
+                                        title={localeString(
+                                            'views.Settings.title'
+                                        )}
+                                        containerStyle={{
+                                            width: 320
+                                        }}
+                                        titleStyle={{
+                                            color: 'white'
+                                        }}
+                                        onPress={() =>
+                                            navigation.navigate('Settings')
+                                        }
+                                        adaptiveWidth
+                                        iconOnly
+                                    />
+                                </View>
+                            )}
                         </View>
                     )}
                 </View>

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -395,30 +395,33 @@ export default class Wallet extends React.Component<WalletProps, {}> {
                                 </Text>
                                 <LoadingIndicator size={120} />
                             </View>
-                            {settings.nodes && (
-                                <View
-                                    style={{
-                                        bottom: 56
+                            <View
+                                style={{
+                                    bottom: 56
+                                }}
+                            >
+                                <Button
+                                    title={
+                                        settings.nodes
+                                            ? localeString(
+                                                  'views.Settings.title'
+                                              )
+                                            : null
+                                    }
+                                    containerStyle={{
+                                        width: 320
                                     }}
-                                >
-                                    <Button
-                                        title={localeString(
-                                            'views.Settings.title'
-                                        )}
-                                        containerStyle={{
-                                            width: 320
-                                        }}
-                                        titleStyle={{
-                                            color: 'white'
-                                        }}
-                                        onPress={() =>
-                                            navigation.navigate('Settings')
-                                        }
-                                        adaptiveWidth
-                                        iconOnly
-                                    />
-                                </View>
-                            )}
+                                    titleStyle={{
+                                        color: 'white'
+                                    }}
+                                    onPress={() => {
+                                        if (settings.nodes)
+                                            navigation.navigate('Settings');
+                                    }}
+                                    adaptiveWidth
+                                    iconOnly
+                                />
+                            </View>
                         </View>
                     )}
                 </View>


### PR DESCRIPTION
# Description

Previously you were able to:

If pin or password was set:
- Get to settings at start-up by tapping the settings button on the connecting screen

If pin was set:
- From the pinpad login view, get to settings by navigating back to the connecting screen and tapping the settings button

This PR:
- Ensures you cannot navigate back to the connecting screen from the pinpad login
- Creates a new 'Zeus is starting up' view without a Settings button, during which settings are loaded

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [x] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
