### PR TITLE
Sponsors: fix display on iPod Touch

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -345,8 +345,8 @@ PODS:
     - React-RCTImage
   - RNSecureKeyStore (1.0.0):
     - React
-  - RNSVG (9.13.6):
-    - React
+  - RNSVG (13.0.0):
+    - React-Core
   - RNVectorIcons (7.1.0):
     - React
   - TcpSockets (3.3.2):
@@ -532,10 +532,10 @@ SPEC CHECKSUMS:
   FBLazyVector: a7a655862f6b09625d11c772296b01cd5164b648
   FBReactNativeSpec: 81ce99032d5b586fddd6a38d450f8595f7e04be4
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
+  glog: 476ee3e89abb49e07f822b48323c51c57124b572
   hermes-engine: 84e3af1ea01dd7351ac5d8689cbbea1f9903ffc3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
+  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 3e917ea5377751094f38145fdece525aa90545a0
   RCTTypeSafety: c43c072a4bd60feb49a9570b0517892b4305c45e
   React: 176dd882de001854ced260fad41bb68a31aa4bd0
@@ -579,7 +579,7 @@ SPEC CHECKSUMS:
   RNOS: 6f2f9a70895bbbfbdad7196abd952e7b01d45027
   RNScreens: 522705f2e5c9d27efb17f24aceb2bf8335bc7b8e
   RNSecureKeyStore: f1ad870e53806453039f650720d2845c678d89c8
-  RNSVG: 8ba35cbeb385a52fd960fd28db9d7d18b4c2974f
+  RNSVG: 42a0c731b11179ebbd27a3eeeafa7201ebb476ff
   RNVectorIcons: bc69e6a278b14842063605de32bec61f0b251a59
   TcpSockets: 14306fb79f9750ea7d2ddd02d8bed182abb01797
   Yoga: 99652481fcd320aefa4a7ef90095b95acd181952

--- a/views/Settings/Gods.tsx
+++ b/views/Settings/Gods.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FlatList, Text, View } from 'react-native';
+import { Dimensions, FlatList, Text, View } from 'react-native';
 import { Avatar, Header, Icon, ListItem } from 'react-native-elements';
 import { inject, observer } from 'mobx-react';
 
@@ -77,13 +77,16 @@ export default class Gods extends React.Component<GodsProps, {}> {
                                     }
                                 >
                                     <Avatar
-                                        size={76}
+                                        size={
+                                            Dimensions.get('window').width / 4 -
+                                            13
+                                        }
                                         rounded
                                         source={{
                                             uri: `https://zeusln.app/api/twitter-images/${item.handle}.jpg`
                                         }}
                                         key={1}
-                                        containerStyle={{ margin: 10 }}
+                                        containerStyle={{ margin: 5 }}
                                     />
                                 </ListItem>
                             )}

--- a/views/Settings/Mortals.tsx
+++ b/views/Settings/Mortals.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FlatList, Text, View } from 'react-native';
+import { Dimensions, FlatList, Text, View } from 'react-native';
 import { Avatar, Header, Icon, ListItem } from 'react-native-elements';
 import { inject, observer } from 'mobx-react';
 
@@ -77,13 +77,16 @@ export default class Mortals extends React.Component<MortalsProps, {}> {
                                     }
                                 >
                                     <Avatar
-                                        size={60}
+                                        size={
+                                            Dimensions.get('window').width / 5 -
+                                            10
+                                        }
                                         rounded
                                         source={{
                                             uri: `https://zeusln.app/api/twitter-images/${item.handle}.jpg`
                                         }}
                                         key={1}
-                                        containerStyle={{ margin: 7 }}
+                                        containerStyle={{ margin: 5 }}
                                     />
                                 </ListItem>
                             )}

--- a/views/Settings/Olympians.tsx
+++ b/views/Settings/Olympians.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FlatList, Text, View } from 'react-native';
+import { Dimensions, FlatList, Text, View } from 'react-native';
 import { Avatar, Header, Icon, ListItem } from 'react-native-elements';
 import { inject, observer } from 'mobx-react';
 
@@ -77,13 +77,16 @@ export default class Olympians extends React.Component<OlympiansProps, {}> {
                                     }
                                 >
                                     <Avatar
-                                        size={100}
+                                        size={
+                                            Dimensions.get('window').width / 3 -
+                                            20
+                                        }
                                         rounded
                                         source={{
                                             uri: `https://zeusln.app/api/twitter-images/${item.handle}.jpg`
                                         }}
                                         key={1}
-                                        containerStyle={{ margin: 10 }}
+                                        containerStyle={{ margin: 8 }}
                                     />
                                 </ListItem>
                             )}


### PR DESCRIPTION
Before (iPod Touch):

![Simulator Screen Shot - iPod touch (7th generation) - 2022-09-05 at 19 51 32](https://user-images.githubusercontent.com/1878621/188522136-50e88993-0ebb-4cbe-84a9-bcb54cf6aa73.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2022-09-05 at 19 51 15](https://user-images.githubusercontent.com/1878621/188522138-fc323670-1d4e-4a8b-afdb-e286d75e92ed.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2022-09-05 at 19 50 55](https://user-images.githubusercontent.com/1878621/188522139-94f608f8-b019-41cb-bf7a-cadb88798821.png)

After (iPod Touch):

![Simulator Screen Shot - iPod touch (7th generation) - 2022-09-05 at 20 00 50](https://user-images.githubusercontent.com/1878621/188522155-33ca26e1-e84f-4026-9e9a-eb220212da6c.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2022-09-05 at 20 00 46](https://user-images.githubusercontent.com/1878621/188522158-ff8fce06-1f61-4632-9645-ef6d9e8411d3.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2022-09-05 at 20 00 42](https://user-images.githubusercontent.com/1878621/188522159-abeade66-a774-4cc6-adf3-62c9e34d85ec.png)

After (iPhone 11 Pro Max):

![Simulator Screen Shot - iPhone 11 Pro Max - 2022-09-05 at 20 01 04](https://user-images.githubusercontent.com/1878621/188522174-2e88ccef-8081-472a-9fb6-5d0e233b3cca.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2022-09-05 at 20 00 59](https://user-images.githubusercontent.com/1878621/188522176-2e13dae1-8b10-41df-801a-c9d840781104.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2022-09-05 at 20 00 55](https://user-images.githubusercontent.com/1878621/188522178-2d3684bb-7c3f-4a26-b122-81a1f990a5f1.png)

