### PR TITLE
Settings: Display: Show all decimal places

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -488,6 +488,7 @@
     "views.Settings.Display.defaultView": "Default view",
     "views.Settings.Display.displayNickname": "Display node nickname on main views",
     "views.Settings.Display.bigKeypadButtons": "Big keypad buttons",
+    "views.Settings.Display.showAllDecimalPlaces": "Show all decimal places",
     "views.Settings.privacy": "Privacy",
     "views.Settings.payments": "Payments",
     "views.Settings.Privacy.title": "Privacy settings",

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -39,6 +39,7 @@ interface DisplaySettings {
     defaultView?: string;
     displayNickname?: boolean;
     bigKeypadButtons?: boolean;
+    showAllDecimalPlaces?: boolean;
 }
 
 interface PosSettings {
@@ -260,7 +261,8 @@ export default class SettingsStore {
             theme: DEFAULT_THEME,
             defaultView: 'Keypad',
             displayNickname: false,
-            bigKeypadButtons: false
+            bigKeypadButtons: false,
+            showAllDecimalPlaces: false
         },
         pos: {
             squareEnabled: false,

--- a/stores/UnitsStore.ts
+++ b/stores/UnitsStore.ts
@@ -60,7 +60,9 @@ export default class UnitsStore {
         fixedUnits?: string
     ): ValueDisplayProps => {
         const { settings } = this.settingsStore;
-        const { fiat } = settings;
+        const { fiat, display } = settings;
+        const showAllDecimalPlaces: boolean =
+            (display && display.showAllDecimalPlaces) || false;
         const units = fixedUnits || this.units;
 
         const sats = Number(value);
@@ -69,7 +71,10 @@ export default class UnitsStore {
 
         if (units === 'BTC') {
             return {
-                amount: FeeUtils.toFixed(absValueSats / SATS_PER_BTC),
+                amount: FeeUtils.toFixed(
+                    absValueSats / SATS_PER_BTC,
+                    showAllDecimalPlaces
+                ),
                 unit: 'BTC',
                 negative,
                 space: false

--- a/utils/FeeUtils.test.ts
+++ b/utils/FeeUtils.test.ts
@@ -41,5 +41,33 @@ describe('FeeUtils', () => {
                 '-0.005'
             );
         });
+
+        it('Properly handles decimals in Bitcoin unit format - with showAllDecimalPlaces enabled', () => {
+            expect(FeeUtils.toFixed(100 / satoshisPerBTC, true)).toEqual(
+                '0.00000100'
+            );
+            expect(FeeUtils.toFixed(1000 / satoshisPerBTC, true)).toEqual(
+                '0.00001000'
+            );
+            expect(FeeUtils.toFixed(10000 / satoshisPerBTC, true)).toEqual(
+                '0.00010000'
+            );
+            // was returning "0.00000009999999999999999" in original version
+            expect(
+                FeeUtils.toFixed(Number('10') / satoshisPerBTC, true).toString()
+            ).toBe('0.00000010');
+            expect(FeeUtils.toFixed(1 / satoshisPerBTC, true)).toEqual(
+                '0.00000001'
+            );
+            expect(FeeUtils.toFixed(283190 / satoshisPerBTC, true)).toEqual(
+                '0.00283190'
+            );
+            expect(FeeUtils.toFixed(500000 / satoshisPerBTC, true)).toEqual(
+                '0.00500000'
+            );
+            expect(FeeUtils.toFixed(-500000 / satoshisPerBTC, true)).toEqual(
+                '-0.00500000'
+            );
+        });
     });
 });

--- a/utils/FeeUtils.ts
+++ b/utils/FeeUtils.ts
@@ -18,7 +18,8 @@ class FeeUtils {
 
         return split[0];
     };
-    toFixed = (x: any) => {
+    toFixed = (x: any, showAllDecimalPlaces?: boolean) => {
+        if (showAllDecimalPlaces) return x.toFixed(8);
         return x.toFixed(8).replace(/\.?0+$/, '');
     };
 }

--- a/views/Settings/Display.tsx
+++ b/views/Settings/Display.tsx
@@ -23,6 +23,7 @@ interface DisplayState {
     defaultView: string;
     displayNickname: boolean;
     bigKeypadButtons: boolean;
+    showAllDecimalPlaces: boolean;
 }
 
 @inject('SettingsStore')
@@ -35,7 +36,8 @@ export default class Display extends React.Component<
         theme: 'Dark',
         defaultView: 'Keypad',
         displayNickname: false,
-        bigKeypadButtons: false
+        bigKeypadButtons: false,
+        showAllDecimalPlaces: false
     };
 
     async UNSAFE_componentWillMount() {
@@ -50,7 +52,11 @@ export default class Display extends React.Component<
             displayNickname:
                 (settings.display && settings.display.displayNickname) || false,
             bigKeypadButtons:
-                (settings.display && settings.display.bigKeypadButtons) || false
+                (settings.display && settings.display.bigKeypadButtons) ||
+                false,
+            showAllDecimalPlaces:
+                (settings.display && settings.display.showAllDecimalPlaces) ||
+                false
         });
     }
 
@@ -65,8 +71,13 @@ export default class Display extends React.Component<
 
     render() {
         const { navigation, SettingsStore } = this.props;
-        const { defaultView, displayNickname, bigKeypadButtons, theme } =
-            this.state;
+        const {
+            defaultView,
+            displayNickname,
+            bigKeypadButtons,
+            theme,
+            showAllDecimalPlaces
+        } = this.state;
         const { updateSettings }: any = SettingsStore;
 
         const BackButton = () => (
@@ -111,7 +122,8 @@ export default class Display extends React.Component<
                                     theme: value,
                                     displayNickname,
                                     bigKeypadButtons,
-                                    defaultView
+                                    defaultView,
+                                    showAllDecimalPlaces
                                 }
                             });
                         }}
@@ -132,7 +144,8 @@ export default class Display extends React.Component<
                                     defaultView: value,
                                     displayNickname,
                                     bigKeypadButtons,
-                                    theme
+                                    theme,
+                                    showAllDecimalPlaces
                                 }
                             });
                         }}
@@ -174,7 +187,8 @@ export default class Display extends React.Component<
                                             defaultView,
                                             theme,
                                             bigKeypadButtons,
-                                            displayNickname: !displayNickname
+                                            displayNickname: !displayNickname,
+                                            showAllDecimalPlaces
                                         }
                                     });
                                 }}
@@ -217,7 +231,54 @@ export default class Display extends React.Component<
                                             defaultView,
                                             theme,
                                             displayNickname,
-                                            bigKeypadButtons: !bigKeypadButtons
+                                            bigKeypadButtons: !bigKeypadButtons,
+                                            showAllDecimalPlaces
+                                        }
+                                    });
+                                }}
+                            />
+                        </View>
+                    </ListItem>
+
+                    <ListItem
+                        containerStyle={{
+                            borderBottomWidth: 0,
+                            backgroundColor: 'transparent'
+                        }}
+                    >
+                        <ListItem.Title
+                            style={{
+                                color: themeColor('secondaryText'),
+                                fontFamily: 'Lato-Regular',
+                                left: -10
+                            }}
+                        >
+                            {localeString(
+                                'views.Settings.Display.showAllDecimalPlaces'
+                            )}
+                        </ListItem.Title>
+                        <View
+                            style={{
+                                flex: 1,
+                                flexDirection: 'row',
+                                justifyContent: 'flex-end'
+                            }}
+                        >
+                            <Switch
+                                value={showAllDecimalPlaces}
+                                onValueChange={async () => {
+                                    this.setState({
+                                        showAllDecimalPlaces:
+                                            !showAllDecimalPlaces
+                                    });
+                                    await updateSettings({
+                                        display: {
+                                            defaultView,
+                                            theme,
+                                            displayNickname,
+                                            bigKeypadButtons,
+                                            showAllDecimalPlaces:
+                                                !showAllDecimalPlaces
                                         }
                                     });
                                 }}


### PR DESCRIPTION
# Description

This PR adds the ability for a user to choose whether or not they want to see all 8 decimals when the unit selected is bitcoin. Originally we would default to showing only the required places.

Settings:

![Screenshot_1679628834](https://user-images.githubusercontent.com/1878621/227417884-a584c223-bc9a-4c89-ab3e-4818f7e2cca7.png)

Disabled (original, default behavior):
![Screenshot_1679628955](https://user-images.githubusercontent.com/1878621/227417998-f4c07475-5530-4f5f-975f-d4373e0dec04.png)
![Screenshot_1679628959](https://user-images.githubusercontent.com/1878621/227418018-d4b8910a-d1b6-4bf8-9d7d-c4c838e12e33.png)

Enabled:
![Screenshot_1679628742](https://user-images.githubusercontent.com/1878621/227417916-9a97ae39-37e7-47ba-abc2-7466f514e3b0.png)
![Screenshot_1679629005](https://user-images.githubusercontent.com/1878621/227418106-a6cf6754-783a-4f71-a59e-3fbe8f5c1d69.png)


This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
