### PR TITLE
Remove scramble pin hint on confirmation screen

### DIFF
--- a/views/Settings/SetPin.tsx
+++ b/views/Settings/SetPin.tsx
@@ -145,8 +145,7 @@ export default class SetPin extends React.Component<SetPinProps, SetPinState> {
                                 )}
                             </Text>
                             {(settings.scramblePin ||
-                                typeof typeof settings.scramblePin ===
-                                    'undefined') && (
+                                settings.scramblePin == null) && (
                                 <Text
                                     style={{
                                         ...styles.secondaryText,
@@ -192,18 +191,21 @@ export default class SetPin extends React.Component<SetPinProps, SetPinState> {
                                     'views.Settings.SetPin.confirmPin'
                                 )}
                             </Text>
-                            <Text
-                                style={{
-                                    ...styles.secondaryText,
-                                    color: themeColor('secondaryText'),
-                                    flex: 1,
-                                    justifyContent: 'flex-end'
-                                }}
-                            >
-                                {localeString(
-                                    'views.Settings.SetPin.scramblePin'
-                                )}
-                            </Text>
+                            {(settings.scramblePin ||
+                                settings.scramblePin == null) && (
+                                <Text
+                                    style={{
+                                        ...styles.secondaryText,
+                                        color: themeColor('secondaryText'),
+                                        flex: 1,
+                                        justifyContent: 'flex-end'
+                                    }}
+                                >
+                                    {localeString(
+                                        'views.Settings.SetPin.scramblePin'
+                                    )}
+                                </Text>
+                            )}
                             <View
                                 style={{
                                     flex: 6,


### PR DESCRIPTION
# Description

Even when "Scramble PIN numbers" is disabled, the related hint was displayed on confirm PIN screen.

![grafik](https://github.com/ZeusLN/zeus/assets/77545287/76f623f4-d205-43f3-8ac2-72ba337db773)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
