### PR TITLE
ZEUS-1549: limit combined balance to 3 decimals

### DIFF
--- a/views/Wallet/BalancePane.tsx
+++ b/views/Wallet/BalancePane.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 import { inject, observer } from 'mobx-react';
+import BigNumber from 'bignumber.js';
+
 import Button from '../../components/Button';
 import WalletHeader from '../../components/WalletHeader';
 import Amount from '../../components/Amount';
@@ -38,10 +40,14 @@ export default class BalancePane extends React.PureComponent<
         } = BalanceStore;
         const { implementation } = SettingsStore;
 
-        const pendingUnconfirmedBalance =
-            Number(pendingOpenBalance) + Number(unconfirmedBlockchainBalance);
-        const combinedBalanceValue =
-            Number(totalBlockchainBalance) + Number(lightningBalance);
+        const pendingUnconfirmedBalance = new BigNumber(pendingOpenBalance)
+            .plus(unconfirmedBlockchainBalance)
+            .toNumber()
+            .toFixed(3);
+        const combinedBalanceValue = new BigNumber(totalBlockchainBalance)
+            .plus(lightningBalance)
+            .toNumber()
+            .toFixed(3);
 
         const LightningBalance = () => (
             <View style={styles.balance}>


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1549**](https://github.com/ZeusLN/zeus/issues/1549)

There is a bug in c-lightning-REST that causes the backend to return more than 3 decimal places (msat) in returned balances. This PR ensures that at most 3 decimal places are shown. If a balance is only whole numbers, no decimal places will be shown.

This was covered already in same changes to the balance slider code but not in the combined balance

BEFORE

![Simulator Screen Shot - iPhone 14 - 2023-08-05 at 19 22 13](https://github.com/ZeusLN/zeus/assets/1878621/77eee315-f93a-4a14-8ce0-87f5307f7e40)

AFTER

![Simulator Screen Shot - iPhone 14 - 2023-08-05 at 19 16 18](https://github.com/ZeusLN/zeus/assets/1878621/5ab6c639-beb9-43c0-9fba-28b844be99a8)

![Simulator Screen Shot - iPhone 14 - 2023-08-05 at 19 20 35](https://github.com/ZeusLN/zeus/assets/1878621/571575ae-091c-41db-907b-1689e615a421)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
