### PR TITLE
Channels: force close channel timer display

### DIFF
--- a/backends/CLightningREST.ts
+++ b/backends/CLightningREST.ts
@@ -156,6 +156,7 @@ export default class CLightningREST extends LND {
     supportsOnchainReceiving = () => true;
     supportsKeysend = () => true;
     supportsChannelManagement = () => true;
+    supportsPendingChannels = () => false;
     supportsMPP = () => false;
     supportsAMP = () => false;
     supportsCoinControl = () => this.supports('v0.8.2', undefined, 'v0.4.0');

--- a/backends/Eclair.ts
+++ b/backends/Eclair.ts
@@ -472,6 +472,7 @@ export default class Eclair {
     supportsOnchainReceiving = () => true;
     supportsKeysend = () => false;
     supportsChannelManagement = () => true;
+    supportsPendingChannels = () => false;
     supportsMPP = () => false;
     supportsAMP = () => false;
     supportsCoinControl = () => false;

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -346,6 +346,7 @@ export default class LND {
     supportsOnchainReceiving = () => true;
     supportsKeysend = () => true;
     supportsChannelManagement = () => true;
+    supportsPendingChannels = () => true;
     supportsMPP = () => this.supports('v0.10.0');
     supportsAMP = () => this.supports('v0.13.0');
     supportsCoinControl = () => this.supports('v0.12.0');

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -200,6 +200,8 @@ export default class LND {
             transactions: data.transactions.reverse()
         }));
     getChannels = () => this.getRequest('/v1/channels');
+    getPendingChannels = () => this.getRequest('/v1/channels/pending');
+    getClosedChannels = () => this.getRequest('/v1/channels/closed');
     getChannelInfo = (chanId: string) =>
         this.getRequest(`/v1/graph/edge/${chanId}`);
     getBlockchainBalance = () => this.getRequest('/v1/balance/blockchain');

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -297,6 +297,7 @@ export default class LightningNodeConnect {
     supportsOnchainReceiving = () => true;
     supportsKeysend = () => true;
     supportsChannelManagement = () => true;
+    supportsPendingChannels = () => true;
     supportsMPP = () => this.supports('v0.10.0');
     supportsAMP = () => this.supports('v0.13.0');
     supportsCoinControl = () => this.supports('v0.12.0');

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -53,6 +53,14 @@ export default class LightningNodeConnect {
         await this.lnc.lnd.lightning
             .listChannels({})
             .then((data: lnrpc.ListChannelsResponse) => snakeize(data));
+    getPendingChannels = async () =>
+        await this.lnc.lnd.lightning
+            .pendingChannels({})
+            .then((data: lnrpc.PendingChannelsResponse) => snakeize(data));
+    getClosedChannels = async () =>
+        await this.lnc.lnd.lightning
+            .closedChannels({})
+            .then((data: lnrpc.ClosedChannelsResponse) => snakeize(data));
     getChannelInfo = async (chanId: string) => {
         const request: lnrpc.ChanInfoRequest = { chanId };
         return await this.lnc.lnd.lightning

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -84,6 +84,7 @@ export default class LndHub extends LND {
         );
     supportsKeysend = () => false;
     supportsChannelManagement = () => false;
+    supportsPendingChannels = () => false;
     supportsMPP = () => false;
     supportsAMP = () => false;
     supportsCoinControl = () => false;

--- a/backends/Spark.ts
+++ b/backends/Spark.ts
@@ -315,6 +315,7 @@ export default class Spark {
     supportsOnchainReceiving = () => true;
     supportsKeysend = () => false;
     supportsChannelManagement = () => true;
+    supportsPendingChannels = () => false;
     supportsMPP = () => false;
     supportsAMP = () => false;
     supportsCoinControl = () => false;

--- a/components/Channels/ChannelItem.tsx
+++ b/components/Channels/ChannelItem.tsx
@@ -13,22 +13,31 @@ import { themeColor } from './../../utils/ThemeUtils';
 
 import Stores from '../../stores/Stores';
 
+import ClockIcon from '../../assets/images/SVG/Clock.svg';
+
 export function ChannelItem({
     title,
     inbound,
     outbound,
     largestTotal,
-    status
+    status,
+    pendingTimelock
 }: {
     title: string;
     inbound: number;
     outbound: number;
     largestTotal?: number;
     status: Status;
+    pendingTimelock?: String;
 }) {
     const { settings } = Stores.settingsStore;
     const { privacy } = settings;
     const lurkerMode = (privacy && privacy.lurkerMode) || false;
+
+    const isOffline =
+        status === Status.Offline ||
+        status === Status.Closing ||
+        status === Status.Opening;
 
     const percentOfLargest = largestTotal
         ? (Number(inbound) + Number(outbound)) / largestTotal
@@ -47,6 +56,17 @@ export function ChannelItem({
                 <View style={{ flex: 1, paddingRight: 10 }}>
                     <Body>{PrivacyUtils.sensitiveValue(title)}</Body>
                 </View>
+                {pendingTimelock ? (
+                    <View style={{ flexDirection: 'row', marginRight: 5 }}>
+                        <ClockIcon
+                            color={themeColor('bitcoin')}
+                            width={17}
+                            height={17}
+                            style={{ marginRight: 5 }}
+                        />
+                        <Body small={true}>{pendingTimelock}</Body>
+                    </View>
+                ) : null}
                 <Tag status={status} />
             </Row>
             {inbound && outbound && (
@@ -54,7 +74,7 @@ export function ChannelItem({
                     <BalanceBar
                         left={lurkerMode ? 50 : Number(outbound)}
                         right={lurkerMode ? 50 : Number(inbound)}
-                        offline={status === Status.Offline}
+                        offline={isOffline}
                         percentOfLargest={percentOfLargest}
                         showProportionally={lurkerMode ? false : true}
                     />

--- a/components/Channels/ChannelItem.tsx
+++ b/components/Channels/ChannelItem.tsx
@@ -49,15 +49,17 @@ export function ChannelItem({
                 </View>
                 <Tag status={status} />
             </Row>
-            <Row>
-                <BalanceBar
-                    left={lurkerMode ? 50 : Number(outbound)}
-                    right={lurkerMode ? 50 : Number(inbound)}
-                    offline={status === Status.Offline}
-                    percentOfLargest={percentOfLargest}
-                    showProportionally={lurkerMode ? false : true}
-                />
-            </Row>
+            {inbound && outbound && (
+                <Row>
+                    <BalanceBar
+                        left={lurkerMode ? 50 : Number(outbound)}
+                        right={lurkerMode ? 50 : Number(inbound)}
+                        offline={status === Status.Offline}
+                        percentOfLargest={percentOfLargest}
+                        showProportionally={lurkerMode ? false : true}
+                    />
+                </Row>
+            )}
             <Row justify="space-between">
                 <Amount sats={outbound} sensitive />
                 <Amount sats={inbound} sensitive />

--- a/components/Channels/Tag.tsx
+++ b/components/Channels/Tag.tsx
@@ -24,6 +24,8 @@ export function Tag({ status }: { status: Status }) {
             colors.background = '#E14C4C';
             colors.dot = '#FF0000';
             break;
+        case Status.Opening:
+        case Status.Closing:
         case Status.Offline:
             colors.background = '#A7A9AC';
             colors.dot = '#E5E5E5';

--- a/models/ChannelClose.ts
+++ b/models/ChannelClose.ts
@@ -1,0 +1,34 @@
+import { computed } from 'mobx';
+import BaseModel from './BaseModel';
+import { localeString } from './../utils/LocaleUtils';
+
+export default class ChannelClose extends BaseModel {
+    channel_point: string;
+    chain_hash: string;
+    chan_id: string;
+    closing_tx_hash: string;
+    remote_pubkey: string;
+    capacity: string;
+    close_height: number;
+    settled_balance: string;
+    time_lock_balance: string;
+    close_time: number;
+    open_initiator: any;
+    close_initiator: any;
+    resolutions: any;
+
+    @computed
+    public get channelId(): string {
+        return this.chan_id || localeString('models.Channel.unknownId');
+    }
+
+    @computed
+    public get localBalance(): string {
+        return this.settled_balance;
+    }
+
+    @computed
+    public get remoteBalance(): string {
+        return `${Number(this.capacity) - Number(this.settled_balance)}`;
+    }
+}

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -153,10 +153,35 @@ export default class ChannelsStore {
                 //    "pending_closing_channels": <ClosedChannel>,
                 //    "pending_force_closing_channels": <ForceClosedChannel>,
                 //    "waiting_close_channels": <WaitingCloseChannel>,
-                const pendingChannels = data.pending_open_channels.map(
-                    (channel: any) => new Channel(channel)
+                const pendingOpenChannels = data.pending_open_channels.map(
+                    (pending: any) => {
+                        pending.channel.pendingOpen = true;
+                        return new Channel(pending.channel);
+                    }
                 );
-                this.pendingChannels = pendingChannels;
+                const pendingCloseChannels = data.pending_closing_channels.map(
+                    (pending: any) => {
+                        pending.channel.pendingClose = true;
+                        return new Channel(pending.channel);
+                    }
+                );
+                const forceCloseChannels =
+                    data.pending_force_closing_channels.map((pending: any) => {
+                        pending.channel.blocks_til_maturity =
+                            pending.blocks_til_maturity;
+                        pending.channel.forceClose = true;
+                        return new Channel(pending.channel);
+                    });
+                const waitCloseChannels = data.waiting_close_channels.map(
+                    (pending: any) => {
+                        pending.channel.closing = true;
+                        return new Channel(pending.channel);
+                    }
+                );
+                this.pendingChannels = pendingOpenChannels
+                    .concat(pendingCloseChannels)
+                    .concat(forceCloseChannels)
+                    .concat(waitCloseChannels);
                 this.error = false;
             })
             .catch(() => {

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -147,12 +147,6 @@ export default class ChannelsStore {
 
         BackendUtils.getPendingChannels()
             .then((data: any) => {
-                // TODO parse out
-                //    "total_limbo_balance": <int64>,
-                //    "pending_open_channels": <PendingOpenChannel>,
-                //    "pending_closing_channels": <ClosedChannel>,
-                //    "pending_force_closing_channels": <ForceClosedChannel>,
-                //    "waiting_close_channels": <WaitingCloseChannel>,
                 const pendingOpenChannels = data.pending_open_channels.map(
                     (pending: any) => {
                         pending.channel.pendingOpen = true;

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -112,6 +112,7 @@ class BackendUtils {
     supportsOnchainReceiving = () => this.call('supportsOnchainReceiving');
     supportsKeysend = () => this.call('supportsKeysend');
     supportsChannelManagement = () => this.call('supportsChannelManagement');
+    supportsPendingChannels = () => this.call('supportsPendingChannels');
     supportsMPP = () => this.call('supportsMPP');
     supportsAMP = () => this.call('supportsAMP');
     supportsCoinControl = () => this.call('supportsCoinControl');

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -54,6 +54,10 @@ class BackendUtils {
 
     getTransactions = (...args: any[]) => this.call('getTransactions', args);
     getChannels = (...args: any[]) => this.call('getChannels', args);
+    getPendingChannels = (...args: any[]) =>
+        this.call('getPendingChannels', args);
+    getClosedChannels = (...args: any[]) =>
+        this.call('getClosedChannels', args);
     getChannelInfo = (...args: any[]) => this.call('getChannelInfo', args);
     getBlockchainBalance = (...args: any[]) =>
         this.call('getBlockchainBalance', args);

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { FlatList, View, TouchableHighlight } from 'react-native';
+import {
+    FlatList,
+    View,
+    TouchableHighlight,
+    TouchableOpacity
+} from 'react-native';
 
 import { inject, observer } from 'mobx-react';
 
@@ -26,12 +31,20 @@ interface ChannelsProps {
     ChannelsStore: ChannelsStore;
 }
 
+interface ChannelsState {
+    channelsType: number;
+}
+
 @inject('ChannelsStore', 'SettingsStore')
 @observer
 export default class ChannelsPane extends React.PureComponent<
     ChannelsProps,
-    {}
+    ChannelsState
 > {
+    state = {
+        channelsType: 0
+    };
+
     renderItem = ({ item }) => {
         const { ChannelsStore, navigation } = this.props;
         const { nodes, largestChannelSats } = ChannelsStore;
@@ -40,6 +53,27 @@ export default class ChannelsPane extends React.PureComponent<
             (nodes[item.remote_pubkey] && nodes[item.remote_pubkey].alias) ||
             item.remote_pubkey ||
             item.channelId;
+
+        if (this.state.channelsType === 0) {
+            return (
+                <TouchableHighlight
+                    onPress={() =>
+                        navigation.navigate('Channel', {
+                            channel: item
+                        })
+                    }
+                >
+                    <ChannelItem
+                        title={displayName}
+                        status={item.isActive ? Status.Good : Status.Offline}
+                        inbound={item.remoteBalance}
+                        outbound={item.localBalance}
+                        largestTotal={largestChannelSats}
+                    />
+                </TouchableHighlight>
+            );
+        }
+
         return (
             <TouchableHighlight
                 onPress={() =>
@@ -50,37 +84,70 @@ export default class ChannelsPane extends React.PureComponent<
             >
                 <ChannelItem
                     title={displayName}
-                    status={item.isActive ? Status.Good : Status.Offline}
                     inbound={item.remoteBalance}
                     outbound={item.localBalance}
-                    largestTotal={largestChannelSats}
+                    status={item.isActive ? Status.Good : Status.Offline}
                 />
             </TouchableHighlight>
         );
     };
 
+    toggleChannelsType = () => {
+        const { channelsType } = this.state;
+        if (channelsType === 2) {
+            this.setState({
+                channelsType: 0
+            });
+        } else {
+            this.setState({
+                channelsType: channelsType + 1
+            });
+        }
+    };
+
     render() {
         const { ChannelsStore, SettingsStore, navigation } = this.props;
+        const { channelsType } = this.state;
         const {
             loading,
             getChannels,
             totalInbound,
             totalOutbound,
             totalOffline,
-            channels
+            channels,
+            pendingChannels,
+            closedChannels
         } = ChannelsStore;
-        const headerString = `${localeString(
-            'views.Wallet.Wallet.channels'
-        )} (${channels.length})`;
+
+        let headerString;
+        let channelsData;
+        switch (channelsType) {
+            case 0:
+                headerString = `${localeString(
+                    'views.Wallet.Wallet.channels'
+                )} (${channels.length})`;
+                channelsData = channels;
+                break;
+            case 1:
+                headerString = `Pending Channels (${pendingChannels.length})`;
+                channelsData = pendingChannels;
+                break;
+            case 2:
+                headerString = `Closed Channels (${closedChannels.length})`;
+                channelsData = closedChannels;
+                break;
+        }
 
         return (
             <View style={{ flex: 1 }}>
-                <WalletHeader
-                    navigation={navigation}
-                    title={headerString}
-                    SettingsStore={SettingsStore}
-                    channels
-                />
+                <TouchableOpacity onPress={() => this.toggleChannelsType()}>
+                    <WalletHeader
+                        navigation={navigation}
+                        title={headerString}
+                        SettingsStore={SettingsStore}
+                        channels
+                    />
+                </TouchableOpacity>
                 <ChannelsHeader
                     totalInbound={totalInbound}
                     totalOutbound={totalOutbound}
@@ -90,7 +157,7 @@ export default class ChannelsPane extends React.PureComponent<
                     <LoadingIndicator />
                 ) : (
                     <FlatList
-                        data={channels}
+                        data={channelsData}
                         renderItem={this.renderItem}
                         ListFooterComponent={<Spacer height={100} />}
                         onRefresh={() => getChannels()}

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -19,6 +19,7 @@ import { Spacer } from '../../components/layout/Spacer';
 import ChannelsStore from '../../stores/ChannelsStore';
 
 import { duration } from 'moment';
+import BackendUtils from '../../utils/BackendUtils';
 
 // TODO: does this belong in the model? Or can it be computed from the model?
 export enum Status {
@@ -165,7 +166,12 @@ export default class ChannelsPane extends React.PureComponent<
 
         return (
             <View style={{ flex: 1 }}>
-                <TouchableOpacity onPress={() => this.toggleChannelsType()}>
+                <TouchableOpacity
+                    onPress={() => {
+                        if (BackendUtils.supportsPendingChannels())
+                            this.toggleChannelsType();
+                    }}
+                >
                     <WalletHeader
                         navigation={navigation}
                         title={headerString}


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

Timer for force closed channels. Added supportsPendingChannels check to backends. Updated so pending/closed channel views only show for LND (REST/LNC) for now.

Note: this PR makes use of moment package however I haven't modified packages.json here as i think the package is already in use upstream.

This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] LND (REST)
- [X] LND (Lightning Node Connect)
- [X] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
