### PR TITLE
components/DropdownSetting: enhance styling

### DIFF
--- a/assets/images/SVG/Caret Down.svg
+++ b/assets/images/SVG/Caret Down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" data-v-4fa90e7f="" style="--darkreader-inline-fill: currentColor;" data-darkreader-inline-fill="">
+<path fill-rule="evenodd" d="M4.47 9.4a.75.75 0 011.06 0l6.364 6.364a.25.25 0 00.354 0L18.612 9.4a.75.75 0 011.06 1.06l-6.364 6.364a1.75 1.75 0 01-2.475 0L4.47 10.46a.75.75 0 010-1.06z" clip-rule="evenodd"></path>
+</svg>

--- a/components/DropdownSetting.tsx
+++ b/components/DropdownSetting.tsx
@@ -42,7 +42,7 @@ export default class DropdownSetting extends React.Component<
         return (
             <React.Fragment>
                 {Platform.OS === 'android' && (
-                    <View style={{ height: 75 }}>
+                    <View>
                         <Text
                             style={{
                                 ...styles.secondaryText,
@@ -57,8 +57,11 @@ export default class DropdownSetting extends React.Component<
                                 onValueChange(itemValue)
                             }
                             style={{
-                                color: themeColor('text')
+                                color: themeColor('text'),
+                                backgroundColor: themeColor('secondary'),
+                                ...styles.field
                             }}
+                            dropdownIconColor={themeColor('text')}
                         >
                             {pickerValuesAndroid}
                         </Picker>

--- a/components/DropdownSetting.tsx
+++ b/components/DropdownSetting.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { themeColor } from './../utils/ThemeUtils';
+import CaretDown from './../assets/images/SVG/Caret Down.svg';
 
 interface DropdownSettingProps {
     title: string;
@@ -104,6 +105,18 @@ export default class DropdownSetting extends React.Component<
                             >
                                 {displayValue ? displayValue : selectedValue}
                             </Text>
+                            <View
+                                style={{
+                                    position: 'absolute',
+                                    right: 10,
+                                    top: '33%'
+                                }}
+                            >
+                                <CaretDown
+                                    stroke={themeColor('text')}
+                                    fill={themeColor('text')}
+                                />
+                            </View>
                         </TouchableOpacity>
                     </View>
                 )}

--- a/ios/zeus.xcodeproj/project.pbxproj
+++ b/ios/zeus.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		659C049013BD4A618AA4275C /* Temple.svg in Resources */ = {isa = PBXBuildFile; fileRef = 259ED6E1C36A4BB38A5BFB8B /* Temple.svg */; };
 		692A2B7E895144DDB6D5813C /* PeersContact.svg in Resources */ = {isa = PBXBuildFile; fileRef = 299B155651FE4C3CB3D558D1 /* PeersContact.svg */; };
 		6ACB3216EC1B40A190B0A268 /* Channels.svg in Resources */ = {isa = PBXBuildFile; fileRef = 289689C09C974491A933737A /* Channels.svg */; };
+		745E06AA295CB0E500597EE8 /* Caret Down.svg in Resources */ = {isa = PBXBuildFile; fileRef = 745E06A9295CB0E500597EE8 /* Caret Down.svg */; };
 		748582B6293A4E8300494AD8 /* Lncmobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 748582B5293A4E8300494AD8 /* Lncmobile.xcframework */; };
 		78FB5414F55B4D94804920B7 /* Caret Right-1.svg in Resources */ = {isa = PBXBuildFile; fileRef = 34845404A9F04B35ADA34F80 /* Caret Right-1.svg */; };
 		7C9A1A0DC41A4B56BC555750 /* Node On.svg in Resources */ = {isa = PBXBuildFile; fileRef = 62458EE70D8546B7AE7F87DF /* Node On.svg */; };
@@ -344,6 +345,7 @@
 		6F7490ECB1F7403FB5236410 /* FontAwesome5_Solid.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Solid.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Solid.ttf"; sourceTree = "<group>"; };
 		7407D2CD274E076D00850BAB /* zeus.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = zeus.entitlements; path = zeus/zeus.entitlements; sourceTree = "<group>"; };
 		7407D2CE274E079100850BAB /* zeusRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = zeusRelease.entitlements; path = zeus/zeusRelease.entitlements; sourceTree = "<group>"; };
+		745E06A9295CB0E500597EE8 /* Caret Down.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "Caret Down.svg"; path = "../assets/images/SVG/Caret Down.svg"; sourceTree = "<group>"; };
 		748582B5293A4E8300494AD8 /* Lncmobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Lncmobile.xcframework; path = "../node_modules/@lightninglabs/lnc-rn/ios/Lncmobile.xcframework"; sourceTree = "<group>"; };
 		77EC666A91C04742A050DEF4 /* Help Icon.svg */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Help Icon.svg"; path = "../assets/images/SVG/Help Icon.svg"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
@@ -746,6 +748,7 @@
 				C8B74E7F5FE74AB1B75DD331 /* Backspace.svg */,
 				291FF6091426421DB569BEC4 /* Bitcoin.svg */,
 				5CC0E65B8E6447A38BD1EE91 /* Brush.svg */,
+				745E06A9295CB0E500597EE8 /* Caret Down.svg */,
 				571E23F345EB49B99F8150D2 /* Caret Left.svg */,
 				34845404A9F04B35ADA34F80 /* Caret Right-1.svg */,
 				FB2BF1C8E61649A58A6E1A61 /* Caret Right-3.svg */,
@@ -1214,6 +1217,7 @@
 				BFEB12685B664218922995B1 /* Scan.svg in Resources */,
 				A79D6320396A4D6AA420E33C /* Send.svg in Resources */,
 				0EB04476647C460EA1358028 /* Switch.svg in Resources */,
+				745E06AA295CB0E500597EE8 /* Caret Down.svg in Resources */,
 				659C049013BD4A618AA4275C /* Temple.svg in Resources */,
 				F6BA97FE98FB4D8890855BEC /* Wallet.svg in Resources */,
 				395880B8BA0647E3908DBD6A /* Wallet2.svg in Resources */,


### PR DESCRIPTION
# Description

Some users cannot distinguish the node interface field on the node config page as a dropdown, so we've improved the styling of it on Android and iOS:

Android

![Screenshot_1672160844](https://user-images.githubusercontent.com/1878621/209699109-a8e5db5c-55d8-420d-9e32-192e37e3fb8a.png)

iOS

![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-12-28 at 12 41 57](https://user-images.githubusercontent.com/1878621/209851749-ab15da35-e488-42f9-affc-7b860e4aad00.png)

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
