### PR TITLE
Exit app on back press on IntroSplash

### DIFF
--- a/views/IntroSplash.tsx
+++ b/views/IntroSplash.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import {
+    BackHandler,
+    NativeEventSubscription,
     Image,
     View,
     SafeAreaView,
@@ -41,6 +43,8 @@ export default class IntroSplash extends React.Component<
     IntroSplashProps,
     IntroSplashState
 > {
+    private backPressSubscription: NativeEventSubscription;
+
     state = {
         creatingWallet: false,
         error: false
@@ -51,6 +55,23 @@ export default class IntroSplash extends React.Component<
         this.props.navigation.addListener('didFocus', () => {
             this.props.SettingsStore.getSettings();
         });
+
+        this.backPressSubscription = BackHandler.addEventListener(
+            'hardwareBackPress',
+            this.handleBackPress.bind(this)
+        );
+    }
+
+    handleBackPress = () => {
+        if (this.state.creatingWallet) {
+            return true;
+        }
+        BackHandler.exitApp();
+        return true;
+    };
+
+    componentWillUnmount(): void {
+        this.backPressSubscription?.remove();
     }
 
     render() {


### PR DESCRIPTION
# Description

This fixes #1703. Pressing back now exits the app except while wallet is creating.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
