### PR TITLE
Payment request: Show fiat conversion below main amount

### DIFF
--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -37,6 +37,7 @@ import { Row } from '../components/layout/Row';
 
 import CaretDown from '../assets/images/SVG/Caret Down.svg';
 import CaretRight from '../assets/images/SVG/Caret Right.svg';
+import Conversion from '../components/Conversion';
 
 interface InvoiceProps {
     exitSetup: any;
@@ -359,6 +360,9 @@ export default class PaymentRequest extends React.Component<
                                             jumboText
                                             toggleable
                                         />
+                                        <View style={{ top: 10 }}>
+                                            <Conversion sats={requestAmount} />
+                                        </View>
                                     </View>
                                 )}
                             </>


### PR DESCRIPTION
# Description

This fixes #1304 by showing the fiat rate (if enabled in settings) on lightning payment request screen.

After some thoughts I think the conversion is not needed for historical transactions (Activity screen).

Screenshot:

![grafik](https://github.com/ZeusLN/zeus/assets/77545287/7e1854fa-0313-4083-b03b-f8f6ee09651f)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
