### PR TITLE
fixed issue with expiry in C-Lightning-REST being unix timestamp

### DIFF
--- a/backends/CLightningREST.ts
+++ b/backends/CLightningREST.ts
@@ -77,7 +77,7 @@ export default class CLightningREST extends LND {
             description: data.memo,
             label: 'zeus.' + Math.random() * 1000000,
             amount: Number(data.value) * 1000,
-            expiry: Math.round(Date.now() / 1000) + Number(data.expiry),
+            expiry: Number(data.expiry),
             private: true
         });
     getPayments = () => this.getRequest('/v1/pay/listPays');


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-1112**

Fixed problem with full timestamp being set as expiry when it should just be number of seconds.

https://github.com/ZeusLN/zeus/issues/1112

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS 14.4 iPhone 11 Pro

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [X] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
