### PR TITLE
Bump react-native to 0.68.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "punycode": "1.4.1",
     "querystring-es3": "0.2.1",
     "react": "18.1.0",
-    "react-native": "0.68.2",
+    "react-native": "0.68.5",
     "react-native-blob-util": "0.14.0",
     "react-native-camera": "4.2.1",
     "react-native-crypto": "2.2.0",


### PR DESCRIPTION
Fixes this build error: "Class 'kotlin.Unit' was compiled with an incompatible version of Kotlin"
```
"Class 'kotlin.Unit' was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.6.0, expected version is 1.4.0"
```
See https://github.com/facebook/react-native/issues/35210

I am new to this repo and am just learning node, js, react-native and android, so hope this is ok.

`npm run test` passed,
`npm run tsc` Found 9 errors, (typo's?) in `@react-native-picker` and `react-native-hce` source code, not sure about those.

### Third Party Dependencies and Packages

- [x] Contributors will need to run `npm install` after this PR is merged in
- [x ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms