### PR TITLE
README: npm i: add workaround to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Zeus is proud to be integrated on the following platforms:
 [enable Developer mode and USB Debugging](https://developer.android.com/studio/debug/dev-options)
 , then make sure it is connected to your computer by running `adb devices`
 3. install node dependencies with `npm i`
+    1. if you encounter errors with this step involving conflicting react native dependencies, use the legacy peer dependencies option `npm i --legacy-peer-deps` 
 4. open up your Android simulator or connect your phone and run `npx react-native start`
 5. open a new tab and run `npx react-native run-android`
 
@@ -115,6 +116,7 @@ Zeus is proud to be integrated on the following platforms:
 1. install and setup react-native and its related dependencies under **"Building Projects with Native Code"** on
 [react-native's Getting Started page](https://reactnative.dev/docs/environment-setup)
 2. install node dependencies with `npm i`
+    1. if you encounter errors with this step involving conflicting react native dependencies, use the legacy peer dependencies option `npm i --legacy-peer-deps` 
 3. `cd ios && pod install`
 4. open `ios/zeus.xcworkspace` in Xcode and hit Run. NOTE: if you're using an M1 mac, you may need to right click Xcode > get info > check `Open using Rosetta` before opening `zeus.xcworkspace`.
 


### PR DESCRIPTION
# Description

This adds guidance to the docs to get around a conflicting peer dependency error when building from source

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [x] Other
