### PR TITLE
Add missing `BITCOIN:` url scheme for iOS

### DIFF
--- a/ios/zeus/Info.plist
+++ b/ios/zeus/Info.plist
@@ -28,6 +28,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>bitcoin</string>
+				<string>BITCOIN</string>
 				<string>lightning</string>
 				<string>LIGHTNING</string>
 				<string>lnurl</string>


### PR DESCRIPTION
This was already done in android but not for iOS