### PR TITLE
Add lndhub.io as the first custodial lndhub

### DIFF
--- a/utils/AddressUtils.test.ts
+++ b/utils/AddressUtils.test.ts
@@ -357,7 +357,7 @@ describe('AddressUtils', () => {
                         'lndhub://9a1e4e972f732352c75e:4a1e4e172f732352c75e'
                     )
                 ).toEqual({
-                    host: 'https://lndhub.herokuapp.com',
+                    host: 'https://lndhub.io',
                     username: '9a1e4e972f732352c75e',
                     password: '4a1e4e172f732352c75e'
                 });

--- a/utils/AddressUtils.ts
+++ b/utils/AddressUtils.ts
@@ -23,6 +23,7 @@ const lightningAddress =
 const blueWalletAddress = /^bluewallet:setlndhuburl\?url=(\S+)/;
 
 export const CUSTODIAL_LNDHUBS = [
+    'https://lndhub.io',
     'https://lndhub.herokuapp.com',
     'https://legend.lnbits.com/wallet',
     'https://infinity.lnbits.com/wallet',

--- a/utils/AddressUtils.ts
+++ b/utils/AddressUtils.ts
@@ -105,7 +105,7 @@ class AddressUtils {
                 host = serverURL;
             } else {
                 value = input;
-                host = CUSTODIAL_LNDHUB[0];
+                host = CUSTODIAL_LNDHUBS[0];
             }
 
             const [username, password] = value.split(':');


### PR DESCRIPTION
# Description

It seems that BlueWallet is connecting to `lndhub.io` by default and by looking at https://lndhub.io and https://lndhub.herokuapp.com it seems these two are using the same backend

Commit 5db5082 fixes a typo in variable name introduced by a464ab3

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other
