### PR TITLE
Lurker mode: add timer for reveal toggle

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -235,7 +235,9 @@ export default class Amount extends React.Component<AmountProps, {}> {
                     }}
                     onPressOut={() => {
                         if (!lurkerMode && lurkerExposed) {
-                            SettingsStore.toggleLurker();
+                            setTimeout(() => {
+                                SettingsStore.toggleLurker();
+                            }, 3000);
                         }
                     }}
                 >


### PR DESCRIPTION
# Description

This PR adds a timer for the reveal functionality (hold on `Amount`) when in Lurker mode. Previously you had to keep holding to reveal the sensitive balance, which wouldn't be ideal as your thumb was often obfuscating the view of the value. Now there is a 3 second timer that gets triggered after revealing the value.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
