### PR TITLE
SetFeesForm: only display Timelock Delta field for LND

### DIFF
--- a/components/SetFeesForm.tsx
+++ b/components/SetFeesForm.tsx
@@ -194,31 +194,31 @@ export default class SetFeesForm extends React.Component<
                             autoCorrect={false}
                         />
 
-                        <Text
-                            style={{
-                                ...styles.text,
-                                color: themeColor('secondaryText')
-                            }}
-                        >
-                            {localeString(
-                                'components.SetFeesForm.timeLockDelta'
-                            )}
-                        </Text>
-                        <TextInput
-                            keyboardType="numeric"
-                            placeholder={timeLockDelta || '144'}
-                            value={newTimeLockDelta}
-                            onChangeText={(text: string) =>
-                                this.setState({
-                                    newTimeLockDelta: text
-                                })
-                            }
-                            autoCapitalize="none"
-                            autoCorrect={false}
-                        />
-
                         {implementation === 'lnd' && (
                             <>
+                                <Text
+                                    style={{
+                                        ...styles.text,
+                                        color: themeColor('secondaryText')
+                                    }}
+                                >
+                                    {localeString(
+                                        'components.SetFeesForm.timeLockDelta'
+                                    )}
+                                </Text>
+                                <TextInput
+                                    keyboardType="numeric"
+                                    placeholder={timeLockDelta || '144'}
+                                    value={newTimeLockDelta}
+                                    onChangeText={(text: string) =>
+                                        this.setState({
+                                            newTimeLockDelta: text
+                                        })
+                                    }
+                                    autoCapitalize="none"
+                                    autoCorrect={false}
+                                />
+
                                 <Text
                                     style={{
                                         ...styles.text,


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1072**](https://github.com/ZeusLN/zeus/issues/1072)

Timelock Delta is not changable via CLN's set fees API.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
