### PR TITLE
backends/LndHub: supportsOnchainReceiving: check for LNbits url

### DIFF
--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -120,7 +120,9 @@ export default class LndHub extends LND {
     supportsOnchainReceiving = () =>
         !(
             stores.settingsStore.lndhubUrl.includes('lnbank/api/lndhub') ||
-            stores.settingsStore.lndhubUrl.includes('lntxbot')
+            stores.settingsStore.lndhubUrl.includes('lntxbot') ||
+            // LNBits
+            stores.settingsStore.lndhubUrl.includes('/lndhub/ext/')
         );
     supportsKeysend = () => false;
     supportsChannelManagement = () => false;


### PR DESCRIPTION
# Description

LNbits does not support on-chain receiving, so in our `LNDHub` backend definition, let's check for the LNBits url path `/lndhub/ext`, and if it matches the user's host, don't show the on-chain components in the UI.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
