### PR TITLE
build.sh: make sure build process can be interrupted

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ BUILDER_IMAGE="reactnativecommunity/react-native-android@sha256:7bbad62c74f01b20
 CONTAINER_NAME="zeus_builder_container"
 ZEUS_PATH=/olympus/zeus
 
-docker run --rm --name $CONTAINER_NAME -v `pwd`:$ZEUS_PATH $BUILDER_IMAGE bash -c \
+docker run --rm -it --name $CONTAINER_NAME -v `pwd`:$ZEUS_PATH $BUILDER_IMAGE bash -c \
      'echo -e "\n\n********************************\n*** Building Zeus...\n********************************\n" && \
       cd /olympus/zeus ; yarn install --frozen-lockfile && \
       cd /olympus/zeus/node_modules/@lightninglabs/lnc-rn ; bash fetch-libraries.sh && \


### PR DESCRIPTION
This keeps stdin open and allocates a pseudo-TTY.
