### PR TITLE
Channels: fix loading aliases for new channels of known nodes

### DIFF
--- a/android/app/src/main/java/com/zeus/MainApplication.java
+++ b/android/app/src/main/java/com/zeus/MainApplication.java
@@ -14,7 +14,7 @@ import com.facebook.react.ReactApplication;
 import com.oblador.vectoricons.VectorIconsPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
-import com.remobile.qrcodeLocalImage.RCTQRCodeLocalImagePackage; 
+import com.remobile.qrcodeLocalImage.RCTQRCodeLocalImagePackage;
 import android.content.Context;
 
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
@@ -23,6 +23,9 @@ import com.facebook.soloader.SoLoader;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import javax.net.ssl.X509TrustManager;
+
+import com.ReactNativeBlobUtil.ReactNativeBlobUtilUtils;
 
 public class MainApplication extends Application implements ReactApplication {
 
@@ -39,7 +42,7 @@ public class MainApplication extends Application implements ReactApplication {
           List<ReactPackage> packages = new PackageList(this).getPackages();
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // packages.add(new MyReactNativePackage());
-             
+
           // ZEUS
           packages.add(new MobileToolsPackage());
           packages.add(new LndMobilePackage());
@@ -79,5 +82,20 @@ public class MainApplication extends Application implements ReactApplication {
       // If you opted-in for the New Architecture, we load the native entry point for this app.
       DefaultNewArchitectureEntryPoint.load();
     }
+
+    ReactNativeBlobUtilUtils.sharedTrustManager = new X509TrustManager() {
+      @Override
+      public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) {
+      }
+
+      @Override
+      public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) {
+      }
+
+      @Override
+      public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+        return new java.security.cert.X509Certificate[]{};
+      }
+    };
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react": "18.2.0",
     "react-native": "0.72.4",
     "react-native-biometrics": "3.0.1",
-    "react-native-blob-util": "0.14.0",
+    "react-native-blob-util": "0.19.1",
     "react-native-camera-kit": "13.0.0",
     "react-native-circular-progress-indicator": "4.4.2",
     "react-native-crypto": "2.2.0",

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -21,6 +21,8 @@ import BackendUtils from '../../utils/BackendUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 
+import Channel from '../../models/Channel';
+
 // TODO: does this belong in the model? Or can it be computed from the model?
 export enum Status {
     Good = 'Good',
@@ -132,7 +134,7 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
         return sortKeys;
     };
 
-    renderItem = ({ item }) => {
+    renderItem = ({ item }: { item: Channel }) => {
         const { ChannelsStore, navigation } = this.props;
         const { largestChannelSats, channelsType } = ChannelsStore;
         const displayName = item.alias || item.remotePubkey || item.channelId;
@@ -240,7 +242,7 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
             SettingsStore?.settings?.privacy?.lurkerMode || false;
 
         let headerString;
-        let channelsData;
+        let channelsData: Channel[];
         switch (channelsType) {
             case ChannelsType.Open:
                 headerString = `${localeString(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5199,7 +5199,7 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.1.3, glob@^7.1.4, glob@^7.2.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -8013,13 +8013,13 @@ react-native-biometrics@3.0.1:
   resolved "https://registry.yarnpkg.com/react-native-biometrics/-/react-native-biometrics-3.0.1.tgz#23c5a0bdbae1fcb1e08b22936223fe0fc4af846e"
   integrity sha512-Ru80gXRa9KG04sl5AB9HyjLjVbduhqZVjA+AiOSGqr+fNqCDmCu9y5WEksnjbnniNLmq1yGcw+qcLXmR1ddLDQ==
 
-react-native-blob-util@0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/react-native-blob-util/-/react-native-blob-util-0.14.0.tgz#60c7e61b574bff8acc8c661f967aa350ceb2cf2f"
-  integrity sha512-cr2Tw5VdvUijreMdnBYmsBVQvxwiLWKe37UG8dPnPJ8sQ8rZJQo9IfpfPho+w/8fWrKqCJAoTSLpHI1ar059ew==
+react-native-blob-util@0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/react-native-blob-util/-/react-native-blob-util-0.19.1.tgz#7a1cc49db5c987e7091e6bc18334a2b38a7ab8ce"
+  integrity sha512-X1+MAcijR1AEky9dqNTFtsKvUPAoof2qsmmbSYThj/RWIucc2hhzrK3V2BJVU/hemNuz7E0NDaErmpNDpDHtNw==
   dependencies:
     base-64 "0.1.0"
-    glob "^7.1.6"
+    glob "^7.2.3"
 
 react-native-camera-kit@13.0.0:
   version "13.0.0"


### PR DESCRIPTION
# Description

Currently, when creating a new channel for a known node, the node has no alias (pub key is displayed instead).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [x] Contributors will need to run `yarn` after this PR is merged in
- [x] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
