### PR TITLE
LNC: race condition fix

### DIFF
--- a/backends/LNC/credentialStore.ts
+++ b/backends/LNC/credentialStore.ts
@@ -33,8 +33,6 @@ export default class LncCredentialStore implements CredentialStore {
      */
     constructor(pairingPhrase?: string) {
         if (pairingPhrase) this.pairingPhrase = pairingPhrase;
-
-        this.load(pairingPhrase);
     }
 
     //
@@ -123,9 +121,11 @@ export default class LncCredentialStore implements CredentialStore {
                 this._localKey = this.persisted.localKey;
                 this._remoteKey = this.persisted.remoteKey;
             }
+            return;
         } catch (error) {
             const msg = (error as Error).message;
             throw new Error(`Failed to load secure data: ${msg}`);
+            return;
         }
     }
 

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -18,7 +18,7 @@ const ADDRESS_TYPES = [
 export default class LightningNodeConnect {
     lnc: any;
 
-    initLNC = () => {
+    initLNC = async () => {
         const { pairingPhrase, mailboxServer, customMailboxServer } =
             stores.settingsStore;
 
@@ -31,6 +31,8 @@ export default class LightningNodeConnect {
             mailboxServer === 'custom-defined'
                 ? customMailboxServer
                 : mailboxServer;
+
+        return await this.lnc.credentials.load(pairingPhrase);
     };
 
     connect = async () => await this.lnc.connect();

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -467,7 +467,7 @@ export default class SettingsStore {
     public connect = async () => {
         this.loading = true;
 
-        RESTUtils.initLNC();
+        await RESTUtils.initLNC();
 
         const error = await RESTUtils.connect();
         if (error) {


### PR DESCRIPTION
# Description

There is a race condition between LNC's credential store load call and the initial connect call to your node. This would often result in iOS users unable to reconnect to their nodes using the local and remote keys

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
