### PR TITLE
iOS: clear Keychain data on uninstall (2/2)

### DIFF
--- a/ios/zeus/AppDelegate.m
+++ b/ios/zeus/AppDelegate.m
@@ -33,20 +33,19 @@ static void ClearKeychainIfNecessary() {
         // Set the appropriate value so we don't clear next time the app is launched
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"HAS_RUN_BEFORE"];
 
-    // TODO for now leave delete process disabled and enable for v0.7.5
-    //     NSArray *secItemClasses = @[
-    //         (__bridge id)kSecClassGenericPassword,
-    //         (__bridge id)kSecClassInternetPassword,
-    //         (__bridge id)kSecClassCertificate,
-    //         (__bridge id)kSecClassKey,
-    //         (__bridge id)kSecClassIdentity
-    //     ];
+        NSArray *secItemClasses = @[
+            (__bridge id)kSecClassGenericPassword,
+            (__bridge id)kSecClassInternetPassword,
+            (__bridge id)kSecClassCertificate,
+            (__bridge id)kSecClassKey,
+            (__bridge id)kSecClassIdentity
+        ];
 
-    //     // Maps through all Keychain classes and deletes all items that match
-    //     for (id secItemClass in secItemClasses) {
-    //         NSDictionary *spec = @{(__bridge id)kSecClass: secItemClass};
-    //         SecItemDelete((__bridge CFDictionaryRef)spec);
-    //     }
+        // Maps through all Keychain classes and deletes all items that match
+        for (id secItemClass in secItemClasses) {
+            NSDictionary *spec = @{(__bridge id)kSecClass: secItemClass};
+            SecItemDelete((__bridge CFDictionaryRef)spec);
+        }
     }
 }
 


### PR DESCRIPTION
This change ensures that persistent data on iOS is cleared out upon uninstall. See notes from `react-native-encrypted-storage` here: https://github.com/emeraldsanto/react-native-encrypted-storage#note-regarding-keychain-persistence

[pt 1/2](https://github.com/ZeusLN/zeus/pull/1397)