### PR TITLE
Style pinpad to avoid overlap on smaller screens

### DIFF
--- a/components/PinPad.tsx
+++ b/components/PinPad.tsx
@@ -228,7 +228,7 @@ const styles = StyleSheet.create({
     },
     bottom: {
         justifyContent: 'flex-end',
-        marginBottom: 75
+        marginBottom: 25
     },
     key: {
         flex: 1,

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -447,7 +447,7 @@ export default class Lockscreen extends React.Component<
                                     <View
                                         style={{
                                             flex: 2,
-                                            marginTop: 50,
+                                            marginTop: 25,
                                             marginBottom: 25
                                         }}
                                     >
@@ -464,7 +464,7 @@ export default class Lockscreen extends React.Component<
                                         <View
                                             style={{
                                                 flex: 2,
-                                                marginTop: 125,
+                                                marginTop: 25,
                                                 marginBottom: 25
                                             }}
                                         >

--- a/views/Settings/SetPin.tsx
+++ b/views/Settings/SetPin.tsx
@@ -267,7 +267,7 @@ const styles = StyleSheet.create({
         fontFamily: 'Lato-Regular',
         fontSize: 20,
         textAlign: 'center',
-        marginTop: 50
+        marginTop: 10
     },
     secondaryText: {
         fontFamily: 'Lato-Regular',


### PR DESCRIPTION
Before screenshots on smaller screen (iPhone SE):

![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-08-31 at 18 45 25](https://user-images.githubusercontent.com/93104057/187806785-4f862ee4-ae2d-4adc-9288-fff8464616a5.png)
![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-08-31 at 18 45 57](https://user-images.githubusercontent.com/93104057/187806796-5bbbb7bd-373c-4f63-b720-c94a3db19deb.png)

After screenshots on smaller screen (iPhone SE):

![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-08-31 at 19 11 48](https://user-images.githubusercontent.com/93104057/187806824-eb17650d-5164-4cf9-96aa-2fa14dd28f86.png)
![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-08-31 at 19 11 17](https://user-images.githubusercontent.com/93104057/187806825-4b647dd2-2e3e-45ca-8592-4478f14f4dad.png)

After screenshots on modern phone (iPhone 11 Pro):

![Simulator Screen Shot - iPhone 11 Pro - 2022-08-31 at 19 15 24](https://user-images.githubusercontent.com/93104057/187806884-b3c23f23-8e44-4d85-8541-783f5359351d.png)
![Simulator Screen Shot - iPhone 11 Pro - 2022-08-31 at 19 14 46](https://user-images.githubusercontent.com/93104057/187806885-16d62f7e-cc06-4dcb-9505-c56b442375fa.png)

