### PR TITLE
Show loading indicators on node info screen

### DIFF
--- a/components/KeyValue.tsx
+++ b/components/KeyValue.tsx
@@ -15,6 +15,7 @@ import { Row } from './layout/Row';
 import { themeColor } from '../utils/ThemeUtils';
 import PrivacyUtils from '../utils/PrivacyUtils';
 import SettingsStore from '../stores/SettingsStore';
+import LoadingIndicator from './LoadingIndicator';
 
 interface KeyValueProps {
     keyValue: string;
@@ -22,13 +23,21 @@ interface KeyValueProps {
     color?: string;
     sensitive?: boolean;
     SettingsStore: SettingsStore;
+    showLoadingIndicator?: boolean;
 }
 
 @inject('SettingsStore')
 @observer
 export default class KeyValue extends React.Component<KeyValueProps, {}> {
     render() {
-        const { keyValue, value, color, sensitive, SettingsStore } = this.props;
+        const {
+            keyValue,
+            value,
+            color,
+            sensitive,
+            SettingsStore,
+            showLoadingIndicator
+        } = this.props;
 
         const lurkerMode: boolean =
             SettingsStore?.settings?.privacy?.lurkerMode || false;
@@ -75,11 +84,25 @@ export default class KeyValue extends React.Component<KeyValueProps, {}> {
             <Row justify="space-between">
                 <View style={rtl ? styles.rtlValue : styles.key}>
                     <Text style={{ color: themeColor('secondaryText') }}>
-                        {rtl ? Value : Key}
+                        {rtl ? (
+                            showLoadingIndicator ? (
+                                <LoadingIndicator size={18} />
+                            ) : (
+                                Value
+                            )
+                        ) : (
+                            Key
+                        )}
                     </Text>
                 </View>
                 <View style={rtl ? styles.rtlKey : styles.value}>
-                    {rtl ? Key : Value}
+                    {rtl ? (
+                        Key
+                    ) : showLoadingIndicator ? (
+                        <LoadingIndicator size={18} />
+                    ) : (
+                        Value
+                    )}
                 </View>
             </Row>
         );

--- a/stores/NodeInfoStore.ts
+++ b/stores/NodeInfoStore.ts
@@ -42,7 +42,7 @@ export default class NodeInfoStore {
     public getNodeInfo = () => {
         this.errorMsg = '';
         this.loading = true;
-        BackendUtils.getMyNodeInfo()
+        return BackendUtils.getMyNodeInfo()
             .then((data: any) => {
                 const nodeInfo = new NodeInfo(data);
                 this.nodeInfo = nodeInfo;

--- a/views/NodeInfo.tsx
+++ b/views/NodeInfo.tsx
@@ -20,12 +20,26 @@ interface NodeInfoProps {
     SettingsStore: SettingsStore;
 }
 
+interface NodeInfoState {
+    loading: boolean;
+}
+
 @inject('NodeInfoStore', 'SettingsStore')
 @observer
-export default class NodeInfo extends React.Component<NodeInfoProps, {}> {
+export default class NodeInfo extends React.Component<
+    NodeInfoProps,
+    NodeInfoState
+> {
+    state = {
+        loading: false
+    };
+
     UNSAFE_componentWillMount() {
         const { NodeInfoStore } = this.props;
-        NodeInfoStore.getNodeInfo();
+        this.setState({ loading: true });
+        NodeInfoStore.getNodeInfo().then(() =>
+            this.setState({ loading: false })
+        );
     }
 
     render() {
@@ -58,6 +72,7 @@ export default class NodeInfo extends React.Component<NodeInfoProps, {}> {
                     keyValue={localeString('views.NodeInfo.alias')}
                     value={nodeInfo.alias}
                     sensitive
+                    showLoadingIndicator={this.state.loading}
                 />
 
                 {nodeInfo.nodeId && (
@@ -65,6 +80,7 @@ export default class NodeInfo extends React.Component<NodeInfoProps, {}> {
                         keyValue={localeString('views.NodeInfo.pubkey')}
                         value={nodeInfo.nodeId}
                         sensitive
+                        showLoadingIndicator={this.state.loading}
                     />
                 )}
 
@@ -75,46 +91,52 @@ export default class NodeInfo extends React.Component<NodeInfoProps, {}> {
                         )}
                         value={nodeInfo.version}
                         sensitive
+                        showLoadingIndicator={this.state.loading}
                     />
                 )}
 
-                {nodeInfo.version && (
-                    <KeyValue
-                        keyValue={localeString('views.NodeInfo.zeusVersion')}
-                        value={`v${version}`}
-                    />
-                )}
+                <KeyValue
+                    keyValue={localeString('views.NodeInfo.zeusVersion')}
+                    value={`v${version}`}
+                />
 
                 {!!nodeInfo.synced_to_chain && (
                     <KeyValue
                         keyValue={localeString('views.NodeInfo.synced')}
                         value={nodeInfo.synced_to_chain ? 'True' : 'False'}
                         color={nodeInfo.synced_to_chain ? 'green' : 'red'}
+                        showLoadingIndicator={this.state.loading}
                     />
                 )}
 
                 <KeyValue
                     keyValue={localeString('views.NodeInfo.blockHeight')}
                     value={nodeInfo.currentBlockHeight}
+                    showLoadingIndicator={this.state.loading}
                 />
 
                 {nodeInfo.block_hash && (
                     <KeyValue
                         keyValue={localeString('views.NodeInfo.blockHash')}
                         value={nodeInfo.block_hash}
+                        showLoadingIndicator={this.state.loading}
                     />
                 )}
 
-                <KeyValue keyValue={localeString('views.NodeInfo.uris')} />
-                {nodeInfo.getURIs &&
-                nodeInfo.getURIs.length > 0 &&
-                !lurkerMode ? (
-                    <URIs uris={nodeInfo.getURIs} />
-                ) : (
-                    <Text style={styles.error}>
-                        {localeString('views.NodeInfo.noUris')}
-                    </Text>
-                )}
+                <KeyValue
+                    keyValue={localeString('views.NodeInfo.uris')}
+                    showLoadingIndicator={this.state.loading}
+                />
+                {!this.state.loading &&
+                    (nodeInfo.getURIs &&
+                    nodeInfo.getURIs.length > 0 &&
+                    !lurkerMode ? (
+                        <URIs uris={nodeInfo.getURIs} />
+                    ) : (
+                        <Text style={styles.error}>
+                            {localeString('views.NodeInfo.noUris')}
+                        </Text>
+                    ))}
             </React.Fragment>
         );
 


### PR DESCRIPTION
# Description

This fixes #1498. Now showing loading indicators while node info is loading. If loading fails, the loading indicators are endlessly shown. Should probably be improved in the future by showing an error message.

Also removed a wrong condition for displaying the Zeus version (was dependent of the node version).

![grafik](https://github.com/ZeusLN/zeus/assets/77545287/203f2d8a-4411-41b1-b1ad-f742689a5bcd)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
