### PR TITLE
views/PaymentRequest: new fee fields enhancements

### DIFF
--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -219,7 +219,9 @@ export default class PaymentRequest extends React.Component<
         const description = pay_req && pay_req.description;
         const payment_hash = pay_req && pay_req.payment_hash;
         const timestamp = pay_req && pay_req.timestamp;
-        const percentAmount = requestAmount
+        const percentAmount = customAmount
+            ? (Number(customAmount) * (Number(maxFeePercent) / 100)).toFixed()
+            : requestAmount
             ? (requestAmount * (Number(maxFeePercent) / 100)).toFixed()
             : 0;
 

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -461,13 +461,13 @@ export default class PaymentRequest extends React.Component<
                                     </View>
                                     <View
                                         style={{
-                                            flexDirection: 'row'
+                                            flexDirection: 'row',
+                                            width: '95%'
                                         }}
                                     >
                                         <TextInput
                                             style={{
-                                                width: 170,
-                                                paddingRight: 30,
+                                                width: '50%',
                                                 opacity:
                                                     feeOption == 'sats'
                                                         ? 1
@@ -502,9 +502,7 @@ export default class PaymentRequest extends React.Component<
                                         </Text>
                                         <TextInput
                                             style={{
-                                                left: 10,
-                                                width: 160,
-                                                paddingRight: 20,
+                                                width: '50%',
                                                 opacity:
                                                     feeOption == 'percent'
                                                         ? 1
@@ -528,7 +526,7 @@ export default class PaymentRequest extends React.Component<
                                                 ...styles.label,
                                                 color: themeColor('text'),
                                                 top: 28,
-                                                right: 10,
+                                                right: 18,
                                                 opacity:
                                                     feeOption == 'percent'
                                                         ? 1


### PR DESCRIPTION
# Description

This PR adds some enhancements to the new fee fields on the `PaymentRequest` view:

- Take custom amount (0-amt invoice) values into account when calculating amount for max fee percentage
- Updated styling

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
