### PR TITLE
iOS: clear Keychain data on uninstall (1/2)

### DIFF
--- a/ios/zeus/AppDelegate.m
+++ b/ios/zeus/AppDelegate.m
@@ -24,6 +24,32 @@ static void InitializeFlipper(UIApplication *application) {
 }
 #endif
 
+/**
+ Deletes all Keychain items accessible by this app if this is the first time the user launches the app
+ */
+static void ClearKeychainIfNecessary() {
+    // Checks whether or not this is the first time the app is run
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"HAS_RUN_BEFORE"] == NO) {
+        // Set the appropriate value so we don't clear next time the app is launched
+        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"HAS_RUN_BEFORE"];
+
+    // TODO for now leave delete process disabled and enable for v0.7.5
+    //     NSArray *secItemClasses = @[
+    //         (__bridge id)kSecClassGenericPassword,
+    //         (__bridge id)kSecClassInternetPassword,
+    //         (__bridge id)kSecClassCertificate,
+    //         (__bridge id)kSecClassKey,
+    //         (__bridge id)kSecClassIdentity
+    //     ];
+
+    //     // Maps through all Keychain classes and deletes all items that match
+    //     for (id secItemClass in secItemClasses) {
+    //         NSDictionary *spec = @{(__bridge id)kSecClass: secItemClass};
+    //         SecItemDelete((__bridge CFDictionaryRef)spec);
+    //     }
+    }
+}
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application
@@ -38,6 +64,9 @@ static void InitializeFlipper(UIApplication *application) {
 #ifdef FB_SONARKIT_ENABLED
   InitializeFlipper(application);
 #endif
+
+  // Add this line to call the above function
+  ClearKeychainIfNecessary();
 
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge


### PR DESCRIPTION
# Description

This change ensures that persistent data on iOS is cleared out upon uninstall. See notes from `react-native-encrypted-storage` here: https://github.com/emeraldsanto/react-native-encrypted-storage#note-regarding-keychain-persistence

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
