### PR TITLE
Improve back press handling in SendingLightning

### DIFF
--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -4,6 +4,7 @@ import {
     AppState,
     BackHandler,
     Linking,
+    NativeEventSubscription,
     PanResponder,
     Platform,
     Text,
@@ -102,6 +103,7 @@ interface WalletState {
 @observer
 export default class Wallet extends React.Component<WalletProps, WalletState> {
     private tabNavigationRef = React.createRef<NavigationContainerRef<any>>();
+    private backPressSubscription: NativeEventSubscription;
 
     constructor(props) {
         super(props);
@@ -182,7 +184,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         });
 
         AppState.addEventListener('change', this.handleAppStateChange);
-        BackHandler.addEventListener(
+        this.backPressSubscription = BackHandler.addEventListener(
             'hardwareBackPress',
             this.handleBackButton.bind(this)
         );
@@ -193,10 +195,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             this.props.navigation.removeListener('didFocus');
         AppState.removeEventListener &&
             AppState.removeEventListener('change', this.handleAppStateChange);
-        BackHandler.removeEventListener(
-            'hardwareBackPress',
-            this.handleBackButton
-        );
+        this.backPressSubscription?.remove();
     }
 
     handleAppStateChange = (nextAppState: any) => {


### PR DESCRIPTION
# Description

This fixes #1511.
When transaction is successfully sent or is in transit, back press now navigates to Wallet.
Additionally improved back press subscription removal in Wallet.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
