### PR TITLE
React-native-elements update, "link" and "mainStyle" optional in SuccessErrorMessage.tsx

### DIFF
--- a/components/SuccessErrorMessage.tsx
+++ b/components/SuccessErrorMessage.tsx
@@ -5,8 +5,8 @@ import UrlUtils from '../utils/UrlUtils';
 interface MessageProps {
     message?: string;
     fontSize?: number;
-    link: string;
-    mainStyle: any;
+    link?: string;
+    mainStyle?: any;
     dismissable?: boolean;
 }
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-native-circular-progress-indicator": "4.4.2",
     "react-native-crypto": "2.2.0",
     "react-native-date-picker": "4.3.3",
-    "react-native-elements": "3.4.2",
+    "react-native-elements": "3.4.3",
     "react-native-encrypted-storage": "4.0.3",
     "react-native-gesture-handler": "2.12.1",
     "react-native-hce": "0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8056,10 +8056,10 @@ react-native-date-picker@4.3.3:
   resolved "https://registry.yarnpkg.com/react-native-date-picker/-/react-native-date-picker-4.3.3.tgz#5ca4ca10283538ab9307b7f2dc6b83233ded122b"
   integrity sha512-Lq2hGZkwoyCMsxi/uw4KVGu4/xdPZ8AHEx2SU5KY2mipHFpX+r4n5/gXa+rpCRkARJaTFYPZ7S59bT9KMh7fGw==
 
-react-native-elements@3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/react-native-elements/-/react-native-elements-3.4.2.tgz#66602be9c5e0e0a2a831913adec80ff6518d1ee2"
-  integrity sha512-m0eAWOn7JuR1wNTNY0WHuaqst4LI/gFE4N5Bbyfsc4DiryWsMST7aAg5w/Gos4IexWIzhLKCIkPxthND1m/8Xg==
+react-native-elements@3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/react-native-elements/-/react-native-elements-3.4.3.tgz#c33919002aef83a0c0f98d0ed56009714ad9b1b3"
+  integrity sha512-VtZc25EecPZyUBER85zFK9ZbY6kkUdcm1ZwJ9hdoGSCr1R/GFgxor4jngOcSYeMvQ+qimd5No44OVJW3rSJECA==
   dependencies:
     "@types/react-native-vector-icons" "^6.4.6"
     color "^3.1.2"


### PR DESCRIPTION
# Description

- Updating react-native-elements 3.4.2 -> 3.4.3
- Making "link" and "mainStyle" optional in SuccessErrorMessage.tsx

-> This fixes all TypeScript type errors for: `Icon`, `ListItem`, `SuccessMessage/WarningMessage/ErrorMessage`

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [x] Contributors will need to run `yarn` after this PR is merged in
- [x] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
