### PR TITLE
LNC: gracefully handle changes to nickname (reconnect flow)

### DIFF
--- a/views/Settings/AddEditNode.tsx
+++ b/views/Settings/AddEditNode.tsx
@@ -17,6 +17,7 @@ import { hash, STORAGE_KEY } from './../../backends/LNC/credentialStore';
 import AddressUtils, { CUSTODIAL_LNDHUBS } from './../../utils/AddressUtils';
 import ConnectionFormatUtils from './../../utils/ConnectionFormatUtils';
 import { localeString } from './../../utils/LocaleUtils';
+import RESTUtils from './../../utils/RESTUtils';
 import { themeColor } from './../../utils/ThemeUtils';
 
 import Button from './../../components/Button';
@@ -343,6 +344,9 @@ export default class AddEditNode extends React.Component<
             });
 
             if (nodes.length === 1) {
+                if (implementation === 'lightning-node-connect') {
+                    RESTUtils.disconnect();
+                }
                 setConnectingStatus(true);
                 navigation.navigate('Wallet', { refresh: true });
             } else {


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1214**](https://github.com/ZeusLN/zeus/issues/1214)

In this instance, the user would have a single node saved (LNC), go back to add a nickname to it, and lose their LNC session connection. This was because we would automatically set the node to be in reconnecting mode, and attempt to connect with LNC, without first disconnecting.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
