### PR TITLE
stores/ChannelsStore: only make calls to pending and closed channels if supported

### DIFF
--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -192,57 +192,63 @@ export default class ChannelsStore {
                 this.getChannelsError();
             });
 
-        BackendUtils.getPendingChannels()
-            .then((data: any) => {
-                const pendingOpenChannels = data.pending_open_channels.map(
-                    (pending: any) => {
-                        pending.channel.pendingOpen = true;
-                        return new Channel(pending.channel);
-                    }
-                );
-                const pendingCloseChannels = data.pending_closing_channels.map(
-                    (pending: any) => {
-                        pending.channel.pendingClose = true;
-                        pending.channel.closing_txid = pending.closing_txid;
-                        return new Channel(pending.channel);
-                    }
-                );
-                const forceCloseChannels =
-                    data.pending_force_closing_channels.map((pending: any) => {
-                        pending.channel.blocks_til_maturity =
-                            pending.blocks_til_maturity;
-                        pending.channel.forceClose = true;
-                        pending.channel.closing_txid = pending.closing_txid;
-                        return new Channel(pending.channel);
-                    });
-                const waitCloseChannels = data.waiting_close_channels.map(
-                    (pending: any) => {
-                        pending.channel.closing = true;
-                        return new Channel(pending.channel);
-                    }
-                );
-                this.pendingChannels = pendingOpenChannels
-                    .concat(pendingCloseChannels)
-                    .concat(forceCloseChannels)
-                    .concat(waitCloseChannels);
-                this.error = false;
-            })
-            .catch(() => {
-                this.getChannelsError();
-            });
+        if (BackendUtils.supportsPendingChannels()) {
+            BackendUtils.getPendingChannels()
+                .then((data: any) => {
+                    const pendingOpenChannels = data.pending_open_channels.map(
+                        (pending: any) => {
+                            pending.channel.pendingOpen = true;
+                            return new Channel(pending.channel);
+                        }
+                    );
+                    const pendingCloseChannels =
+                        data.pending_closing_channels.map((pending: any) => {
+                            pending.channel.pendingClose = true;
+                            pending.channel.closing_txid = pending.closing_txid;
+                            return new Channel(pending.channel);
+                        });
+                    const forceCloseChannels =
+                        data.pending_force_closing_channels.map(
+                            (pending: any) => {
+                                pending.channel.blocks_til_maturity =
+                                    pending.blocks_til_maturity;
+                                pending.channel.forceClose = true;
+                                pending.channel.closing_txid =
+                                    pending.closing_txid;
+                                return new Channel(pending.channel);
+                            }
+                        );
+                    const waitCloseChannels = data.waiting_close_channels.map(
+                        (pending: any) => {
+                            pending.channel.closing = true;
+                            return new Channel(pending.channel);
+                        }
+                    );
+                    this.pendingChannels = pendingOpenChannels
+                        .concat(pendingCloseChannels)
+                        .concat(forceCloseChannels)
+                        .concat(waitCloseChannels);
+                    this.error = false;
+                })
+                .catch(() => {
+                    this.getChannelsError();
+                });
+        }
 
-        BackendUtils.getClosedChannels()
-            .then((data: any) => {
-                const closedChannels = data.channels.map(
-                    (channel: any) => new ClosedChannel(channel)
-                );
-                this.closedChannels = closedChannels;
-                this.error = false;
-                this.loading = false;
-            })
-            .catch(() => {
-                this.getChannelsError();
-            });
+        if (BackendUtils.supportsPendingChannels()) {
+            BackendUtils.getClosedChannels()
+                .then((data: any) => {
+                    const closedChannels = data.channels.map(
+                        (channel: any) => new ClosedChannel(channel)
+                    );
+                    this.closedChannels = closedChannels;
+                    this.error = false;
+                    this.loading = false;
+                })
+                .catch(() => {
+                    this.getChannelsError();
+                });
+        }
     };
 
     @action

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -233,9 +233,7 @@ export default class ChannelsStore {
                 .catch(() => {
                     this.getChannelsError();
                 });
-        }
 
-        if (BackendUtils.supportsPendingChannels()) {
             BackendUtils.getClosedChannels()
                 .then((data: any) => {
                     const closedChannels = data.channels.map(


### PR DESCRIPTION
# Description

This caused `Sparko` interfaces to not be able to load.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [x] Core Lightning (Sparko)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
