### PR TITLE
LNDHub: transactions call fix

### DIFF
--- a/stores/ActivityStore.ts
+++ b/stores/ActivityStore.ts
@@ -9,7 +9,9 @@ import SettingsStore from './SettingsStore';
 import PaymentsStore from './PaymentsStore';
 import InvoicesStore from './InvoicesStore';
 import TransactionsStore from './TransactionsStore';
+
 import { localeString } from './../utils/LocaleUtils';
+import RESTUtils from './../utils/RESTUtils';
 
 interface ActivityFilter {
     [index: string]: any;
@@ -82,7 +84,8 @@ export default class ActivityStore {
         this.loading = true;
         this.activity = [];
         await this.paymentsStore.getPayments();
-        await this.transactionsStore.getTransactions();
+        if (RESTUtils.supportsOnchainSends())
+            await this.transactionsStore.getTransactions();
         await this.invoicesStore.getInvoices();
         const activity: any = [];
         const payments = this.paymentsStore.payments;
@@ -92,7 +95,9 @@ export default class ActivityStore {
         // push payments, txs, invoices to one array
         activity.push.apply(
             activity,
-            payments.concat(transactions).concat(invoices)
+            RESTUtils.supportsOnchainSends()
+                ? payments.concat(transactions).concat(invoices)
+                : payments.concat(invoices)
         );
         // sort activity by timestamp
         const sortedActivity = activity.sort((a: any, b: any) =>


### PR DESCRIPTION
# Description

LNDHub doesn't support on-chain payments, so make sure it doesn't call the Transactions call when fetching activity.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [ ] I’ve run `npm run tsc` and made sure my code compiles correctly
- [ ] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
