### PR TITLE
Fixed issue with NFC reading LUD-17 cards

### DIFF
--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -1,5 +1,5 @@
 import { Alert } from 'react-native';
-import { getParams as getlnurlParams, findlnurl } from 'js-lnurl';
+import { getParams as getlnurlParams, findlnurl, decodelnurl } from 'js-lnurl';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 import stores from '../stores/Stores';
 import AddressUtils from './../utils/AddressUtils';
@@ -23,6 +23,10 @@ const handleAnything = async (
     const { value, amount, lightning }: any =
         AddressUtils.processSendAddress(data);
     const hasAt: boolean = value.includes('@');
+    let lnurl;
+    try {
+        lnurl = decodelnurl(data);
+    } catch (e) {}
 
     if (
         !hasAt &&
@@ -151,8 +155,8 @@ const handleAnything = async (
             .catch(() => {
                 throw new Error(error);
             });
-    } else if (findlnurl(value) !== null) {
-        const raw: string = findlnurl(value) || '';
+    } else if (findlnurl(value) !== null || lnurl !== null) {
+        const raw: string = findlnurl(value) || lnurl || '';
         return getlnurlParams(raw).then((params: any) => {
             switch (params.tag) {
                 case 'withdrawRequest':

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -15,7 +15,11 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import { inject, observer } from 'mobx-react';
 import { Header, Icon } from 'react-native-elements';
 
-import NfcManager, { NfcEvents, TagEvent } from 'react-native-nfc-manager';
+import NfcManager, {
+    NfcEvents,
+    TagEvent,
+    Ndef
+} from 'react-native-nfc-manager';
 
 import handleAnything, { isClipboardValue } from './../utils/handleAnything';
 
@@ -209,7 +213,14 @@ export default class Send extends React.Component<SendProps, SendState> {
                     const bytes = new Uint8Array(
                         tagFound.ndefMessage[0].payload
                     );
-                    const str = NFCUtils.nfcUtf8ArrayToStr(bytes) || '';
+
+                    let str;
+                    const decoded = Ndef.text.decodePayload(bytes);
+                    if (decoded.match(/^(https?|lnurl)/)) {
+                        str = decoded;
+                    } else {
+                        str = NFCUtils.nfcUtf8ArrayToStr(bytes) || '';
+                    }
                     resolve(this.validateAddress(str));
                     NfcManager.unregisterTagEvent().catch(() => 0);
                 }


### PR DESCRIPTION
# Description

There was an issue reading Bolt Cards / LUD-17 LNURL NFC where the first 2 characters from the URL were stripped.

This change should allow this format to work while still maintaining previously supported formats.

_Note: My NFC cards that I had on hand only supported a maximum of 140 bytes so I wasn't able to test with a bech32 encoded LNURL_ 

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
