### PR TITLE
[Pegasus] Backend: Wiring up signMessage and verifyMessage

### DIFF
--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -28,6 +28,7 @@ const {
     closeChannel,
     openChannel
 } = lndMobile.channel;
+const { signMessageNodePubkey, verifyMessageNodePubkey } = lndMobile.wallet;
 const { walletBalance, newAddress, getTransactions, sendCoins } =
     lndMobile.onchain;
 
@@ -104,6 +105,14 @@ export default class EmbeddedLND extends LND {
 
     getNodeInfo = async (urlParams?: Array<string>) =>
         await getNodeInfo(urlParams[0]);
+    signMessage = async (msg: Uint8Array) => {
+        return await signMessageNodePubkey(msg);
+    };
+    verifyMessage = async (data: object) => {
+        const { signature, msg } = data;
+        return await verifyMessageNodePubkey(signature, msg);
+    };
+
     // getFees = () => N/A;
     // TODO remove functionality to SetFees for Embedded LND users
     // setFees = (data: any) => {

--- a/lndmobile/wallet.ts
+++ b/lndmobile/wallet.ts
@@ -144,41 +144,54 @@ export const verifyMessageNodePubkey = async (
     signature: string,
     msg: Uint8Array
 ): Promise<lnrpc.VerifyMessageResponse> => {
-    const response = await sendCommand<
-        lnrpc.IVerifyMessageRequest,
-        lnrpc.VerifyMessageRequest,
-        lnrpc.VerifyMessageResponse
-    >({
-        request: lnrpc.VerifyMessageRequest,
-        response: lnrpc.VerifyMessageResponse,
-        method: 'VerifyMessage',
-        options: {
-            signature,
-            msg
-        }
-    });
-    return response;
+    try {
+        const response = await sendCommand<
+            lnrpc.IVerifyMessageRequest,
+            lnrpc.VerifyMessageRequest,
+            lnrpc.VerifyMessageResponse
+        >({
+            request: lnrpc.VerifyMessageRequest,
+            response: lnrpc.VerifyMessageResponse,
+            method: 'VerifyMessage',
+            options: {
+                signature,
+                msg
+            }
+        });
+
+        return response;
+    } catch (error) {
+        console.error('Error in verifyMessageNodePubkey:', error);
+        throw error;
+    }
 };
 
 /**
  * @throws
  */
+
 export const signMessageNodePubkey = async (
     msg: Uint8Array
 ): Promise<lnrpc.SignMessageResponse> => {
-    const response = await sendCommand<
-        lnrpc.ISignMessageRequest,
-        lnrpc.SignMessageRequest,
-        lnrpc.SignMessageResponse
-    >({
-        request: lnrpc.SignMessageRequest,
-        response: lnrpc.SignMessageResponse,
-        method: 'SignMessage',
-        options: {
-            msg
-        }
-    });
-    return response;
+    try {
+        const response = await sendCommand<
+            lnrpc.ISignMessageRequest,
+            lnrpc.SignMessageRequest,
+            lnrpc.SignMessageResponse
+        >({
+            request: lnrpc.SignMessageRequest,
+            response: lnrpc.SignMessageResponse,
+            method: 'SignMessage',
+            options: {
+                msg
+            }
+        });
+
+        return response;
+    } catch (error) {
+        console.error('Error in signMessageNodePubkey:', error);
+        throw error;
+    }
 };
 
 /**


### PR DESCRIPTION
Wire up `signMessage` and `verifyMessage` in *EmbeddedLnd.tsx*