### PR TITLE
Settings/Privacy: fix input of custom block explorer

### DIFF
--- a/views/Settings/Privacy.tsx
+++ b/views/Settings/Privacy.tsx
@@ -9,7 +9,6 @@ import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
 
 import DropdownSetting from './../../components/DropdownSetting';
-import LoadingIndicator from './../../components/LoadingIndicator';
 import Switch from './../../components/Switch';
 import TextInput from './../../components/TextInput';
 
@@ -56,10 +55,13 @@ export default class Privacy extends React.Component<
             customBlockExplorer:
                 (settings.privacy && settings.privacy.customBlockExplorer) ||
                 '',
-            clipboard: settings.privacy && settings.privacy.clipboard,
-            lurkerMode: settings.privacy && settings.privacy.lurkerMode,
+            clipboard:
+                (settings.privacy && settings.privacy.clipboard) || false,
+            lurkerMode:
+                (settings.privacy && settings.privacy.lurkerMode) || false,
             enableMempoolRates:
-                settings.privacy && settings.privacy.enableMempoolRates
+                (settings.privacy && settings.privacy.enableMempoolRates) ||
+                false
         });
     }
 
@@ -81,7 +83,7 @@ export default class Privacy extends React.Component<
             lurkerMode,
             enableMempoolRates
         } = this.state;
-        const { updateSettings, loading }: any = SettingsStore;
+        const { updateSettings }: any = SettingsStore;
 
         const BackButton = () => (
             <Icon
@@ -117,198 +119,189 @@ export default class Privacy extends React.Component<
                         borderBottomWidth: 0
                     }}
                 />
-                {loading ? (
-                    <LoadingIndicator />
-                ) : (
-                    <ScrollView style={{ flex: 1, padding: 15 }}>
-                        <DropdownSetting
-                            title={localeString(
-                                'views.Settings.Privacy.blockExplorer'
-                            )}
-                            selectedValue={defaultBlockExplorer}
-                            onValueChange={async (value: string) => {
-                                this.setState({
-                                    defaultBlockExplorer: value
-                                });
-                                await updateSettings({
-                                    privacy: {
-                                        defaultBlockExplorer: value,
-                                        customBlockExplorer,
-                                        clipboard,
-                                        lurkerMode,
-                                        enableMempoolRates
-                                    }
-                                });
-                            }}
-                            values={BLOCK_EXPLORER_KEYS}
-                        />
-
-                        {defaultBlockExplorer === 'Custom' && (
-                            <>
-                                <Text
-                                    style={{
-                                        color: themeColor('secondaryText'),
-                                        fontFamily: 'Lato-Regular'
-                                    }}
-                                >
-                                    {localeString(
-                                        'views.Settings.Privacy.customBlockExplorer'
-                                    )}
-                                </Text>
-                                <TextInput
-                                    value={customBlockExplorer}
-                                    onChangeText={async (text: string) => {
-                                        this.setState({
-                                            customBlockExplorer: text
-                                        });
-
-                                        await updateSettings({
-                                            privacy: {
-                                                defaultBlockExplorer,
-                                                customBlockExplorer: text,
-                                                clipboard,
-                                                lurkerMode,
-                                                enableMempoolRates
-                                            }
-                                        });
-                                    }}
-                                />
-                            </>
+                <ScrollView style={{ flex: 1, padding: 15 }}>
+                    <DropdownSetting
+                        title={localeString(
+                            'views.Settings.Privacy.blockExplorer'
                         )}
+                        selectedValue={defaultBlockExplorer}
+                        onValueChange={async (value: string) => {
+                            this.setState({
+                                defaultBlockExplorer: value
+                            });
+                            await updateSettings({
+                                privacy: {
+                                    defaultBlockExplorer: value,
+                                    customBlockExplorer,
+                                    clipboard,
+                                    lurkerMode,
+                                    enableMempoolRates
+                                }
+                            });
+                        }}
+                        values={BLOCK_EXPLORER_KEYS}
+                    />
 
-                        <ListItem
-                            containerStyle={{
-                                borderBottomWidth: 0,
-                                backgroundColor: themeColor('background')
-                            }}
-                        >
-                            <ListItem.Title
+                    {defaultBlockExplorer === 'Custom' && (
+                        <>
+                            <Text
                                 style={{
                                     color: themeColor('secondaryText'),
-                                    fontFamily: 'Lato-Regular',
-                                    left: -10
+                                    fontFamily: 'Lato-Regular'
                                 }}
                             >
                                 {localeString(
-                                    'views.Settings.Privacy.clipboard'
+                                    'views.Settings.Privacy.customBlockExplorer'
                                 )}
-                            </ListItem.Title>
-                            <View
-                                style={{
-                                    flex: 1,
-                                    flexDirection: 'row',
-                                    justifyContent: 'flex-end'
+                            </Text>
+                            <TextInput
+                                value={customBlockExplorer}
+                                onChangeText={async (text: string) => {
+                                    this.setState({
+                                        customBlockExplorer: text
+                                    });
+
+                                    await updateSettings({
+                                        privacy: {
+                                            defaultBlockExplorer,
+                                            customBlockExplorer: text,
+                                            clipboard,
+                                            lurkerMode,
+                                            enableMempoolRates
+                                        }
+                                    });
                                 }}
-                            >
-                                <Switch
-                                    value={clipboard}
-                                    onValueChange={async () => {
-                                        this.setState({
-                                            clipboard: !clipboard
-                                        });
-                                        await updateSettings({
-                                            privacy: {
-                                                defaultBlockExplorer,
-                                                customBlockExplorer,
-                                                clipboard: !clipboard,
-                                                lurkerMode,
-                                                enableMempoolRates
-                                            }
-                                        });
-                                    }}
-                                />
-                            </View>
-                        </ListItem>
-                        <ListItem
-                            containerStyle={{
-                                borderBottomWidth: 0,
-                                backgroundColor: themeColor('background')
+                            />
+                        </>
+                    )}
+
+                    <ListItem
+                        containerStyle={{
+                            borderBottomWidth: 0,
+                            backgroundColor: themeColor('background')
+                        }}
+                    >
+                        <ListItem.Title
+                            style={{
+                                color: themeColor('secondaryText'),
+                                fontFamily: 'Lato-Regular',
+                                left: -10
                             }}
                         >
-                            <ListItem.Title
-                                style={{
-                                    color: themeColor('secondaryText'),
-                                    fontFamily: 'Lato-Regular',
-                                    left: -10
-                                }}
-                            >
-                                {localeString(
-                                    'views.Settings.Privacy.lurkerMode'
-                                )}
-                            </ListItem.Title>
-                            <View
-                                style={{
-                                    flex: 1,
-                                    flexDirection: 'row',
-                                    justifyContent: 'flex-end'
-                                }}
-                            >
-                                <Switch
-                                    value={lurkerMode}
-                                    onValueChange={async () => {
-                                        this.setState({
-                                            lurkerMode: !lurkerMode
-                                        });
-                                        await updateSettings({
-                                            privacy: {
-                                                defaultBlockExplorer,
-                                                customBlockExplorer,
-                                                clipboard,
-                                                lurkerMode: !lurkerMode,
-                                                enableMempoolRates
-                                            }
-                                        });
-                                    }}
-                                />
-                            </View>
-                        </ListItem>
-                        <ListItem
-                            containerStyle={{
-                                borderBottomWidth: 0,
-                                backgroundColor: themeColor('background')
+                            {localeString('views.Settings.Privacy.clipboard')}
+                        </ListItem.Title>
+                        <View
+                            style={{
+                                flex: 1,
+                                flexDirection: 'row',
+                                justifyContent: 'flex-end'
                             }}
                         >
-                            <ListItem.Title
-                                style={{
-                                    color: themeColor('secondaryText'),
-                                    fontFamily: 'Lato-Regular',
-                                    left: -10
+                            <Switch
+                                value={clipboard}
+                                onValueChange={async () => {
+                                    this.setState({
+                                        clipboard: !clipboard
+                                    });
+                                    await updateSettings({
+                                        privacy: {
+                                            defaultBlockExplorer,
+                                            customBlockExplorer,
+                                            clipboard: !clipboard,
+                                            lurkerMode,
+                                            enableMempoolRates
+                                        }
+                                    });
                                 }}
-                            >
-                                {localeString(
-                                    'views.Settings.Privacy.enableMempoolRates'
-                                )}
-                            </ListItem.Title>
-                            <View
-                                style={{
-                                    flex: 1,
-                                    flexDirection: 'row',
-                                    justifyContent: 'flex-end'
+                            />
+                        </View>
+                    </ListItem>
+                    <ListItem
+                        containerStyle={{
+                            borderBottomWidth: 0,
+                            backgroundColor: themeColor('background')
+                        }}
+                    >
+                        <ListItem.Title
+                            style={{
+                                color: themeColor('secondaryText'),
+                                fontFamily: 'Lato-Regular',
+                                left: -10
+                            }}
+                        >
+                            {localeString('views.Settings.Privacy.lurkerMode')}
+                        </ListItem.Title>
+                        <View
+                            style={{
+                                flex: 1,
+                                flexDirection: 'row',
+                                justifyContent: 'flex-end'
+                            }}
+                        >
+                            <Switch
+                                value={lurkerMode}
+                                onValueChange={async () => {
+                                    this.setState({
+                                        lurkerMode: !lurkerMode
+                                    });
+                                    await updateSettings({
+                                        privacy: {
+                                            defaultBlockExplorer,
+                                            customBlockExplorer,
+                                            clipboard,
+                                            lurkerMode: !lurkerMode,
+                                            enableMempoolRates
+                                        }
+                                    });
                                 }}
-                            >
-                                <Switch
-                                    value={enableMempoolRates}
-                                    onValueChange={async () => {
-                                        this.setState({
+                            />
+                        </View>
+                    </ListItem>
+                    <ListItem
+                        containerStyle={{
+                            borderBottomWidth: 0,
+                            backgroundColor: themeColor('background')
+                        }}
+                    >
+                        <ListItem.Title
+                            style={{
+                                color: themeColor('secondaryText'),
+                                fontFamily: 'Lato-Regular',
+                                left: -10
+                            }}
+                        >
+                            {localeString(
+                                'views.Settings.Privacy.enableMempoolRates'
+                            )}
+                        </ListItem.Title>
+                        <View
+                            style={{
+                                flex: 1,
+                                flexDirection: 'row',
+                                justifyContent: 'flex-end'
+                            }}
+                        >
+                            <Switch
+                                value={enableMempoolRates}
+                                onValueChange={async () => {
+                                    this.setState({
+                                        enableMempoolRates: !enableMempoolRates
+                                    });
+                                    await updateSettings({
+                                        privacy: {
+                                            defaultBlockExplorer,
+                                            customBlockExplorer,
+                                            clipboard,
+                                            lurkerMode,
                                             enableMempoolRates:
                                                 !enableMempoolRates
-                                        });
-                                        await updateSettings({
-                                            privacy: {
-                                                defaultBlockExplorer,
-                                                customBlockExplorer,
-                                                clipboard,
-                                                lurkerMode,
-                                                enableMempoolRates:
-                                                    !enableMempoolRates
-                                            }
-                                        });
-                                    }}
-                                />
-                            </View>
-                        </ListItem>
-                    </ScrollView>
-                )}
+                                        }
+                                    });
+                                }}
+                            />
+                        </View>
+                    </ListItem>
+                </ScrollView>
             </View>
         );
     }


### PR DESCRIPTION
# Description

This PR fixes a bug where the custom block explorer text field could only enter one character in at a time. The field saves to storage with each input. The page logic was causing the `LoadingIndicator` to flash in place of the page form on write to local storage.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
