### PR TITLE
LNURL-pay: Drop metadata description hash validation

### DIFF
--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -5,7 +5,6 @@ import ReactNativeBlobUtil from 'react-native-blob-util';
 import { Alert } from 'react-native';
 import { LNURLWithdrawParams } from 'js-lnurl';
 import querystring from 'querystring-es3';
-import hashjs from 'hash.js';
 
 import Invoice from '../models/Invoice';
 import SettingsStore from './SettingsStore';
@@ -384,10 +383,7 @@ export default class InvoicesStore {
     };
 
     @action
-    public getPayReq = (
-        paymentRequest: string,
-        descriptionPreimage?: string
-    ) => {
+    public getPayReq = (paymentRequest: string) => {
         this.loading = true;
         this.pay_req = null;
         this.paymentRequest = paymentRequest;
@@ -396,21 +392,6 @@ export default class InvoicesStore {
         return BackendUtils.decodePaymentRequest([paymentRequest])
             .then((data: any) => {
                 this.pay_req = new Invoice(data);
-
-                // check description_hash if asked for
-                const needed = hashjs
-                    .sha256()
-                    .update(descriptionPreimage)
-                    .digest('hex');
-                if (
-                    descriptionPreimage &&
-                    this.pay_req.description_hash !== needed
-                ) {
-                    throw new Error(
-                        `wrong description_hash! got ${this.pay_req.description_hash}, needed ${needed}.`
-                    );
-                }
-
                 this.getPayReqError = null;
                 this.loading = false;
             })

--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -120,7 +120,7 @@ export default class LnurlPay extends React.Component<
                     tag: 'noop'
                 };
 
-                InvoicesStore.getPayReq(pr, lnurl.metadata).then(() => {
+                InvoicesStore.getPayReq(pr).then(() => {
                     if (InvoicesStore.getPayReqError) {
                         Alert.alert(
                             localeString(


### PR DESCRIPTION
# Description

Relates to issue: [ lnurl / luds #234: LNURL-pay: Drop metadata description hash validation](https://github.com/lnurl/luds/pull/234)

See attached issue.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
