### PR TITLE
Bug fix: locking when going to background

### DIFF
--- a/components/WalletHeader.tsx
+++ b/components/WalletHeader.tsx
@@ -49,7 +49,7 @@ const protectedNavigation = async (
             attemptAdminLogin: true
         });
     } else {
-        if (disactivatePOS) await setPosStatus('inactive');
+        if (disactivatePOS) setPosStatus('inactive');
         navigation.navigate(route);
     }
 };
@@ -113,7 +113,7 @@ const POSBadge = ({
     <TouchableOpacity
         onPress={async () => {
             getOrders();
-            await setPosStatus('active');
+            setPosStatus('active');
         }}
     >
         <POS stroke={themeColor('text')} width="34" height="34" />

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1002,14 +1002,15 @@ export default class SettingsStore {
         });
     };
 
-    public loginRequired = () =>
+    public loginRequired = () => this.loginMethodConfigured() && !this.loggedIn;
+
+    public loginMethodConfigured = () =>
         this.settings &&
         (this.settings.passphrase ||
             this.settings.pin ||
-            this.isBiometryRequired()) &&
-        !this.loggedIn;
+            this.isBiometryConfigured());
 
-    public isBiometryRequired = () =>
+    public isBiometryConfigured = () =>
         this.settings != null &&
         this.settings.isBiometryEnabled &&
         this.settings.supportedBiometryType !== undefined;

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -76,10 +76,10 @@ export default class Lockscreen extends React.Component<
         const posEnabled: boolean =
             (settings && settings.pos && settings.pos.squareEnabled) || false;
 
-        const isBiometryRequired = SettingsStore.isBiometryRequired();
+        const isBiometryConfigured = SettingsStore.isBiometryConfigured();
 
         if (
-            isBiometryRequired &&
+            isBiometryConfigured &&
             !attemptAdminLogin &&
             !deletePin &&
             !deleteDuressPin &&
@@ -184,7 +184,7 @@ export default class Lockscreen extends React.Component<
             } else if (deleteDuressPin) {
                 this.deleteDuressPin();
             } else {
-                await setPosStatus('inactive');
+                setPosStatus('inactive');
                 this.resetAuthenticationAttempts();
                 navigation.navigate('Wallet');
             }


### PR DESCRIPTION
# Description

The commit 22a9c8c broke the setting "Require login after app returns from background" because it did not logout when the user was logged in. Not sure if this breaks FaceID again because I can't test it on iOS.

Also fixed an error when pressing back while on POS screen in certain situations.

Additionally removed some unnecessary `await`s.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
