### PR TITLE
Bug fix: Custom block explorer url force prefixed with https:/

### DIFF
--- a/utils/UrlUtils.ts
+++ b/utils/UrlUtils.ts
@@ -21,7 +21,7 @@ const goToBlockExplorer = (
     let url: string = `https://${host}/${testnet ? 'testnet/' : ''}${path}/${value}`;
     if (custom && host.indexOf('://') !== -1)
     {
-        // handle <schema>://<ip>:<port>#mempool.space
+        // handle <scheme>://<ip>:<port>#mempool.space
         url = `${host.split('#')[0]}/${testnet ? 'testnet/' : ''}${path}/${value}`;
     }
     goToUrl(url);

--- a/utils/UrlUtils.ts
+++ b/utils/UrlUtils.ts
@@ -19,10 +19,13 @@ const goToBlockExplorer = (
     }
 
     let url: string = `https://${host}/${testnet ? 'testnet/' : ''}${path}/${value}`;
+    
+    // Handle url <scheme>://<ip|host_name>:<port>[#convention_hint] in host
+    // Currently '...#mempool.space' is the only meaningful convention hint
     if (custom && host.indexOf('://') !== -1)
     {
-        // handle <scheme>://<ip>:<port>#mempool.space
-        url = `${host.split('#')[0]}/${testnet ? 'testnet/' : ''}${path}/${value}`;
+        const hostUrl = host.split('#')[0];  // Strip optional url convention hints
+        url = `${hostUrl}/${testnet ? 'testnet/' : ''}${path}/${value}`;
     }
     goToUrl(url);
 };

--- a/utils/UrlUtils.ts
+++ b/utils/UrlUtils.ts
@@ -8,21 +8,21 @@ const goToBlockExplorer = (
 ) => {
     const { settings } = stores.settingsStore;
     const { privacy } = settings;
-    const host =
-        privacy && privacy.defaultBlockExplorer === 'Custom'
+    const custom = privacy && privacy.defaultBlockExplorer === 'Custom';
+    const host = custom
             ? privacy.customBlockExplorer
             : (privacy && privacy.defaultBlockExplorer) || 'mempool.space';
 
     let path: string = type;
     if (type === 'block-height') {
-        // this logic fails, when running own mempool.space instance!
-        path = host === 'mempool.space' ? 'block' : 'block-height';
+        path = host.endsWith('mempool.space') ? 'block' : 'block-height';
     }
 
     let url: string = `https://${host}/${testnet ? 'testnet/' : ''}${path}/${value}`;
-    if (host.indexOf('://') !== -1)
+    if (custom && host.indexOf('://') !== -1)
     {
-        url = `${host}/${testnet ? 'testnet/' : ''}${path}/${value}`;
+        // handle <schema>://<ip>:<port>#mempool.space
+        url = `${host.split('#')[0]}/${testnet ? 'testnet/' : ''}${path}/${value}`;
     }
     goToUrl(url);
 };

--- a/utils/UrlUtils.ts
+++ b/utils/UrlUtils.ts
@@ -19,7 +19,7 @@ const goToBlockExplorer = (
         path = host.endsWith('mempool.space') ? 'block' : 'block-height';
     }
 
-    let url: string = `https://${host}/${network}${path}/${value}`;
+    let url = `https://${host}/${network}${path}/${value}`;
 
     // Handle url <scheme>://<ip|host_name>:<port>[#convention_hint] in host
     // Currently '...#mempool.space' is the only meaningful convention hint

--- a/utils/UrlUtils.ts
+++ b/utils/UrlUtils.ts
@@ -15,10 +15,15 @@ const goToBlockExplorer = (
 
     let path: string = type;
     if (type === 'block-height') {
+        // this logic fails, when running own mempool.space instance!
         path = host === 'mempool.space' ? 'block' : 'block-height';
     }
 
-    const url = `https://${host}/${testnet ? 'testnet/' : ''}${path}/${value}`;
+    let url: string = `https://${host}/${testnet ? 'testnet/' : ''}${path}/${value}`;
+    if (host.indexOf('://') !== -1)
+    {
+        url = `${host}/${testnet ? 'testnet/' : ''}${path}/${value}`;
+    }
     goToUrl(url);
 };
 

--- a/utils/UrlUtils.ts
+++ b/utils/UrlUtils.ts
@@ -10,22 +10,22 @@ const goToBlockExplorer = (
     const { privacy } = settings;
     const custom = privacy && privacy.defaultBlockExplorer === 'Custom';
     const host = custom
-            ? privacy.customBlockExplorer
-            : (privacy && privacy.defaultBlockExplorer) || 'mempool.space';
+        ? privacy.customBlockExplorer
+        : (privacy && privacy.defaultBlockExplorer) || 'mempool.space';
+    const network = testnet ? 'testnet/' : '';
 
     let path: string = type;
     if (type === 'block-height') {
         path = host.endsWith('mempool.space') ? 'block' : 'block-height';
     }
 
-    let url: string = `https://${host}/${testnet ? 'testnet/' : ''}${path}/${value}`;
-    
+    let url: string = `https://${host}/${network}${path}/${value}`;
+
     // Handle url <scheme>://<ip|host_name>:<port>[#convention_hint] in host
     // Currently '...#mempool.space' is the only meaningful convention hint
-    if (custom && host.indexOf('://') !== -1)
-    {
-        const hostUrl = host.split('#')[0];  // Strip optional url convention hints
-        url = `${hostUrl}/${testnet ? 'testnet/' : ''}${path}/${value}`;
+    if (custom && host.indexOf('://') !== -1) {
+        const hostUrl = host.split('#')[0]; // Strip optional url convention hints
+        url = `${hostUrl}/${network}${path}/${value}`;
     }
     goToUrl(url);
 };


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1051**](https://github.com/ZeusLN/zeus/issues/1051)

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [ ] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [X] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
