### PR TITLE
ZEUS-954: [LND] Channel view: Initiating node label incorrect

### DIFF
--- a/components/FeeBreakdown.tsx
+++ b/components/FeeBreakdown.tsx
@@ -26,6 +26,7 @@ interface FeeBreakdownProps {
     channelId: string;
     channelPoint: string;
     peerDisplay?: string;
+    initiator?: boolean;
 }
 
 @inject('FeeStore', 'ChannelsStore', 'NodeInfoStore', 'SettingsStore')
@@ -39,6 +40,7 @@ export default class FeeBreakdown extends React.Component<
             channelId,
             channelPoint,
             peerDisplay,
+            initiator,
             ChannelsStore,
             FeeStore,
             NodeInfoStore,
@@ -63,7 +65,16 @@ export default class FeeBreakdown extends React.Component<
                                     color: themeColor('text')
                                 }}
                             >
-                                {localeString('views.Channel.initiatingParty')}
+                                {(chanInfo[channelId].node1_pub === nodeId &&
+                                    initiator) ||
+                                (chanInfo[channelId].node1_pub !== nodeId &&
+                                    !initiator)
+                                    ? localeString(
+                                          'views.Channel.initiatingParty'
+                                      )
+                                    : localeString(
+                                          'views.Channel.counterparty'
+                                      )}
                             </Text>
                             <Text
                                 style={{
@@ -219,7 +230,17 @@ export default class FeeBreakdown extends React.Component<
                                         color: themeColor('text')
                                     }}
                                 >
-                                    {localeString('views.Channel.counterparty')}
+                                    {(chanInfo[channelId].node2_pub ===
+                                        nodeId &&
+                                        initiator) ||
+                                    (chanInfo[channelId].node2_pub !== nodeId &&
+                                        !initiator)
+                                        ? localeString(
+                                              'views.Channel.initiatingParty'
+                                          )
+                                        : localeString(
+                                              'views.Channel.counterparty'
+                                          )}
                                 </Text>
                                 <Text
                                     style={{

--- a/models/Channel.ts
+++ b/models/Channel.ts
@@ -28,6 +28,7 @@ export default class Channel extends BaseModel {
     remote_pubkey: string;
     capacity: string;
     private: boolean;
+    initiator?: boolean;
     // c-lightning
     @observable
     state: string;

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -139,7 +139,8 @@ export default class ChannelView extends React.Component<
             remote_pubkey,
             capacity,
             alias,
-            channelId
+            channelId,
+            initiator
         } = channel;
         const privateChannel = channel.private;
 
@@ -355,6 +356,7 @@ export default class ChannelView extends React.Component<
                             channelId={channelId}
                             peerDisplay={peerDisplay}
                             channelPoint={channel_point}
+                            initiator={initiator}
                         />
                     )}
 


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-954**](https://github.com/ZeusLN/zeus/issues/954)

We should leverage the `initiator` bool value on the `ListChannels` call for this. First node returned from a chan policy call is not necessarily the initiator - nodes are returned lexicographically by pubkey. 

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you added new functionality or fixed a bug, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
