### PR TITLE
Conversion: display rate in sats when it's the unit selected

### DIFF
--- a/components/Conversion.tsx
+++ b/components/Conversion.tsx
@@ -112,7 +112,9 @@ export default class Conversion extends React.Component<
                 {showRate && (
                     <>
                         <Text style={{ color: themeColor('secondaryText') }}>
-                            {` | ${getRate()}`}
+                            {` | ${getRate(
+                                this.props.UnitsStore.units === 'sats'
+                            )}`}
                         </Text>
                     </>
                 )}
@@ -150,7 +152,9 @@ export default class Conversion extends React.Component<
                 {showRate && (
                     <>
                         <Text style={{ color: themeColor('secondaryText') }}>
-                            {` | ${getRate()}`}
+                            {` | ${getRate(
+                                this.props.UnitsStore.units === 'sats'
+                            )}`}
                         </Text>
                     </>
                 )}

--- a/locales/en.json
+++ b/locales/en.json
@@ -353,7 +353,7 @@
     "views.OpenChannel.nodePubkey": "Node pubkey",
     "views.OpenChannel.host": "Host",
     "views.OpenChannel.hostPort": "Hostname:Port",
-    "views.OpenChannel.localAmt": "Local amount (in satoshis)",
+    "views.OpenChannel.localAmt": "Local amount",
     "views.OpenChannel.amtExample": "20000 (min)",
     "views.OpenChannel.numConf": "Number of Confirmations",
     "views.OpenChannel.satsPerByte": "Satoshis per byte",

--- a/locales/en.json
+++ b/locales/en.json
@@ -367,7 +367,7 @@
     "views.Payment.path": "Path",
     "views.PaymentRequest.title": "Lightning Invoice",
     "views.PaymentRequest.error": "Error loading invoice",
-    "views.PaymentRequest.customAmt": "Custom Amount (in satoshis)",
+    "views.PaymentRequest.customAmt": "Custom Amount",
     "views.PaymentRequest.payDefault": "Pay default amount",
     "views.PaymentRequest.payCustom": "Pay custom amount",
     "views.PaymentRequest.feeEstimate": "Fee Estimate",

--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -322,13 +322,10 @@ export default class LnurlPay extends React.Component<
                         }
                         toggleUnits={changeUnits}
                     />
-                    {units !== 'sats' && (
-                        <Amount sats={satAmount} fixedUnits="sats" toggleable />
+                    {fiat !== 'Disabled' && units !== 'fiat' && (
+                        <Amount sats={satAmount} fixedUnits="fiat" toggleable />
                     )}
-                    {units !== 'BTC' && (
-                        <Amount sats={satAmount} fixedUnits="BTC" toggleable />
-                    )}
-                    {units === 'fiat' && (
+                    {fiat !== 'Disabled' && (
                         <TouchableOpacity onPress={() => changeUnits()}>
                             <Text
                                 style={{
@@ -336,9 +333,15 @@ export default class LnurlPay extends React.Component<
                                     color: themeColor('text')
                                 }}
                             >
-                                {FiatStore.getRate()}
+                                {FiatStore.getRate(units === 'sats')}
                             </Text>
                         </TouchableOpacity>
+                    )}
+                    {units !== 'sats' && (
+                        <Amount sats={satAmount} fixedUnits="sats" toggleable />
+                    )}
+                    {units !== 'BTC' && (
+                        <Amount sats={satAmount} fixedUnits="BTC" toggleable />
                     )}
                     {lnurl.commentAllowed > 0 ? (
                         <>

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -944,11 +944,12 @@ export default class PaymentRequest extends React.Component<
                             {!!pay_req && (
                                 <View style={styles.button}>
                                     <Button
-                                        title="Pay this invoice"
+                                        title={localeString(
+                                            'views.PaymentRequest.payInvoice'
+                                        )}
                                         icon={{
                                             name: 'send',
-                                            size: 25,
-                                            color: 'white'
+                                            size: 25
                                         }}
                                         onPress={() => {
                                             this.sendPayment(

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -20,10 +20,11 @@ import Screen from '../components/Screen';
 import Switch from '../components/Switch';
 import TextInput from '../components/TextInput';
 
+import ChannelsStore from '../stores/ChannelsStore';
+import FiatStore from '../stores/FiatStore';
 import InvoicesStore from '../stores/InvoicesStore';
 import TransactionsStore, { SendPaymentReq } from '../stores/TransactionsStore';
-import UnitsStore from '../stores/UnitsStore';
-import ChannelsStore from '../stores/ChannelsStore';
+import UnitsStore, { SATS_PER_BTC } from '../stores/UnitsStore';
 import SettingsStore from '../stores/SettingsStore';
 
 import FeeUtils from '../utils/FeeUtils';
@@ -44,6 +45,7 @@ interface InvoiceProps {
     UnitsStore: UnitsStore;
     ChannelsStore: ChannelsStore;
     SettingsStore: SettingsStore;
+    FiatStore: FiatStore;
 }
 
 interface InvoiceState {
@@ -61,6 +63,7 @@ interface InvoiceState {
 }
 
 @inject(
+    'FiatStore',
     'InvoicesStore',
     'TransactionsStore',
     'UnitsStore',
@@ -203,6 +206,7 @@ export default class PaymentRequest extends React.Component<
     render() {
         const {
             InvoicesStore,
+            FiatStore,
             UnitsStore,
             ChannelsStore,
             SettingsStore,
@@ -231,6 +235,10 @@ export default class PaymentRequest extends React.Component<
             feeEstimate,
             clearPayReq
         } = InvoicesStore;
+        const { units, changeUnits } = UnitsStore;
+        const { fiatRates, getSymbol } = FiatStore;
+        const { settings } = SettingsStore;
+        const { fiat } = settings;
 
         const requestAmount = pay_req && pay_req.getRequestAmount;
         const expiry = pay_req && pay_req.expiry;
@@ -239,6 +247,33 @@ export default class PaymentRequest extends React.Component<
         const description = pay_req && pay_req.description;
         const payment_hash = pay_req && pay_req.payment_hash;
         const timestamp = pay_req && pay_req.timestamp;
+
+        const fiatEntry =
+            fiat && fiatRates && fiatRates.filter
+                ? fiatRates.filter((entry: any) => entry.code === fiat)[0]
+                : null;
+
+        const rate =
+            fiat && fiat !== 'Disabled' && fiatRates && fiatEntry
+                ? fiatEntry.rate
+                : 0;
+
+        // conversion
+        let satAmount: string | number;
+        switch (units) {
+            case 'sats':
+                satAmount = customAmount;
+                break;
+            case 'BTC':
+                satAmount = Number(customAmount) * SATS_PER_BTC;
+                break;
+            case 'fiat':
+                satAmount = Number(
+                    (Number(customAmount.replace(/,/g, '.')) / Number(rate)) *
+                        Number(SATS_PER_BTC)
+                ).toFixed(0);
+                break;
+        }
 
         // handle fee percents that use commas
         const maxFeePercentFormatted = maxFeePercent.replace(/,/g, '.');
@@ -330,7 +365,7 @@ export default class PaymentRequest extends React.Component<
 
                     {!loading && !loadingFeeEstimate && !!pay_req && (
                         <View style={styles.content}>
-                            <View style={styles.center}>
+                            <>
                                 {isNoAmountInvoice ? (
                                     <>
                                         <Text
@@ -361,7 +396,62 @@ export default class PaymentRequest extends React.Component<
                                                 color: themeColor('text')
                                             }}
                                             placeholderTextColor="gray"
+                                            prefix={
+                                                units !== 'sats' &&
+                                                (units === 'BTC'
+                                                    ? '₿'
+                                                    : !getSymbol().rtl
+                                                    ? getSymbol().symbol
+                                                    : null)
+                                            }
+                                            suffix={
+                                                units === 'sats'
+                                                    ? units
+                                                    : getSymbol().rtl &&
+                                                      units === 'fiat' &&
+                                                      getSymbol().symbol
+                                            }
+                                            toggleUnits={changeUnits}
                                         />
+                                        {fiat !== 'Disabled' &&
+                                            units !== 'fiat' && (
+                                                <Amount
+                                                    sats={satAmount}
+                                                    fixedUnits="fiat"
+                                                    toggleable
+                                                />
+                                            )}
+                                        {fiat !== 'Disabled' && (
+                                            <TouchableOpacity
+                                                onPress={() => changeUnits()}
+                                            >
+                                                <Text
+                                                    style={{
+                                                        color: themeColor(
+                                                            'text'
+                                                        )
+                                                    }}
+                                                >
+                                                    {FiatStore.getRate(
+                                                        units === 'sats'
+                                                    )}
+                                                </Text>
+                                            </TouchableOpacity>
+                                        )}
+                                        {units !== 'sats' && (
+                                            <Amount
+                                                sats={satAmount}
+                                                fixedUnits="sats"
+                                                toggleable
+                                            />
+                                        )}
+                                        {units !== 'BTC' && (
+                                            <Amount
+                                                sats={satAmount}
+                                                fixedUnits="BTC"
+                                                toggleable
+                                            />
+                                        )}
                                     </>
                                 ) : (
                                     <Amount
@@ -370,7 +460,7 @@ export default class PaymentRequest extends React.Component<
                                         toggleable
                                     />
                                 )}
-                            </View>
+                            </>
 
                             {!!description && (
                                 <KeyValue
@@ -867,7 +957,9 @@ export default class PaymentRequest extends React.Component<
                                                 {
                                                     payment_request:
                                                         paymentRequest,
-                                                    amount: customAmount,
+                                                    amount: satAmount
+                                                        ? satAmount.toString()
+                                                        : undefined,
                                                     max_parts:
                                                         enableMultiPathPayment
                                                             ? maxParts
@@ -904,7 +996,8 @@ export default class PaymentRequest extends React.Component<
 
 const styles = StyleSheet.create({
     content: {
-        padding: 20
+        paddingLeft: 20,
+        paddingRight: 20
     },
     label: {
         fontFamily: 'Lato-Regular',
@@ -919,10 +1012,5 @@ const styles = StyleSheet.create({
         paddingBottom: 15,
         paddingLeft: 10,
         paddingRight: 10
-    },
-    center: {
-        alignItems: 'center',
-        paddingTop: 15,
-        paddingBottom: 15
     }
 });

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -682,6 +682,30 @@ export default class Send extends React.Component<SendProps, SendState> {
                                     }
                                     toggleUnits={changeUnits}
                                 />
+
+                                {fiat !== 'Disabled' && units !== 'fiat' && (
+                                    <Amount
+                                        sats={satAmount}
+                                        fixedUnits="fiat"
+                                        toggleable
+                                    />
+                                )}
+                                {fiat !== 'Disabled' && (
+                                    <TouchableOpacity
+                                        onPress={() => changeUnits()}
+                                    >
+                                        <Text
+                                            style={{
+                                                ...styles.text,
+                                                color: themeColor('text')
+                                            }}
+                                        >
+                                            {FiatStore.getRate(
+                                                units === 'sats'
+                                            )}
+                                        </Text>
+                                    </TouchableOpacity>
+                                )}
                                 {units !== 'sats' && (
                                     <Amount
                                         sats={satAmount}
@@ -695,20 +719,6 @@ export default class Send extends React.Component<SendProps, SendState> {
                                         fixedUnits="BTC"
                                         toggleable
                                     />
-                                )}
-                                {units === 'fiat' && (
-                                    <TouchableOpacity
-                                        onPress={() => changeUnits()}
-                                    >
-                                        <Text
-                                            style={{
-                                                ...styles.text,
-                                                color: themeColor('text')
-                                            }}
-                                        >
-                                            {FiatStore.getRate()}
-                                        </Text>
-                                    </TouchableOpacity>
                                 )}
 
                                 {BackendUtils.supportsAMP() && (

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -153,7 +153,7 @@ export default class SendingLightning extends React.Component<
 
                     <View style={styles.buttons}>
                         {payment_hash && !(!!error || !!payment_error) && (
-                            <View style={{ margin: 10, width: '100%' }}>
+                            <View style={{ marginBottom: 10, width: '100%' }}>
                                 <CopyButton
                                     title={localeString(
                                         'views.SendingLightning.copyPaymentHash'


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1354**](https://github.com/ZeusLN/zeus/issues/1354), [**ZEUS-1304**](https://github.com/ZeusLN/zeus/issues/1304)

This PR:
- Displays rate in sats when it's the unit selected [**ZEUS-1354**](https://github.com/ZeusLN/zeus/issues/1354)
- Fleshed out the conversion rates displayed on various views [**ZEUS-1304**](https://github.com/ZeusLN/zeus/issues/1304)
- Allows users to choose their units when opening a channel or paying a 0 amount lightning invoice

![Screenshot_1679174288](https://user-images.githubusercontent.com/1878621/226140669-06c9489f-d5e5-4a0b-90c8-45ed3e961779.png)
![Screenshot_1679174295](https://user-images.githubusercontent.com/1878621/226140671-c6b4f7fc-1283-48e1-8b9c-d44d7ad531b1.png)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
