### PR TITLE
Node config: require confirmation to delete a node

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -153,6 +153,7 @@
     "views.Settings.AddEditNode.scanLndhub": "Scan LNDHub QR",
     "views.Settings.AddEditNode.scanSpark": "Scan Spark QR",
     "views.Settings.AddEditNode.deleteNode": "Delete Node config",
+    "views.Settings.AddEditNode.tapToConfirm": "Tap to confirm",
     "views.Settings.AddEditNode.copyNode": "Copy Node config",
     "views.Settings.AddEditNode.nodeInterface": "Node interface",
     "views.Settings.AddEditNode.useTor": "Use Tor",

--- a/views/Settings/NodeConfiguration.tsx
+++ b/views/Settings/NodeConfiguration.tsx
@@ -70,6 +70,7 @@ interface NodeConfigurationState {
     customMailboxServer: string;
     localKey: string;
     remoteKey: string;
+    deletionAwaitingConfirmation: boolean;
 }
 
 const ScanBadge = ({ onPress }: { onPress: () => void }) => (
@@ -110,7 +111,8 @@ export default class NodeConfiguration extends React.Component<
         mailboxServer: 'mailbox.terminal.lightning.today:443',
         customMailboxServer: '',
         localKey: '',
-        remoteKey: ''
+        remoteKey: '',
+        deletionAwaitingConfirmation: false
     };
 
     async UNSAFE_componentWillMount() {
@@ -457,7 +459,8 @@ export default class NodeConfiguration extends React.Component<
             mailboxServer,
             customMailboxServer,
             localKey,
-            remoteKey
+            remoteKey,
+            deletionAwaitingConfirmation
         } = this.state;
         const {
             loading,
@@ -1318,10 +1321,24 @@ export default class NodeConfiguration extends React.Component<
                     {saved && (
                         <View style={styles.button}>
                             <Button
-                                title={localeString(
-                                    'views.Settings.AddEditNode.deleteNode'
-                                )}
-                                onPress={() => this.deleteNodeConfig()}
+                                title={
+                                    deletionAwaitingConfirmation
+                                        ? localeString(
+                                              'views.Settings.AddEditNode.tapToConfirm'
+                                          )
+                                        : localeString(
+                                              'views.Settings.AddEditNode.deleteNode'
+                                          )
+                                }
+                                onPress={() => {
+                                    if (!deletionAwaitingConfirmation) {
+                                        this.setState({
+                                            deletionAwaitingConfirmation: true
+                                        });
+                                    } else {
+                                        this.deleteNodeConfig();
+                                    }
+                                }}
                                 containerStyle={{
                                     borderColor: themeColor('delete')
                                 }}


### PR DESCRIPTION
# Description

Currently, a node can be deleted by tapping the delete button once. To avoid unwanted deletion, confirmation is now required by changing the button text on the first tap to 'Tap to confirm' and actually deleting on the second tap.

![grafik](https://github.com/ZeusLN/zeus/assets/77545287/83bc32fa-a937-4e48-9a9e-aaa3deb127e1)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
