### PR TITLE
Settings: change locale keys to ISO 639-1

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -156,6 +156,7 @@ export const LOCALE_KEYS = [
     { key: 'hr', value: 'Hrvatski' }
 ];
 
+// this mapping is only for migration and does not need to be updated when new languages are added
 const localeMigrationMapping: { [oldLocale: string]: string } = {
     English: 'en',
     Español: 'es',

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -127,35 +127,64 @@ export const LNC_MAILBOX_KEYS = [
 ];
 
 export const LOCALE_KEYS = [
-    { key: 'English', value: 'English' },
-    { key: 'Español', value: 'Español' },
-    { key: 'Português', value: 'Português' },
-    { key: 'Français', value: 'Français' },
-    { key: 'Čeština', value: 'Čeština' },
-    { key: 'Slovenčina', value: 'Slovenčina' },
-    { key: 'Deutsch', value: 'Deutsch' },
-    { key: 'Polski', value: 'Polski' },
-    { key: 'Türkçe', value: 'Türkçe' },
-    { key: 'magyar nyelv', value: 'magyar nyelv' },
-    { key: '简化字', value: '简化字' },
-    { key: 'Nederlands', value: 'Nederlands' },
-    { key: 'Bokmål', value: 'Bokmål' },
-    { key: 'Svenska', value: 'Svenska' },
-    { key: 'ภาษาไทย', value: 'ภาษาไทย' },
-    { key: 'украї́нська мо́ва', value: 'украї́нська мо́ва' },
-    { key: 'Limba română', value: 'Limba română' },
-    // in progress
-    { key: 'Ελληνικά', value: 'Ελληνικά' },
-    { key: 'زبان فارسي', value: 'زبان فارسي' },
-    { key: 'Slovenski jezik', value: 'Slovenski jezik' },
-    { key: 'русский язык', value: 'русский язык' },
-    { key: 'Suomen kieli', value: 'Suomen kieli' },
-    { key: 'Italiano', value: 'Italiano' },
-    { key: 'Tiếng Việt', value: 'Tiếng Việt' },
-    { key: '日本語', value: '日本語' },
-    { key: 'עִבְרִית', value: 'עִבְרִית' },
-    { key: 'Hrvatski', value: 'Hrvatski' }
+    { key: 'en', value: 'English' },
+    { key: 'es', value: 'Español' },
+    { key: 'pt', value: 'Português' },
+    { key: 'fr', value: 'Français' },
+    { key: 'cs', value: 'Čeština' },
+    { key: 'sk', value: 'Slovenčina' },
+    { key: 'de', value: 'Deutsch' },
+    { key: 'pl', value: 'Polski' },
+    { key: 'tr', value: 'Türkçe' },
+    { key: 'hu', value: 'magyar nyelv' },
+    { key: 'zh', value: '简化字' },
+    { key: 'nl', value: 'Nederlands' },
+    { key: 'nb', value: 'Bokmål' },
+    { key: 'sv', value: 'Svenska' },
+    { key: 'th', value: 'ภาษาไทย' },
+    { key: 'uk', value: 'украї́нська мо́ва' },
+    { key: 'ro', value: 'Limba română' },
+    { key: 'el', value: 'Ελληνικά' },
+    { key: 'fa', value: 'زبان فارسي' },
+    { key: 'sl', value: 'Slovenski jezik' },
+    { key: 'ru', value: 'русский язык' },
+    { key: 'fi', value: 'Suomen kieli' },
+    { key: 'it', value: 'Italiano' },
+    { key: 'vi', value: 'Tiếng Việt' },
+    { key: 'jp', value: '日本語' },
+    { key: 'he', value: 'עִבְרִית' },
+    { key: 'hr', value: 'Hrvatski' }
 ];
+
+const localeMigrationMapping: { [oldLocale: string]: string } = {
+    English: 'en',
+    Español: 'es',
+    Português: 'pt',
+    Français: 'fr',
+    Čeština: 'cs',
+    Slovenčina: 'sk',
+    Deutsch: 'de',
+    Polski: 'pl',
+    Türkçe: 'tr',
+    'magyar nyelv': 'hu',
+    简化字: 'zh',
+    Nederlands: 'nl',
+    Bokmål: 'nb',
+    Svenska: 'sv',
+    ภาษาไทย: 'th',
+    'украї́нська мо́ва': 'uk',
+    'Limba română': 'ro',
+    Ελληνικά: 'el',
+    'زبان فارسي': 'fa',
+    'Slovenski jezik': 'sl',
+    'русский язык': 'ru',
+    'Suomen kieli': 'fi',
+    Italiano: 'it',
+    'Tiếng Việt': 'vi',
+    日本語: 'jp',
+    עִבְרִית: 'he',
+    Hrvatski: 'hr'
+};
 
 export const CURRENCY_KEYS = [
     {
@@ -796,6 +825,15 @@ export default class SettingsStore {
                     this.settings.fiatEnabled = false;
                 } else if (this.settings.fiatEnabled == null) {
                     this.settings.fiatEnabled = true;
+                }
+
+                // migrate locale to ISO 639-1
+                if (
+                    this.settings.locale != null &&
+                    localeMigrationMapping[this.settings.locale]
+                ) {
+                    this.settings.locale =
+                        localeMigrationMapping[this.settings.locale];
                 }
 
                 const node: any =

--- a/utils/LocaleUtils.ts
+++ b/utils/LocaleUtils.ts
@@ -65,57 +65,57 @@ export function localeString(localeString: string): any {
     const { locale } = settings;
 
     switch (locale) {
-        case 'Español':
+        case 'es':
             return Spanish[localeString] || English[localeString];
-        case 'Português':
+        case 'pt':
             return BrazilianPortuguese[localeString] || English[localeString];
-        case 'Türkçe':
+        case 'tr':
             return Turkish[localeString] || English[localeString];
-        case 'Slovenčina':
+        case 'sk':
             return Slovak[localeString] || English[localeString];
-        case 'Čeština':
+        case 'cs':
             return Czech[localeString] || English[localeString];
-        case 'Deutsch':
+        case 'de':
             return German[localeString] || English[localeString];
-        case 'Ελληνικά':
+        case 'el':
             return Greek[localeString] || English[localeString];
-        case 'Bokmål':
+        case 'nb':
             return NorwegianBokmal[localeString] || English[localeString];
-        case 'Svenska':
+        case 'sv':
             return Swedish[localeString] || English[localeString];
-        case 'ภาษาไทย':
+        case 'th':
             return Thai[localeString] || English[localeString];
-        case 'украї́нська мо́ва':
+        case 'uk':
             return Ukranian[localeString] || English[localeString];
-        case 'Limba română':
+        case 'ro':
             return Romanian[localeString] || English[localeString];
-        case 'Polski':
+        case 'pl':
             return Polish[localeString] || English[localeString];
-        case 'زبان فارسي':
+        case 'fa':
             return Persian[localeString] || English[localeString];
-        case 'Français':
+        case 'fr':
             return French[localeString] || English[localeString];
-        case 'Nederlands':
+        case 'nl':
             return Dutch[localeString] || English[localeString];
-        case 'Magyar nyelv':
+        case 'hu':
             return Hungarian[localeString] || English[localeString];
-        case '简化字':
+        case 'zh':
             return SimplifiedChinese[localeString] || English[localeString];
-        case 'Slovenski jezik':
+        case 'sl':
             return Slovenian[localeString] || English[localeString];
-        case 'русский язык':
+        case 'ru':
             return Russian[localeString] || English[localeString];
-        case 'Suomen kieli':
+        case 'fi':
             return Finnish[localeString] || English[localeString];
-        case 'Italiano':
+        case 'it':
             return Italian[localeString] || English[localeString];
-        case 'Tiếng Việt':
+        case 'vi':
             return Vietnamese[localeString] || English[localeString];
-        case '日本語':
+        case 'jp':
             return Japanese[localeString] || English[localeString];
-        case 'עִבְרִית':
+        case 'he':
             return Hebrew[localeString] || English[localeString];
-        case 'Hrvatski':
+        case 'hr':
             return Croatian[localeString] || English[localeString];
         default:
             return English[localeString];

--- a/views/Settings/Language.tsx
+++ b/views/Settings/Language.tsx
@@ -117,7 +117,7 @@ export default class Language extends React.Component<
                                     <ListItem.Title
                                         style={{
                                             color:
-                                                selectedLocale === item.value ||
+                                                selectedLocale === item.key ||
                                                 (!selectedLocale &&
                                                     item.value === 'English')
                                                     ? themeColor('highlight')
@@ -127,7 +127,7 @@ export default class Language extends React.Component<
                                         {item.value}
                                     </ListItem.Title>
                                 </ListItem.Content>
-                                {(selectedLocale === item.value ||
+                                {(selectedLocale === item.key ||
                                     (!selectedLocale &&
                                         item.value === 'English')) && (
                                     <View style={{ textAlign: 'right' }}>


### PR DESCRIPTION
# Description

Changed the keys of LOCALE_KEYS to ISO 639-1 to be able to use it as language for libs like humanize-duration.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
