### PR TITLE
ZEUS-1339: views/PaymentRequest: handle Fee Limit percentage w/ comma

### DIFF
--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -231,10 +231,17 @@ export default class PaymentRequest extends React.Component<
         const description = pay_req && pay_req.description;
         const payment_hash = pay_req && pay_req.payment_hash;
         const timestamp = pay_req && pay_req.timestamp;
+
+        // handle fee percents that use commas
+        const maxFeePercentFormatted = maxFeePercent.replace(/,/g, '.');
+
         const percentAmount = customAmount
-            ? (Number(customAmount) * (Number(maxFeePercent) / 100)).toFixed()
+            ? (
+                  Number(customAmount) *
+                  (Number(maxFeePercentFormatted) / 100)
+              ).toFixed()
             : requestAmount
-            ? (requestAmount * (Number(maxFeePercent) / 100)).toFixed()
+            ? (requestAmount * (Number(maxFeePercentFormatted) / 100)).toFixed()
             : 0;
 
         let lockAtomicMultiPathPayment = false;
@@ -793,7 +800,7 @@ export default class PaymentRequest extends React.Component<
                                                         : null,
                                                     max_fee_percent:
                                                         isCLightning
-                                                            ? maxFeePercent
+                                                            ? maxFeePercentFormatted
                                                             : null,
                                                     outgoing_chan_id:
                                                         outgoingChanId,


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1339**](https://github.com/ZeusLN/zeus/issues/1339)

This allows locales that use commas in place of decimals to set a fee limit percentage that's not a whole number

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
