### PR TITLE
ZEUS-1336: Initial load: only handle initial URL after node is fully initiated

### DIFF
--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -67,6 +67,7 @@ interface WalletProps {
 
 interface WalletState {
     unlocked: boolean;
+    initialLoad: boolean;
 }
 
 @inject(
@@ -85,7 +86,8 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
     constructor(props) {
         super(props);
         this.state = {
-            unlocked: false
+            unlocked: false,
+            initialLoad: true
         };
         this.pan = new Animated.ValueXY();
         this.panResponder = PanResponder.create({
@@ -150,7 +152,6 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
 
     startListeners() {
         Linking.addEventListener('url', this.handleOpenURL);
-        LinkingUtils.handleInitialUrl(this.props.navigation);
     }
 
     async getSettingsAndNavigate() {
@@ -278,6 +279,14 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
 
         if (connecting) {
             setConnectingStatus(false);
+        }
+
+        // only navigate to initial url after connection and main calls are made
+        if (this.state.initialLoad) {
+            this.setState({
+                initialLoad: false
+            });
+            LinkingUtils.handleInitialUrl(this.props.navigation);
         }
     }
 


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1336**](https://github.com/ZeusLN/zeus/issues/1336)

Previously, people would have issues tipping or zapping when LNC was selected as the default node as we would handle the initial deep link URL before fulling loading the node (in case of LNC, ensuring the `connect` call has completed and everything has initialized).

This change ensures that the initial URL is only handled after everything is initialized.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
