### PR TITLE
LNURL-pay: confirm button: use theme colors

### DIFF
--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -366,17 +366,20 @@ export default class LnurlPay extends React.Component<
                     <View style={styles.button}>
                         <Button
                             title="Confirm"
+                            titleStyle={{
+                                color: themeColor('text')
+                            }}
                             icon={{
                                 name: 'send',
                                 size: 25,
-                                color: 'white'
+                                color: themeColor('text')
                             }}
                             onPress={() => {
                                 this.sendValues(satAmount);
                             }}
                             style={styles.button}
                             buttonStyle={{
-                                backgroundColor: 'orange',
+                                backgroundColor: themeColor('secondary'),
                                 borderRadius: 30
                             }}
                         />


### PR DESCRIPTION
# Description

Updated Confirm button colors on LNURL pay screen to match selected theme's colors. No more orange Confirm button for every theme!

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [X] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [X] Android
- [ ] iOS
Note: I tested this on all themes and looks good. Also fixes an issue on the Orange theme where the button couldn't be seen due to the default color of the button being the same as the background.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
