### PR TITLE
SetFees: Use local value of timeLockDelta

### DIFF
--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -176,6 +176,7 @@ export default class ChannelView extends React.Component<
             <View style={{ top: -3 }}>
                 <Edit
                     onPress={() => navigation.navigate('SetFees', { channel })}
+                    fill={themeColor('text')}
                 />
             </View>
         );
@@ -189,6 +190,7 @@ export default class ChannelView extends React.Component<
                         isValid: true
                     })
                 }
+                fill={themeColor('text')}
             />
         );
 

--- a/views/Routing/SetFees.tsx
+++ b/views/Routing/SetFees.tsx
@@ -105,9 +105,7 @@ export default class SetFees extends React.PureComponent<SetFeesProps, {}> {
                             feeRate={`${
                                 Number(policy.fee_rate_milli_msat) / 10000
                             }`}
-                            timeLockDelta={chanInfo[
-                                channelId
-                            ].node1Policy.time_lock_delta.toString()}
+                            timeLockDelta={policy.time_lock_delta.toString()}
                             minHtlc={`${Number(policy.min_htlc) / 1000}`}
                             maxHtlc={`${Number(policy.max_htlc_msat) / 1000}`}
                             channelPoint={channelPoint}


### PR DESCRIPTION

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
