### PR TITLE
Fix animation transition for middle action in SwippeableRow

### DIFF
--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -95,7 +95,7 @@ export default class LightningSwipeableRow extends Component<
             {RESTUtils.supportsRouting() &&
                 this.renderAction(
                     localeString('general.routing'),
-                    100,
+                    200,
                     progress
                 )}
             {this.renderAction(

--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -31,9 +31,13 @@ export default class LightningSwipeableRow extends Component<
         x: number,
         progress: Animated.AnimatedInterpolation
     ) => {
-        const trans = progress.interpolate({
+        const transTranslateX = progress.interpolate({
             inputRange: [0.25, 1],
             outputRange: [x, 0]
+        });
+        const transOpacity = progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, 1]
         });
         const pressHandler = () => {
             this.close();
@@ -49,7 +53,11 @@ export default class LightningSwipeableRow extends Component<
 
         return (
             <Animated.View
-                style={{ flex: 1, transform: [{ translateX: trans }] }}
+                style={{
+                    flex: 1,
+                    transform: [{ translateX: transTranslateX }],
+                    opacity: transOpacity
+                }}
             >
                 <RectButton style={[styles.action]} onPress={pressHandler}>
                     {text === localeString('general.routing') && (

--- a/components/LayerBalances/OnchainSwipeableRow.tsx
+++ b/components/LayerBalances/OnchainSwipeableRow.tsx
@@ -93,7 +93,7 @@ export default class OnchainSwipeableRow extends Component<
                 progress
             )}
             {RESTUtils.supportsCoinControl() &&
-                this.renderAction(localeString('general.coins'), 100, progress)}
+                this.renderAction(localeString('general.coins'), 200, progress)}
             {this.renderAction(
                 localeString('general.send'),
                 RESTUtils.supportsCoinControl() ? 200 : 135,

--- a/components/LayerBalances/OnchainSwipeableRow.tsx
+++ b/components/LayerBalances/OnchainSwipeableRow.tsx
@@ -89,14 +89,14 @@ export default class OnchainSwipeableRow extends Component<
         >
             {this.renderAction(
                 localeString('general.receive'),
-                RESTUtils.supportsRouting() ? 200 : 135,
+                RESTUtils.supportsCoinControl() ? 200 : 135,
                 progress
             )}
             {RESTUtils.supportsCoinControl() &&
                 this.renderAction(localeString('general.coins'), 100, progress)}
             {this.renderAction(
                 localeString('general.send'),
-                RESTUtils.supportsRouting() ? 200 : 135,
+                RESTUtils.supportsCoinControl() ? 200 : 135,
                 progress
             )}
         </View>

--- a/components/LayerBalances/OnchainSwipeableRow.tsx
+++ b/components/LayerBalances/OnchainSwipeableRow.tsx
@@ -31,9 +31,13 @@ export default class OnchainSwipeableRow extends Component<
         x: number,
         progress: Animated.AnimatedInterpolation
     ) => {
-        const trans = progress.interpolate({
+        const transTranslateX = progress.interpolate({
             inputRange: [0.25, 1],
             outputRange: [x, 0]
+        });
+        const transOpacity = progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, 1]
         });
         const pressHandler = () => {
             this.close();
@@ -49,7 +53,11 @@ export default class OnchainSwipeableRow extends Component<
 
         return (
             <Animated.View
-                style={{ flex: 1, transform: [{ translateX: trans }] }}
+                style={{
+                    flex: 1,
+                    transform: [{ translateX: transTranslateX }],
+                    opacity: transOpacity
+                }}
             >
                 <RectButton style={[styles.action]} onPress={pressHandler}>
                     {text === localeString('general.coins') && (


### PR DESCRIPTION
# Description

Relates to issue: None

Fix animation transition for middle action in both OnchainSwippeableRow and LightningSwippeableRow.
In fact, the middle button (if supported) had a different animation width compared to other, resulting in strange result.

Before:

[Before](https://user-images.githubusercontent.com/35492518/177412569-d08b90f0-1b4f-49df-b212-7be05d01b969.webm)

After:

[After](https://user-images.githubusercontent.com/35492518/177412595-447b74df-a793-4977-9e88-df37f2a4b7ca.webm)

Tested with Nexus 5 (emulated)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
