### PR TITLE
fixed issue with error string mismatch in ErrorUtils

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -480,5 +480,8 @@
     "stores.SettingsStore.btcPayFetchConfigError": "Error fetching BTCPay configuration",
     "stores.SettingsStore.olympianFetchError": "Error fetching Olympians",
     "stores.SettingsStore.lndhubSuccess": "Successfully created LNDHub account. Record the username and password somewhere so you can restore your funds if something happens to your device. Then hit Save Node Config to continue.",
-    "stores.SettingsStore.lndhubError": "Error creating LNDHub account. Please check the host and try again."
+    "stores.SettingsStore.lndhubError": "Error creating LNDHub account. Please check the host and try again.",
+    "error.connectionRefused": "Host unreachable. Try restarting your node or its Tor process.",
+    "error.hostUnreachable": "Host unreachable. Try restarting your node or its Tor process.",
+    "error.torBootstrap": "Error starting up Tor on your phone. Try restarting Zeus. If the problem persists consider reinstalling the app."
 }

--- a/utils/ErrorUtils.test.ts
+++ b/utils/ErrorUtils.test.ts
@@ -17,6 +17,13 @@ describe('ErrorUtils', () => {
             ).toEqual(
                 'Error starting up Tor on your phone. Try restarting Zeus. If the problem persists consider reinstalling the app.'
             );
+            expect(
+                ErrorUtils.errorToUserFriendly(
+                    'Error: called `Result::unwrap()` on an `Err` value: BootStrapError("Timeout waiting for boostrap")'
+                )
+            ).toEqual(
+                'Error starting up Tor on your phone. Try restarting Zeus. If the problem persists consider reinstalling the app.'
+            );
         });
 
         it('Returns inputted error if no match found', () => {

--- a/utils/ErrorUtils.test.ts
+++ b/utils/ErrorUtils.test.ts
@@ -5,21 +5,24 @@ describe('ErrorUtils', () => {
         it('Turns error message to user friendly values', () => {
             expect(
                 ErrorUtils.errorToUserFriendly(
-                    'Error: SOCKS: Connection refused'
+                    'Error: SOCKS: Connection refused',
+                    false
                 )
             ).toEqual(
                 'Host unreachable. Try restarting your node or its Tor process.'
             );
             expect(
                 ErrorUtils.errorToUserFriendly(
-                    'Error: called `Result::unwrap()` on an `Err` value: BootStrapError("Timeout waiting for bootstrap")'
+                    'Error: called `Result::unwrap()` on an `Err` value: BootStrapError("Timeout waiting for bootstrap")',
+                    false
                 )
             ).toEqual(
                 'Error starting up Tor on your phone. Try restarting Zeus. If the problem persists consider reinstalling the app.'
             );
             expect(
                 ErrorUtils.errorToUserFriendly(
-                    'Error: called `Result::unwrap()` on an `Err` value: BootStrapError("Timeout waiting for boostrap")'
+                    'Error: called `Result::unwrap()` on an `Err` value: BootStrapError("Timeout waiting for boostrap")',
+                    false
                 )
             ).toEqual(
                 'Error starting up Tor on your phone. Try restarting Zeus. If the problem persists consider reinstalling the app.'
@@ -27,9 +30,9 @@ describe('ErrorUtils', () => {
         });
 
         it('Returns inputted error if no match found', () => {
-            expect(ErrorUtils.errorToUserFriendly('Random message')).toEqual(
-                'Random message'
-            );
+            expect(
+                ErrorUtils.errorToUserFriendly('Random message', false)
+            ).toEqual('Random message');
         });
     });
 });

--- a/utils/ErrorUtils.ts
+++ b/utils/ErrorUtils.ts
@@ -1,16 +1,22 @@
 const userFriendlyErrors: any = {
-    'Error: SOCKS: Connection refused':
-        'Host unreachable. Try restarting your node or its Tor process.',
-    'Error: SOCKS: Host unreachable':
-        'Host unreachable. Try restarting your node or its Tor process.',
+    'Error: SOCKS: Connection refused': 'error.connectionRefused',
+    'Error: SOCKS: Host unreachable': 'error.hostUnreachable',
     'Error: called `Result::unwrap()` on an `Err` value: BootStrapError("Timeout waiting for bootstrap")':
-        'Error starting up Tor on your phone. Try restarting Zeus. If the problem persists consider reinstalling the app.',
+        'error.torBootstrap',
     'Error: called `Result::unwrap()` on an `Err` value: BootStrapError("Timeout waiting for boostrap")':
-        'Error starting up Tor on your phone. Try restarting Zeus. If the problem persists consider reinstalling the app.'
+        'error.torBootstrap'
 };
 
 class ErrorUtils {
-    errorToUserFriendly = (error: string) => userFriendlyErrors[error] || error;
+    errorToUserFriendly = (error: string, localize = true) => {
+        if (localize) {
+            const localeString = require('./LocaleUtils').localeString;
+            return localeString(userFriendlyErrors[error]) || error;
+        } else {
+            const EN = require('../locales/en.json');
+            return EN[userFriendlyErrors[error]] || error;
+        }
+    };
 }
 
 const errorUtils = new ErrorUtils();

--- a/utils/ErrorUtils.ts
+++ b/utils/ErrorUtils.ts
@@ -4,6 +4,8 @@ const userFriendlyErrors: any = {
     'Error: SOCKS: Host unreachable':
         'Host unreachable. Try restarting your node or its Tor process.',
     'Error: called `Result::unwrap()` on an `Err` value: BootStrapError("Timeout waiting for bootstrap")':
+        'Error starting up Tor on your phone. Try restarting Zeus. If the problem persists consider reinstalling the app.',
+    'Error: called `Result::unwrap()` on an `Err` value: BootStrapError("Timeout waiting for boostrap")':
         'Error starting up Tor on your phone. Try restarting Zeus. If the problem persists consider reinstalling the app.'
 };
 


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

![IMG_8833](https://user-images.githubusercontent.com/45887/203436399-1c070fa0-17c5-49a1-a686-2cc37d8b0651.PNG)

Fixed problem in ErrorUtils when tor bootstrapping failed. Error message wasn't correctly mapping to user friendly message. Updated to include a new case for the *actual* message thrown. Left original message in there just to be sure no other cases use the original string.

This pull request is categorized as a:

- [ X] Bug fix

## Checklist
- [ X] I’ve run `npm run tsc` and made sure my code compiles correctly
- [ X] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [X ] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [ X] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ X] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ X] iOS 14 - iPhone 11 Max

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
