### PR TITLE
Fee Limit UX Improvements

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -355,6 +355,8 @@
     "views.SendingLightning.success": "Transaction successfully sent",
     "views.SendingLightning.paymentHash": "Payment Hash",
     "views.SendingLightning.goToWallet": "Go to Wallet",
+    "views.SendingLightning.lowFeeLimitMessage": "This payment may have failed due to a low fee limit. Try again with a higher fee limit",
+    "views.SendingLightning.tryAgain": "Try Again",
     "views.SendingLightning.copyPaymentHash": "Copy Hash to Clipboard",
     "views.SendingOnChain.broadcasting": "Broadcasting Transaction",
     "views.SendingOnChain.success": "Transaction successfully sent",

--- a/locales/en.json
+++ b/locales/en.json
@@ -291,6 +291,7 @@
     "views.PaymentRequest.payDefault": "Pay default amount",
     "views.PaymentRequest.payCustom": "Pay custom amount",
     "views.PaymentRequest.feeEstimate": "Fee Estimate",
+    "views.PaymentRequest.feeEstimateExceedsLimit": "The estimated fee for this payment is higher than the limit set below. Consider raising the fee limit to avoid payment failures.",
     "views.PaymentRequest.successProbability": "Success Probability",
     "views.PaymentRequest.description": "Description",
     "views.PaymentRequest.timestamp": "Timestamp",

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -11,7 +11,7 @@ const keySendPreimageType = '5482373484';
 const keySendMessageType = '34349334';
 const preimageByteLength = 32;
 
-interface SendPaymentReq {
+export interface SendPaymentReq {
     payment_request?: string;
     amount?: string;
     pubkey?: string;

--- a/utils/FeeUtils.test.ts
+++ b/utils/FeeUtils.test.ts
@@ -3,6 +3,19 @@ import FeeUtils from './FeeUtils';
 const satoshisPerBTC = 100000000;
 
 describe('FeeUtils', () => {
+    describe('calculateDefaultRoutingFee', () => {
+        it('Calculates a fee based on the amount', () => {
+            expect(FeeUtils.calculateDefaultRoutingFee(0)).toEqual('0');
+            expect(FeeUtils.calculateDefaultRoutingFee(999)).toEqual('999');
+            expect(FeeUtils.calculateDefaultRoutingFee(1000)).toEqual('1000');
+            expect(FeeUtils.calculateDefaultRoutingFee(1001)).toEqual('50');
+            expect(FeeUtils.calculateDefaultRoutingFee(1003)).toEqual('50');
+            expect(FeeUtils.calculateDefaultRoutingFee(1010)).toEqual('51');
+            expect(FeeUtils.calculateDefaultRoutingFee(1011)).toEqual('51');
+            expect(FeeUtils.calculateDefaultRoutingFee(10000)).toEqual('500');
+        });
+    });
+
     describe('roundFee', () => {
         it('Rounds fees', () => {
             expect(FeeUtils.roundFee('11.5')).toEqual('12');

--- a/utils/FeeUtils.ts
+++ b/utils/FeeUtils.ts
@@ -1,4 +1,13 @@
 class FeeUtils {
+    static DEFAULT_ROUTING_FEE_PERCENT = 0.05;
+
+    calculateDefaultRoutingFee = (amount: number) => {
+        if (amount > 1000) {
+            return (amount * FeeUtils.DEFAULT_ROUTING_FEE_PERCENT).toFixed(0);
+        }
+
+        return amount.toString();
+    };
     roundFee = (text: string) => {
         const split = text.split('.');
 

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -68,6 +68,27 @@ export default class PaymentRequest extends React.Component<
         lastHopPubkey: null
     };
 
+    displayFeeRecommendation = () => {
+        const { feeLimitSat } = this.state;
+        const { InvoicesStore } = this.props;
+        const { feeEstimate } = InvoicesStore;
+
+        if (feeEstimate && Number(feeEstimate) > Number(feeLimitSat)) {
+            return (
+                <Text
+                    style={{
+                        color: themeColor('warning')
+                    }}
+                >
+                    {localeString(
+                        'views.PaymentRequest.feeEstimateExceedsLimit'
+                    )}
+                </Text>
+            );
+        }
+        return null;
+    };
+
     sendPayment = ({
         payment_request,
         amount,
@@ -340,8 +361,13 @@ export default class PaymentRequest extends React.Component<
                                     >
                                         {`${localeString(
                                             'views.PaymentRequest.feeLimit'
-                                        )} (${localeString('general.sats')})`}
+                                        )} (${localeString(
+                                            'general.sats'
+                                        )}) (${localeString(
+                                            'general.optional'
+                                        )})`}
                                     </Text>
+                                    {this.displayFeeRecommendation()}
                                     <TextInput
                                         keyboardType="numeric"
                                         value={feeLimitSat}

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -11,7 +11,9 @@ import LoadingIndicator from './../components/LoadingIndicator';
 import TextInput from './../components/TextInput';
 
 import InvoicesStore from './../stores/InvoicesStore';
-import TransactionsStore from './../stores/TransactionsStore';
+import TransactionsStore, {
+    SendPaymentReq
+} from './../stores/TransactionsStore';
 import UnitsStore from './../stores/UnitsStore';
 import ChannelsStore from './../stores/ChannelsStore';
 import SettingsStore from './../stores/SettingsStore';
@@ -66,9 +68,34 @@ export default class PaymentRequest extends React.Component<
         lastHopPubkey: null
     };
 
+    sendPayment = ({
+        payment_request,
+        amount,
+        max_parts,
+        max_shard_amt,
+        fee_limit_sat,
+        max_fee_percent,
+        outgoing_chan_id,
+        last_hop_pubkey,
+        amp
+    }: SendPaymentReq) => {
+        this.props.TransactionsStore.sendPayment({
+            payment_request,
+            amount,
+            max_parts,
+            max_shard_amt,
+            fee_limit_sat,
+            max_fee_percent,
+            outgoing_chan_id,
+            last_hop_pubkey,
+            amp
+        });
+
+        this.props.navigation.navigate('SendingLightning');
+    };
+
     render() {
         const {
-            TransactionsStore,
             InvoicesStore,
             UnitsStore,
             ChannelsStore,
@@ -555,7 +582,7 @@ export default class PaymentRequest extends React.Component<
                                             color: 'white'
                                         }}
                                         onPress={() => {
-                                            TransactionsStore.sendPayment({
+                                            this.sendPayment({
                                                 payment_request: paymentRequest,
                                                 amount: customAmount,
                                                 max_parts:
@@ -577,10 +604,6 @@ export default class PaymentRequest extends React.Component<
                                                 last_hop_pubkey: lastHopPubkey,
                                                 amp: enableAmp
                                             });
-
-                                            navigation.navigate(
-                                                'SendingLightning'
-                                            );
                                         }}
                                     />
                                 </View>

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -82,7 +82,7 @@ export default class PaymentRequest extends React.Component<
             return (
                 <Text
                     style={{
-                        color: themeColor('warning')
+                        color: themeColor('error')
                     }}
                 >
                     {localeString(

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -60,7 +60,7 @@ export default class PaymentRequest extends React.Component<
         enableAtomicMultiPathPayment: false,
         maxParts: '16',
         maxShardAmt: '',
-        feeLimitSat: '10',
+        feeLimitSat: '100',
         maxFeePercent: '0.5',
         outgoingChanId: null,
         lastHopPubkey: null

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -317,7 +317,6 @@ export default class PaymentRequest extends React.Component<
                                     </Text>
                                     <TextInput
                                         keyboardType="numeric"
-                                        placeholder={feeEstimate || '10'}
                                         value={feeLimitSat}
                                         onChangeText={(text: string) =>
                                             this.setState({

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -219,6 +219,47 @@ export default class SendingLightning extends React.Component<
                                 containerStyle={{ width: '100%' }}
                             />
                         )}
+
+                        {payment_error == `FAILURE_REASON_NO_ROUTE` && (
+                            <>
+                                <Text
+                                    style={{
+                                        textAlign: 'center',
+                                        color: 'white',
+                                        fontFamily: 'Lato-Regular',
+                                        marginTop: 50,
+                                        padding: 20,
+                                        fontSize: 14
+                                    }}
+                                >
+                                    {localeString(
+                                        'views.SendingLightning.lowFeeLimitMessage'
+                                    )}
+                                </Text>
+                                <Button
+                                    title={localeString(
+                                        'views.SendingLightning.tryAgain'
+                                    )}
+                                    icon={{
+                                        name: 'return-up-back',
+                                        type: 'ionicon',
+                                        size: 25,
+                                        color: 'darkred'
+                                    }}
+                                    onPress={() => navigation.goBack()}
+                                    titleStyle={{
+                                        color: 'darkred'
+                                    }}
+                                    buttonStyle={{
+                                        backgroundColor: 'white'
+                                    }}
+                                    containerStyle={{
+                                        width: '100%',
+                                        marginTop: 10
+                                    }}
+                                />
+                            </>
+                        )}
                     </View>
                 </View>
             </ScrollView>


### PR DESCRIPTION
# Description

Builds directly on top of the branch in https://github.com/ZeusLN/zeus/pull/1101

Addresses issue #1106 with a piecemeal approach. Currently this build is stable and tested but is missing a few of the additional improvements that will be added in a separate PR. That PR will build directly on top of this branch as a base in case we want to merge this one as-is.

> - [x] make the field completely optional, ~leave it blank by default~, and attempt the payment with some dynamic fee limit that doesn't exceed X% of the payment amount (X = 100% for 1-1000 sats, X=5% if >1000 sats)
> - [ ] allow users to enter either a fixed sat limit OR a percentage of the payment
> - [x] leave a default value of 100 sat limit but use fee estimation to detect whether the fee will likely exceed 100 sats, and show an indicator alerting the user they may want increase the fee limit
> - [ ] allow the user to change their default fee limit in settings
> - [x] show a proper error message when the route fails due to a low fee limit and allow the user to try again with a higher fee

<img width="40%" src="https://user-images.githubusercontent.com/4914611/198330018-67f4cd7a-6199-4e0c-9d96-2606493e9d77.png"><img width="40%" src="https://user-images.githubusercontent.com/4914611/198329505-e0538e30-0af7-4174-8e21-9e17da1efeb3.png">


This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [x] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
