### PR TITLE
Fixed updating selected node after deleting a node

### DIFF
--- a/views/Settings/NodeConfiguration.tsx
+++ b/views/Settings/NodeConfiguration.tsx
@@ -37,6 +37,7 @@ import SettingsStore, {
 } from '../../stores/SettingsStore';
 
 import Scan from '../../assets/images/SVG/Scan.svg';
+import { Settings } from '../../stores/SettingsStore';
 
 interface NodeConfigurationProps {
     navigation: any;
@@ -90,7 +91,7 @@ export default class NodeConfiguration extends React.Component<
         port: '',
         macaroonHex: '',
         saved: false,
-        index: null,
+        index: null as number | null,
         active: false,
         newEntry: false,
         implementation: 'lnd',
@@ -407,12 +408,30 @@ export default class NodeConfiguration extends React.Component<
 
         updateSettings({
             nodes: newNodes,
-            selectedNode:
-                index === settings.selectedNode ? 0 : settings.selectedNode
+            selectedNode: this.getNewSelectedNodeIndex(index, settings)
         }).then(() => {
             navigation.navigate('Nodes', { refresh: true });
         });
     };
+
+    getNewSelectedNodeIndex(
+        indexOfDeletedNode: number | null,
+        settings: Settings
+    ): number | undefined {
+        if (
+            settings.selectedNode == null ||
+            indexOfDeletedNode == null ||
+            indexOfDeletedNode > settings.selectedNode
+        ) {
+            return settings.selectedNode;
+        }
+        if (indexOfDeletedNode < settings.selectedNode) {
+            return settings.selectedNode - 1;
+        }
+        return settings.nodes?.length != null && settings.nodes?.length > 0
+            ? 0
+            : undefined;
+    }
 
     setNodeConfigurationAsActive = () => {
         const { SettingsStore, navigation } = this.props;


### PR DESCRIPTION
# Description

When deleting a node which has a lower index than the selected one, the index of the selected node was not updated. So another node became active or the index even was out of bounds.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
