### PR TITLE
views/Channel: Pending channel: show channel point

### DIFF
--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -364,6 +364,26 @@ export default class ChannelView extends React.Component<
                                 />
                             </TouchableOpacity>
                         )}
+                        {(pendingOpen || pendingClose || closing) &&
+                            channel_point && (
+                                <TouchableOpacity
+                                    onPress={() =>
+                                        UrlUtils.goToBlockExplorerTXID(
+                                            channel_point,
+                                            testnet
+                                        )
+                                    }
+                                >
+                                    <KeyValue
+                                        keyValue={localeString(
+                                            'views.Channel.channelPoint'
+                                        )}
+                                        value={channel_point}
+                                        sensitive
+                                        color={themeColor('chain')}
+                                    />
+                                </TouchableOpacity>
+                            )}
                         <KeyValue
                             keyValue={localeString(
                                 'views.Channel.channelBalance'


### PR DESCRIPTION
# Description

Users can see the channel point in the funding section on an active, opened channel. They can see the closed TX on a closed channel. However, prior to this PR, they were unable to see the channel ID or channel point on a pending channel.

![Screenshot_1682192051](https://user-images.githubusercontent.com/1878621/233803215-98d94d49-819c-47d6-8bc0-63eb960e7466.png)
![Screenshot_1682191778](https://user-images.githubusercontent.com/1878621/233803216-08c5fabe-5b55-403e-ad19-616b568dba69.png)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
