### PR TITLE
LNC: credentialStore patch

### DIFF
--- a/backends/LNC/credentialStore.ts
+++ b/backends/LNC/credentialStore.ts
@@ -135,8 +135,9 @@ export default class LncCredentialStore implements CredentialStore {
 
     /** Saves persisted data to EncryptedStorage */
     private _save() {
-        // only save if pairingPhrase is set
-        if (!this._pairingPhrase) return;
+        // only save if localKey and remoteKey is set
+        if (!this._localKey) return;
+        if (!this._remoteKey) return;
         const key = `${STORAGE_KEY}:${hash(this._pairingPhrase)}`;
         EncryptedStorage.setItem(key, JSON.stringify(this.persisted));
     }


### PR DESCRIPTION
This bug was causing some users to have their credentials overwritten and LNC connections lost. This change will make sure entries are written to storage is there is a local and remote key.