### PR TITLE
Remove jsBundleURLForBundleRoot fallbackResource

### DIFF
--- a/ios/zeus/AppDelegate.m
+++ b/ios/zeus/AppDelegate.m
@@ -61,7 +61,7 @@ static void InitializeFlipper(UIApplication *application) {
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
 #if DEBUG
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif


### PR DESCRIPTION
Wasn't able to build the app without this change, followed the instructions [here](https://github.com/facebook/react-native/issues/33451).