### PR TITLE
deps: remove `react-native-restart`

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -262,12 +262,8 @@ PODS:
     - React-Core
   - react-native-nfc-manager (3.13.0):
     - React
-  - react-native-qrcode-local-image (1.0.4):
-    - React
   - react-native-randombytes (3.5.3):
     - React
-  - react-native-restart (0.0.24):
-    - React-Core
   - react-native-safe-area-context (0.6.2):
     - React
   - react-native-tor (0.1.8):
@@ -343,6 +339,8 @@ PODS:
     - React-perflogger (= 0.70.6)
   - ReactNativeCameraKit (13.0.0):
     - React-Core
+  - RemobileReactNativeQrcodeLocalImage (1.0.4):
+    - React
   - RNCClipboard (1.9.0):
     - React-Core
   - RNCMaskedView (0.1.11):
@@ -398,9 +396,7 @@ DEPENDENCIES:
   - react-native-hce (from `../node_modules/react-native-hce`)
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - react-native-nfc-manager (from `../node_modules/react-native-nfc-manager`)
-  - "react-native-qrcode-local-image (from `../node_modules/@remobile/react-native-qrcode-local-image`)"
   - react-native-randombytes (from `../node_modules/react-native-randombytes`)
-  - react-native-restart (from `../node_modules/react-native-restart`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-tor (from `../node_modules/react-native-tor`)
   - react-native-udp (from `../node_modules/react-native-udp`)
@@ -417,6 +413,7 @@ DEPENDENCIES:
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - ReactNativeCameraKit (from `../node_modules/react-native-camera-kit`)
+  - "RemobileReactNativeQrcodeLocalImage (from `../node_modules/@remobile/react-native-qrcode-local-image`)"
   - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
@@ -498,12 +495,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-image-picker"
   react-native-nfc-manager:
     :path: "../node_modules/react-native-nfc-manager"
-  react-native-qrcode-local-image:
-    :path: "../node_modules/@remobile/react-native-qrcode-local-image"
   react-native-randombytes:
     :path: "../node_modules/react-native-randombytes"
-  react-native-restart:
-    :path: "../node_modules/react-native-restart"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-tor:
@@ -536,6 +529,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   ReactNativeCameraKit:
     :path: "../node_modules/react-native-camera-kit"
+  RemobileReactNativeQrcodeLocalImage:
+    :path: "../node_modules/@remobile/react-native-qrcode-local-image"
   RNCClipboard:
     :path: "../node_modules/@react-native-clipboard/clipboard"
   RNCMaskedView:
@@ -593,9 +588,7 @@ SPEC CHECKSUMS:
   react-native-hce: 677aa1c41edf183523bb7b1014d106a08631ff88
   react-native-image-picker: 8cb4280e2c1efc3daeb2d9d597f9429a60472e40
   react-native-nfc-manager: 001c3a98e68efd57b7fb04b1837ab06ca7243238
-  react-native-qrcode-local-image: 35ccb306e4265bc5545f813e54cc830b5d75bcfc
   react-native-randombytes: 3638d24759d67c68f6ccba60c52a7a8a8faa6a23
-  react-native-restart: 45c8dca02491980f2958595333cbccd6877cb57e
   react-native-safe-area-context: 25260c5d0b9c53fd7aa88e569e2edae72af1f6a3
   react-native-tor: 3b14e9160b2eb7fa3f310921b2dee71a5171e5b7
   react-native-udp: df79c3cb72c4e71240cd3ce4687bfb8a137140d5
@@ -612,6 +605,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 15437b576139df27635400de0599d9844f1ab817
   ReactCommon: 349be31adeecffc7986a0de875d7fb0dcf4e251c
   ReactNativeCameraKit: 9d46a5d7dd544ca64aa9c03c150d2348faf437eb
+  RemobileReactNativeQrcodeLocalImage: 57aadc12896b148fb5e04bc7c6805f3565f5c3fa
   RNCClipboard: 99fc8ad669a376b756fbc8098ae2fd05c0ed0668
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "react-native-permissions": "3.8.0",
     "react-native-qrcode-svg": "6.1.2",
     "react-native-randombytes": "3.5.3",
-    "react-native-restart": "0.0.24",
     "react-native-safe-area-context": "0.6.2",
     "react-native-screens": "3.10.1",
     "react-native-snap-carousel": "meliorence/react-native-snap-carousel#962/head",

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -17,7 +17,6 @@ import {
     NavigationContainerRef
 } from '@react-navigation/native';
 import { inject, observer } from 'mobx-react';
-import RNRestart from 'react-native-restart';
 
 import ChannelsPane from '../Channels/ChannelsPane';
 import BalancePane from './BalancePane';
@@ -351,8 +350,14 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         } = this.props;
         const { nodeInfo } = NodeInfoStore;
         const error = NodeInfoStore.error || SettingsStore.error;
-        const { implementation, settings, loggedIn, connecting, posStatus } =
-            SettingsStore;
+        const {
+            implementation,
+            settings,
+            loggedIn,
+            connecting,
+            posStatus,
+            setConnectingStatus
+        } = SettingsStore;
         const loginRequired = !settings || SettingsStore.loginRequired();
 
         const squareEnabled: boolean =
@@ -379,7 +384,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                                     name: 'sync',
                                     size: 25
                                 }}
-                                onPress={() => RNRestart.Restart()}
+                                onPress={() => {
+                                    setConnectingStatus(true);
+                                    this.refresh();
+                                }}
                             />
                         </View>
                     )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7848,11 +7848,6 @@ react-native-ratings@8.0.4:
   dependencies:
     lodash "^4.17.15"
 
-react-native-restart@0.0.24:
-  version "0.0.24"
-  resolved "https://registry.npmjs.org/react-native-restart/-/react-native-restart-0.0.24.tgz"
-  integrity sha512-pvJNU3NwQk6bCG2gOWcQpZ4IxhtELB0K9gzmtixfsaTFbW1UXXHkJNjk1kHazcbH5hrD7QbUkR63fsAVh8X4VQ==
-
 react-native-safe-area-context@0.6.2:
   version "0.6.2"
   resolved "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-0.6.2.tgz"


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1463**](https://github.com/ZeusLN/zeus/issues/1463)

This PR removes dependency `react-native-restart`, which we were using to allow users to restart the app when they were facing connection issues.

The library was contributing to an issue where iOS users had their settings cleared out due to a race condition. We also maintain the restart functionality by clearing the stores, resetting the node connection status, and making all the required calls again.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
