### PR TITLE
Prevent calling refreshSettings twice when nodes screen is opened

### DIFF
--- a/views/Settings/Nodes.tsx
+++ b/views/Settings/Nodes.tsx
@@ -36,17 +36,17 @@ interface NodesState {
 @inject('BalanceStore', 'NodeInfoStore', 'ChannelsStore', 'SettingsStore')
 @observer
 export default class Nodes extends React.Component<NodesProps, NodesState> {
+    isInitialFocus = true;
+
     state = {
         nodes: [],
         loading: false
     };
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         this.refreshSettings();
 
-        this.props.navigation.addListener('didFocus', () => {
-            this.refreshSettings();
-        });
+        this.props.navigation.addListener('didFocus', this.handleFocus);
     }
 
     componentWillUnmount() {
@@ -56,6 +56,14 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
 
     UNSAFE_componentWillReceiveProps = () => {
         this.refreshSettings();
+    };
+
+    handleFocus = () => {
+        if (this.isInitialFocus) {
+            this.isInitialFocus = false;
+        } else {
+            this.refreshSettings();
+        }
     };
 
     async refreshSettings() {


### PR DESCRIPTION
This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
