### PR TITLE
Reproducible builds: update Docker image, use SHA256 hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Reproducible builds are available for Android only right now. You'll need Docker
     You can also remove the `--branch v0.7.0` parameter to build APKs for `master`.
 2. Change to the zeus directory: `cd zeus`
 3. Execute the build script: `./build.sh`
-4. If everything goes well, the script will print a list of all the generated APK files and MD5 for each one of them: armv7, armv8, x86, x86_64, universal. The equivalent to the one provided in the web page is the one ending in 'universal'. You can compare MD5s with the ones provided on the [GitHub releases page](https://github.com/ZeusLN/zeus/releases)
+4. If everything goes well, the script will print a list of all the generated APK files and SHA256 hashes for each one of them: armv7, armv8, x86, x86_64, universal. The equivalent to the one provided in the web page is the one ending in 'universal'. You can compare SHA256 hashes with the ones provided on the [GitHub releases page](https://github.com/ZeusLN/zeus/releases)
 5. Download the oficial apk from [GitHub releases page](https://github.com/ZeusLN/zeus/releases) or from the [Zeus homepage](https://zeusln.app/): `wget https://zeusln.app/zeus-v0.7.0.apk`
 6. Compare both APKs with a suitable utility like `diffoscope`, `apksigcopier` or by running `diff --brief --recursive ./unpacked_oficial_apk ./unpacked_built_apk`. You should only get differences for the certificates used to sign the official APK
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-BUILDER_IMAGE="reactnativecommunity/react-native-android:5.4"
+BUILDER_IMAGE="reactnativecommunity/react-native-android:7.0"
 CONTAINER_NAME="zeus_builder_container"
 ZEUS_PATH=/olympus/zeus
 
@@ -9,13 +9,13 @@ docker run --rm --name $CONTAINER_NAME -v `pwd`:$ZEUS_PATH $BUILDER_IMAGE bash -
       cd /olympus/zeus/node_modules/@lightninglabs/lnc-rn ; bash fetch-libraries.sh && \
       cd /olympus/zeus/android ; ./gradlew assembleRelease && \
 
-      echo -e "\n\n********************************\n**** APKs and MD5\n********************************\n" && \
+      echo -e "\n\n********************************\n**** APKs and SHA256 Hashes\n********************************\n" && \
       cd /olympus/zeus && \
       for f in android/app/build/outputs/apk/release/*.apk;
       do
 	      RENAMED_FILENAME=$(echo $f | sed -e "s/app-/zeus-/" | sed -e "s/-release-unsigned//")
 	      mv $f $RENAMED_FILENAME
-	      md5sum $RENAMED_FILENAME
+	      sha256sum $RENAMED_FILENAME
       done && \
       echo -e "\n" ';
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-BUILDER_IMAGE="reactnativecommunity/react-native-android:7.0"
+# reactnativecommunity/react-native-android:7.0
+BUILDER_IMAGE="reactnativecommunity/react-native-android@sha256:7bbad62c74f01b2099163890fd11ab7b37e8a496528e6af2dfaa1f29369c2e24"
 CONTAINER_NAME="zeus_builder_container"
 ZEUS_PATH=/olympus/zeus
 


### PR DESCRIPTION
This PR:

- Updates `reactnativecommunity/react-native-android` from v5.4 to v7.0, which
Updates Node from v14 to v16
Updates Android NDK from v21.4.7075529 to v23.1.7779620
Updates cmake from v3.18.1 to v3.22.1
- Pins Docker image by SHA256 hash
- Replaces MD5 hashes with SHA256 hashes