### PR TITLE
Send: Fix - Reset isValid state during input validation

### DIFF
--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -287,7 +287,9 @@ export default class Send extends React.Component<SendProps, SendState> {
     validateAddress = (text: string) => {
         const { navigation } = this.props;
         this.setState({
-            loading: true
+            loading: true,
+            isValid: true,
+            error_msg: ''
         });
         handleAnything(text, this.state.amount)
             .then((response) => {


### PR DESCRIPTION
Fixes: #1731 
This PR addresses a bug where the `isValid` state was not being reset to true when a correct value of address was entered after an error.