### PR TITLE
Updated Android libraries

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -118,7 +118,7 @@ def jscFlavor = 'org.webkit:android-jsc:+'
  * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
  * and the benefits of using Hermes will therefore be sharply reduced.
  */
-def enableHermes = project.ext.react.get("enableHermes", false);
+def enableHermes = project.ext.react.get("enableHermes", false)
 
 /**
  * Architectures to build native code for in debug.
@@ -126,9 +126,8 @@ def enableHermes = project.ext.react.get("enableHermes", false);
 def nativeArchitectures = project.getProperties().get("reactNativeDebugArchitectures")
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
-
     defaultConfig {
+        compileSdk rootProject.ext.compileSdkVersion
         applicationId "app.zeusln.zeus"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
@@ -172,7 +171,7 @@ android {
         }
     }
     // applicationVariants are e.g. debug, release
-    applicationVariants.all { variant ->
+    applicationVariants.configureEach { variant ->
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
             // https://developer.android.com/studio/build/configure-apk-splits.html
@@ -213,13 +212,12 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'com.android.support:multidex:1.0.3'
-    implementation 'com.android.support:support-v13:+'
+    implementation 'androidx.multidex:multidex:2.0.1'
     implementation project(':react-native-randombytes')
     implementation "com.facebook.react:react-native:0.70.6!!"  // From node_modules
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.0'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0-alpha01'
     implementation files("../../node_modules/react-native-tor/android/libs/sifir_android.aar")
     implementation project(':react-native-qrcode-local-image')
     // gif
@@ -240,10 +238,10 @@ dependencies {
     // Pegasus
     implementation project(":lndmobile")
     implementation "androidx.concurrent:concurrent-futures:1.1.0"
-    implementation "androidx.work:work-runtime:2.7.1"
+    implementation "androidx.work:work-runtime:2.8.1"
     implementation "androidx.concurrent:concurrent-futures:1.1.0"
     implementation "com.google.guava:guava:31.0.1-android"
-    implementation "io.grpc:grpc-protobuf-lite:1.30.0"
+    implementation "io.grpc:grpc-protobuf-lite:1.45.1"
 
     implementation "com.jakewharton:process-phoenix:2.0.0"
     implementation 'org.brotli:dec:0.1.2'
@@ -256,7 +254,7 @@ configurations {
 
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
-task copyDownloadableDepsToLibs(type: Copy) {
+tasks.register('copyDownloadableDepsToLibs', Copy) {
     from configurations.implementation
     into 'libs'
 }
@@ -265,7 +263,7 @@ apply from: file("../../node_modules/@react-native-community/cli-platform-androi
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:21.0-rc-1"
+        artifact = "com.google.protobuf:protoc:3.24.1"
     }
     generateProtoTasks {
         all().each { task ->
@@ -279,4 +277,3 @@ protobuf {
 }
 
 apply plugin: "kotlin-android"
-apply plugin: "kotlin-android-extensions"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,8 +6,7 @@ buildscript {
         compileSdkVersion = 33
         targetSdkVersion = 33
         ndkVersion = "22.1.7171670"
-        supportLibVersion = "28.0.0"
-        kotlinVersion = "1.6.0"
+        kotlinVersion = "1.6.21"
         // hack for react-native-camera-kit
         kotlin_version = kotlinVersion
     }
@@ -17,7 +16,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.1")
+        classpath("com.android.tools.build:gradle:7.2.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.12"
 
@@ -29,7 +28,7 @@ buildscript {
 allprojects {
     def REACT_NATIVE_VERSION = new File(['node', '--print',"JSON.parse(require('fs').readFileSync(require.resolve('react-native/package.json'), 'utf-8')).version"].execute(null, rootDir).text.trim())
 
-    configurations.all {
+    configurations.configureEach {
         resolutionStrategy {
             force "com.facebook.react:react-native:" + REACT_NATIVE_VERSION
         }


### PR DESCRIPTION
# Description

Updated Android libraries, migrated to androidx, removed support library, updated Kotlin.

Might be a good idea to test with Android 9 to be sure that the support library is really not needed anymore.

Version 3.24.1 of protoc is newer than 21.0-rc-1... (see here: https://protobuf.dev/support/version-support/)

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [x] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] Eclair
- [x] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
