### PR TITLE
Refactor: clipboard handling

### DIFF
--- a/components/WalletHeader.tsx
+++ b/components/WalletHeader.tsx
@@ -22,7 +22,7 @@ import Header from './Header';
 import LoadingIndicator from '../components/LoadingIndicator';
 import NodeIdenticon from '../components/NodeIdenticon';
 
-import { isClipboardValue } from '../utils/handleAnything';
+import handleAnything, { isClipboardValue } from '../utils/handleAnything';
 import { localeString } from '../utils/LocaleUtils';
 import PrivacyUtils from '../utils/PrivacyUtils';
 import { themeColor } from '../utils/ThemeUtils';
@@ -106,7 +106,11 @@ const ClipboardBadge = ({
     clipboard: string;
 }) => (
     <TouchableOpacity
-        onPress={() => navigation.navigate('Send', { destination: clipboard })}
+        onPress={async () => {
+            const response = await handleAnything(clipboard);
+            const [route, props] = response;
+            navigation.navigate(route, props);
+        }}
     >
         <ClipboardSVG fill={themeColor('text')} width="30" height="30" />
     </TouchableOpacity>


### PR DESCRIPTION
# Description

Instead of navigating to Send component and let it handle the clipboard value, handle it the same way the QR code handler does it. One advantage is that clipboard values that cannot be handled by the Send component can still be handled without changes to the handling code in WalletHeader.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
