### PR TITLE
Fix SpendUnconfirmed true with MinConfs > 0 bug

### DIFF
--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -274,7 +274,9 @@ export default class ChannelsStore {
                         outputs
                     },
                     sat_per_vbyte: Number(sat_per_byte),
-                    spend_unconfirmed: true
+                    spend_unconfirmed:
+                        openChanRequest.min_confs &&
+                        openChanRequest.min_confs === 0
                 };
 
                 RESTUtils.fundPsbt(fundPsbtRequest)

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -69,7 +69,7 @@ export default class OpenChannel extends React.Component<
             node_pubkey_string: '',
             local_funding_amount: '',
             min_confs: 1,
-            spend_unconfirmed: true,
+            spend_unconfirmed: false,
             sat_per_byte: '2',
             private: false,
             host: '',
@@ -409,11 +409,13 @@ export default class OpenChannel extends React.Component<
                         keyboardType="numeric"
                         placeholder={'1'}
                         value={min_confs.toString()}
-                        onChangeText={(text: string) =>
+                        onChangeText={(text: string) => {
+                            const newMinConfs = Number(text) || min_confs;
                             this.setState({
-                                min_confs: Number(text) || min_confs
-                            })
-                        }
+                                min_confs: newMinConfs,
+                                spend_unconfirmed: newMinConfs === 0
+                            });
+                        }}
                         editable={!openingChannel}
                     />
 

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -410,7 +410,7 @@ export default class OpenChannel extends React.Component<
                         placeholder={'1'}
                         value={min_confs.toString()}
                         onChangeText={(text: string) => {
-                            const newMinConfs = Number(text) || min_confs;
+                            const newMinConfs = Number(text);
                             this.setState({
                                 min_confs: newMinConfs,
                                 spend_unconfirmed: newMinConfs === 0


### PR DESCRIPTION
Screenshot of bug below. Changed so that we only set `spend_unconfirmed` true when `min_confs` is zero. Also changed the open channel screen to allow `min_confs` to be set to zero.

![telegram-cloud-photo-size-1-5145582666031147524-y](https://user-images.githubusercontent.com/93104057/166128743-c96a137d-ac87-4ecc-a8e6-babbe135bb55.jpg)