### PR TITLE
Channels: maintain channelsType state between renders

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -193,6 +193,8 @@
     "views.Wallet.Wallet.invoices": "Invoices",
     "views.Wallet.Wallet.onchain": "On-chain",
     "views.Wallet.Wallet.channels": "Channels",
+    "views.Wallet.Wallet.pendingChannels": "Pending Channels",
+    "views.Wallet.Wallet.closedChannels": "Closed Channels",
     "views.Wallet.Wallet.startingUp": "Zeus is starting up.",
     "views.Wallet.Wallet.connecting": "Zeus is connecting to your node.",
     "views.Wallet.restart": "Restart",

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -43,6 +43,7 @@ export default class ChannelsStore {
     @observable public totalInbound = 0;
     @observable public totalOffline = 0;
     @observable public chanInfo: ChannelInfoIndex = {};
+    @observable public channelsType = 0;
 
     settingsStore: SettingsStore;
 
@@ -114,6 +115,7 @@ export default class ChannelsStore {
         this.totalOutbound = 0;
         this.totalInbound = 0;
         this.totalOffline = 0;
+        this.channelsType = 0;
     };
 
     @action

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -17,6 +17,12 @@ interface ChannelInfoIndex {
     [key: string]: ChannelInfo;
 }
 
+export enum ChannelsType {
+    Open = 0,
+    Pending = 1,
+    Closed = 2
+}
+
 export default class ChannelsStore {
     @observable public loading = false;
     @observable public error = false;
@@ -43,7 +49,7 @@ export default class ChannelsStore {
     @observable public totalInbound = 0;
     @observable public totalOffline = 0;
     @observable public chanInfo: ChannelInfoIndex = {};
-    @observable public channelsType = 0;
+    @observable public channelsType = ChannelsType.Open;
 
     settingsStore: SettingsStore;
 
@@ -115,7 +121,7 @@ export default class ChannelsStore {
         this.totalOutbound = 0;
         this.totalInbound = 0;
         this.totalOffline = 0;
-        this.channelsType = 0;
+        this.channelsType = ChannelsType.Open;
     };
 
     @action
@@ -473,7 +479,7 @@ export default class ChannelsStore {
             });
     };
 
-    public setChannelsType = (type: number) => {
+    public setChannelsType = (type: ChannelsType) => {
         this.channelsType = type;
     };
 }

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -472,4 +472,8 @@ export default class ChannelsStore {
                 this.loading = false;
             });
     };
+
+    public setChannelsType = (type: number) => {
+        this.channelsType = type;
+    };
 }

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -49,7 +49,7 @@ export default class ChannelsPane extends React.PureComponent<
     ChannelsState
 > {
     state = {
-        channelsType: 0
+        channelsType: this.props.ChannelsStore.channelsType || 0
     };
 
     renderItem = ({ item }) => {
@@ -121,12 +121,15 @@ export default class ChannelsPane extends React.PureComponent<
     };
 
     toggleChannelsType = () => {
+        const { ChannelsStore } = this.props;
         const { channelsType } = this.state;
         if (channelsType === 2) {
+            ChannelsStore.channelsType = 0;
             this.setState({
                 channelsType: 0
             });
         } else {
+            ChannelsStore.channelsType = channelsType + 1;
             this.setState({
                 channelsType: channelsType + 1
             });

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -38,23 +38,12 @@ interface ChannelsProps {
     SettingsStore: SettingsStore;
 }
 
-interface ChannelsState {
-    channelsType: number;
-}
-
 @inject('ChannelsStore', 'SettingsStore')
 @observer
-export default class ChannelsPane extends React.PureComponent<
-    ChannelsProps,
-    ChannelsState
-> {
-    state = {
-        channelsType: this.props.ChannelsStore.channelsType || 0
-    };
-
+export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
     renderItem = ({ item }) => {
         const { ChannelsStore, navigation } = this.props;
-        const { nodes, largestChannelSats } = ChannelsStore;
+        const { nodes, largestChannelSats, channelsType } = ChannelsStore;
         const displayName =
             item.alias ||
             (nodes[item.remotePubkey] && nodes[item.remotePubkey].alias) ||
@@ -77,7 +66,7 @@ export default class ChannelsPane extends React.PureComponent<
             return duration(maturity * 10, 'minutes').humanize();
         };
 
-        if (this.state.channelsType === 0) {
+        if (channelsType === 0) {
             return (
                 <TouchableHighlight
                     onPress={() =>
@@ -122,23 +111,17 @@ export default class ChannelsPane extends React.PureComponent<
 
     toggleChannelsType = () => {
         const { ChannelsStore } = this.props;
-        const { channelsType } = this.state;
+        const { channelsType } = ChannelsStore;
         if (channelsType === 2) {
-            ChannelsStore.channelsType = 0;
-            this.setState({
-                channelsType: 0
-            });
+            ChannelsStore.setChannelsType(0);
         } else {
-            ChannelsStore.channelsType = channelsType + 1;
-            this.setState({
-                channelsType: channelsType + 1
-            });
+            ChannelsStore.setChannelsType(channelsType + 1);
         }
     };
 
     render() {
         const { ChannelsStore, SettingsStore, navigation } = this.props;
-        const { channelsType } = this.state;
+        const { channelsType } = ChannelsStore;
         const {
             loading,
             getChannels,

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -16,7 +16,7 @@ import WalletHeader from '../../components/WalletHeader';
 import { localeString } from '../../utils/LocaleUtils';
 import { Spacer } from '../../components/layout/Spacer';
 
-import ChannelsStore from '../../stores/ChannelsStore';
+import ChannelsStore, { ChannelsType } from '../../stores/ChannelsStore';
 import SettingsStore from '../../stores/SettingsStore';
 
 import { duration } from 'moment';
@@ -66,7 +66,7 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
             return duration(maturity * 10, 'minutes').humanize();
         };
 
-        if (channelsType === 0) {
+        if (channelsType === ChannelsType.Open) {
             return (
                 <TouchableHighlight
                     onPress={() =>
@@ -112,11 +112,20 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
     toggleChannelsType = () => {
         const { ChannelsStore } = this.props;
         const { channelsType } = ChannelsStore;
-        if (channelsType === 2) {
-            ChannelsStore.setChannelsType(0);
-        } else {
-            ChannelsStore.setChannelsType(channelsType + 1);
+
+        let newType = ChannelsType.Open;
+        switch (channelsType) {
+            case ChannelsType.Open:
+                newType = ChannelsType.Pending;
+                break;
+            case ChannelsType.Pending:
+                newType = ChannelsType.Closed;
+                break;
+
+            default:
+                newType = ChannelsType.Open;
         }
+        ChannelsStore.setChannelsType(newType);
     };
 
     render() {
@@ -136,18 +145,22 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
         let headerString;
         let channelsData;
         switch (channelsType) {
-            case 0:
+            case ChannelsType.Open:
                 headerString = `${localeString(
                     'views.Wallet.Wallet.channels'
                 )} (${channels.length})`;
                 channelsData = channels;
                 break;
-            case 1:
-                headerString = `Pending Channels (${pendingChannels.length})`;
+            case ChannelsType.Pending:
+                headerString = `${localeString(
+                    'views.Wallet.Wallet.pendingChannels'
+                )} (${pendingChannels.length})`;
                 channelsData = pendingChannels;
                 break;
-            case 2:
-                headerString = `Closed Channels (${closedChannels.length})`;
+            case ChannelsType.Closed:
+                headerString = `${localeString(
+                    'views.Wallet.Wallet.closedChannels'
+                )} (${closedChannels.length})`;
                 channelsData = closedChannels;
                 break;
         }

--- a/views/Settings/Nodes.tsx
+++ b/views/Settings/Nodes.tsx
@@ -13,6 +13,7 @@ import NodeInfoStore from '../../stores/NodeInfoStore';
 import SettingsStore, { INTERFACE_KEYS } from './../../stores/SettingsStore';
 import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
+import ChannelsStore from '../../stores/ChannelsStore';
 
 interface NodesProps {
     nodes: any[];
@@ -22,6 +23,7 @@ interface NodesProps {
     selectedNode?: number;
     BalanceStore: BalanceStore;
     NodeInfoStore: NodeInfoStore;
+    ChannelsStore: ChannelsStore;
     SettingsStore: SettingsStore;
 }
 
@@ -30,7 +32,7 @@ interface NodesState {
     loading: boolean;
 }
 
-@inject('BalanceStore', 'NodeInfoStore', 'SettingsStore')
+@inject('BalanceStore', 'NodeInfoStore', 'ChannelsStore', 'SettingsStore')
 @observer
 export default class Nodes extends React.Component<NodesProps, NodesState> {
     state = {
@@ -70,8 +72,13 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
     );
 
     render() {
-        const { navigation, BalanceStore, NodeInfoStore, SettingsStore } =
-            this.props;
+        const {
+            navigation,
+            BalanceStore,
+            NodeInfoStore,
+            ChannelsStore,
+            SettingsStore
+        } = this.props;
         const { loading, nodes } = this.state;
         const {
             updateSettings,
@@ -158,6 +165,7 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                                             }
                                             BalanceStore.reset();
                                             NodeInfoStore.reset();
+                                            ChannelsStore.reset();
                                             setConnectingStatus(true);
                                             navigation.navigate('Wallet', {
                                                 refresh: true


### PR DESCRIPTION
# Description

After viewing a closed channel and then going back to the list of channels the channel list is refreshed and sent back to the open channel view. This change maintains the current channel list view.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [X] LND (Lightning Node Connect)
- [X] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [X] I’ve added new locale text that requires translations
- [X] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
