### PR TITLE
LNC: use v1 endpoints for SignMessage + VerifyMessage

### DIFF
--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -3,6 +3,7 @@ import LNC, { lnrpc, walletrpc } from '@lightninglabs/lnc-rn';
 import stores from '../stores/Stores';
 import CredentialStore from './LNC/credentialStore';
 import OpenChannelRequest from './../models/OpenChannelRequest';
+import Base64Utils from './../utils/Base64Utils';
 import { snakeize } from './../utils/DataFormatUtils';
 import VersionUtils from './../utils/VersionUtils';
 
@@ -257,12 +258,18 @@ export default class LightningNodeConnect {
             .importAccount(req)
             .then((data: walletrpc.ImportAccountResponse) => snakeize(data));
     signMessage = async (message: string) =>
-        await this.lnc.lnd.signer
-            .signMessage({ msg: message })
+        await this.lnc.lnd.lightning
+            .signMessage({ msg: Base64Utils.btoa(message) })
             .then((data: lnrpc.SignMessageResponse) => snakeize(data));
     verifyMessage = async (req: lnrpc.VerifyMessageRequest) =>
-        await this.lnc.lnd.signer
-            .verifyMessage({ msg: req.msg, signature: req.signature })
+        await this.lnc.lnd.lightning
+            .verifyMessage({
+                msg:
+                    typeof req.msg === 'string'
+                        ? Base64Utils.btoa(req.msg)
+                        : req.msg,
+                signature: req.signature
+            })
             .then((data: lnrpc.VerifyMessageResponse) => snakeize(data));
     subscribeInvoice = (r_hash: string) =>
         this.lnc.lnd.invoices.subscribeSingleInvoice({ r_hash });


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1216**](https://github.com/ZeusLN/zeus/issues/1216)

Sign and verify messages calls were failing for LNC users as we were using the the updated endpoints on the `Signer` RPC service. REST uses the V1 calls on the `Lightning` RPC service, so let's switch to using that for now to remain consistent. Will evaluate need to more to new calls moving forward.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
