### PR TITLE
POS: add ability and associate existing payments with open orders and hide open orders

### DIFF
--- a/components/WalletHeader.tsx
+++ b/components/WalletHeader.tsx
@@ -54,6 +54,20 @@ const protectedNavigation = async (
     }
 };
 
+const ActivityButton = ({ navigation }: { navigation: any }) => (
+    <View style={{ width: 80 }}>
+        <Button
+            icon={{
+                name: 'list',
+                size: 40
+            }}
+            containerStyle={{ top: -7 }}
+            iconOnly
+            onPress={() => navigation.navigate('Activity')}
+        ></Button>
+    </View>
+);
+
 const TempleButton = ({ navigation }: { navigation: any }) => (
     <TouchableOpacity
         onPress={() => protectedNavigation(navigation, 'Wallet', true)}
@@ -300,7 +314,10 @@ export default class WalletHeader extends React.Component<
                 }
                 rightComponent={
                     posStatus === 'active' ? (
-                        <TempleButton navigation={navigation} />
+                        <Row>
+                            <ActivityButton navigation={navigation} />
+                            <TempleButton navigation={navigation} />
+                        </Row>
                     ) : channels ? (
                         <Row>
                             <SearchButton />

--- a/ios/zeus.xcodeproj/project.pbxproj
+++ b/ios/zeus.xcodeproj/project.pbxproj
@@ -1567,7 +1567,7 @@
 				CODE_SIGN_ENTITLEMENTS = zeus/zeus.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 7222UU8F2H;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -1613,7 +1613,7 @@
 				CODE_SIGN_ENTITLEMENTS = zeus/zeusRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 7222UU8F2H;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;

--- a/ios/zeus.xcodeproj/project.pbxproj
+++ b/ios/zeus.xcodeproj/project.pbxproj
@@ -1567,7 +1567,7 @@
 				CODE_SIGN_ENTITLEMENTS = zeus/zeus.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7222UU8F2H;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -1582,7 +1582,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.7.5;
+				MARKETING_VERSION = 0.7.6;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -1613,7 +1613,7 @@
 				CODE_SIGN_ENTITLEMENTS = zeus/zeusRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7222UU8F2H;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -1629,7 +1629,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.7.5;
+				MARKETING_VERSION = 0.7.6;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/ios/zeus.xcodeproj/project.pbxproj
+++ b/ios/zeus.xcodeproj/project.pbxproj
@@ -1567,7 +1567,7 @@
 				CODE_SIGN_ENTITLEMENTS = zeus/zeus.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 7222UU8F2H;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -1613,7 +1613,7 @@
 				CODE_SIGN_ENTITLEMENTS = zeus/zeusRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 7222UU8F2H;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;

--- a/ios/zeus.xcodeproj/project.pbxproj
+++ b/ios/zeus.xcodeproj/project.pbxproj
@@ -1567,7 +1567,7 @@
 				CODE_SIGN_ENTITLEMENTS = zeus/zeus.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 7222UU8F2H;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -1613,7 +1613,7 @@
 				CODE_SIGN_ENTITLEMENTS = zeus/zeusRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 7222UU8F2H;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;

--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -153,6 +153,16 @@ export default class Invoice extends BaseModel {
               );
     }
 
+    @computed public get getDisplayTimeOrder(): string {
+        return DateTimeUtils.listFormattedDateOrder(
+            new Date(
+                Number(
+                    this.settle_date || this.paid_at || this.timestamp || 0
+                ) * 1000
+            )
+        );
+    }
+
     @computed public get getDisplayTimeShort(): string {
         return this.isPaid
             ? DateTimeUtils.listFormattedDateShort(

--- a/models/Transaction.ts
+++ b/models/Transaction.ts
@@ -1,4 +1,5 @@
 import { computed } from 'mobx';
+
 import BaseModel from './BaseModel';
 import DateTimeUtils from './../utils/DateTimeUtils';
 import { localeString } from './../utils/LocaleUtils';
@@ -56,6 +57,12 @@ export default class Transaction extends BaseModel {
         return this.getTimestamp === 0
             ? this.getBlockHeight
             : DateTimeUtils.listFormattedDateShort(this.getTimestamp);
+    }
+
+    @computed public get getDisplayTimeOrder(): string {
+        return DateTimeUtils.listFormattedDateOrder(
+            new Date(Number(this.getTimestamp) * 1000)
+        );
     }
 
     @computed public get getDate(): string | Date {

--- a/stores/ActivityStore.ts
+++ b/stores/ActivityStore.ts
@@ -75,6 +75,24 @@ export default class ActivityStore {
     };
 
     @action
+    public setFiltersPos = async () => {
+        this.filters = {
+            lightning: true,
+            onChain: true,
+            sent: false,
+            received: true,
+            unpaid: false,
+            minimumAmount: 0,
+            startDate: null,
+            endDate: null
+        };
+        await EncryptedStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify(this.filters)
+        );
+    };
+
+    @action
     public setAmountFilter = (filter: any) => {
         this.filters.minimumAmount = filter;
         this.setFilters(this.filters);

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -33,7 +33,7 @@ export default class FiatStore {
 
     // Resource below may be helpful for formatting
     // https://fastspring.com/blog/how-to-format-30-currencies-from-countries-all-over-the-world/
-    private symbolLookup = (symbol: string): CurrencyDisplayRules => {
+    symbolLookup = (symbol: string): CurrencyDisplayRules => {
         const symbolPairs: any = {
             USD: {
                 symbol: '$',

--- a/utils/DateTimeUtils.ts
+++ b/utils/DateTimeUtils.ts
@@ -17,6 +17,12 @@ class DateTimeUtils {
 
     listFormattedDateShort = (timestamp: number | string) =>
         this.listFormattedDate(timestamp, 'mmm d, HH:MM');
+
+    listFormattedDateOrder = (timestamp: Date) => {
+        const updated = dateFormat(timestamp, 'hh:mm tt');
+        const day = dateFormat(timestamp, 'ddd, mmm dd');
+        return `${updated} | ${day}`;
+    };
 }
 
 const dateTimeUtils = new DateTimeUtils();

--- a/utils/ThemeUtils.ts
+++ b/utils/ThemeUtils.ts
@@ -177,7 +177,7 @@ export function themeColor(themeString: string): any {
         background: '#4C09F4',
         secondary: '#141414',
         separator: '#141414',
-        highlight: '#fff',
+        highlight: '#ffd24b',
         bolt: '#fff',
         chain: '#fff'
     };

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -6,7 +6,7 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
-import { Button, ListItem } from 'react-native-elements';
+import { Button, Icon, ListItem } from 'react-native-elements';
 import { inject, observer } from 'mobx-react';
 import BigNumber from 'bignumber.js';
 
@@ -147,7 +147,8 @@ export default class Activity extends React.PureComponent<
         const order = navigation.getParam('order', null);
 
         const MarkPaymentButton = () => (
-            <Button
+            <Icon
+                name="payments"
                 onPress={() => {
                     if (!order || !selectedPaymentForOrder) return;
                     const payment: any = selectedPaymentForOrder;
@@ -201,13 +202,9 @@ export default class Activity extends React.PureComponent<
                         navigation.goBack();
                     });
                 }}
-                icon={{
-                    name: 'payments',
-                    size: 25
-                }}
-                buttonStyle={{ backgroundColor: themeColor('highlight') }}
-                iconOnly
-            ></Button>
+                color={themeColor('highlight')}
+                underlayColor="transparent"
+            />
         );
 
         const FilterButton = () => (
@@ -325,10 +322,20 @@ export default class Activity extends React.PureComponent<
                                         }}
                                         onPress={() => {
                                             if (order) {
-                                                this.setState({
-                                                    selectedPaymentForOrder:
-                                                        item
-                                                });
+                                                if (
+                                                    selectedPaymentForOrder ===
+                                                    item
+                                                ) {
+                                                    this.setState({
+                                                        selectedPaymentForOrder:
+                                                            null
+                                                    });
+                                                } else {
+                                                    this.setState({
+                                                        selectedPaymentForOrder:
+                                                            item
+                                                    });
+                                                }
                                                 return;
                                             }
                                             if (

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -429,7 +429,9 @@ export default class Activity extends React.PureComponent<
                                                     fontFamily: 'Lato-Regular'
                                                 }}
                                             >
-                                                {item.getDisplayTimeShort}
+                                                {order
+                                                    ? item.getDisplayTimeOrder
+                                                    : item.getDisplayTimeShort}
                                             </ListItem.Subtitle>
                                         </ListItem.Content>
                                     </ListItem>

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -869,7 +869,7 @@ export default class Receive extends React.Component<
                                     name: 'list',
                                     size: 25
                                 }}
-                                onPress={() => this.navBack()}
+                                onPress={() => navigation.navigate('Wallet')}
                                 containerStyle={{ width: '100%' }}
                             />
                         </View>

--- a/views/Wallet/PosPane.tsx
+++ b/views/Wallet/PosPane.tsx
@@ -85,7 +85,6 @@ export default class PosPane extends React.PureComponent<
         let prevOpenedRow;
 
         const closeRow = (index) => {
-            console.log('closerow');
             if (prevOpenedRow && prevOpenedRow !== row[index]) {
                 prevOpenedRow.close();
             }


### PR DESCRIPTION
# Description

On the POS orders list, items can now be slided to the left to expose a payment and delete button. The delete button will hide the order from the open orders list. This is useful for removing orders that customer were unable to pay. The payment button will take the server to the activity list (filtered only to received payments) to associate a made payment with an order.

![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2023-05-06 at 19 16 38](https://user-images.githubusercontent.com/1878621/236649936-ae034bb5-b5b0-4563-99e9-4e6cb5f3beab.png)
![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2023-05-09 at 17 02 16](https://github.com/ZeusLN/zeus/assets/1878621/e341c1b8-80ce-4cf8-a5e2-6d0e1633cff2)


This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
