### PR TITLE
Unified QRs: present case-sensitive onchain addresses in original format

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -488,8 +488,13 @@ export default class Receive extends React.Component<
         const haveInvoice = !!payment_request || !!address;
 
         let unifiedInvoice, lnInvoice, btcAddress;
+        // if format is case insensitive, format as all caps to save QR space, otherwise present in original format
+        const onChainFormatted =
+            address && address === address.toLowerCase()
+                ? address.toUpperCase()
+                : address;
         if (haveUnifiedInvoice) {
-            unifiedInvoice = `bitcoin:${address.toUpperCase()}?${`lightning=${payment_request.toUpperCase()}`}${
+            unifiedInvoice = `bitcoin:${onChainFormatted}?${`lightning=${payment_request.toUpperCase()}`}${
                 Number(satAmount) > 0
                     ? `&amount=${new BigNumber(satAmount)
                           .dividedBy(SATS_PER_BTC)
@@ -503,7 +508,7 @@ export default class Receive extends React.Component<
         }
 
         if (address) {
-            btcAddress = `bitcoin:${address.toUpperCase()}${
+            btcAddress = `bitcoin:${onChainFormatted}${
                 (Number(satAmount) > 0 || memo) && '?'
             }${
                 Number(satAmount) > 0


### PR DESCRIPTION
# Description

Previously, we were converting all onchain addresses to all caps to save on space in QRs. This PR assesses whether the address is case sensitive, and leaves it in its original format if it is (see Nested Segwit)

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
