### PR TITLE
views/IntroSplash: add Scan Node Config button

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -488,6 +488,7 @@
     "views.Sponsors.title": "Sponsors",
     "views.Gods.title": "Gods",
     "views.Mortals.title": "Mortals",
+    "views.Splash.scanConfig": "Scan node config",
     "components.UTXOPicker.modal.title": "Select UTXOs to use",
     "components.UTXOPicker.modal.description": "Select the UTXOs to be used in this operation. You may want to only use specific UTXOs to preserve your privacy.",
     "components.UTXOPicker.modal.set": "Set UTXOs",

--- a/views/IntroSplash.tsx
+++ b/views/IntroSplash.tsx
@@ -88,13 +88,26 @@ export default class IntroSplash extends React.Component<IntroSplashProps, {}> {
                     </View>
                     <View
                         style={{
-                            padding: 10,
-                            marginBottom: 40
+                            padding: 10
                         }}
                     >
                         <Button
                             title={localeString('views.Intro.getStarted')}
                             onPress={() => navigation.navigate('Settings')}
+                        />
+                    </View>
+                    <View
+                        style={{
+                            padding: 10,
+                            marginBottom: 40
+                        }}
+                    >
+                        <Button
+                            title={localeString('views.Splash.scanConfig')}
+                            onPress={() =>
+                                navigation.navigate('HandleAnythingQRScanner')
+                            }
+                            secondary
                         />
                     </View>
                 </SafeAreaView>


### PR DESCRIPTION
# Description

For quicker initial set-up

![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-12-31 at 10 25 39](https://user-images.githubusercontent.com/1878621/210142349-04555cc4-bd8e-416d-815b-93f1d39dae0f.png)
![Screenshot_1672500203](https://user-images.githubusercontent.com/1878621/210142356-d0ed996d-a0e7-4160-804e-67ab88706980.png)


This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
