### PR TITLE
Balance pane: fix display of Conversion component

### DIFF
--- a/components/Conversion.tsx
+++ b/components/Conversion.tsx
@@ -4,15 +4,20 @@ import { inject, observer } from 'mobx-react';
 
 import Amount from '../components/Amount';
 
+import { Row } from '../components/layout/Row';
+
 import FiatStore from '../stores/UnitsStore';
 import UnitsStore, { SATS_PER_BTC } from '../stores/UnitsStore';
 import SettingsStore, { DEFAULT_FIAT } from '../stores/SettingsStore';
 
 import { themeColor } from '../utils/ThemeUtils';
 
+import ClockIcon from '../assets/images/SVG/Clock.svg';
+
 interface ConversionProps {
     amount: string | number;
     sats: string | number;
+    satsPending: string | number;
     FiatStore: FiatStore;
     UnitsStore: UnitsStore;
     SettingsStore: SettingsStore;
@@ -43,6 +48,7 @@ export default class Conversion extends React.Component<
         const {
             amount,
             sats,
+            satsPending,
             FiatStore,
             UnitsStore,
             SettingsStore,
@@ -89,6 +95,44 @@ export default class Conversion extends React.Component<
 
         if (!fiat || fiat === DEFAULT_FIAT || (!amount && !sats)) return;
 
+        const ConversionDisplay = ({ units = 'sats' }: { units: string }) => (
+            <Amount
+                sats={satAmount}
+                fixedUnits={units}
+                sensitive={sensitive}
+                color="secondaryText"
+            />
+        );
+
+        const ConversionPendingDisplay = ({
+            units = 'sats'
+        }: {
+            units: string;
+        }) => (
+            <Row align="flex-end">
+                <Amount
+                    sats={satAmount}
+                    fixedUnits={units}
+                    sensitive={sensitive}
+                    color="secondaryText"
+                />
+                <Text style={{ color: themeColor('secondaryText') }}>
+                    {' | '}
+                </Text>
+                <ClockIcon
+                    color={themeColor('bitcoin')}
+                    width={17}
+                    height={17}
+                />
+                <Amount
+                    sats={satsPending}
+                    fixedUnits={units}
+                    sensitive={sensitive}
+                    color="secondaryText"
+                />
+            </Row>
+        );
+
         // TODO negative is hardcoded to false because we're inconsistent
         // an on-chain debit is a negative number, but a lightning debit isn't
         return (
@@ -98,12 +142,11 @@ export default class Conversion extends React.Component<
                         style={{ alignItems: 'center' }}
                         onPress={() => this.toggleShowRate()}
                     >
-                        <Amount
-                            sats={satAmount}
-                            fixedUnits="sats"
-                            sensitive={sensitive}
-                            color={themeColor('secondaryText')}
-                        />
+                        {satsPending ? (
+                            <ConversionPendingDisplay units="sats" />
+                        ) : (
+                            <ConversionDisplay units="sats" />
+                        )}
                         {showRate && (
                             <Text
                                 style={{ color: themeColor('secondaryText') }}
@@ -118,12 +161,11 @@ export default class Conversion extends React.Component<
                         style={{ alignItems: 'center' }}
                         onPress={() => this.toggleShowRate()}
                     >
-                        <Amount
-                            sats={satAmount}
-                            fixedUnits="fiat"
-                            sensitive={sensitive}
-                            color={themeColor('secondaryText')}
-                        />
+                        {satsPending ? (
+                            <ConversionPendingDisplay units="fiat" />
+                        ) : (
+                            <ConversionDisplay units="fiat" />
+                        )}
                         {showRate && (
                             <Text
                                 style={{ color: themeColor('secondaryText') }}

--- a/views/Wallet/MainPane.tsx
+++ b/views/Wallet/MainPane.tsx
@@ -52,9 +52,11 @@ export default class MainPane extends React.PureComponent<MainPaneProps, {}> {
                     jumboText
                     toggleable
                 />
-                <View style={styles.conversion}>
-                    <Conversion sats={lightningBalance} sensitive />
-                </View>
+                {!(pendingOpenBalance > 0) && (
+                    <View style={styles.conversion}>
+                        <Conversion sats={lightningBalance} sensitive />
+                    </View>
+                )}
                 {pendingOpenBalance > 0 ? (
                     <>
                         <Amount
@@ -65,7 +67,11 @@ export default class MainPane extends React.PureComponent<MainPaneProps, {}> {
                             pending
                         />
                         <View style={styles.conversion}>
-                            <Conversion sats={pendingOpenBalance} sensitive />
+                            <Conversion
+                                sats={lightningBalance}
+                                satsPending={pendingOpenBalance}
+                                sensitive
+                            />
                         </View>
                     </>
                 ) : null}
@@ -79,9 +85,11 @@ export default class MainPane extends React.PureComponent<MainPaneProps, {}> {
                     jumboText
                     toggleable
                 />
-                <View style={styles.conversion}>
-                    <Conversion sats={combinedBalanceValue} sensitive />
-                </View>
+                {!(unconfirmedBlockchainBalance || pendingOpenBalance) && (
+                    <View style={styles.conversion}>
+                        <Conversion sats={combinedBalanceValue} sensitive />
+                    </View>
+                )}
                 {unconfirmedBlockchainBalance || pendingOpenBalance ? (
                     <>
                         <Amount
@@ -91,9 +99,10 @@ export default class MainPane extends React.PureComponent<MainPaneProps, {}> {
                             toggleable
                             pending
                         />
-                        <View style={styles.conversion}>
+                        <View style={styles.conversionSecondary}>
                             <Conversion
-                                sats={pendingUnconfirmedBalance}
+                                sats={combinedBalanceValue}
+                                satsPending={pendingUnconfirmedBalance}
                                 sensitive
                             />
                         </View>
@@ -237,6 +246,10 @@ const styles = StyleSheet.create({
     },
     conversion: {
         top: 10,
+        alignItems: 'center'
+    },
+    conversionSecondary: {
+        top: 3,
         alignItems: 'center'
     }
 });


### PR DESCRIPTION
# Description

Early report from a Carman on the v0.7.0-beta1 release showed that the text color of the `Conversion` component while using iOS was incorrect. Furthermore, the display was a bit wonky when dealing with pending balances.

This PR
- Fixes color issues
- Condenses the `Conversion` components to a single line when dealing with a pending amount on the balance pane

This pull request is categorized as a:

- [x] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
