### PR TITLE
LNC: ensure that disconnect is called when switching nodes

### DIFF
--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -35,6 +35,7 @@ export default class LightningNodeConnect {
 
     connect = async () => await this.lnc.connect();
     isConnected = async () => await this.lnc.isConnected();
+    disconnect = () => this.lnc.disconnect();
 
     getTransactions = async () =>
         await this.lnc.lnd.lightning

--- a/utils/RESTUtils.ts
+++ b/utils/RESTUtils.ts
@@ -123,6 +123,7 @@ class RESTUtils {
     initLNC = (...args: any[]) => this.call('initLNC', args);
     connect = (...args: any[]) => this.call('connect', args);
     isConnected = (...args: any[]) => this.call('isConnected', args);
+    disconnect = (...args: any[]) => this.call('disconnect', args);
 }
 
 const restUtils = new RESTUtils();

--- a/views/Settings/Nodes.tsx
+++ b/views/Settings/Nodes.tsx
@@ -7,6 +7,7 @@ import Button from './../../components/Button';
 import LoadingIndicator from './../../components/LoadingIndicator';
 import NodeIdenticon, { NodeTitle } from './../../components/NodeIdenticon';
 
+import RESTUtils from './../../utils/RESTUtils';
 import SettingsStore, { INTERFACE_KEYS } from './../../stores/SettingsStore';
 import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
@@ -67,8 +68,12 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
     render() {
         const { navigation, SettingsStore } = this.props;
         const { loading, nodes } = this.state;
-        const { setSettings, settings, setConnectingStatus }: any =
-            SettingsStore;
+        const {
+            setSettings,
+            settings,
+            setConnectingStatus,
+            implementation
+        }: any = SettingsStore;
         const { selectedNode } = settings;
 
         const implementationDisplayValue = {};
@@ -134,6 +139,8 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                                             themeColor('background')
                                     }}
                                     onPress={async () => {
+                                        const currentImplementation =
+                                            implementation;
                                         await setSettings(
                                             JSON.stringify({
                                                 nodes,
@@ -152,6 +159,12 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                                                 privacy: settings.privacy
                                             })
                                         ).then(() => {
+                                            if (
+                                                currentImplementation ===
+                                                'lightning-node-connect'
+                                            ) {
+                                                RESTUtils.disconnect();
+                                            }
                                             setConnectingStatus(true);
                                             navigation.navigate('Wallet', {
                                                 refresh: true


### PR DESCRIPTION
# Description

Previously when using LNC you would hit a connection issue when switching away from your LNC connection to another node and then switching back.

This PR ensures that disconnect is called when switching away from an LNC connection.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
