### PR TITLE
Bug fix: LNDHub: allow balance refresh

### DIFF
--- a/stores/BalanceStore.ts
+++ b/stores/BalanceStore.ts
@@ -98,7 +98,7 @@ export default class BalanceStore {
     };
 
     @action
-    public getLightningBalance = (set: boolean, reset: boolean) => {
+    public getLightningBalance = (set: boolean, reset?: boolean) => {
         this.loadingLightningBalance = true;
         if (reset) this.resetLightningBalance();
         return BackendUtils.getLightningBalance()

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -244,6 +244,8 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 await login({ login: username, password }).then(async () => {
                     BalanceStore.getLightningBalance(true);
                 });
+            } else {
+                BalanceStore.getLightningBalance(true);
             }
         } else if (implementation === 'lightning-node-connect') {
             let error;


### PR DESCRIPTION
# Description

In [this commit](https://github.com/ZeusLN/zeus/commit/73b0beda77795d3afe6785d39f6d352c182802fa) we added a regression that caused balances for LNDHub accounts to only refresh on initial connection.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
