### PR TITLE
Invoice: fix display of r_hash and r_preimage

### DIFF
--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -1,5 +1,6 @@
 import { observable, computed } from 'mobx';
 import BaseModel from './BaseModel';
+import Base64Utils from './../utils/Base64Utils';
 import DateTimeUtils from './../utils/DateTimeUtils';
 import { localeString } from './../utils/LocaleUtils';
 
@@ -59,6 +60,20 @@ export default class Invoice extends BaseModel {
 
     @computed public get model(): string {
         return 'Invoice';
+    }
+
+    @computed public get getRPreimage(): string {
+        const preimage = this.r_preimage;
+        return typeof preimage === 'string' && preimage.includes('=')
+            ? Base64Utils.base64ToHex(preimage)
+            : preimage;
+    }
+
+    @computed public get getRHash(): string {
+        const hash = this.r_hash;
+        return typeof hash === 'string' && hash.includes('=')
+            ? Base64Utils.base64ToHex(hash)
+            : hash;
     }
 
     @computed public get getTimestamp(): string | number {

--- a/utils/AddressUtils.ts
+++ b/utils/AddressUtils.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import { SATS_PER_BTC } from '../stores/UnitsStore';
 
 const btcNonBech = /^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/;
 const btcBech = /^(bc1|BC1|[13])[a-zA-HJ-NP-Z0-9]{25,87}$/;
@@ -45,7 +46,7 @@ const bitcoinQrParser = (input: string, prefix: string) => {
 
     const value = btcAddress;
     if (result.amount) {
-        amount = new BigNumber(result.amount).multipliedBy(satoshisPerBTC);
+        amount = new BigNumber(result.amount).multipliedBy(SATS_PER_BTC);
         amount = amount.toString();
     }
 

--- a/utils/Base64Utils.test.ts
+++ b/utils/Base64Utils.test.ts
@@ -19,4 +19,23 @@ describe('Base64Utils', () => {
             );
         });
     });
+
+    describe('base64ToHex', () => {
+        it('Converts base64 string to hexidecimal string', () => {
+            expect(
+                Base64Utils.base64ToHex('VGhpcyBpcyB0aGUgZmlyc3QgdGVzdA==')
+            ).toEqual('54686973206973207468652066697273742074657374');
+            expect(Base64Utils.base64ToHex('RW5kIHRoZSBGZWQ=')).toEqual(
+                '456e642074686520466564'
+            );
+            expect(
+                Base64Utils.base64ToHex(
+                    'RGVjb2RpbmcgdGhpcyBCYXNlNjQ/IFF1aXRlIHNwb29reS4='
+                )
+            ).toEqual(
+                '4465636f64696e672074686973204261736536343f2051756974652073706f6f6b792e'
+            );
+            expect(Base64Utils.base64ToHex('WkVVUw==')).toEqual('5a455553');
+        });
+    });
 });

--- a/utils/Base64Utils.ts
+++ b/utils/Base64Utils.ts
@@ -87,6 +87,16 @@ class Base64Utils {
 
     utf8ToHexString = (hexString: string) =>
         Buffer.from(hexString, 'utf8').toString('hex');
+
+    base64ToHex = (base64String: string) => {
+        const raw = this.atob(base64String);
+        let result = '';
+        for (let i = 0; i < raw.length; i++) {
+            const hex = raw.charCodeAt(i).toString(16);
+            result += hex.length === 2 ? hex : '0' + hex;
+        }
+        return result;
+    };
 }
 
 const base64Utils = new Base64Utils();

--- a/views/Invoice.tsx
+++ b/views/Invoice.tsx
@@ -18,14 +18,14 @@ export default class InvoiceView extends React.Component<InvoiceProps> {
         const invoice: Invoice = navigation.getParam('invoice', null);
         const {
             fallback_addr,
-            r_hash,
+            getRHash,
             isPaid,
             getMemo,
             receipt,
             creation_date,
             description_hash,
             payment_hash,
-            r_preimage,
+            getRPreimage,
             cltv_expiry,
             expirationDate,
             payment_request,
@@ -141,18 +141,18 @@ export default class InvoiceView extends React.Component<InvoiceProps> {
                         />
                     )}
 
-                    {!!r_hash && typeof r_hash === 'string' && (
+                    {getRHash && (
                         <KeyValue
                             keyValue={localeString('views.Invoice.rHash')}
-                            value={r_hash}
+                            value={getRHash}
                             sensitive
                         />
                     )}
 
-                    {!!r_preimage && (
+                    {getRPreimage && (
                         <KeyValue
                             keyValue={localeString('views.Invoice.rPreimage')}
-                            value={r_preimage}
+                            value={getRPreimage}
                             sensitive
                         />
                     )}


### PR DESCRIPTION
# Description

This PR fixes the display of R Hashes and R Preimages that are formatted in Base64.

This pull request is categorized as a:

- [x] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
