### PR TITLE
Change Private field in channel description

### DIFF
--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -276,7 +276,7 @@ export default class ChannelView extends React.Component<
 
                     <KeyValue
                         keyValue={localeString('views.Channel.private')}
-                        value={privateChannel ? 'True' : 'False'}
+                        value={privateChannel ? 'Private' : 'Public'}
                         color={privateChannel ? 'green' : '#808000'}
                     />
 


### PR DESCRIPTION
In the channel description (views.channels.channel.tsx) the private field is misleading. At first glance it looks like the channel is private when private = false.

FIX: change text field for locales views.Channel.private to "visibility" or like field, then display public or private.

![Screenshot 2022-10-08 113510](https://user-images.githubusercontent.com/48340051/194705791-4ab05ddc-7577-4640-8ede-4a3be083ece5.png)

This pull request is categorized as a:

- [x] Locales update