### PR TITLE
Contacts: Fixes

### DIFF
--- a/views/ContactDetails.tsx
+++ b/views/ContactDetails.tsx
@@ -163,6 +163,7 @@ export default class ContactDetails extends React.Component<
                 }}
                 color={themeColor('text')}
                 underlayColor="transparent"
+                size={35}
             />
         );
         const StarButton = () => (
@@ -171,7 +172,7 @@ export default class ContactDetails extends React.Component<
                 onPress={this.toggleFavorite}
                 color={themeColor('text')}
                 underlayColor="transparent"
-                size={28}
+                size={32}
             />
         );
         const EditContactButton = () => (
@@ -183,7 +184,7 @@ export default class ContactDetails extends React.Component<
                     })
                 }
             >
-                <EditContact height={36} width={36} />
+                <EditContact height={40} width={40} />
             </TouchableOpacity>
         );
         return (

--- a/views/Settings/AddContact.tsx
+++ b/views/Settings/AddContact.tsx
@@ -1068,15 +1068,17 @@ export default class AddContact extends React.Component<
                                 !isValidNIP05 ||
                                 !isValidNpub ||
                                 !isValidPubkey ||
-                                (lnAddress.length > 1 &&
+                                (lnAddress?.length > 1 &&
                                     lnAddress[lnAddress.length - 1] === '') ||
-                                (onchainAddress.length > 1 &&
+                                (pubkey?.length > 1 &&
+                                    pubkey[pubkey.length - 1] === '') ||
+                                (onchainAddress?.length > 1 &&
                                     onchainAddress[
                                         onchainAddress.length - 1
                                     ]) === '' ||
-                                (nip05.length > 1 &&
+                                (nip05?.length > 1 &&
                                     nip05[nip05.length - 1] === '') ||
-                                (nostrNpub.length > 1 &&
+                                (nostrNpub?.length > 1 &&
                                     nostrNpub[nostrNpub.length - 1] === '') ||
                                 !(lnAddress[0] || onchainAddress[0])
                             }

--- a/views/Settings/AddContact.tsx
+++ b/views/Settings/AddContact.tsx
@@ -327,6 +327,7 @@ export default class AddContact extends React.Component<
                 }}
                 color={themeColor('text')}
                 underlayColor="transparent"
+                size={35}
             />
         );
 
@@ -347,6 +348,7 @@ export default class AddContact extends React.Component<
                 onPress={onPress}
                 color={themeColor('text')}
                 underlayColor="transparent"
+                size={35}
             />
         );
 

--- a/views/Settings/AddContact.tsx
+++ b/views/Settings/AddContact.tsx
@@ -332,14 +332,12 @@ export default class AddContact extends React.Component<
         );
 
         const AddPhotos = () => (
-            <TouchableOpacity onPress={this.selectPhoto}>
-                <AddIcon
-                    fill={themeColor('background')}
-                    width="20"
-                    height="20"
-                    style={{ alignSelf: 'center' }}
-                />
-            </TouchableOpacity>
+            <AddIcon
+                fill={themeColor('background')}
+                width="20"
+                height="20"
+                style={{ alignSelf: 'center' }}
+            />
         );
 
         const StarButton = ({ isFavourite, onPress }) => (
@@ -385,30 +383,30 @@ export default class AddContact extends React.Component<
                                 alignItems: 'center'
                             }}
                         >
-                            <View
-                                style={{
-                                    backgroundColor:
-                                        themeColor('secondaryText'),
-                                    marginTop: 40,
-                                    width: 136,
-                                    height: 136,
-                                    borderRadius: 68,
-                                    justifyContent: 'center'
-                                }}
-                            >
-                                {this.state.photo ? (
-                                    <TouchableOpacity
-                                        onPress={this.selectPhoto}
-                                    >
+                            <TouchableOpacity onPress={this.selectPhoto}>
+                                <View
+                                    style={{
+                                        backgroundColor:
+                                            themeColor('secondaryText'),
+                                        marginTop: 40,
+                                        width: 136,
+                                        height: 136,
+                                        borderRadius: 68,
+                                        justifyContent: 'center'
+                                    }}
+                                >
+                                    {this.state.photo ? (
                                         <Image
-                                            source={{ uri: this.state.photo }}
+                                            source={{
+                                                uri: this.state.photo
+                                            }}
                                             style={styles.photo}
                                         />
-                                    </TouchableOpacity>
-                                ) : (
-                                    <AddPhotos />
-                                )}
-                            </View>
+                                    ) : (
+                                        <AddPhotos />
+                                    )}
+                                </View>
+                            </TouchableOpacity>
                         </View>
 
                         <View

--- a/views/Settings/AddContact.tsx
+++ b/views/Settings/AddContact.tsx
@@ -33,11 +33,11 @@ interface AddContactProps {
 }
 
 interface Contact {
-    lnAddress: string;
-    onchainAddress: string;
-    nip05: string;
-    nostrNpub: string;
-    pubkey: string;
+    lnAddress: string[];
+    onchainAddress: string[];
+    nip05: string[];
+    nostrNpub: string[];
+    pubkey: string[];
     name: string;
     description: string;
     id: string;
@@ -1078,7 +1078,11 @@ export default class AddContact extends React.Component<
                                     nip05[nip05.length - 1] === '') ||
                                 (nostrNpub?.length > 1 &&
                                     nostrNpub[nostrNpub.length - 1] === '') ||
-                                !(lnAddress[0] || onchainAddress[0])
+                                !(
+                                    lnAddress[0] ||
+                                    onchainAddress[0] ||
+                                    pubkey[0]
+                                )
                             }
                         />
                     </View>

--- a/views/Settings/Contacts.tsx
+++ b/views/Settings/Contacts.tsx
@@ -181,14 +181,15 @@ export default class Contacts extends React.Component<
                 }}
                 color={themeColor('text')}
                 underlayColor="transparent"
+                size={35}
             />
         );
         const Add = ({ navigation }: { navigation: any }) => (
             <TouchableOpacity onPress={() => navigation.navigate('AddContact')}>
                 <View
                     style={{
-                        width: 30,
-                        height: 30,
+                        width: 35,
+                        height: 35,
                         borderRadius: 25,
                         backgroundColor: themeColor('chain'),
                         justifyContent: 'center',
@@ -197,23 +198,12 @@ export default class Contacts extends React.Component<
                 >
                     <AddIcon
                         fill={themeColor('background')}
-                        width={12}
-                        height={12}
+                        width={16}
+                        height={16}
                         style={{ alignSelf: 'center' }}
                     />
                 </View>
             </TouchableOpacity>
-        );
-        const PayButton = ({ navigation }: { navigation: any }) => (
-            <Chip
-                title="Pay"
-                titleStyle={{ color: 'black', fontSize: 16 }}
-                buttonStyle={{
-                    backgroundColor: themeColor('chain'),
-                    minWidth: 70
-                }}
-                onPress={() => navigation.navigate('AddContact')}
-            />
         );
 
         const favoriteContacts = filteredContacts.filter(
@@ -237,11 +227,7 @@ export default class Contacts extends React.Component<
                         borderBottomWidth: 0
                     }}
                     rightComponent={
-                        SendScreen ? (
-                            <PayButton navigation={navigation} />
-                        ) : (
-                            <Add navigation={navigation} />
-                        )
+                        !SendScreen && <Add navigation={navigation} />
                     }
                 />
                 <View>

--- a/views/Settings/Contacts.tsx
+++ b/views/Settings/Contacts.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Text, View, TouchableOpacity, FlatList, Image } from 'react-native';
-import { Header, Icon, SearchBar, Chip, Divider } from 'react-native-elements';
+import { Header, Icon, SearchBar, Divider } from 'react-native-elements';
 import AddIcon from '../../assets/images/SVG/Add.svg';
 import EncryptedStorage from 'react-native-encrypted-storage';
 
@@ -74,14 +74,85 @@ export default class Contacts extends React.Component<
             }
         });
     };
+    displayAddress = (item) => {
+        const hasLnAddress =
+            item.lnAddress &&
+            item.lnAddress.length === 1 &&
+            item.lnAddress[0] !== '';
+        const hasOnchainAddress =
+            item.onchainAddress &&
+            item.onchainAddress.length === 1 &&
+            item.onchainAddress[0] !== '';
+        const hasPubkey =
+            item.pubkey && item.pubkey.length === 1 && item.pubkey[0] !== '';
+
+        if (hasLnAddress + hasOnchainAddress + hasPubkey >= 2) {
+            return localeString('views.Settings.Contacts.multipleAddresses');
+        }
+
+        if (hasLnAddress) {
+            return item.lnAddress[0].length > 15
+                ? `${item.lnAddress[0].slice(0, 4)}...${item.lnAddress[0].slice(
+                      -4
+                  )}`
+                : item.lnAddress[0];
+        }
+
+        if (hasOnchainAddress) {
+            return item.onchainAddress[0].length > 15
+                ? `${item.onchainAddress[0].slice(
+                      0,
+                      4
+                  )}...${item.onchainAddress[0].slice(-4)}`
+                : item.onchainAddress[0];
+        }
+
+        if (hasPubkey) {
+            return item.pubkey[0].length > 15
+                ? `${item.pubkey[0].slice(0, 4)}...${item.pubkey[0].slice(-4)}`
+                : item.pubkey[0];
+        }
+
+        return localeString('views.Settings.Contacts.multipleAddresses');
+    };
 
     renderContactItem = ({ item }: { item: ContactItem }) => (
         <TouchableOpacity
-            onPress={() =>
-                this.props.navigation.navigate('ContactDetails', {
-                    contactId: item.id
-                })
-            }
+            onPress={() => {
+                (item.lnAddress &&
+                    item.lnAddress.length === 1 &&
+                    item.lnAddress[0] !== '' &&
+                    item.onchainAddress[0] === '' &&
+                    item.pubkey[0] === '' &&
+                    this.state.SendScreen &&
+                    this.props.navigation.navigate('Send', {
+                        destination: item.lnAddress[0],
+                        contactName: item.name
+                    })) ||
+                    (item.onchainAddress &&
+                        item.onchainAddress.length === 1 &&
+                        item.onchainAddress[0] !== '' &&
+                        item.lnAddress[0] === '' &&
+                        item.pubkey[0] === '' &&
+                        this.state.SendScreen &&
+                        this.props.navigation.navigate('Send', {
+                            destination: item.onchainAddress[0],
+                            contactName: item.name
+                        })) ||
+                    (item.pubkey &&
+                        item.pubkey.length === 1 &&
+                        item.pubkey[0] !== '' &&
+                        item.lnAddress[0] === '' &&
+                        item.onchainAddress[0] === '' &&
+                        this.state.SendScreen &&
+                        this.props.navigation.navigate('Send', {
+                            destination: item.pubkey[0],
+                            contactName: item.name
+                        })) ||
+                    this.props.navigation.navigate('ContactDetails', {
+                        contactId: item.id
+                    });
+            }}
         >
             <View
                 style={{
@@ -112,33 +183,7 @@ export default class Contacts extends React.Component<
                             color: themeColor('secondaryText')
                         }}
                     >
-                        {item.lnAddress &&
-                        item.lnAddress.length === 1 &&
-                        item.lnAddress[0] !== '' &&
-                        item.onchainAddress[0] === ''
-                            ? item.lnAddress[0].length > 15
-                                ? `${item.lnAddress[0].slice(
-                                      0,
-                                      4
-                                  )}...${item.lnAddress[0].slice(-4)}`
-                                : item.lnAddress[0]
-                            : item.lnAddress.length > 1
-                            ? `${localeString(
-                                  'views.Settings.Contacts.multipleAddresses'
-                              )}`
-                            : item.onchainAddress &&
-                              item.onchainAddress.length === 1 &&
-                              item.onchainAddress[0] !== '' &&
-                              item.lnAddress[0] === ''
-                            ? item.onchainAddress[0].length > 15
-                                ? `${item.onchainAddress[0].slice(
-                                      0,
-                                      4
-                                  )}...${item.onchainAddress[0].slice(-4)}`
-                                : item.onchainAddress[0]
-                            : `${localeString(
-                                  'views.Settings.Contacts.multipleAddresses'
-                              )}`}
+                        {this.displayAddress(item)}
                     </Text>
                 </View>
             </View>


### PR DESCRIPTION
- Fixing the size of Header icons, mainly the **Back** button on the `AddContact,` `Contacts` and `ContactDetails` view.
- Disabling the `SAVE CONTACT` button if an extra field of pubkey is generated and not being filled correctly.
- On `AddContact`Previously we had to tap on the plus icon to open the gallery for adding photos, we changed that to make the whole background circle pressable.
- If the contact has only one address available (either lnAddress, onchainAddress, or pubkey) , we get forwarded to the payments and skip going to `ContactDetails` view only if the user is coming from the `Send` view (we still will be forwarded to the `ContactDetails` view if we coming from `Settings` so the user can edit the contact).