### PR TITLE
Fixed showing loading indicator for fiat amount endlessly

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { inject, observer } from 'mobx-react';
+import FiatStore from '../stores/FiatStore';
 import UnitsStore from '../stores/UnitsStore';
 import SettingsStore from '../stores/SettingsStore';
 import PrivacyUtils from '../utils/PrivacyUtils';
@@ -24,6 +25,7 @@ interface AmountDisplayProps {
     jumboText?: boolean;
     color?: 'text' | 'success' | 'warning' | 'highlight' | 'secondaryText';
     pending?: boolean;
+    fiatRatesLoading?: boolean;
 }
 
 function AmountDisplay({
@@ -36,7 +38,8 @@ function AmountDisplay({
     space = false,
     jumboText = false,
     color = undefined,
-    pending = false
+    pending = false,
+    fiatRatesLoading = false
 }: AmountDisplayProps) {
     if (unit === 'fiat' && !symbol) {
         console.error('Must include a symbol when rendering fiat');
@@ -95,7 +98,7 @@ function AmountDisplay({
                     <Row align="flex-end">
                         <Body jumbo={jumboText} color={color}>
                             {negative ? '-' : ''}
-                            {amount === 'N/A' ? (
+                            {amount === 'N/A' && fiatRatesLoading ? (
                                 <LoadingIndicator size={20} />
                             ) : (
                                 amount.toString()
@@ -114,7 +117,7 @@ function AmountDisplay({
                         {space ? <TextSpace /> : <Spacer width={1} />}
                         <Body jumbo={jumboText} color={color}>
                             {negative ? '-' : ''}
-                            {amount === 'N/A' ? (
+                            {amount === 'N/A' && fiatRatesLoading ? (
                                 <LoadingIndicator size={20} />
                             ) : (
                                 amount.toString()
@@ -127,6 +130,7 @@ function AmountDisplay({
 }
 
 interface AmountProps {
+    FiatStore?: FiatStore;
     UnitsStore?: UnitsStore;
     SettingsStore?: SettingsStore;
     sats: number | string;
@@ -142,7 +146,7 @@ interface AmountProps {
     pending?: boolean;
 }
 
-@inject('UnitsStore', 'SettingsStore')
+@inject('FiatStore', 'UnitsStore', 'SettingsStore')
 @observer
 export default class Amount extends React.Component<AmountProps, {}> {
     render() {
@@ -158,6 +162,7 @@ export default class Amount extends React.Component<AmountProps, {}> {
             color = undefined,
             pending = false
         } = this.props;
+        const FiatStore = this.props.FiatStore!;
         const UnitsStore = this.props.UnitsStore!;
         const SettingsStore = this.props.SettingsStore!;
         const lurkerMode =
@@ -193,6 +198,7 @@ export default class Amount extends React.Component<AmountProps, {}> {
                             negative={false}
                             jumboText={jumboText}
                             pending={pending}
+                            fiatRatesLoading={FiatStore.loading}
                         />
                     </TouchableOpacity>
                 );
@@ -206,6 +212,7 @@ export default class Amount extends React.Component<AmountProps, {}> {
                     negative={false}
                     jumboText={jumboText}
                     pending={pending}
+                    fiatRatesLoading={FiatStore.loading}
                 />
             );
         }
@@ -246,6 +253,7 @@ export default class Amount extends React.Component<AmountProps, {}> {
                         jumboText={jumboText}
                         color={textColor}
                         pending={pending}
+                        fiatRatesLoading={FiatStore.loading}
                     />
                 </TouchableOpacity>
             );
@@ -260,6 +268,7 @@ export default class Amount extends React.Component<AmountProps, {}> {
                 jumboText={jumboText}
                 color={textColor}
                 pending={pending}
+                fiatRatesLoading={FiatStore.loading}
             />
         );
     }

--- a/components/Conversion.tsx
+++ b/components/Conversion.tsx
@@ -7,7 +7,7 @@ import Amount from '../components/Amount';
 import { Row } from '../components/layout/Row';
 import { getSatAmount } from '../components/AmountInput';
 
-import FiatStore from '../stores/UnitsStore';
+import FiatStore from '../stores/FiatStore';
 import UnitsStore from '../stores/UnitsStore';
 import SettingsStore, { DEFAULT_FIAT } from '../stores/SettingsStore';
 

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -447,8 +447,8 @@ export default class FiatStore {
                 const status = response.info().status;
                 if (status == 200) {
                     const data = response.json();
-                    this.loading = false;
                     this.fiatRates = data;
+                    this.loading = false;
                 } else {
                     this.loading = false;
                 }


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-1453**

This fixes #1453. Additionally when loading fails N/A is now shown instead of also showing the loading indicator endlessly.

Also fixed an import in Conversion.tsc (not sure why this had no negative effect before).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
   - a lot of errors are found in node modules
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
