### PR TITLE
Embedded node: Neutrino config changes

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -706,7 +706,7 @@ export default class SettingsStore {
         expressGraphSyncMobile: false,
         resetExpressGraphSyncOnStartup: false,
         bimodalPathfinding: false,
-        dontAllowOtherPeers: false,
+        dontAllowOtherPeers: true,
         neutrinoPeers: [],
         zeroConfPeers: [],
         waitForGraphSync: false,

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -904,6 +904,15 @@ export default class SettingsStore {
                     this.settings.fiatEnabled = true;
                 }
 
+                // TODO PEGASUS
+                // temporarily toggle all alpha users settings for now
+                const MOD_KEY_1 = 'neutrino-mod-1';
+                const mod1 = await EncryptedStorage.getItem(MOD_KEY_1);
+                if (!mod1) {
+                    this.settings.dontAllowOtherPeers = true;
+                    await EncryptedStorage.setItem(MOD_KEY_1, 'true');
+                }
+
                 // set default LSPs if not defined
                 if (this.settings.enableLSP === undefined) {
                     this.settings.enableLSP = true;

--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -74,12 +74,12 @@ const writeLndConfig = async (isTestnet?: boolean, rescan?: boolean) => {
             ? 'btcd-testnet.lightning.computer'
             : 'btcd-mainnet.lightning.computer'
     }
-    neutrino.${peerMode}=${isTestnet ? 'testnet.lnolymp.us' : 'node.lnolymp.us'}
-    neutrino.${peerMode}=${
-        isTestnet ? 'testnet.blixtwallet.com' : 'node.blixtwallet.com'
-    }
+    ${!isTestnet ? `neutrino.${peerMode}=btcd1.lnolymp.us` : ''}
+    ${!isTestnet ? `neutrino.${peerMode}=btcd2.lnolymp.us` : ''}
+    ${!isTestnet ? `neutrino.${peerMode}=node.eldamar.icu` : ''}
     ${!isTestnet ? `neutrino.${peerMode}=noad.sathoarder.com` : ''}
-    ${!isTestnet ? `neutrino.${peerMode}=btcd.lnolymp.us` : ''}`;
+    ${isTestnet ? `neutrino.${peerMode}=testnet.lnolymp.us` : ''}
+    ${isTestnet ? `neutrino.${peerMode}=testnet.blixtwallet.com` : ''}`;
 
     const config = `[Application Options]
     debuglevel=info


### PR DESCRIPTION
# Description

This PR makes some changes to the default Neutrino config for embedded nodes.

First, mainnet nodes are limited to known BTCD instances. BTCD seems to handle broadcasting+fee bumping better as the mempool size is uncapped by default and generally plays nicer with LND as it is also written in Go.

Our new BTCD instance `btcd2.lnolymp.us` has been added along with `node.eldamar.icu`. Bitcoin Core instances `node.lnolymp.us` and `node.blixtwallet.com` have been removed (at least for the time being). `btcd.lnolymp.us` has taken the new hostname `btcd1.lnolymp.us`.

Secondly, the Neutrino setting `dontAllowOtherPeers` has been set to `true` by default. This will ensure that Zeus doesn't connect to any Bitcoin Core peers that may cause problems.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
