### PR TITLE
Unconfirmed balance hot fix

### DIFF
--- a/stores/BalanceStore.ts
+++ b/stores/BalanceStore.ts
@@ -86,7 +86,8 @@ export default class BalanceStore {
                 }
                 this.loadingBlockchainBalance = false;
                 return {
-                    unconfirmedBlockchainBalance: confirmedBlockchainBalance,
+                    unconfirmedBlockchainBalance,
+                    confirmedBlockchainBalance,
                     totalBlockchainBalance,
                     accounts
                 };


### PR DESCRIPTION
Error in https://github.com/ZeusLN/zeus/pull/913/commits/7e30d265583f5e53366a61fcc468814d792c5abb sets the confirmed balance as the unconfirmed balance and does not return the confirmed balance at all.

https://github.com/ZeusLN/zeus/pull/913/files#diff-1b1ab925e436632e85604044e7813783665a20ad5664918a067c7d20dfafab92R89