### PR TITLE
eslint: enable ban-type to ensure strong typing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,6 @@ module.exports = {
   ],
   rules: {
     '@typescript-eslint/ban-ts-comment': 'off',
-    '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -135,7 +135,10 @@ interface AmountProps {
 
 @inject('UnitsStore')
 @observer
-export class Amount extends React.Component<AmountProps, {}> {
+export class Amount extends React.Component<
+    AmountProps,
+    Record<string, never>
+> {
     render() {
         const {
             sats: value,

--- a/components/BalanceSlider.tsx
+++ b/components/BalanceSlider.tsx
@@ -11,7 +11,7 @@ interface BalanceSliderProps {
 
 export default class BalanceSlider extends React.Component<
     BalanceSliderProps,
-    {}
+    Record<string, never>
 > {
     render() {
         const { localBalance, remoteBalance, list } = this.props;

--- a/components/DropdownSetting.tsx
+++ b/components/DropdownSetting.tsx
@@ -20,7 +20,7 @@ interface DropdownSettingProps {
 
 export default class DropdownSetting extends React.Component<
     DropdownSettingProps,
-    {}
+    Record<string, never>
 > {
     render() {
         const { title, selectedValue, displayValue, onValueChange, values } =

--- a/components/FeeBreakdown.tsx
+++ b/components/FeeBreakdown.tsx
@@ -33,7 +33,7 @@ interface FeeBreakdownProps {
 @observer
 export default class FeeBreakdown extends React.Component<
     FeeBreakdownProps,
-    {}
+    Record<string, never>
 > {
     render() {
         const {

--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -24,7 +24,7 @@ interface LightningSwipeableRowProps {
 
 export default class LightningSwipeableRow extends Component<
     LightningSwipeableRowProps,
-    {}
+    Record<string, never>
 > {
     private renderAction = (
         text: string,

--- a/components/LayerBalances/OnchainSwipeableRow.tsx
+++ b/components/LayerBalances/OnchainSwipeableRow.tsx
@@ -24,7 +24,7 @@ interface OnchainSwipeableRowProps {
 
 export default class OnchainSwipeableRow extends Component<
     OnchainSwipeableRowProps,
-    {}
+    Record<string, never>
 > {
     private renderAction = (
         text: string,

--- a/components/LayerBalances/index.tsx
+++ b/components/LayerBalances/index.tsx
@@ -77,7 +77,10 @@ const SwipeableRow = ({
 
 @inject()
 @observer
-export default class LayerBalances extends Component<LayerBalancesProps, {}> {
+export default class LayerBalances extends Component<
+    LayerBalancesProps,
+    Record<string, never>
+> {
     render() {
         const { BalanceStore, navigation, onRefresh } = this.props;
 

--- a/components/UnitToggle.tsx
+++ b/components/UnitToggle.tsx
@@ -14,7 +14,10 @@ interface UnitToggleProps {
 
 @inject('UnitsStore', 'SettingsStore')
 @observer
-export default class UnitToggle extends React.Component<UnitToggleProps, {}> {
+export default class UnitToggle extends React.Component<
+    UnitToggleProps,
+    Record<string, never>
+> {
     render() {
         const { UnitsStore, SettingsStore, onToggle } = this.props;
         const { changeUnits, units } = UnitsStore;

--- a/models/NodeInfo.ts
+++ b/models/NodeInfo.ts
@@ -48,7 +48,7 @@ export default class NodeInfo extends BaseModel {
         );
     }
 
-    @computed public get currentBlockHeight(): Number {
+    @computed public get currentBlockHeight(): number {
         return this.block_height || this.blockheight || 0;
     }
 

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -21,7 +21,10 @@ interface ActivityProps {
 
 @inject('ActivityStore')
 @observer
-export default class Activity extends React.Component<ActivityProps, {}> {
+export default class Activity extends React.Component<
+    ActivityProps,
+    Record<string, never>
+> {
     async UNSAFE_componentWillMount() {
         const { ActivityStore } = this.props;
         const { getActivityAndFilter, resetFilters } = ActivityStore;

--- a/views/AddressQRScanner.tsx
+++ b/views/AddressQRScanner.tsx
@@ -14,7 +14,7 @@ interface AddressQRProps {
 @observer
 export default class AddressQRScanner extends React.Component<
     AddressQRProps,
-    {}
+    Record<string, never>
 > {
     constructor(props: any) {
         super(props);

--- a/views/BTCPayConfigQRScanner.tsx
+++ b/views/BTCPayConfigQRScanner.tsx
@@ -15,7 +15,7 @@ interface BTCPayConfigQRProps {
 @observer
 export default class BTCPayConfigQRScanner extends React.Component<
     BTCPayConfigQRProps,
-    {}
+    Record<string, never>
 > {
     handleBTCPayConfigInvoiceScanned = (data: string) => {
         const { SettingsStore, navigation } = this.props;

--- a/views/CLightningRestQRScanner.tsx
+++ b/views/CLightningRestQRScanner.tsx
@@ -10,7 +10,7 @@ interface CLightningRestQRScannerProps {
 
 export default class CLightningRestQRScanner extends React.Component<
     CLightningRestQRScannerProps,
-    {}
+    Record<string, never>
 > {
     handleLNDConnectConfigInvoiceScanned = (data: string) => {
         const { navigation } = this.props;

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -30,7 +30,7 @@ interface ChannelsProps {
 @observer
 export default class ChannelsPane extends React.PureComponent<
     ChannelsProps,
-    {}
+    Record<string, never>
 > {
     renderItem = ({ item }) => {
         const { ChannelsStore, navigation } = this.props;

--- a/views/IntroSplash.tsx
+++ b/views/IntroSplash.tsx
@@ -22,7 +22,10 @@ interface IntroSplashProps {
 
 @inject('SettingsStore')
 @observer
-export default class IntroSplash extends React.Component<IntroSplashProps, {}> {
+export default class IntroSplash extends React.Component<
+    IntroSplashProps,
+    Record<string, never>
+> {
     componentDidMount() {
         // triggers when loaded from navigation or back action
         this.props.navigation.addListener('didFocus', () => {

--- a/views/LNDConnectConfigQRScanner.tsx
+++ b/views/LNDConnectConfigQRScanner.tsx
@@ -10,7 +10,7 @@ interface LNDConnectConfigQRProps {
 
 export default class LNDConnectConfigQRScanner extends React.Component<
     LNDConnectConfigQRProps,
-    {}
+    Record<string, never>
 > {
     handleLNDConnectConfigInvoiceScanned = (data: string) => {
         const { navigation } = this.props;

--- a/views/LNDHubQRScanner.tsx
+++ b/views/LNDHubQRScanner.tsx
@@ -12,7 +12,7 @@ interface LNDHubQRProps {
 @observer
 export default class LNDHubQRScanner extends React.Component<
     LNDHubQRProps,
-    {}
+    Record<string, never>
 > {
     handleCodeScanned = (data: string) => {
         const { navigation } = this.props;

--- a/views/NodeInfo.tsx
+++ b/views/NodeInfo.tsx
@@ -20,7 +20,10 @@ interface NodeInfoProps {
 
 @inject('NodeInfoStore', 'SettingsStore')
 @observer
-export default class NodeInfo extends React.Component<NodeInfoProps, {}> {
+export default class NodeInfo extends React.Component<
+    NodeInfoProps,
+    Record<string, never>
+> {
     UNSAFE_componentWillMount() {
         const { NodeInfoStore } = this.props;
         NodeInfoStore.getNodeInfo();

--- a/views/Routing/SetFees.tsx
+++ b/views/Routing/SetFees.tsx
@@ -15,7 +15,10 @@ interface SetFeesProps {
 
 @inject('FeeStore')
 @observer
-export default class SetFees extends React.PureComponent<SetFeesProps, {}> {
+export default class SetFees extends React.PureComponent<
+    SetFeesProps,
+    Record<string, never>
+> {
     render() {
         const { FeeStore, navigation } = this.props;
 

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -26,7 +26,7 @@ interface SendingLightningProps {
 @observer
 export default class SendingLightning extends React.Component<
     SendingLightningProps,
-    {}
+    Record<string, never>
 > {
     getBackgroundColor() {
         const { TransactionsStore } = this.props;

--- a/views/SendingOnChain.tsx
+++ b/views/SendingOnChain.tsx
@@ -26,7 +26,7 @@ interface SendingOnChainProps {
 @observer
 export default class SendingOnChain extends React.Component<
     SendingOnChainProps,
-    {}
+    Record<string, never>
 > {
     getBackgroundColor() {
         const { TransactionsStore } = this.props;

--- a/views/Settings/CertInstallInstructions.tsx
+++ b/views/Settings/CertInstallInstructions.tsx
@@ -14,7 +14,7 @@ interface CertInstallInstructionsProps {
 @observer
 export default class CertInstallInstructions extends React.Component<
     CertInstallInstructionsProps,
-    {}
+    Record<string, never>
 > {
     render() {
         const { navigation } = this.props;

--- a/views/Settings/Gods.tsx
+++ b/views/Settings/Gods.tsx
@@ -19,7 +19,10 @@ interface GodsProps {
 
 @inject('SettingsStore')
 @observer
-export default class Gods extends React.Component<GodsProps, {}> {
+export default class Gods extends React.Component<
+    GodsProps,
+    Record<string, never>
+> {
     UNSAFE_componentWillMount() {
         this.props.SettingsStore.fetchSponsors();
     }

--- a/views/Settings/Mortals.tsx
+++ b/views/Settings/Mortals.tsx
@@ -19,7 +19,10 @@ interface MortalsProps {
 
 @inject('SettingsStore')
 @observer
-export default class Mortals extends React.Component<MortalsProps, {}> {
+export default class Mortals extends React.Component<
+    MortalsProps,
+    Record<string, never>
+> {
     UNSAFE_componentWillMount() {
         this.props.SettingsStore.fetchSponsors();
     }

--- a/views/Settings/Olympians.tsx
+++ b/views/Settings/Olympians.tsx
@@ -19,7 +19,10 @@ interface OlympiansProps {
 
 @inject('SettingsStore')
 @observer
-export default class Olympians extends React.Component<OlympiansProps, {}> {
+export default class Olympians extends React.Component<
+    OlympiansProps,
+    Record<string, never>
+> {
     UNSAFE_componentWillMount() {
         this.props.SettingsStore.fetchSponsors();
     }

--- a/views/Settings/Settings.tsx
+++ b/views/Settings/Settings.tsx
@@ -31,7 +31,10 @@ interface SettingsProps {
 
 @inject('SettingsStore', 'UnitsStore')
 @observer
-export default class Settings extends React.Component<SettingsProps, {}> {
+export default class Settings extends React.Component<
+    SettingsProps,
+    Record<string, never>
+> {
     componentDidMount() {
         // triggers when loaded from navigation or back action
         this.props.navigation.addListener('didFocus', () => {

--- a/views/SparkQRScanner.tsx
+++ b/views/SparkQRScanner.tsx
@@ -7,7 +7,10 @@ interface SparkQRProps {
     navigation: any;
 }
 
-export default class SparkQRScanner extends React.Component<SparkQRProps, {}> {
+export default class SparkQRScanner extends React.Component<
+    SparkQRProps,
+    Record<string, never>
+> {
     handleSparkInvoiceScanned = (data: string) => {
         const { navigation } = this.props;
 

--- a/views/UTXOs/CoinControl.tsx
+++ b/views/UTXOs/CoinControl.tsx
@@ -19,7 +19,10 @@ interface CoinControlProps {
 
 @inject('UTXOsStore')
 @observer
-export default class CoinControl extends React.Component<CoinControlProps, {}> {
+export default class CoinControl extends React.Component<
+    CoinControlProps,
+    Record<string, never>
+> {
     async UNSAFE_componentWillMount() {
         const { UTXOsStore } = this.props;
         const { getUTXOs, listAccounts } = UTXOsStore;

--- a/views/Wallet/MainPane.tsx
+++ b/views/Wallet/MainPane.tsx
@@ -25,7 +25,10 @@ interface MainPaneProps {
 
 @inject('BalanceStore', 'SettingsStore')
 @observer
-export default class MainPane extends React.PureComponent<MainPaneProps, {}> {
+export default class MainPane extends React.PureComponent<
+    MainPaneProps,
+    Record<string, never>
+> {
     render() {
         const { NodeInfoStore, BalanceStore, SettingsStore, navigation } =
             this.props;


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

Enable ban-type to ensure strong typing.
{} can be interpreted in many ways.
Additionally, this disabled option can mask other issues.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND
- [x] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
