### PR TITLE
Theme color fixes

### DIFF
--- a/components/PinPad.tsx
+++ b/components/PinPad.tsx
@@ -77,7 +77,14 @@ export default function PinPad({
                     highlight={numberHighlight}
                     style={styles.key}
                 >
-                    <Text style={styles.pinPadNumber}>{pinNumbers[1]}</Text>
+                    <Text
+                        style={{
+                            ...styles.pinPadNumber,
+                            color: themeColor('text')
+                        }}
+                    >
+                        {pinNumbers[1]}
+                    </Text>
                 </Touchable>
                 <Touchable
                     touch={() => {
@@ -87,7 +94,14 @@ export default function PinPad({
                     highlight={numberHighlight}
                     style={styles.key}
                 >
-                    <Text style={styles.pinPadNumber}>{pinNumbers[2]}</Text>
+                    <Text
+                        style={{
+                            ...styles.pinPadNumber,
+                            color: themeColor('text')
+                        }}
+                    >
+                        {pinNumbers[2]}
+                    </Text>
                 </Touchable>
                 <Touchable
                     touch={() => {
@@ -97,7 +111,14 @@ export default function PinPad({
                     highlight={numberHighlight}
                     style={styles.key}
                 >
-                    <Text style={styles.pinPadNumber}>{pinNumbers[3]}</Text>
+                    <Text
+                        style={{
+                            ...styles.pinPadNumber,
+                            color: themeColor('text')
+                        }}
+                    >
+                        {pinNumbers[3]}
+                    </Text>
                 </Touchable>
             </Row>
             <Row align="flex-end" style={styles.pinPadRow}>
@@ -109,7 +130,14 @@ export default function PinPad({
                     highlight={numberHighlight}
                     style={styles.key}
                 >
-                    <Text style={styles.pinPadNumber}>{pinNumbers[4]}</Text>
+                    <Text
+                        style={{
+                            ...styles.pinPadNumber,
+                            color: themeColor('text')
+                        }}
+                    >
+                        {pinNumbers[4]}
+                    </Text>
                 </Touchable>
                 <Touchable
                     touch={() => {
@@ -119,7 +147,14 @@ export default function PinPad({
                     highlight={numberHighlight}
                     style={styles.key}
                 >
-                    <Text style={styles.pinPadNumber}>{pinNumbers[5]}</Text>
+                    <Text
+                        style={{
+                            ...styles.pinPadNumber,
+                            color: themeColor('text')
+                        }}
+                    >
+                        {pinNumbers[5]}
+                    </Text>
                 </Touchable>
                 <Touchable
                     touch={() => {
@@ -129,7 +164,14 @@ export default function PinPad({
                     highlight={numberHighlight}
                     style={styles.key}
                 >
-                    <Text style={styles.pinPadNumber}>{pinNumbers[6]}</Text>
+                    <Text
+                        style={{
+                            ...styles.pinPadNumber,
+                            color: themeColor('text')
+                        }}
+                    >
+                        {pinNumbers[6]}
+                    </Text>
                 </Touchable>
             </Row>
             <Row align="flex-end" style={styles.pinPadRow}>
@@ -141,7 +183,14 @@ export default function PinPad({
                     highlight={numberHighlight}
                     style={styles.key}
                 >
-                    <Text style={styles.pinPadNumber}>{pinNumbers[7]}</Text>
+                    <Text
+                        style={{
+                            ...styles.pinPadNumber,
+                            color: themeColor('text')
+                        }}
+                    >
+                        {pinNumbers[7]}
+                    </Text>
                 </Touchable>
                 <Touchable
                     touch={() => {
@@ -151,7 +200,14 @@ export default function PinPad({
                     highlight={numberHighlight}
                     style={styles.key}
                 >
-                    <Text style={styles.pinPadNumber}>{pinNumbers[8]}</Text>
+                    <Text
+                        style={{
+                            ...styles.pinPadNumber,
+                            color: themeColor('text')
+                        }}
+                    >
+                        {pinNumbers[8]}
+                    </Text>
                 </Touchable>
                 <Touchable
                     touch={() => {
@@ -161,7 +217,14 @@ export default function PinPad({
                     highlight={numberHighlight}
                     style={styles.key}
                 >
-                    <Text style={styles.pinPadNumber}>{pinNumbers[9]}</Text>
+                    <Text
+                        style={{
+                            ...styles.pinPadNumber,
+                            color: themeColor('text')
+                        }}
+                    >
+                        {pinNumbers[9]}
+                    </Text>
                 </Touchable>
             </Row>
             <Row align="flex-end" style={styles.pinPadRow}>
@@ -173,7 +236,14 @@ export default function PinPad({
                         highlight={numberHighlight}
                         style={styles.key}
                     >
-                        <Text style={styles.pinPadNumber}>{'.'}</Text>
+                        <Text
+                            style={{
+                                ...styles.pinPadNumber,
+                                color: themeColor('text')
+                            }}
+                        >
+                            {'.'}
+                        </Text>
                     </Touchable>
                 ) : (
                     <Touchable
@@ -184,7 +254,14 @@ export default function PinPad({
                         highlight={numberHighlight}
                         style={styles.key}
                     >
-                        <Text style={styles.pinPadNumber}>{'<'}</Text>
+                        <Text
+                            style={{
+                                ...styles.pinPadNumber,
+                                color: themeColor('text')
+                            }}
+                        >
+                            {'<'}
+                        </Text>
                     </Touchable>
                 )}
                 <Touchable
@@ -195,7 +272,14 @@ export default function PinPad({
                     highlight={numberHighlight}
                     style={styles.key}
                 >
-                    <Text style={styles.pinPadNumber}>{pinNumbers[0]}</Text>
+                    <Text
+                        style={{
+                            ...styles.pinPadNumber,
+                            color: themeColor('text')
+                        }}
+                    >
+                        {pinNumbers[0]}
+                    </Text>
                 </Touchable>
                 {!hidePinLength &&
                     (amount ? (
@@ -207,7 +291,14 @@ export default function PinPad({
                             highlight={numberHighlight}
                             style={styles.key}
                         >
-                            <Text style={styles.pinPadNumber}>{'<'}</Text>
+                            <Text
+                                style={{
+                                    ...styles.pinPadNumber,
+                                    color: themeColor('text')
+                                }}
+                            >
+                                {'<'}
+                            </Text>
                         </Touchable>
                     ) : (
                         <Touchable
@@ -218,7 +309,14 @@ export default function PinPad({
                             highlight={numberHighlight}
                             style={styles.key}
                         >
-                            <Text style={styles.pinPadNumber}>C</Text>
+                            <Text
+                                style={{
+                                    ...styles.pinPadNumber,
+                                    color: themeColor('text')
+                                }}
+                            >
+                                C
+                            </Text>
                         </Touchable>
                     ))}
                 {!!hidePinLength && pinValueLength >= minLength && (

--- a/components/TextInput.tsx
+++ b/components/TextInput.tsx
@@ -60,12 +60,20 @@ export default function TextInput(props: TextInputProps) {
             style={{
                 ...style,
                 ...defaultStyle,
-                ...styles.wrapper
+                ...styles.wrapper,
+                backgroundColor: themeColor('secondary')
             }}
         >
             {prefix && (
                 <TouchableOpacity onPress={() => toggleUnits()}>
-                    <Text style={{ ...styles.unit, marginRight: 5 }}>
+                    <Text
+                        style={{
+                            ...styles.unit,
+                            marginRight: 5,
+                            color: themeColor('text'),
+                            backgroundColor: themeColor('background')
+                        }}
+                    >
                         {prefix}
                     </Text>
                 </TouchableOpacity>
@@ -75,7 +83,7 @@ export default function TextInput(props: TextInputProps) {
                 value={value}
                 onChangeText={onChangeText}
                 numberOfLines={numberOfLines || 1}
-                style={styles.input}
+                style={{ ...styles.input, color: themeColor('text') }}
                 placeholderTextColor={
                     placeholderTextColor || themeColor('secondaryText')
                 }
@@ -92,7 +100,9 @@ export default function TextInput(props: TextInputProps) {
                     <Text
                         style={{
                             ...styles.unit,
-                            right: 45
+                            right: 45,
+                            color: themeColor('text'),
+                            backgroundColor: themeColor('background')
                         }}
                     >
                         {suffix}
@@ -111,18 +121,14 @@ const styles = StyleSheet.create({
         borderRadius: 6,
         marginBottom: 20,
         padding: 10,
-        backgroundColor: themeColor('secondary'),
         overflow: 'hidden'
     },
     unit: {
-        color: themeColor('text'),
-        backgroundColor: themeColor('background'),
         fontSize: 20,
         borderRadius: 6,
         padding: 5
     },
     input: {
-        color: themeColor('text'),
         fontSize: 20,
         width: '100%',
         fontFamily: 'Lato-Regular',

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -368,7 +368,12 @@ export default class Lockscreen extends React.Component<
         );
 
         return (
-            <View style={styles.container}>
+            <View
+                style={{
+                    ...styles.container,
+                    backgroundColor: themeColor('background')
+                }}
+            >
                 {(!!modifySecurityScreen || deletePin || deleteDuressPin) && (
                     <Header
                         leftComponent={<BackButton />}
@@ -518,8 +523,7 @@ const styles = StyleSheet.create({
         alignItems: 'center'
     },
     container: {
-        flex: 1,
-        backgroundColor: '#1f2328'
+        flex: 1
     },
     button: {
         paddingTop: 15,

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -40,7 +40,7 @@ import Bitcoin from './../../assets/images/SVG/Bitcoin.svg';
 import Temple from './../../assets/images/SVG/Temple.svg';
 import ChannelsIcon from './../../assets/images/SVG/Channels.svg';
 import CaretUp from './../../assets/images/SVG/Caret Up.svg';
-import WordLogo from './../../assets/images/SVG/Word Logo - no outline.svg';
+import WordLogo from './../../assets/images/SVG/Word Logo.svg';
 
 interface WalletProps {
     enterSetup: any;
@@ -397,7 +397,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                     {connecting && !loginRequired && (
                         <View
                             style={{
-                                backgroundColor: '#1F242D',
+                                backgroundColor: themeColor('background'),
                                 height: '100%'
                             }}
                         >
@@ -451,7 +451,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                                         width: 320
                                     }}
                                     titleStyle={{
-                                        color: 'white'
+                                        color: themeColor('text')
                                     }}
                                     onPress={() => {
                                         if (settings.nodes)


### PR DESCRIPTION
# Description

This PR fixes numerous theme-specific styling issues:

- Pin pad buttons not showing up on light themes
- Dark theme styling appearing for `TextInput` components
- Style clashes on `Lockscreen` view
- `Wallet` Loading screen style reflects selected theme on node switching

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `npm run tsc` and made sure my code compiles correctly
- [x] I’ve run `npm run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `npm run prettier` and made sure my code is formatted correctly
- [x] I’ve run `npm run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND
- [ ] c-lightning-REST
- [ ] spark
- [ ] Eclair
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `npm install` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
