### PR TITLE
DefaultPane: add ability to quickly generate invoice without memo

### DIFF
--- a/views/Wallet/DefaultPane.tsx
+++ b/views/Wallet/DefaultPane.tsx
@@ -225,9 +225,27 @@ export default class DefaultPane extends React.PureComponent<
                             bottom: 10
                         }}
                     >
-                        <View style={{ width: '50%' }}>
+                        <View style={{ width: '40%' }}>
                             <Button
                                 title={localeString('general.request')}
+                                quinary
+                                noUppercase
+                                onPress={() => {
+                                    navigation.navigate('Receive', {
+                                        amount,
+                                        autoGenerate: true
+                                    });
+                                }}
+                            />
+                        </View>
+                        <View style={{ width: '20%' }}>
+                            <Button
+                                icon={{
+                                    name: 'pencil',
+                                    type: 'font-awesome',
+                                    size: 20,
+                                    color: themeColor('text')
+                                }}
                                 quinary
                                 noUppercase
                                 onPress={() => {
@@ -237,7 +255,7 @@ export default class DefaultPane extends React.PureComponent<
                                 }}
                             />
                         </View>
-                        <View style={{ width: '50%' }}>
+                        <View style={{ width: '40%' }}>
                             <Button
                                 title={localeString('general.send')}
                                 quinary


### PR DESCRIPTION
# Description

<img width="440" alt="Screen Shot 2022-11-27 at 11 45 22" src="https://user-images.githubusercontent.com/1878621/204148692-c2b275fe-d323-4b3d-8887-0ad6c4f166d0.png">

This PR adds a new button to the `DefaultPane` view. This icon, marked with a pencil will take you to the `Receive` view with the amount populated so you can change settings and add a memo. The Receive button on the `DefaultPane` view will now automatically generate an invoice for you when pressed. This takes one click away from invoice generation.

H/T @godsayshodl for the suggestion

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
