### PR TITLE
CLN: createInvoice: expiry fix

### DIFF
--- a/backends/CLightningREST.ts
+++ b/backends/CLightningREST.ts
@@ -77,7 +77,7 @@ export default class CLightningREST extends LND {
             description: data.memo,
             label: 'zeus.' + Math.random() * 1000000,
             amount: Number(data.value) * 1000,
-            expiry: data.expiry,
+            expiry: Math.round(Date.now() / 1000) + Number(data.expiry),
             private: true
         });
     getPayments = () => this.getRequest('/v1/pay/listPays');

--- a/backends/Spark.ts
+++ b/backends/Spark.ts
@@ -163,7 +163,7 @@ export default class Spark {
             description: data.memo,
             label: 'zeus.' + Math.random() * 1000000,
             msatoshi: Number(data.value) * 1000,
-            expiry: data.expiry,
+            expiry: Math.round(Date.now() / 1000) + Number(data.expiry),
             exposeprivatechannels: true
         });
     getPayments = () =>


### PR DESCRIPTION
# Description

CLN interfaces were incorrectly setting expiry using time in seconds instead of UNIX timestamp (time since epoch)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [x] c-lightning-REST
- [x] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
