### PR TITLE
LNDHub: fix display of expiry time, hash, preimage

### DIFF
--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -47,7 +47,7 @@ export default class Invoice extends BaseModel {
     public private: boolean;
     public creation_date: string;
     public description_hash: string;
-    public r_preimage: string;
+    public r_preimage: any;
     public cltv_expiry: string;
     public htlcs: Array<HTLC>;
     // c-lightning, eclair
@@ -77,7 +77,8 @@ export default class Invoice extends BaseModel {
     }
 
     @computed public get getRPreimage(): string {
-        const preimage = this.r_preimage;
+        if (!this.r_preimage) return '';
+        const preimage = this.r_preimage.data || this.r_preimage;
         return typeof preimage === 'object'
             ? Base64Utils.bytesToHexString(preimage)
             : typeof preimage === 'string'
@@ -88,7 +89,8 @@ export default class Invoice extends BaseModel {
     }
 
     @computed public get getRHash(): string {
-        const hash = this.r_hash;
+        if (!this.r_hash) return '';
+        const hash = this.r_hash.data || this.r_hash;
         return typeof hash === 'object'
             ? Base64Utils.bytesToHexString(hash)
             : typeof hash === 'string'


### PR DESCRIPTION
# Description

This fixes the display of expiry time for invoices in LNDHub when the expiry is returned as a UNIX timestamp

Before:
![Simulator Screen Shot - iPhone 14 - 2023-09-06 at 12 43 18](https://github.com/ZeusLN/zeus/assets/1878621/4221d08e-1c9c-49a5-b7f7-d173cf0f1f29)

After:
![Simulator Screen Shot - iPhone 14 - 2023-09-06 at 12 43 37](https://github.com/ZeusLN/zeus/assets/1878621/22e3d5a8-ae03-4d31-ac50-f4133c89c54f)


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
