### PR TITLE
LNC: add perm checks for custodial accounts

### DIFF
--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -20,6 +20,13 @@ const ADDRESS_TYPES = [
 export default class LightningNodeConnect {
     lnc: any;
 
+    permOpenChannel: boolean;
+    permSendCoins: boolean;
+    permNewAddress: boolean;
+    permImportAccount: boolean;
+    permForwardingHistory: boolean;
+    permSignMessage: boolean;
+
     initLNC = async () => {
         const { pairingPhrase, mailboxServer, customMailboxServer } =
             stores.settingsStore;
@@ -38,6 +45,26 @@ export default class LightningNodeConnect {
     };
 
     connect = async () => await this.lnc.connect();
+    checkPerms = async () => {
+        this.permOpenChannel = await this.lnc.hasPerms(
+            'lnrpc.Lightning.OpenChannel'
+        );
+        this.permSendCoins = await this.lnc.hasPerms(
+            'lnrpc.Lightning.SendCoins'
+        );
+        this.permNewAddress = await this.lnc.hasPerms(
+            'lnrpc.Lightning.NewAddress'
+        );
+        this.permImportAccount = await this.lnc.hasPerms(
+            'walletrpc.WalletKit.ImportAccount'
+        );
+        this.permForwardingHistory = await this.lnc.hasPerms(
+            'lnrpc.Lightning.ForwardingHistory'
+        );
+        this.permSignMessage = await this.lnc.hasPerms(
+            'signrpc.Signer.SignMessage'
+        );
+    };
     isConnected = async () => await this.lnc.isConnected();
     disconnect = () => this.lnc.disconnect();
 
@@ -301,19 +328,19 @@ export default class LightningNodeConnect {
         return isSupportedVersion(version, minVersion, eosVersion);
     };
 
-    supportsMessageSigning = () => true;
+    supportsMessageSigning = () => this.permSignMessage;
     supportsLnurlAuth = () => true;
-    supportsOnchainSends = () => true;
-    supportsOnchainReceiving = () => true;
+    supportsOnchainSends = () => this.permSendCoins;
+    supportsOnchainReceiving = () => this.permNewAddress;
     supportsKeysend = () => true;
-    supportsChannelManagement = () => true;
+    supportsChannelManagement = () => this.permOpenChannel;
     supportsPendingChannels = () => true;
     supportsMPP = () => this.supports('v0.10.0');
     supportsAMP = () => this.supports('v0.13.0');
-    supportsCoinControl = () => this.supports('v0.12.0');
-    supportsHopPicking = () => this.supports('v0.11.0');
-    supportsAccounts = () => this.supports('v0.13.0');
-    supportsRouting = () => true;
+    supportsCoinControl = () => this.permNewAddress;
+    supportsHopPicking = () => this.permOpenChannel;
+    supportsAccounts = () => this.permImportAccount;
+    supportsRouting = () => this.permForwardingHistory;
     supportsNodeInfo = () => true;
     singleFeesEarnedTotal = () => false;
     supportsAddressTypeSelection = () => true;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@keystonehq/bc-ur-registry": "0.4.2",
-    "@lightninglabs/lnc-rn": "0.2.1-alpha.2",
+    "@lightninglabs/lnc-rn": "0.2.3-alpha",
     "@ngraveio/bc-ur": "1.1.6",
     "@react-native-clipboard/clipboard": "1.9.0",
     "@react-native-community/masked-view": "0.1.11",

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -131,6 +131,7 @@ class BackendUtils {
     // LNC
     initLNC = (...args: any[]) => this.call('initLNC', args);
     connect = (...args: any[]) => this.call('connect', args);
+    checkPerms = () => this.call('checkPerms');
     isConnected = (...args: any[]) => this.call('isConnected', args);
     disconnect = (...args: any[]) => this.call('disconnect', args);
 }

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -251,12 +251,15 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 error = await connect();
             }
             if (!error) {
+                await BackendUtils.checkPerms();
                 NodeInfoStore.getNodeInfo();
-                UTXOsStore.listAccounts();
+                if (BackendUtils.supportsAccounts()) UTXOsStore.listAccounts();
                 await BalanceStore.getCombinedBalance();
-                ChannelsStore.getChannels();
-                FeeStore.getFees();
-                FeeStore.getForwardingHistory();
+                if (BackendUtils.supportsChannelManagement())
+                    ChannelsStore.getChannels();
+                if (BackendUtils.supportsRouting()) FeeStore.getFees();
+                if (BackendUtils.supportsRouting())
+                    FeeStore.getForwardingHistory();
             }
         } else {
             NodeInfoStore.getNodeInfo();
@@ -504,24 +507,14 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                                             />
                                         )}
                                         {BackendUtils.supportsChannelManagement() &&
-                                        !error ? (
-                                            <Tab.Screen
-                                                name={localeString(
-                                                    'views.Wallet.Wallet.channels'
-                                                )}
-                                                component={ChannelsScreen}
-                                            />
-                                        ) : (
-                                            <Tab.Screen
-                                                name={' '}
-                                                component={
-                                                    squareEnabled &&
-                                                    posStatus === 'active'
-                                                        ? PosScreen
-                                                        : BalanceScreen
-                                                }
-                                            />
-                                        )}
+                                            !error && (
+                                                <Tab.Screen
+                                                    name={localeString(
+                                                        'views.Wallet.Wallet.channels'
+                                                    )}
+                                                    component={ChannelsScreen}
+                                                />
+                                            )}
                                     </>
                                 )}
                             </Tab.Navigator>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,17 +1218,17 @@
     base58check "^2.0.0"
     tslib "~2.2.0"
 
-"@lightninglabs/lnc-core@0.2.1-alpha":
-  version "0.2.1-alpha"
-  resolved "https://registry.npmjs.org/@lightninglabs/lnc-core/-/lnc-core-0.2.1-alpha.tgz"
-  integrity sha512-H297V3seL+PE786HcuAQiSass/3y0NSYCy3b4hNTZL4Io80Oy4WY49s08CpRuV8cNfjAzWjYSXkhorALjaRdwA==
+"@lightninglabs/lnc-core@0.2.3-alpha":
+  version "0.2.3-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.3-alpha.tgz#e1b92a9071d1dfb92e2d565710b56f28f57cbbd4"
+  integrity sha512-93D/uU64ayAaJv5kv4Pqwvkt+uT7yCtmHD08aUzvql+lbWm6U7m5loZLxz7tACFLXVPOQ8OHJL25W+3QMEYthg==
 
-"@lightninglabs/lnc-rn@0.2.1-alpha.2":
-  version "0.2.1-alpha.2"
-  resolved "https://registry.npmjs.org/@lightninglabs/lnc-rn/-/lnc-rn-0.2.1-alpha.2.tgz"
-  integrity sha512-yLn80pmWlPGNcFH8Ha2k9bBxRjMrGGk7ZUaQ2QtAAmnn/+SXavtm4h03NLJHKPkID0I9+hfqEgV+Dg+NpaR6vA==
+"@lightninglabs/lnc-rn@0.2.3-alpha":
+  version "0.2.3-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-rn/-/lnc-rn-0.2.3-alpha.tgz#b9b06e30a711384b8c94d578767858965d8804e2"
+  integrity sha512-t1eWjZcbizoI2xKw4Uu/gPM0pNh1KdIpFCUzOmCXiaW36bCxgR7d8M069yU9xck6mbGCnhwFS4TIEqVN4sGSkg==
   dependencies:
-    "@lightninglabs/lnc-core" "0.2.1-alpha"
+    "@lightninglabs/lnc-core" "0.2.3-alpha"
 
 "@ngraveio/bc-ur@1.1.6", "@ngraveio/bc-ur@^1.1.5":
   version "1.1.6"


### PR DESCRIPTION
# Description

Lightning Terminal recently added support for custodial accounts via LNC. This PR adds perm checks for LNC connections to ensure that the proper features are displayed to the user.

*NOTE*: There are some caveats here that need to be addressed in Lightning Terminal:

The following checks for perms using the `hasPermissions` call throws true on the follow endpoints even though they should be throwing false:
- `lnrpc.Lightning.ListChannels`
- `walletrpc.WalletKit.ListAccounts`
- `lnrpc.Lightning.ForwardingHistory`

For now:

- In place of `lnrpc.Lightning.ListChannels`, `lnrpc.Lightning.OpenChannel` is used
- In place of `walletrpc.WalletKit.ListAccounts`, `walletrpc.WalletKit.ImportAccount` is used

There is no good workaround for `lnrpc.Lightning.ForwardingHistory`, as `lnrpc.Lightning.FeeReport` and `lnrpc.Lightning.UpdateChannelPolicy` also return true even though they should return false. This results in the custodial user being able to navigate to the `Routing` view even though the calls fail.

We will return and correct these once Terminal has been updated.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
