### PR TITLE
LND: handle commas when setting channel fees

### DIFF
--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -253,10 +253,14 @@ export default class LND {
         this.getRequest(`/v1/graph/node/${urlParams && urlParams[0]}`);
     getFees = () => this.getRequest('/v1/fees');
     setFees = (data: any) => {
+        // handle commas in place of decimals
+        const base_fee_msat = data.base_fee_msat.replace(/,/g, '.');
+        const fee_rate = data.fee_rate.replace(/,/g, '.');
+
         if (data.global) {
             return this.postRequest('/v1/chanpolicy', {
-                base_fee_msat: data.base_fee_msat,
-                fee_rate: `${Number(data.fee_rate) / 100}`,
+                base_fee_msat,
+                fee_rate: `${Number(fee_rate) / 100}`,
                 global: true,
                 time_lock_delta: Number(data.time_lock_delta),
                 min_htlc_msat: data.min_htlc
@@ -269,8 +273,8 @@ export default class LND {
             });
         }
         return this.postRequest('/v1/chanpolicy', {
-            base_fee_msat: data.base_fee_msat,
-            fee_rate: `${Number(data.fee_rate) / 100}`,
+            base_fee_msat,
+            fee_rate: `${Number(fee_rate) / 100}`,
             chan_point: {
                 funding_txid_str: data.chan_point.funding_txid_str,
                 output_index: data.chan_point.output_index


### PR DESCRIPTION
# Description

Some locales use commas in place of decimals and this is reflected on systems' numeric keyboards. This PR handles those commas before passing them to the LND API.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
