### PR TITLE
Fix button press when keyboard is open

### DIFF
--- a/components/SetFeesForm.tsx
+++ b/components/SetFeesForm.tsx
@@ -91,7 +91,10 @@ export default class SetFeesForm extends React.Component<
 
         return (
             <React.Fragment>
-                <ScrollView style={{ paddingTop: 15 }}>
+                <ScrollView
+                    style={{ paddingTop: 15 }}
+                    keyboardShouldPersistTaps="handled"
+                >
                     {loading && <LightningIndicator />}
                     {feesSubmitted && setFeesSuccess && (
                         <SuccessMessage

--- a/views/Accounts/ImportAccount.tsx
+++ b/views/Accounts/ImportAccount.tsx
@@ -71,6 +71,7 @@ export default class ImportAccount extends React.Component<
                     flex: 1,
                     backgroundColor: themeColor('background')
                 }}
+                keyboardShouldPersistTaps="handled"
             >
                 <Header
                     leftComponent="Back"

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -212,7 +212,10 @@ export default class ChannelView extends React.Component<
                     placement="right"
                     navigation={navigation}
                 />
-                <ScrollView style={styles.content}>
+                <ScrollView
+                    style={styles.content}
+                    keyboardShouldPersistTaps="handled"
+                >
                     <KeyboardAvoidingView
                         behavior="position"
                         keyboardVerticalOffset={keyboardVerticalOffset}

--- a/views/EditFee.tsx
+++ b/views/EditFee.tsx
@@ -102,7 +102,10 @@ export default class EditFee extends React.Component<
                     behavior="position"
                     keyboardVerticalOffset={keyboardVerticalOffset}
                 >
-                    <ScrollView style={{ paddingTop: 10, alignSelf: 'center' }}>
+                    <ScrollView
+                        style={{ paddingTop: 10, alignSelf: 'center' }}
+                        keyboardShouldPersistTaps="handled"
+                    >
                         {loading && !error && (
                             <View style={{ flex: 1, justifyContent: 'center' }}>
                                 <LightningIndicator />

--- a/views/Invoice.tsx
+++ b/views/Invoice.tsx
@@ -101,7 +101,7 @@ export default class InvoiceView extends React.Component<InvoiceProps> {
                     }
                     navigation={navigation}
                 />
-                <ScrollView>
+                <ScrollView keyboardShouldPersistTaps="handled">
                     <View style={styles.center}>
                         <Amount
                             sats={invoice.getAmount}

--- a/views/LnurlPay/Metadata.tsx
+++ b/views/LnurlPay/Metadata.tsx
@@ -37,6 +37,7 @@ export default class LnurlPayMetadata extends React.Component<LnurlPayMetadataPr
                     justifyContent: 'center',
                     alignItems: 'center'
                 }}
+                keyboardShouldPersistTaps="handled"
             >
                 {image ? (
                     <Image

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -331,7 +331,10 @@ export default class Lockscreen extends React.Component<
                     <Header leftComponent="Back" navigation={navigation} />
                 )}
                 {!!passphrase && (
-                    <ScrollView style={styles.container}>
+                    <ScrollView
+                        style={styles.container}
+                        keyboardShouldPersistTaps="handled"
+                    >
                         <View style={styles.content}>
                             {error && (
                                 <ErrorMessage

--- a/views/NodeInfo.tsx
+++ b/views/NodeInfo.tsx
@@ -132,7 +132,10 @@ export default class NodeInfo extends React.Component<NodeInfoProps, {}> {
                     navigation={navigation}
                 />
 
-                <ScrollView style={styles.content}>
+                <ScrollView
+                    style={styles.content}
+                    keyboardShouldPersistTaps="handled"
+                >
                     <NodeInfoView />
                 </ScrollView>
             </Screen>

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -295,6 +295,7 @@ export default class OpenChannel extends React.Component<
                     style={{
                         flex: 1
                     }}
+                    keyboardShouldPersistTaps="handled"
                 >
                     {!!suggestImport && (
                         <View style={styles.clipboardImport}>

--- a/views/Order.tsx
+++ b/views/Order.tsx
@@ -314,7 +314,10 @@ export default class OrderView extends React.Component<OrderProps, OrderState> {
                     navigation={navigation}
                 />
 
-                <ScrollView style={styles.content}>
+                <ScrollView
+                    style={styles.content}
+                    keyboardShouldPersistTaps="handled"
+                >
                     {lineItems.map((item: any, index: number) => {
                         const keyValue =
                             item.quantity > 1

--- a/views/Payment.tsx
+++ b/views/Payment.tsx
@@ -93,7 +93,7 @@ export default class PaymentView extends React.Component<PaymentProps> {
                     rightComponent={<EditNotesButton />}
                     navigation={navigation}
                 />
-                <ScrollView>
+                <ScrollView keyboardShouldPersistTaps="handled">
                     <View style={styles.center}>
                         <Amount
                             sats={payment.getAmount}

--- a/views/PaymentPaths.tsx
+++ b/views/PaymentPaths.tsx
@@ -35,7 +35,7 @@ export default class PaymentPathsView extends React.Component<PaymentPathsViewPr
                     }}
                     navigation={navigation}
                 />
-                <ScrollView>
+                <ScrollView keyboardShouldPersistTaps="handled">
                     <View style={styles.content}>
                         {enhancedPath.length > 0 && (
                             <PaymentPath value={enhancedPath} />

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -318,7 +318,7 @@ export default class PaymentRequest extends React.Component<
                     </View>
                 )}
 
-                <ScrollView>
+                <ScrollView keyboardShouldPersistTaps="handled">
                     {!!getPayReqError && (
                         <View style={styles.content}>
                             <Text

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -811,7 +811,10 @@ export default class Receive extends React.Component<
                     navigation={navigation}
                 />
 
-                <ScrollView style={styles.content}>
+                <ScrollView
+                    style={styles.content}
+                    keyboardShouldPersistTaps="handled"
+                >
                     {creatingInvoiceError && (
                         <ErrorMessage
                             message={localeString('views.Receive.errorCreate')}

--- a/views/Routing/RoutingEvent.tsx
+++ b/views/Routing/RoutingEvent.tsx
@@ -84,7 +84,10 @@ export default class RoutingEvent extends React.Component<
                     }}
                     navigation={navigation}
                 />
-                <ScrollView style={styles.content}>
+                <ScrollView
+                    style={styles.content}
+                    keyboardShouldPersistTaps="handled"
+                >
                     <View style={styles.amount}>
                         <Amount
                             sats={fee}

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -439,7 +439,10 @@ export default class Send extends React.Component<SendProps, SendState> {
                     }
                     navigation={navigation}
                 />
-                <ScrollView style={styles.content}>
+                <ScrollView
+                    style={styles.content}
+                    keyboardShouldPersistTaps="handled"
+                >
                     <Text
                         style={{
                             ...styles.secondaryText,

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -69,7 +69,7 @@ export default class SendingLightning extends React.Component<
 
         return (
             <Screen>
-                <ScrollView>
+                <ScrollView keyboardShouldPersistTaps="handled">
                     <View
                         style={{
                             ...styles.content

--- a/views/SendingOnChain.tsx
+++ b/views/SendingOnChain.tsx
@@ -55,7 +55,7 @@ export default class SendingOnChain extends React.Component<
 
         return (
             <Screen>
-                <ScrollView>
+                <ScrollView keyboardShouldPersistTaps="handled">
                     <View
                         style={{
                             ...styles.content

--- a/views/Settings/CertInstallInstructions.tsx
+++ b/views/Settings/CertInstallInstructions.tsx
@@ -25,6 +25,7 @@ export default class CertInstallInstructions extends React.Component<
                         flex: 1,
                         backgroundColor: themeColor('background')
                     }}
+                    keyboardShouldPersistTaps="handled"
                 >
                     <Header
                         leftComponent="Back"

--- a/views/Settings/Display.tsx
+++ b/views/Settings/Display.tsx
@@ -94,7 +94,10 @@ export default class Display extends React.Component<
                     }}
                     navigation={navigation}
                 />
-                <ScrollView style={{ flex: 1, padding: 15 }}>
+                <ScrollView
+                    style={{ flex: 1, padding: 15 }}
+                    keyboardShouldPersistTaps="handled"
+                >
                     <DropdownSetting
                         title={localeString('views.Settings.Theme.title')}
                         selectedValue={theme}

--- a/views/Settings/NodeConfiguration.tsx
+++ b/views/Settings/NodeConfiguration.tsx
@@ -750,6 +750,7 @@ export default class NodeConfiguration extends React.Component<
                 <ScrollView
                     ref="_scrollView"
                     style={{ flex: 1, paddingLeft: 15, paddingRight: 15 }}
+                    keyboardShouldPersistTaps="handled"
                 >
                     <View style={styles.form}>
                         {!!createAccountError &&

--- a/views/Settings/PointOfSale.tsx
+++ b/views/Settings/PointOfSale.tsx
@@ -123,7 +123,10 @@ export default class PointOfSale extends React.Component<
                         />
                     </View>
                 ) : (
-                    <ScrollView style={{ flex: 1 }}>
+                    <ScrollView
+                        style={{ flex: 1 }}
+                        keyboardShouldPersistTaps="handled"
+                    >
                         <View style={{ padding: 15 }}>
                             {!BackendUtils.isLNDBased() && (
                                 <WarningMessage

--- a/views/Settings/PointOfSaleReconExport.tsx
+++ b/views/Settings/PointOfSaleReconExport.tsx
@@ -43,6 +43,7 @@ export default class PointOfSaleReconExport extends React.PureComponent<
                     flex: 1,
                     backgroundColor: themeColor('background')
                 }}
+                keyboardShouldPersistTaps="handled"
             >
                 <Header
                     leftComponent="Back"

--- a/views/Settings/Privacy.tsx
+++ b/views/Settings/Privacy.tsx
@@ -98,7 +98,10 @@ export default class Privacy extends React.Component<
                     }}
                     navigation={navigation}
                 />
-                <ScrollView style={{ flex: 1, padding: 15 }}>
+                <ScrollView
+                    style={{ flex: 1, padding: 15 }}
+                    keyboardShouldPersistTaps="handled"
+                >
                     <DropdownSetting
                         title={localeString(
                             'views.Settings.Privacy.blockExplorer'

--- a/views/Settings/Security.tsx
+++ b/views/Settings/Security.tsx
@@ -239,7 +239,7 @@ export default class Security extends React.Component<
                     }}
                     navigation={navigation}
                 />
-                <ScrollView>
+                <ScrollView keyboardShouldPersistTaps="handled">
                     <FlatList
                         data={displaySecurityItems}
                         renderItem={this.renderItem}

--- a/views/Settings/Settings.tsx
+++ b/views/Settings/Settings.tsx
@@ -115,6 +115,7 @@ export default class Settings extends React.Component<
                     style={{
                         flex: 1
                     }}
+                    keyboardShouldPersistTaps="handled"
                 >
                     <TouchableOpacity
                         onPress={() => navigation.navigate('Nodes')}

--- a/views/Settings/SignVerifyMessage.tsx
+++ b/views/Settings/SignVerifyMessage.tsx
@@ -138,7 +138,10 @@ export default class SignVerifyMessage extends React.Component<
                     navigation={navigation}
                 />
 
-                <ScrollView style={styles.content}>
+                <ScrollView
+                    style={styles.content}
+                    keyboardShouldPersistTaps="handled"
+                >
                     <ButtonGroup
                         onPress={this.updateIndex}
                         selectedIndex={selectedIndex}

--- a/views/Transaction.tsx
+++ b/views/Transaction.tsx
@@ -153,7 +153,10 @@ export default class TransactionView extends React.Component<TransactionProps> {
                     />
                 </View>
 
-                <ScrollView style={styles.content}>
+                <ScrollView
+                    style={styles.content}
+                    keyboardShouldPersistTaps="handled"
+                >
                     {total_fees ? (
                         <KeyValue
                             keyValue={localeString(

--- a/views/UTXOs/UTXO.tsx
+++ b/views/UTXOs/UTXO.tsx
@@ -52,7 +52,10 @@ export default class UTXO extends React.Component<UTXOProps> {
                     }}
                     navigation={navigation}
                 />
-                <ScrollView style={styles.content}>
+                <ScrollView
+                    style={styles.content}
+                    keyboardShouldPersistTaps="handled"
+                >
                     <View style={styles.center}>
                         <Amount sats={amount} jumboText toggleable sensitive />
                     </View>


### PR DESCRIPTION
# Description

This fixes #1478 by setting `keyboardShouldPersistTaps='handled'` for all ScrollViews. This allows buttons to handle the press event while a TextInput has focus. Clicking somewhere else outside the TextInput still closes the keyboard (this would not work with `always`). Set this for all ScrollViews, even if they do not contain TextInputs or Buttons because this might change in the future.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
