### PR TITLE
Core Lightning: display multiple channels per peer + update msat fields

### DIFF
--- a/backends/CLightningREST.ts
+++ b/backends/CLightningREST.ts
@@ -48,23 +48,34 @@ export default class CLightningREST extends LND {
                         )
                             return;
 
+                        // CLN v23.05 msat deprecations
                         const to_us_msat =
-                            channel.to_us_msat || channel.msatoshi_to_us || 0;
+                            channel.to_us ||
+                            channel.to_us_msat ||
+                            channel.msatoshi_to_us ||
+                            0;
                         const total_msat =
-                            channel.total_msat || channel.msatoshi_total || 0;
+                            channel.total ||
+                            channel.total_msat ||
+                            channel.msatoshi_total ||
+                            0;
                         const out_fulfilled_msat =
+                            channel.out_fulfilled ||
                             channel.out_fulfilled_msat ||
                             channel.out_msatoshi_fulfilled ||
                             0;
                         const in_fulfilled_msat =
+                            channel.in_fulfilled ||
                             channel.in_fulfilled_msat ||
                             channel.in_msatoshi_fulfilled ||
                             0;
                         const our_reserve_msat =
+                            channel.our_reserve ||
                             channel.our_reserve_msat ||
                             channel.our_channel_reserve_satoshis ||
                             0;
                         const their_reserve_msat =
+                            channel.their_reserve ||
                             channel.their_reserve_msat ||
                             channel.their_channel_reserve_satoshi ||
                             0;

--- a/backends/CLightningREST.ts
+++ b/backends/CLightningREST.ts
@@ -36,52 +36,78 @@ export default class CLightningREST extends LND {
             transactions: data.outputs
         }));
     getChannels = () =>
-        this.getRequest('/v1/peer/listPeers').then((data: any) => ({
-            channels: data
-                .filter((peer: any) => peer.channels.length)
-                .map((peer: any) => {
-                    const channel =
-                        peer.channels.find(
-                            (c: any) =>
-                                c.state !== 'ONCHAIN' && c.state !== 'CLOSED'
-                        ) || peer.channels[0];
+        this.getRequest('/v1/peer/listPeers').then((data: any) => {
+            const formattedChannels: any[] = [];
+            data.filter((peer: any) => peer.channels.length).map(
+                (peer: any) => {
+                    peer.channels.forEach((channel: any) => {
+                        if (
+                            channel.state === 'ONCHAIN' ||
+                            channel.state === 'CLOSED' ||
+                            channel.state === 'CHANNELD_AWAITING_LOCKIN'
+                        )
+                            return;
 
-                    return {
-                        active: peer.connected,
-                        remote_pubkey: peer.id,
-                        channel_point: channel.funding_txid,
-                        chan_id: channel.channel_id,
-                        alias: peer.alias,
-                        capacity: Number(
-                            channel.msatoshi_total / 1000
-                        ).toString(),
-                        local_balance: Number(
-                            channel.msatoshi_to_us / 1000
-                        ).toString(),
-                        remote_balance: Number(
-                            (channel.msatoshi_total - channel.msatoshi_to_us) /
-                                1000
-                        ).toString(),
-                        total_satoshis_sent: Number(
-                            channel.out_msatoshi_fulfilled / 1000
-                        ).toString(),
-                        total_satoshis_received: Number(
-                            channel.in_msatoshi_fulfilled / 1000
-                        ).toString(),
-                        num_updates: (
-                            channel.in_payments_offered +
-                            channel.out_payments_offered
-                        ).toString(),
-                        csv_delay: channel.our_to_self_delay,
-                        private: channel.private,
-                        local_chan_reserve_sat:
-                            channel.our_channel_reserve_satoshis.toString(),
-                        remote_chan_reserve_sat:
-                            channel.their_channel_reserve_satoshis.toString(),
-                        close_address: channel.close_to_addr
-                    };
-                })
-        }));
+                        const to_us_msat =
+                            channel.to_us_msat || channel.msatoshi_to_us || 0;
+                        const total_msat =
+                            channel.total_msat || channel.msatoshi_total || 0;
+                        const out_fulfilled_msat =
+                            channel.out_fulfilled_msat ||
+                            channel.out_msatoshi_fulfilled ||
+                            0;
+                        const in_fulfilled_msat =
+                            channel.in_fulfilled_msat ||
+                            channel.in_msatoshi_fulfilled ||
+                            0;
+                        const our_reserve_msat =
+                            channel.our_reserve_msat ||
+                            channel.our_channel_reserve_satoshis ||
+                            0;
+                        const their_reserve_msat =
+                            channel.their_reserve_msat ||
+                            channel.their_channel_reserve_satoshi ||
+                            0;
+
+                        formattedChannels.push({
+                            active: peer.connected,
+                            remote_pubkey: peer.id,
+                            channel_point: channel.funding_txid,
+                            chan_id: channel.channel_id,
+                            alias: peer.alias,
+                            capacity: Number(total_msat / 1000).toString(),
+                            local_balance: Number(to_us_msat / 1000).toString(),
+                            remote_balance: Number(
+                                (total_msat - to_us_msat) / 1000
+                            ).toString(),
+                            total_satoshis_sent: Number(
+                                out_fulfilled_msat / 1000
+                            ).toString(),
+                            total_satoshis_received: Number(
+                                in_fulfilled_msat / 1000
+                            ).toString(),
+                            num_updates: (
+                                channel.in_payments_offered +
+                                channel.out_payments_offered
+                            ).toString(),
+                            csv_delay: channel.our_to_self_delay,
+                            private: channel.private,
+                            local_chan_reserve_sat: Number(
+                                our_reserve_msat / 1000
+                            ).toString(),
+                            remote_chan_reserve_sat: Number(
+                                their_reserve_msat / 1000
+                            ).toString(),
+                            close_address: channel.close_to_addr
+                        });
+                    });
+                }
+            );
+
+            return {
+                channels: formattedChannels
+            };
+        });
     getBlockchainBalance = () =>
         this.getRequest('/v1/getBalance').then(
             ({ totalBalance, confBalance, unconfBalance }: any) => ({

--- a/backends/Spark.ts
+++ b/backends/Spark.ts
@@ -75,23 +75,34 @@ export default class Spark {
                         )
                             return;
 
+                        // CLN v23.05 msat deprecations
                         const to_us_msat =
-                            channel.to_us_msat || channel.msatoshi_to_us || 0;
+                            channel.to_us ||
+                            channel.to_us_msat ||
+                            channel.msatoshi_to_us ||
+                            0;
                         const total_msat =
-                            channel.total_msat || channel.msatoshi_total || 0;
+                            channel.total ||
+                            channel.total_msat ||
+                            channel.msatoshi_total ||
+                            0;
                         const out_fulfilled_msat =
+                            channel.out_fulfilled ||
                             channel.out_fulfilled_msat ||
                             channel.out_msatoshi_fulfilled ||
                             0;
                         const in_fulfilled_msat =
+                            channel.in_fulfilled ||
                             channel.in_fulfilled_msat ||
                             channel.in_msatoshi_fulfilled ||
                             0;
                         const our_reserve_msat =
+                            channel.our_reserve ||
                             channel.our_reserve_msat ||
                             channel.our_channel_reserve_satoshis ||
                             0;
                         const their_reserve_msat =
+                            channel.their_reserve ||
                             channel.their_reserve_msat ||
                             channel.their_channel_reserve_satoshi ||
                             0;

--- a/backends/Spark.ts
+++ b/backends/Spark.ts
@@ -62,51 +62,78 @@ export default class Spark {
             transactions: outputs
         }));
     getChannels = () =>
-        this.rpc('listpeers').then(({ peers }: any) => ({
-            channels: peers
+        this.rpc('listpeers').then(({ peers }: any) => {
+            const formattedChannels: any[] = [];
+            peers
                 .filter((peer: any) => peer.channels.length)
                 .map((peer: any) => {
-                    const channel =
-                        peer.channels.find(
-                            (c: any) =>
-                                c.state !== 'ONCHAIN' && c.state !== 'CLOSED'
-                        ) || peer.channels[0];
+                    peer.channels.forEach((channel: any) => {
+                        if (
+                            channel.state === 'ONCHAIN' ||
+                            channel.state === 'CLOSED' ||
+                            channel.state === 'CHANNELD_AWAITING_LOCKIN'
+                        )
+                            return;
 
-                    return {
-                        active: peer.connected,
-                        remote_pubkey: peer.id,
-                        channel_point: channel.funding_txid,
-                        chan_id: channel.channel_id,
-                        capacity: Number(
-                            channel.msatoshi_total / 1000
-                        ).toString(),
-                        local_balance: Number(
-                            channel.msatoshi_to_us / 1000
-                        ).toString(),
-                        remote_balance: Number(
-                            (channel.msatoshi_total - channel.msatoshi_to_us) /
-                                1000
-                        ).toString(),
-                        total_satoshis_sent: Number(
-                            channel.out_msatoshi_fulfilled / 1000
-                        ).toString(),
-                        total_satoshis_received: Number(
-                            channel.in_msatoshi_fulfilled / 1000
-                        ).toString(),
-                        num_updates: (
-                            channel.in_payments_offered +
-                            channel.out_payments_offered
-                        ).toString(),
-                        csv_delay: channel.our_to_self_delay,
-                        private: channel.private,
-                        local_chan_reserve_sat:
-                            channel.our_channel_reserve_satoshis.toString(),
-                        remote_chan_reserve_sat:
-                            channel.their_channel_reserve_satoshis.toString(),
-                        close_address: channel.close_to_addr
-                    };
-                })
-        }));
+                        const to_us_msat =
+                            channel.to_us_msat || channel.msatoshi_to_us || 0;
+                        const total_msat =
+                            channel.total_msat || channel.msatoshi_total || 0;
+                        const out_fulfilled_msat =
+                            channel.out_fulfilled_msat ||
+                            channel.out_msatoshi_fulfilled ||
+                            0;
+                        const in_fulfilled_msat =
+                            channel.in_fulfilled_msat ||
+                            channel.in_msatoshi_fulfilled ||
+                            0;
+                        const our_reserve_msat =
+                            channel.our_reserve_msat ||
+                            channel.our_channel_reserve_satoshis ||
+                            0;
+                        const their_reserve_msat =
+                            channel.their_reserve_msat ||
+                            channel.their_channel_reserve_satoshi ||
+                            0;
+
+                        formattedChannels.push({
+                            active: peer.connected,
+                            remote_pubkey: peer.id,
+                            channel_point: channel.funding_txid,
+                            chan_id: channel.channel_id,
+                            alias: peer.alias,
+                            capacity: Number(total_msat / 1000).toString(),
+                            local_balance: Number(to_us_msat / 1000).toString(),
+                            remote_balance: Number(
+                                (total_msat - to_us_msat) / 1000
+                            ).toString(),
+                            total_satoshis_sent: Number(
+                                out_fulfilled_msat / 1000
+                            ).toString(),
+                            total_satoshis_received: Number(
+                                in_fulfilled_msat / 1000
+                            ).toString(),
+                            num_updates: (
+                                channel.in_payments_offered +
+                                channel.out_payments_offered
+                            ).toString(),
+                            csv_delay: channel.our_to_self_delay,
+                            private: channel.private,
+                            local_chan_reserve_sat: Number(
+                                our_reserve_msat / 1000
+                            ).toString(),
+                            remote_chan_reserve_sat: Number(
+                                their_reserve_msat / 1000
+                            ).toString(),
+                            close_address: channel.close_to_addr
+                        });
+                    });
+                });
+
+            return {
+                channels: formattedChannels
+            };
+        });
     getBlockchainBalance = () =>
         this.rpc('listfunds').then(({ outputs }: any) => {
             const unconf = outputs

--- a/components/LayerBalances/index.tsx
+++ b/components/LayerBalances/index.tsx
@@ -111,18 +111,18 @@ export default class LayerBalances extends Component<LayerBalancesProps, {}> {
             DATA = [
                 {
                     layer: 'Lightning',
-                    balance: lightningBalance
+                    balance: Number(lightningBalance).toFixed(3)
                 }
             ];
         } else {
             DATA = [
                 {
                     layer: 'Lightning',
-                    balance: lightningBalance
+                    balance: Number(lightningBalance).toFixed(3)
                 },
                 {
                     layer: 'On-chain',
-                    balance: totalBlockchainBalance
+                    balance: Number(totalBlockchainBalance).toFixed(3)
                 }
             ];
         }

--- a/models/Channel.ts
+++ b/models/Channel.ts
@@ -36,8 +36,15 @@ export default class Channel extends BaseModel {
     // c-lightning
     @observable
     state: string;
+    // CLN v23.05 msat deprecations
     msatoshi_total: string;
     msatoshi_to_us: string;
+    total_msat: string;
+    to_us_msat: string;
+    // CLN v23.05 msat new
+    total: string;
+    to_us: string;
+
     channel_id?: string;
     alias?: string;
     // pending
@@ -60,14 +67,25 @@ export default class Channel extends BaseModel {
 
     @computed
     public get localBalance(): string {
-        return this.msatoshi_to_us
+        return this.to_us
+            ? (Number(this.to_us) / 1000).toString()
+            : this.to_us_msat
+            ? (Number(this.to_us_msat) / 1000).toString()
+            : this.msatoshi_to_us
             ? (Number(this.msatoshi_to_us) / 1000).toString()
             : this.local_balance || '0';
     }
 
     @computed
     public get remoteBalance(): string {
-        return this.msatoshi_total
+        return this.total
+            ? ((Number(this.total) - Number(this.to_us)) / 1000).toString()
+            : this.total_msat
+            ? (
+                  (Number(this.total_msat) - Number(this.to_us_msat)) /
+                  1000
+              ).toString()
+            : this.msatoshi_total
             ? (
                   (Number(this.msatoshi_total) - Number(this.msatoshi_to_us)) /
                   1000


### PR DESCRIPTION
This PR

- Fixed the regression from [this PR](https://github.com/ZeusLN/zeus/pull/1266) that didn't take multiple channels per peer into account
- Fixes msat channel fields that were broken in [CLN v23.05](https://github.com/ElementsProject/lightning/releases/tag/v23.05)
- Handles the CLN-rest bug that displays lightning balances with more than three decimal places, which we believe was introduced in [CLN-REST v0.10.3](https://github.com/Ride-The-Lightning/c-lightning-REST/releases/tag/v0.10.3)