### PR TITLE
components/Amount: use LoadingIndicator component for fiat rate

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -9,6 +9,7 @@ import { themeColor } from '../utils/ThemeUtils';
 import { Spacer } from './layout/Spacer';
 import { Row } from './layout/Row';
 import { Body } from './text/Body';
+import LoadingIndicator from './LoadingIndicator';
 
 type Units = 'sats' | 'BTC' | 'fiat';
 
@@ -94,10 +95,14 @@ function AmountDisplay({
                     <Row align="flex-end">
                         <Body jumbo={jumboText} color={color}>
                             {negative ? '-' : ''}
-                            {amount}
+                            {amount === 'N/A' ? (
+                                <LoadingIndicator size={20} />
+                            ) : (
+                                amount.toString()
+                            )}
                         </Body>
                         {space ? <TextSpace /> : <Spacer width={1} />}
-                        <FiatSymbol />
+                        {amount !== 'N/A' && <FiatSymbol />}
                         {pending ? <Pending /> : null}
                     </Row>
                 );
@@ -105,11 +110,15 @@ function AmountDisplay({
                 return (
                     <Row align="flex-end">
                         {pending ? <Pending /> : null}
-                        <FiatSymbol />
+                        {amount !== 'N/A' && <FiatSymbol />}
                         {space ? <TextSpace /> : <Spacer width={1} />}
                         <Body jumbo={jumboText} color={color}>
                             {negative ? '-' : ''}
-                            {amount.toString()}
+                            {amount === 'N/A' ? (
+                                <LoadingIndicator size={20} />
+                            ) : (
+                                amount.toString()
+                            )}
                         </Body>
                     </Row>
                 );


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

Puts the `LoadingIndicator` component in place of the `$N/A` previously displayed when the fiat exchange rates were loading.

![Screenshot_1678947899](https://user-images.githubusercontent.com/1878621/225532879-c45eb6c7-a9b2-42c4-a888-c1f8efbc1067.png)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
