### PR TITLE
Node Configuration: Default implementation to lnd only if newEntry

### DIFF
--- a/views/Settings/NodeConfiguration.tsx
+++ b/views/Settings/NodeConfiguration.tsx
@@ -236,8 +236,8 @@ export default class NodeConfiguration extends React.Component<
         // remove option to add a new embedded node if initialized already
         const { SettingsStore } = this.props;
         const { settings } = SettingsStore;
-        const { embeddedLndNetwork } = this.state;
-        if (settings.nodes) {
+        const { embeddedLndNetwork, newEntry } = this.state;
+        if (settings.nodes && newEntry) {
             const result = settings?.nodes?.filter(
                 (node) => node.implementation === 'embedded-lnd'
             );


### PR DESCRIPTION
# Description

Right now `implementation` defaults to `lnd` if `!embeddedLndNetwork`. This leads to this issue: If an embedded node exists and you edit an existing CLN node, the node interface was wrongly displayed as `LND (REST)`.

Now `implementation` only defaults to `lnd` if `!embeddedLndNetwork && newEntry`.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
