### PR TITLE
Receive: truncate long QR code values

### DIFF
--- a/components/CollapsedQR.tsx
+++ b/components/CollapsedQR.tsx
@@ -8,10 +8,38 @@ import Button from './../components/Button';
 import CopyButton from './CopyButton';
 import { localeString } from './../utils/LocaleUtils';
 import { themeColor } from './../utils/ThemeUtils';
+import Touchable from './Touchable';
 
 const logo = require('../assets/images/Launcher.png');
 
 let simulation: any;
+
+interface ValueTextProps {
+    value: string;
+    truncateLongValue?: boolean;
+}
+
+function ValueText({ value, truncateLongValue }: ValueTextProps) {
+    const [state, setState] = React.useState<{
+        numberOfValueLines: number | undefined;
+    }>({ numberOfValueLines: truncateLongValue ? 3 : undefined });
+    return truncateLongValue ? (
+        <Touchable
+            touch={() =>
+                setState({
+                    numberOfValueLines: state.numberOfValueLines ? undefined : 3
+                })
+            }
+            highlight={false}
+        >
+            <Text style={styles.value} numberOfLines={state.numberOfValueLines}>
+                {value}
+            </Text>
+        </Touchable>
+    ) : (
+        <Text style={styles.value}>{value}</Text>
+    );
+}
 
 interface CollapsedQRProps {
     value: string;
@@ -22,6 +50,7 @@ interface CollapsedQRProps {
     hideText?: boolean;
     expanded?: boolean;
     textBottom?: boolean;
+    truncateLongValue?: boolean;
 }
 
 interface CollapsedQRState {
@@ -87,7 +116,8 @@ export default class CollapsedQR extends React.Component<
             collapseText,
             hideText,
             expanded,
-            textBottom
+            textBottom,
+            truncateLongValue
         } = this.props;
 
         const { width, height } = Dimensions.get('window');
@@ -95,15 +125,10 @@ export default class CollapsedQR extends React.Component<
         return (
             <React.Fragment>
                 {!hideText && !textBottom && (
-                    <Text
-                        style={{
-                            ...styles.value,
-                            color: themeColor('secondaryText'),
-                            fontFamily: 'Lato-Regular'
-                        }}
-                    >
-                        {value}
-                    </Text>
+                    <ValueText
+                        value={value}
+                        truncateLongValue={truncateLongValue}
+                    />
                 )}
                 {!collapsed && value && (
                     <View style={styles.qrPadding}>
@@ -115,15 +140,10 @@ export default class CollapsedQR extends React.Component<
                     </View>
                 )}
                 {!hideText && textBottom && (
-                    <Text
-                        style={{
-                            ...styles.value,
-                            color: themeColor('secondaryText'),
-                            fontFamily: 'Lato-Regular'
-                        }}
-                    >
-                        {value}
-                    </Text>
+                    <ValueText
+                        value={value}
+                        truncateLongValue={truncateLongValue}
+                    />
                 )}
                 {!expanded && (
                     <Button
@@ -174,7 +194,9 @@ export default class CollapsedQR extends React.Component<
 const styles = StyleSheet.create({
     value: {
         marginBottom: 15,
-        paddingLeft: 20
+        paddingLeft: 20,
+        color: themeColor('secondaryText'),
+        fontFamily: 'Lato-Regular'
     },
     qrPadding: {
         backgroundColor: 'white',

--- a/components/Touchable.tsx
+++ b/components/Touchable.tsx
@@ -5,7 +5,7 @@ interface TouchableProps {
     touch: () => void;
     highlight: boolean;
     children: JSX.Element;
-    style: any;
+    style?: any;
 }
 
 export default function Touchable({

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -920,6 +920,7 @@ export default class Receive extends React.Component<
                                                 )}
                                                 expanded
                                                 textBottom
+                                                truncateLongValue
                                             />
                                         )}
                                     {selectedIndex == 1 &&
@@ -933,6 +934,7 @@ export default class Receive extends React.Component<
                                                 )}
                                                 expanded
                                                 textBottom
+                                                truncateLongValue
                                             />
                                         )}
                                     {selectedIndex == 2 &&
@@ -946,6 +948,7 @@ export default class Receive extends React.Component<
                                                 )}
                                                 expanded
                                                 textBottom
+                                                truncateLongValue
                                             />
                                         )}
                                     {(belowDustLimit ||
@@ -958,6 +961,7 @@ export default class Receive extends React.Component<
                                             )}
                                             expanded
                                             textBottom
+                                            truncateLongValue
                                         />
                                     )}
                                     <View


### PR DESCRIPTION
# Description

The value of the QR code generated on Receive screen is sometimes quite long. To save some space (and avoid unnecessary need for scrolling) the value is now truncated if longer then 3 lines. It can be expanded by clicking on it.

Truncated:
![grafik](https://github.com/ZeusLN/zeus/assets/77545287/4987004e-90cf-40d8-9ffa-10a144214dd7)

Expanded:
![grafik](https://github.com/ZeusLN/zeus/assets/77545287/4c6497ec-e6aa-41bb-8a9a-88aee1b486b6)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Core Lightning (Spark)
- [ ] Eclair
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
