### PR TITLE
AmountInput: unit switcher: fix icon displayed

### DIFF
--- a/components/AmountInput.tsx
+++ b/components/AmountInput.tsx
@@ -179,7 +179,7 @@ export default class AmountInput extends React.Component<
                         onPress={() => !locked && this.onChangeUnits()}
                         style={{ marginTop: 22, marginLeft: 15 }}
                     >
-                        {fiatEnabled && units !== 'fiat' ? (
+                        {UnitsStore!.getNextUnit() === 'fiat' ? (
                             <ExchangeFiatSVG
                                 fill={themeColor('text')}
                                 width="35"

--- a/stores/UnitsStore.ts
+++ b/stores/UnitsStore.ts
@@ -29,23 +29,22 @@ export default class UnitsStore {
     }
 
     @action
-    public changeUnits = () => {
+    public changeUnits = () => (this.units = this.getNextUnit());
+
+    public getNextUnit = () => {
         const { settings } = this.settingsStore;
         const { fiatEnabled } = settings;
 
         if (!fiatEnabled) {
-            this.units = this.units == 'sats' ? 'BTC' : 'sats';
+            return this.units === 'sats' ? 'BTC' : 'sats';
         } else {
             switch (this.units) {
                 case 'sats':
-                    this.units = 'BTC';
-                    break;
+                    return 'BTC';
                 case 'BTC':
-                    this.units = 'fiat';
-                    break;
-                case 'fiat':
-                    this.units = 'sats';
-                    break;
+                    return 'fiat';
+                default:
+                    return 'sats';
             }
         }
     };


### PR DESCRIPTION
# Description

The unit switcher icon was showing dollar when fiat was enabled and the current unit was sats (next unit is Bitcoin so it should show Bitcoin).

Before:
![before](https://github.com/ZeusLN/zeus/assets/77545287/3ceabf3f-db42-470c-b09e-6dcbf4e24572)

After:
![after](https://github.com/ZeusLN/zeus/assets/77545287/73653577-3045-4163-9526-9daaf9ce31b9)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
