### PR TITLE
BIP21/Unified QRs: handle instances that do not return on-chain addresses

### DIFF
--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -233,7 +233,7 @@ export default class InvoicesStore {
         return RESTUtils.getNewAddress(params)
             .then((data: any) => {
                 this.onChainAddress =
-                    data.address || data.bech32 || data[0].address;
+                    data.address || data.bech32 || (data[0] && data[0].address);
                 this.loading = false;
             })
             .catch((error: any) => {

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -358,10 +358,11 @@ export default class Receive extends React.Component<
             { element: onChainButton }
         ];
 
-        const haveInvoice = !!payment_request && !!address;
+        const haveUnifiedInvoice = !!payment_request && !!address;
+        const haveInvoice = !!payment_request || !!address;
 
         let unifiedInvoice, lnInvoice, btcAddress;
-        if (haveInvoice) {
+        if (haveUnifiedInvoice) {
             unifiedInvoice = `bitcoin:${address.toUpperCase()}?${`lightning=${payment_request.toUpperCase()}`}${
                 Number(satAmount) > 0
                     ? `&amount=${new BigNumber(satAmount)
@@ -465,13 +466,14 @@ export default class Receive extends React.Component<
                         <View>
                             {!!payment_request && (
                                 <>
-                                    {implementation === 'lndhub' && (
-                                        <WarningMessage
-                                            message={localeString(
-                                                'views.Receive.warningLndHub'
-                                            )}
-                                        />
-                                    )}
+                                    {implementation === 'lndhub' &&
+                                        !!address && (
+                                            <WarningMessage
+                                                message={localeString(
+                                                    'views.Receive.warningLndHub'
+                                                )}
+                                            />
+                                        )}
                                     {!!lnurl && (
                                         <SuccessMessage
                                             message={
@@ -487,47 +489,54 @@ export default class Receive extends React.Component<
                             {creatingInvoice && <LoadingIndicator />}
                             {haveInvoice && (
                                 <View style={{ marginTop: 10 }}>
-                                    {selectedIndex == 0 && !belowDustLimit && (
-                                        <CollapsedQR
-                                            value={unifiedInvoice}
-                                            copyText={localeString(
-                                                'views.Receive.copyInvoice'
-                                            )}
-                                            expanded
-                                            textBottom
-                                        />
-                                    )}
-                                    {selectedIndex == 1 && !belowDustLimit && (
-                                        <CollapsedQR
-                                            value={lnInvoice}
-                                            copyText={localeString(
-                                                'views.Receive.copyInvoice'
-                                            )}
-                                            expanded
-                                            textBottom
-                                        />
-                                    )}
-                                    {selectedIndex == 2 && !belowDustLimit && (
-                                        <CollapsedQR
-                                            value={btcAddress}
-                                            copyText={localeString(
-                                                'views.Receive.copyAddress'
-                                            )}
-                                            expanded
-                                            textBottom
-                                        />
-                                    )}
-                                    {belowDustLimit && (
-                                        <CollapsedQR
-                                            value={lnInvoice}
-                                            copyText={localeString(
-                                                'views.Receive.copyAddress'
-                                            )}
-                                            expanded
-                                            textBottom
-                                        />
-                                    )}
-                                    {!belowDustLimit && (
+                                    {selectedIndex == 0 &&
+                                        !belowDustLimit &&
+                                        haveUnifiedInvoice && (
+                                            <CollapsedQR
+                                                value={unifiedInvoice}
+                                                copyText={localeString(
+                                                    'views.Receive.copyInvoice'
+                                                )}
+                                                expanded
+                                                textBottom
+                                            />
+                                        )}
+                                    {selectedIndex == 1 &&
+                                        !belowDustLimit &&
+                                        haveUnifiedInvoice && (
+                                            <CollapsedQR
+                                                value={lnInvoice}
+                                                copyText={localeString(
+                                                    'views.Receive.copyInvoice'
+                                                )}
+                                                expanded
+                                                textBottom
+                                            />
+                                        )}
+                                    {selectedIndex == 2 &&
+                                        !belowDustLimit &&
+                                        haveUnifiedInvoice && (
+                                            <CollapsedQR
+                                                value={btcAddress}
+                                                copyText={localeString(
+                                                    'views.Receive.copyAddress'
+                                                )}
+                                                expanded
+                                                textBottom
+                                            />
+                                        )}
+                                    {belowDustLimit ||
+                                        (!haveUnifiedInvoice && (
+                                            <CollapsedQR
+                                                value={lnInvoice}
+                                                copyText={localeString(
+                                                    'views.Receive.copyAddress'
+                                                )}
+                                                expanded
+                                                textBottom
+                                            />
+                                        ))}
+                                    {!belowDustLimit && haveUnifiedInvoice && (
                                         <ButtonGroup
                                             onPress={this.updateIndex}
                                             selectedIndex={selectedIndex}


### PR DESCRIPTION
# Description

Some LNDHub-based instances (LNbits non-selfhosted, BTCPay Lnbank) do not have support for on-chain addresses. This PR adds support for these instances and detects when an on-chain address cannot be generated.

When it is detected that an on-chain address cannot be generated:
- Only the LN invoice is displayed
- Group tabs to toggle between Unified / LN / On-chain is not displayed
- LNDHub singular address warning is not displayed

Tested on legend.lnbits.com

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
