### PR TITLE
LND: make payment timeout configurable

### DIFF
--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -95,7 +95,7 @@ export default class EmbeddedLND extends LND {
                   )
                 : undefined,
             amp: data?.amp,
-            timeout_seconds: 60,
+            timeout_seconds: data?.timeout_seconds || 60,
             allow_self_payment: true,
             multi_path: data?.multi_path,
             max_shard_size_msat: data?.max_shard_size_msat,

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -305,8 +305,6 @@ export default class LND {
         if (data.pubkey) delete data.pubkey;
         return this.postRequest('/v2/router/send', {
             ...data,
-            // Tor timeout is 60 seconds so make sure LND times out first
-            timeout_seconds: 57,
             allow_self_payment: true
         });
     };

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -202,8 +202,7 @@ export default class LightningNodeConnect {
         if (data.pubkey) delete data.pubkey;
         return this.lnc.lnd.router.sendPaymentV2({
             ...data,
-            allow_self_payment: true,
-            timeout_seconds: 60
+            allow_self_payment: true
         });
     };
     closeChannel = async (urlParams?: Array<string>) => {

--- a/locales/en.json
+++ b/locales/en.json
@@ -605,6 +605,7 @@
     "views.Settings.Privacy.title": "Privacy settings",
     "views.Settings.Payments.title": "Payments settings",
     "views.Settings.Payments.defaultFeeLimit": "Default Fee Limit",
+    "views.Settings.Payments.timeoutSeconds": "Timeout (seconds)",
     "views.Settings.Invoices.title": "Invoices settings",
     "views.Settings.Privacy.blockExplorer": "Default Block explorer",
     "views.Settings.Privacy.BlockExplorer.custom": "Custom",

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -56,6 +56,7 @@ interface PaymentsSettings {
     defaultFeeMethod?: string;
     defaultFeePercentage?: string;
     defaultFeeFixed?: string;
+    timeoutSeconds?: string;
 }
 
 interface InvoicesSettings {
@@ -653,7 +654,8 @@ export default class SettingsStore {
         payments: {
             defaultFeeMethod: 'fixed',
             defaultFeePercentage: '0.5',
-            defaultFeeFixed: '100'
+            defaultFeeFixed: '100',
+            timeoutSeconds: '60'
         },
         invoices: {
             addressType: '0',

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -19,14 +19,15 @@ export interface SendPaymentReq {
     payment_request?: string;
     amount?: string;
     pubkey?: string;
-    max_parts?: string | null;
-    max_shard_amt?: string | null;
-    fee_limit_sat?: string | null;
-    max_fee_percent?: string | null;
-    outgoing_chan_id?: string | null;
-    last_hop_pubkey?: string | null;
-    message?: string | null;
+    max_parts?: string;
+    max_shard_amt?: string;
+    fee_limit_sat?: string;
+    max_fee_percent?: string;
+    outgoing_chan_id?: string;
+    last_hop_pubkey?: string;
+    message?: string;
     amp?: boolean;
+    timeout_seconds?: string;
 }
 
 export default class TransactionsStore {
@@ -199,7 +200,8 @@ export default class TransactionsStore {
         outgoing_chan_id,
         last_hop_pubkey,
         message,
-        amp
+        amp,
+        timeout_seconds
     }: SendPaymentReq) => {
         this.loading = true;
         this.error_msg = null;
@@ -271,6 +273,11 @@ export default class TransactionsStore {
         // max fee percent for c-lightning
         if (max_fee_percent) {
             data.max_fee_percent = max_fee_percent;
+        }
+
+        // payment timeout for LND
+        if (BackendUtils.isLNDBased()) {
+            data.timeout_seconds = Number(timeout_seconds) || 60;
         }
 
         const payFunc =

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -62,6 +62,7 @@ interface InvoiceState {
     feeLimitSat: string;
     feeOption: string;
     maxFeePercent: string;
+    timeoutSeconds: string;
     outgoingChanId: string | null;
     lastHopPubkey: string | null;
     settingsToggle: boolean;
@@ -91,6 +92,7 @@ export default class PaymentRequest extends React.Component<
         feeLimitSat: '100',
         feeOption: 'fixed',
         maxFeePercent: '0.5',
+        timeoutSeconds: '60',
         outgoingChanId: null,
         lastHopPubkey: null,
         settingsToggle: false
@@ -104,7 +106,8 @@ export default class PaymentRequest extends React.Component<
         this.setState({
             feeOption: settings?.payments?.defaultFeeMethod || 'fixed',
             feeLimitSat: settings?.payments?.defaultFeeFixed || '100',
-            maxFeePercent: settings?.payments?.defaultFeePercentage || '0.5'
+            maxFeePercent: settings?.payments?.defaultFeePercentage || '0.5',
+            timeoutSeconds: settings?.payments?.timeoutSeconds || '60'
         });
     }
 
@@ -169,7 +172,8 @@ export default class PaymentRequest extends React.Component<
             max_fee_percent,
             outgoing_chan_id,
             last_hop_pubkey,
-            amp
+            amp,
+            timeout_seconds
         }: SendPaymentReq
     ) => {
         const { InvoicesStore, TransactionsStore, SettingsStore, navigation } =
@@ -199,7 +203,8 @@ export default class PaymentRequest extends React.Component<
             max_fee_percent,
             outgoing_chan_id,
             last_hop_pubkey,
-            amp
+            amp,
+            timeout_seconds
         });
 
         if (SettingsStore.implementation === 'lightning-node-connect') {
@@ -229,7 +234,8 @@ export default class PaymentRequest extends React.Component<
             lastHopPubkey,
             customAmount,
             satAmount,
-            settingsToggle
+            settingsToggle,
+            timeoutSeconds
         } = this.state;
         const {
             pay_req,
@@ -588,9 +594,9 @@ export default class PaymentRequest extends React.Component<
                                                                 : 0.25
                                                     }}
                                                 >
-                                                    {`${localeString(
+                                                    {localeString(
                                                         'general.sats'
-                                                    )}`}
+                                                    )}
                                                 </Text>
                                                 <TextInput
                                                     style={{
@@ -862,6 +868,30 @@ export default class PaymentRequest extends React.Component<
                                             />
                                         </React.Fragment>
                                     )}
+
+                                    {isLnd && (
+                                        <>
+                                            <Text
+                                                style={{
+                                                    ...styles.label,
+                                                    color: themeColor('text')
+                                                }}
+                                            >
+                                                {localeString(
+                                                    'views.Settings.Payments.timeoutSeconds'
+                                                )}
+                                            </Text>
+                                            <TextInput
+                                                keyboardType="numeric"
+                                                value={timeoutSeconds}
+                                                onChangeText={(text: string) =>
+                                                    this.setState({
+                                                        timeoutSeconds: text
+                                                    })
+                                                }
+                                            />
+                                        </>
+                                    )}
                                 </>
                             )}
 
@@ -904,7 +934,9 @@ export default class PaymentRequest extends React.Component<
                                                         outgoingChanId,
                                                     last_hop_pubkey:
                                                         lastHopPubkey,
-                                                    amp: enableAmp
+                                                    amp: enableAmp,
+                                                    timeout_seconds:
+                                                        timeoutSeconds
                                                 }
                                             );
                                         }}

--- a/views/Settings/PaymentsSettings.tsx
+++ b/views/Settings/PaymentsSettings.tsx
@@ -21,6 +21,7 @@ interface PaymentsSettingsState {
     feeLimitMethod: string;
     feeLimit: string;
     feePercentage: string;
+    timeoutSeconds: string;
 }
 
 @inject('SettingsStore')
@@ -32,7 +33,8 @@ export default class PaymentsSettings extends React.Component<
     state = {
         feeLimitMethod: 'fixed',
         feeLimit: '100',
-        feePercentage: '0.5'
+        feePercentage: '0.5',
+        timeoutSeconds: '60'
     };
 
     async UNSAFE_componentWillMount() {
@@ -43,7 +45,8 @@ export default class PaymentsSettings extends React.Component<
         this.setState({
             feeLimitMethod: settings?.payments?.defaultFeeMethod || 'fixed',
             feeLimit: settings?.payments?.defaultFeeFixed || '100',
-            feePercentage: settings?.payments?.defaultFeePercentage || '0.5'
+            feePercentage: settings?.payments?.defaultFeePercentage || '0.5',
+            timeoutSeconds: settings?.payments?.timeoutSeconds || '60'
         });
     }
 
@@ -58,7 +61,8 @@ export default class PaymentsSettings extends React.Component<
 
     render() {
         const { navigation } = this.props;
-        const { feeLimit, feeLimitMethod, feePercentage } = this.state;
+        const { feeLimit, feeLimitMethod, feePercentage, timeoutSeconds } =
+            this.state;
         const { SettingsStore } = this.props;
         const { updateSettings } = SettingsStore;
 
@@ -87,9 +91,9 @@ export default class PaymentsSettings extends React.Component<
                             color: themeColor('text')
                         }}
                     >
-                        {`${localeString(
+                        {localeString(
                             'views.Settings.Payments.defaultFeeLimit'
-                        )}`}
+                        )}
                     </Text>
                     <View
                         style={{
@@ -121,7 +125,8 @@ export default class PaymentsSettings extends React.Component<
                                     payments: {
                                         defaultFeeMethod: 'fixed',
                                         defaultFeePercentage: feePercentage,
-                                        defaultFeeFixed: text
+                                        defaultFeeFixed: text,
+                                        timeoutSeconds
                                     }
                                 });
                             }}
@@ -141,7 +146,7 @@ export default class PaymentsSettings extends React.Component<
                                 opacity: feeLimitMethod == 'fixed' ? 1 : 0.25
                             }}
                         >
-                            {`${localeString('general.sats')}`}
+                            {localeString('general.sats')}
                         </Text>
                         <TextInput
                             style={{
@@ -158,7 +163,8 @@ export default class PaymentsSettings extends React.Component<
                                     payments: {
                                         defaultFeeMethod: 'percent',
                                         defaultFeePercentage: text,
-                                        defaultFeeFixed: feeLimit
+                                        defaultFeeFixed: feeLimit,
+                                        timeoutSeconds
                                     }
                                 });
                             }}
@@ -181,6 +187,32 @@ export default class PaymentsSettings extends React.Component<
                             {'%'}
                         </Text>
                     </View>
+                    <Text
+                        style={{
+                            fontFamily: 'Lato-Regular',
+                            paddingTop: 5,
+                            color: themeColor('text')
+                        }}
+                    >
+                        {localeString('views.Settings.Payments.timeoutSeconds')}
+                    </Text>
+                    <TextInput
+                        keyboardType="numeric"
+                        value={timeoutSeconds}
+                        onChangeText={async (text: string) => {
+                            this.setState({
+                                timeoutSeconds: text
+                            });
+                            await updateSettings({
+                                payments: {
+                                    defaultFeeMethod: feeLimitMethod,
+                                    defaultFeePercentage: feePercentage,
+                                    defaultFeeFixed: feeLimit,
+                                    timeoutSeconds: text
+                                }
+                            });
+                        }}
+                    />
                 </View>
             </Screen>
         );


### PR DESCRIPTION
# Description

This PR makes LND's payment timeout setting configurable instead of hard coding it as 60 seconds.

![Simulator Screen Shot - iPhone 14 - 2023-09-03 at 21 54 24](https://github.com/ZeusLN/zeus/assets/1878621/d3879f3f-142f-48c8-835d-3b85e7b90285)

![Simulator Screen Shot - iPhone 14 - 2023-09-03 at 21 53 38](https://github.com/ZeusLN/zeus/assets/1878621/4450a5ae-d1ec-4814-8e37-6adbe20ad409)


This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
