### PR TITLE
LSP: add ability to request Simple Taproot Channels

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -725,6 +725,7 @@
     "views.Settings.LSP.enableLSP": "Enable Lightning Service Provider (LSP)",
     "views.Settings.LSP.enableLSP.subtitle": "The LSP will get you connected to the Lightning network by opening up payment channels for you.",
     "views.Settings.LSP.lspAccessKey": "LSP Access Key (if needed)",
+    "views.Settings.LSP.requestSimpleTaproot": "Request Simple Taproot Channels",
     "views.Settings.AddContact.name": "Name",
     "views.Settings.AddContact.description": "Description (max 120)",
     "views.Settings.AddContact.lnAddress": "LN address",

--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -185,24 +185,24 @@ export default class LSPStore {
         this.error = false;
         this.error_msg = '';
         this.showLspSettings = false;
+
+        const { settings } = this.settingsStore;
+
         return new Promise((resolve, reject) => {
             ReactNativeBlobUtil.fetch(
                 'post',
                 `${this.getLSPHost()}/api/v1/proposal`,
-                this.settingsStore.settings.lspAccessKey
+                settings.lspAccessKey
                     ? {
                           'Content-Type': 'application/json',
-                          'x-auth-token':
-                              this.settingsStore.settings.lspAccessKey
+                          'x-auth-token': settings.lspAccessKey
                       }
                     : {
                           'Content-Type': 'application/json'
                       },
                 JSON.stringify({
                     bolt11,
-                    // TODO investigate why Taproot chans from LSP
-                    // result in unsettled funds
-                    simpleTaproot: false
+                    simpleTaproot: settings.requestSimpleTaproot
                 })
             )
                 .then(async (response: any) => {

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -108,6 +108,7 @@ export interface Settings {
     lspMainnet: string;
     lspTestnet: string;
     lspAccessKey: string;
+    requestSimpleTaproot: boolean;
 }
 
 export const FIAT_RATES_SOURCE_KEYS = [
@@ -718,7 +719,8 @@ export default class SettingsStore {
         enableLSP: true,
         lspMainnet: DEFAULT_LSP_MAINNET,
         lspTestnet: DEFAULT_LSP_TESTNET,
-        lspAccessKey: ''
+        lspAccessKey: '',
+        requestSimpleTaproot: false
     };
     @observable public posStatus: string = 'unselected';
     @observable public loading = false;

--- a/views/Settings/LSP.tsx
+++ b/views/Settings/LSP.tsx
@@ -22,6 +22,7 @@ interface EmbeddedNodeState {
     enableLSP: boolean | undefined;
     lsp: string;
     accessKey: string;
+    requestSimpleTaproot: boolean;
 }
 
 @inject('SettingsStore')
@@ -33,7 +34,8 @@ export default class EmbeddedNode extends React.Component<
     state = {
         enableLSP: true,
         lsp: '',
-        accessKey: ''
+        accessKey: '',
+        requestSimpleTaproot: false
     };
 
     async UNSAFE_componentWillMount() {
@@ -46,13 +48,14 @@ export default class EmbeddedNode extends React.Component<
                 embeddedLndNetwork === 'Mainnet'
                     ? settings.lspMainnet
                     : settings.lspTestnet,
-            accessKey: settings.lspAccessKey
+            accessKey: settings.lspAccessKey,
+            requestSimpleTaproot: settings.requestSimpleTaproot
         });
     }
 
     render() {
         const { navigation, SettingsStore } = this.props;
-        const { enableLSP, lsp, accessKey } = this.state;
+        const { enableLSP, lsp, accessKey, requestSimpleTaproot } = this.state;
         const { updateSettings, embeddedLndNetwork }: any = SettingsStore;
 
         return (
@@ -184,6 +187,44 @@ export default class EmbeddedNode extends React.Component<
                             autoCorrect={false}
                         />
                     </View>
+                    <ListItem
+                        containerStyle={{
+                            borderBottomWidth: 0,
+                            backgroundColor: 'transparent'
+                        }}
+                    >
+                        <ListItem.Title
+                            style={{
+                                color: themeColor('secondaryText'),
+                                fontFamily: 'Lato-Regular'
+                            }}
+                        >
+                            {localeString(
+                                'views.Settings.LSP.requestSimpleTaproot'
+                            )}
+                        </ListItem.Title>
+                        <View
+                            style={{
+                                flex: 1,
+                                flexDirection: 'row',
+                                justifyContent: 'flex-end'
+                            }}
+                        >
+                            <Switch
+                                value={requestSimpleTaproot}
+                                onValueChange={async () => {
+                                    this.setState({
+                                        requestSimpleTaproot:
+                                            !requestSimpleTaproot
+                                    });
+                                    await updateSettings({
+                                        requestSimpleTaproot:
+                                            !requestSimpleTaproot
+                                    });
+                                }}
+                            />
+                        </View>
+                    </ListItem>
                 </View>
             </Screen>
         );


### PR DESCRIPTION
# Description

Users will now be able to request Simple Taproot Channels from their 0-conf chan LSPs. A toggle for the option is now added to `Settings` > `LSP`.

The functionality is already deployed to our LSP, OLYMPUS by ZEUS.

![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-01 at 23 32 33](https://github.com/ZeusLN/zeus/assets/1878621/0b307a9e-e4a4-41d2-9f1f-1f258fc3126d)
![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-01 at 23 36 48](https://github.com/ZeusLN/zeus/assets/1878621/2963d7bc-f90c-4be1-8e57-de4e7cf75832)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
