### PR TITLE
Prevent enabling fiat rates display while loading

### DIFF
--- a/components/Conversion.tsx
+++ b/components/Conversion.tsx
@@ -142,7 +142,10 @@ export default class Conversion extends React.Component<
         return (
             <>
                 {units === 'fiat' && (
-                    <TouchableOpacity onPress={() => this.toggleShowRate()}>
+                    <TouchableOpacity
+                        onPress={() => this.toggleShowRate()}
+                        disabled={FiatStore.loading}
+                    >
                         {satsPending ? (
                             <ConversionPendingDisplay
                                 units="sats"
@@ -157,7 +160,10 @@ export default class Conversion extends React.Component<
                     </TouchableOpacity>
                 )}
                 {units !== 'fiat' && (
-                    <TouchableOpacity onPress={() => this.toggleShowRate()}>
+                    <TouchableOpacity
+                        onPress={() => this.toggleShowRate()}
+                        disabled={FiatStore.loading}
+                    >
                         {satsPending ? (
                             <ConversionPendingDisplay
                                 units="fiat"


### PR DESCRIPTION
# Description

This fixes #1694 by disabling the Conversion component while fiat rates are being loaded. So this loading indicator can no longer be clicked:

![grafik](https://github.com/ZeusLN/zeus/assets/77545287/8357a810-91ca-4536-8c88-e4bfedabf854)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
