### PR TITLE
Channels: fix lurker mode display

### DIFF
--- a/components/Channels/ChannelItem.tsx
+++ b/components/Channels/ChannelItem.tsx
@@ -7,7 +7,11 @@ import { Row } from '../../components/layout/Row';
 import { Status } from '../../views/Channels/ChannelsPane';
 import Amount from '../Amount';
 import { Tag } from './Tag';
+
+import PrivacyUtils from './../../utils/PrivacyUtils';
 import { themeColor } from './../../utils/ThemeUtils';
+
+import Stores from '../../stores/Stores';
 
 export function ChannelItem({
     title,
@@ -22,6 +26,10 @@ export function ChannelItem({
     largestTotal?: number;
     status: Status;
 }) {
+    const { settings } = Stores.settingsStore;
+    const { privacy } = settings;
+    const lurkerMode = (privacy && privacy.lurkerMode) || false;
+
     const percentOfLargest = largestTotal
         ? (Number(inbound) + Number(outbound)) / largestTotal
         : 1.0;
@@ -37,17 +45,17 @@ export function ChannelItem({
         >
             <Row justify="space-between">
                 <View style={{ flex: 1, paddingRight: 10 }}>
-                    <Body>{title}</Body>
+                    <Body>{PrivacyUtils.sensitiveValue(title)}</Body>
                 </View>
                 <Tag status={status} />
             </Row>
             <Row>
                 <BalanceBar
-                    left={Number(outbound)}
-                    right={Number(inbound)}
+                    left={lurkerMode ? 50 : Number(outbound)}
+                    right={lurkerMode ? 50 : Number(inbound)}
                     offline={status === Status.Offline}
                     percentOfLargest={percentOfLargest}
-                    showProportionally={true}
+                    showProportionally={lurkerMode ? false : true}
                 />
             </Row>
             <Row justify="space-between">


### PR DESCRIPTION
# Description

Lurker mode on the channels pane view now conceals channel counter-party aliases, sizes, and ratios.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
