### PR TITLE
Zero-amt invoices: fix amount received in payment notification

### DIFF
--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -26,6 +26,7 @@ export default class InvoicesStore {
     @observable creatingInvoiceError = false;
     @observable invoicesCount: number;
     @observable watchedInvoicePaid = false;
+    @observable watchedInvoicePaidAmt: number | string | null = null;
     settingsStore: SettingsStore;
 
     // lnd
@@ -72,6 +73,7 @@ export default class InvoicesStore {
         this.feeEstimate = null;
         this.successProbability = null;
         this.watchedInvoicePaid = false;
+        this.watchedInvoicePaidAmt = null;
     };
 
     resetInvoices = () => {
@@ -232,8 +234,9 @@ export default class InvoicesStore {
     };
 
     @action
-    public setWatchedInvoicePaid = () => {
+    public setWatchedInvoicePaid = (amount?: string | number) => {
         this.watchedInvoicePaid = true;
+        if (amount) this.watchedInvoicePaidAmt = amount;
     };
 
     @action

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -138,7 +138,7 @@ export default class Receive extends React.Component<
                         try {
                             const result = JSON.parse(event.result);
                             if (result.settled) {
-                                setWatchedInvoicePaid();
+                                setWatchedInvoicePaid(result.amt_paid_sat);
                                 this.listener = null;
                             }
                         } catch (error) {
@@ -152,7 +152,7 @@ export default class Receive extends React.Component<
         if (implementation === 'lnd') {
             BackendUtils.subscribeInvoice(rHash).then((response: any) => {
                 if (response.result && response.result.settled) {
-                    setWatchedInvoicePaid();
+                    setWatchedInvoicePaid(response.result.amt_paid_sat);
                 }
             });
         }
@@ -236,6 +236,7 @@ export default class Receive extends React.Component<
             creatingInvoiceError,
             error_msg,
             watchedInvoicePaid,
+            watchedInvoicePaidAmt,
             clearUnified,
             reset
         } = InvoicesStore;
@@ -472,7 +473,9 @@ export default class Receive extends React.Component<
                             >
                                 {`${localeString(
                                     'views.Receive.youReceived'
-                                )} ${getAmount(payment_request_amt)}`}
+                                )} ${getAmount(
+                                    watchedInvoicePaidAmt || payment_request_amt
+                                )}`}
                             </Text>
                         </View>
                     ) : (

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -477,6 +477,21 @@ export default class Receive extends React.Component<
                                     watchedInvoicePaidAmt || payment_request_amt
                                 )}`}
                             </Text>
+                            <Button
+                                title={localeString(
+                                    'views.SendingLightning.goToWallet'
+                                )}
+                                icon={{
+                                    name: 'list',
+                                    size: 25
+                                }}
+                                onPress={() =>
+                                    navigation.navigate('Wallet', {
+                                        refresh: true
+                                    })
+                                }
+                                containerStyle={{ width: '100%' }}
+                            />
                         </View>
                     ) : (
                         <View>


### PR DESCRIPTION
# Description

Previously, all zero-amt invoices would return that the user received 0 sats upon payment. This PR ensures that the proper amount is displayed.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `package-lock.json` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
