### PR TITLE
Tor icon: move out of BalancePane and into WalletHeader

### DIFF
--- a/components/WalletHeader.tsx
+++ b/components/WalletHeader.tsx
@@ -27,6 +27,8 @@ import { Row } from '../components/layout/Row';
 
 const Contact = require('../assets/images/Mascot.png');
 
+const TorIcon = require('../assets/images/tor.png');
+
 const protectedNavigation = async (
     navigation: any,
     route: string,
@@ -196,6 +198,7 @@ export default class WalletHeader extends React.Component<
         );
 
         const displayName = selectedNode && selectedNode.nickname;
+        const nodeAddress = SettingsStore.host || SettingsStore.url;
 
         let infoValue: string;
         if (NodeInfoStore.nodeInfo.isTestNet) {
@@ -219,6 +222,26 @@ export default class WalletHeader extends React.Component<
             ) : null;
         };
 
+        const TorBadge = () => (
+            <>
+                {nodeAddress && nodeAddress.includes('.onion') ? (
+                    <TouchableOpacity
+                        onPress={() => navigation.navigate('NodeInfo')}
+                    >
+                        <Image
+                            style={{
+                                marginLeft: 5,
+                                marginRight: 5,
+                                width: 25,
+                                height: 25
+                            }}
+                            source={TorIcon}
+                        />
+                    </TouchableOpacity>
+                ) : null}
+            </>
+        );
+
         return (
             <Header
                 leftComponent={loading ? undefined : <SettingsButton />}
@@ -232,10 +255,14 @@ export default class WalletHeader extends React.Component<
                             <Row>
                                 <Body>{displayName}</Body>
                                 <NetworkBadge />
+                                <TorBadge />
                             </Row>
                         </View>
                     ) : (
-                        <NetworkBadge />
+                        <Row>
+                            <NetworkBadge />
+                            <TorBadge />
+                        </Row>
                     )
                 }
                 rightComponent={

--- a/views/Wallet/BalancePane.tsx
+++ b/views/Wallet/BalancePane.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image, Text, View, StyleSheet, TouchableOpacity } from 'react-native';
+import { Text, View, StyleSheet } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import Button from '../../components/Button';
 import WalletHeader from '../../components/WalletHeader';
@@ -13,8 +13,6 @@ import NodeInfoStore from './../../stores/NodeInfoStore';
 import SettingsStore from './../../stores/SettingsStore';
 
 import { version, playStore } from './../../package.json';
-
-const TorIcon = require('./../../assets/images/tor.png');
 
 interface BalancePaneProps {
     navigation: any;
@@ -39,7 +37,6 @@ export default class BalancePane extends React.PureComponent<
             pendingOpenBalance
         } = BalanceStore;
         const { implementation } = SettingsStore;
-        const nodeAddress = SettingsStore.host || SettingsStore.url;
 
         const pendingUnconfirmedBalance =
             Number(pendingOpenBalance) + Number(unconfirmedBlockchainBalance);
@@ -113,21 +110,6 @@ export default class BalancePane extends React.PureComponent<
             </View>
         );
 
-        const NetworkBadge = () => (
-            <>
-                {nodeAddress && nodeAddress.includes('.onion') ? (
-                    <TouchableOpacity
-                        onPress={() => navigation.navigate('NodeInfo')}
-                    >
-                        <Image
-                            style={{ width: 25, height: 25 }}
-                            source={TorIcon}
-                        />
-                    </TouchableOpacity>
-                ) : null}
-            </>
-        );
-
         let balancePane;
         const error = NodeInfoStore.error || SettingsStore.error;
 
@@ -150,14 +132,6 @@ export default class BalancePane extends React.PureComponent<
                         ) : (
                             <BalanceViewCombined />
                         )}
-                        <View
-                            style={{
-                                marginTop: 5,
-                                alignItems: 'center'
-                            }}
-                        >
-                            <NetworkBadge />
-                        </View>
                     </View>
                 </View>
             );


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1355**](https://github.com/ZeusLN/zeus/issues/1355)

This PR moves the Tor icon out from under the balances and conversion rate in the `BalancePane` and into the `WalletHeader`

![Screenshot_1678549965](https://user-images.githubusercontent.com/1878621/224494445-bde4fdeb-8361-46ab-b17b-a7683fc6347e.png)
![Screenshot_1678549951](https://user-images.githubusercontent.com/1878621/224494446-3d173145-a491-4577-9dd6-16c915195deb.png)
![Screenshot_1678549939](https://user-images.githubusercontent.com/1878621/224494447-4f24384f-6e80-4cd1-b252-141adf2c5c89.png)
![Screenshot_1678549867](https://user-images.githubusercontent.com/1878621/224494448-e60409b7-7999-4ff8-b464-8543115adc1b.png)

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
