### PR TITLE
Lurker mode: toggle off with long press on amounts

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import UnitsStore from '../stores/UnitsStore';
+import SettingsStore from '../stores/SettingsStore';
 import PrivacyUtils from '../utils/PrivacyUtils';
 import ClockIcon from '../assets/images/SVG/Clock.svg';
 import { themeColor } from '../utils/ThemeUtils';
@@ -120,6 +121,7 @@ function AmountDisplay({
 
 interface AmountProps {
     UnitsStore?: UnitsStore;
+    SettingsStore?: SettingsStore;
     sats: number | string;
     fixedUnits?: string;
     sensitive?: boolean;
@@ -133,7 +135,7 @@ interface AmountProps {
     pending?: boolean;
 }
 
-@inject('UnitsStore')
+@inject('UnitsStore', 'SettingsStore')
 @observer
 export class Amount extends React.Component<AmountProps, {}> {
     render() {
@@ -150,6 +152,9 @@ export class Amount extends React.Component<AmountProps, {}> {
             pending = false
         } = this.props;
         const UnitsStore = this.props.UnitsStore!;
+        const SettingsStore = this.props.SettingsStore!;
+        const lurkerMode = SettingsStore.settings.privacy.lurkerMode;
+        const lurkerExposed = SettingsStore.lurkerExposed;
 
         // TODO: This doesn't feel like the right place for this but it makes the component "reactive"
         const units = fixedUnits ? fixedUnits : UnitsStore.units;
@@ -164,7 +169,19 @@ export class Amount extends React.Component<AmountProps, {}> {
 
             if (toggleable) {
                 return (
-                    <TouchableOpacity onPress={() => UnitsStore.changeUnits()}>
+                    <TouchableOpacity
+                        onPress={() => UnitsStore.changeUnits()}
+                        onLongPress={() => {
+                            if (lurkerMode) {
+                                SettingsStore.toggleLurker();
+                            }
+                        }}
+                        onPressOut={() => {
+                            if (!lurkerMode && lurkerExposed) {
+                                SettingsStore.toggleLurker();
+                            }
+                        }}
+                    >
                         <AmountDisplay
                             amount={amount}
                             unit={unit}
@@ -211,7 +228,19 @@ export class Amount extends React.Component<AmountProps, {}> {
 
         if (toggleable) {
             return (
-                <TouchableOpacity onPress={() => UnitsStore.changeUnits()}>
+                <TouchableOpacity
+                    onPress={() => UnitsStore.changeUnits()}
+                    onLongPress={() => {
+                        if (lurkerMode) {
+                            SettingsStore.toggleLurker();
+                        }
+                    }}
+                    onPressOut={() => {
+                        if (!lurkerMode && lurkerExposed) {
+                            SettingsStore.toggleLurker();
+                        }
+                    }}
+                >
                     <AmountDisplay
                         {...unformattedAmount}
                         negative={false}

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -177,6 +177,7 @@ export default class SettingsStore {
     @observable certVerification: boolean | undefined;
     @observable public loggedIn = false;
     @observable public connecting = true;
+    @observable public lurkerExposed = false;
     // LNDHub
     @observable username: string;
     @observable password: string;
@@ -515,5 +516,15 @@ export default class SettingsStore {
         }
         this.connecting = status;
         return this.connecting;
+    };
+
+    @action
+    public toggleLurker = () => {
+        if (this.settings.privacy.lurkerMode) {
+            this.lurkerExposed = true;
+        } else {
+            this.lurkerExposed = false;
+        }
+        this.settings.privacy.lurkerMode = !this.settings.privacy.lurkerMode;
     };
 }


### PR DESCRIPTION
# Description

This PR adds the ability to temporarily disable Lurker mode with a long press on amounts.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
