### PR TITLE
Lock without reconnect

### DIFF
--- a/stores/ModalStore.ts
+++ b/stores/ModalStore.ts
@@ -33,4 +33,17 @@ export default class ModalStore {
     public toggleAndroidNfcModal = (status: boolean) => {
         this.showAndroidNfcModal = status;
     };
+
+    @action
+    public closeVisibleModalDialog = () => {
+        if (this.showExternalLinkModal) {
+            this.showExternalLinkModal = false;
+            return true;
+        }
+        if (this.showAndroidNfcModal) {
+            this.showAndroidNfcModal = false;
+            return true;
+        }
+        return false;
+    };
 }

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -673,6 +673,18 @@ export default class SettingsStore {
         });
     };
 
+    public loginRequired = () =>
+        this.settings &&
+        (this.settings.passphrase ||
+            this.settings.pin ||
+            this.isBiometryRequired()) &&
+        !this.loggedIn;
+
+    public isBiometryRequired = () =>
+        this.settings != null &&
+        this.settings.isBiometryEnabled &&
+        this.settings.supportedBiometryType !== undefined;
+
     @action
     public setLoginStatus = (status = false) => {
         this.loggedIn = status;

--- a/utils/BiometricUtils.ts
+++ b/utils/BiometricUtils.ts
@@ -1,5 +1,4 @@
 import ReactNativeBiometrics, { BiometryType } from 'react-native-biometrics';
-import { Settings } from '../stores/SettingsStore';
 
 const rnBiometrics = new ReactNativeBiometrics({
     allowDeviceCredentials: false
@@ -41,10 +40,5 @@ export const verifyBiometry = async (
 
     return false;
 };
-
-export const getIsBiometryRequired = (settings?: Settings): boolean =>
-    settings != null &&
-    settings.isBiometryEnabled &&
-    settings.supportedBiometryType !== undefined;
 
 export default rnBiometrics;

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -11,7 +11,7 @@ import TextInput from '../components/TextInput';
 
 import SettingsStore from '../stores/SettingsStore';
 
-import { getIsBiometryRequired, verifyBiometry } from '../utils/BiometricUtils';
+import { verifyBiometry } from '../utils/BiometricUtils';
 import LinkingUtils from '../utils/LinkingUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
@@ -76,7 +76,7 @@ export default class Lockscreen extends React.Component<
         const posEnabled: boolean =
             (settings && settings.pos && settings.pos.squareEnabled) || false;
 
-        const isBiometryRequired = getIsBiometryRequired(settings);
+        const isBiometryRequired = SettingsStore.isBiometryRequired();
 
         if (
             isBiometryRequired &&

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -11,7 +11,11 @@ import {
 } from 'react-native';
 
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { DefaultTheme, NavigationContainer, NavigationContainerRef } from '@react-navigation/native';
+import {
+    DefaultTheme,
+    NavigationContainer,
+    NavigationContainerRef
+} from '@react-navigation/native';
 import { inject, observer } from 'mobx-react';
 import RNRestart from 'react-native-restart';
 
@@ -120,7 +124,8 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
     }
 
     private handleBackButton() {
-        const dialogHasBeenClosed = this.props.ModalStore.closeVisibleModalDialog();
+        const dialogHasBeenClosed =
+            this.props.ModalStore.closeVisibleModalDialog();
         if (dialogHasBeenClosed) {
             return true;
         }
@@ -137,8 +142,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         if (!tabNavigatorState) {
             return false;
         }
-        const currentTabName = tabNavigatorState.routeNames[tabNavigatorState.index];
-        const defaultView = this.props.SettingsStore.settings.display.defaultView;
+        const currentTabName =
+            tabNavigatorState.routeNames[tabNavigatorState.index];
+        const defaultView =
+            this.props.SettingsStore.settings.display.defaultView;
         if (defaultView === currentTabName) {
             return false;
         } else if (defaultView) {
@@ -154,7 +161,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         });
 
         AppState.addEventListener('change', this.handleAppStateChange);
-        BackHandler.addEventListener('hardwareBackPress', this.handleBackButton.bind(this));
+        BackHandler.addEventListener(
+            'hardwareBackPress',
+            this.handleBackButton.bind(this)
+        );
     }
 
     componentWillUnmount() {
@@ -162,7 +172,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             this.props.navigation.removeListener('didFocus');
         AppState.removeEventListener &&
             AppState.removeEventListener('change', this.handleAppStateChange);
-        BackHandler.removeEventListener('hardwareBackPress', this.handleBackButton);
+        BackHandler.removeEventListener(
+            'hardwareBackPress',
+            this.handleBackButton
+        );
     }
 
     handleAppStateChange = (nextAppState: any) => {
@@ -454,7 +467,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         return (
             <View style={{ flex: 1 }}>
                 {!connecting && (!loginRequired || squareEnabled) && (
-                    <NavigationContainer theme={Theme} ref={this.tabNavigationRef}>
+                    <NavigationContainer
+                        theme={Theme}
+                        ref={this.tabNavigationRef}
+                    >
                         <Tab.Navigator
                             initialRouteName={
                                 squareEnabled && posStatus === 'active'
@@ -463,7 +479,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                                           settings.display.defaultView) ||
                                       'Keypad'
                             }
-                            backBehavior='none'
+                            backBehavior="none"
                             screenOptions={({ route }) => ({
                                 tabBarIcon: ({ color }) => {
                                     if (route.name === 'Keypad') {

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -150,6 +150,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             return false;
         } else if (defaultView) {
             tabNavigator.navigate(defaultView);
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
# Description

This fixes #1279.

Before, when the setting "require login after app returns from background" was enabled, Zeus was always reconnecting to your node when you started the app. Even if the last app usage was seconds ago. This was because a restart of the app was forced when the app state changed to background. Now the loggedIn flag is just set to false instead.

Additionally pressing back button on lock screen now closes the app (before it was just reloading the lock screen).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
