### PR TITLE
FiatStore - fix Malaysian Ringgit display

### DIFF
--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -156,8 +156,8 @@ export default class FiatStore {
             },
             MXN: { symbol: '$', space: true, rtl: false, separatorSwap: false },
             MYR: {
-                symbol: 'MR',
-                space: true,
+                symbol: 'RM',
+                space: false,
                 rtl: false,
                 separatorSwap: false
             },


### PR DESCRIPTION
Change Malaysian Ringgit symbol from 'MR' to 'RM' and no space between symbol and numbers.

# Description

Relates to issue: https://github.com/ZeusLN/zeus/issues/1412

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://www.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
