### PR TITLE
AddEditNode: Bug fix: properly add connections from general scan

### DIFF
--- a/views/Settings/AddEditNode.tsx
+++ b/views/Settings/AddEditNode.tsx
@@ -311,7 +311,7 @@ export default class AddEditNode extends React.Component<
         let nodes: any;
         if (settings.nodes) {
             nodes = settings.nodes;
-            nodes[index] = node;
+            nodes[settings.nodes.length || index] = node;
         } else {
             nodes = [node];
         }


### PR DESCRIPTION
# Description

Previously, node configs scanned from the general scan (on the home or default views) run through 'handleAnything` weren't properly setting indexes. This would cause the nodes to be improperly saved, or to take over the first saved node config in the nodes list.

This change gives context to the `AddEditNode` view of what the index should be when not coming in from the `Nodes` view. 

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
