### PR TITLE
Backends: add supportsChannelCoinControl check

### DIFF
--- a/backends/CLightningREST.ts
+++ b/backends/CLightningREST.ts
@@ -251,6 +251,8 @@ export default class CLightningREST extends LND {
     supportsMPP = () => false;
     supportsAMP = () => false;
     supportsCoinControl = () => this.supports('v0.8.2', undefined, 'v0.4.0');
+    supportsChannelCoinControl = () =>
+        this.supports('v0.8.2', undefined, 'v0.4.0');
     supportsHopPicking = () => false;
     supportsAccounts = () => false;
     supportsRouting = () => true;

--- a/backends/Eclair.ts
+++ b/backends/Eclair.ts
@@ -489,6 +489,7 @@ export default class Eclair {
     supportsMPP = () => false;
     supportsAMP = () => false;
     supportsCoinControl = () => false;
+    supportsChannelCoinControl = () => false;
     supportsHopPicking = () => false;
     supportsRouting = () => true;
     supportsNodeInfo = () => true;

--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -176,6 +176,7 @@ export default class EmbeddedLND extends LND {
     supportsMPP = () => this.supports('v0.10.0');
     supportsAMP = () => this.supports('v0.13.0');
     supportsCoinControl = () => this.supports('v0.12.0');
+    supportsChannelCoinControl = () => this.supports('v0.17.0');
     supportsHopPicking = () => this.supports('v0.11.0');
     // TODO wire up accounts
     // supportsAccounts = () => this.supports('v0.13.0');

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -144,56 +144,39 @@ export default class LightningNodeConnect {
             .newAddress({ type: ADDRESS_TYPES[data.type] })
             .then((data: lnrpc.NewAddressResponse) => snakeize(data));
 
-    openChannel = async (data: OpenChannelRequest) =>
-        await this.lnc.lnd.lightning
-            .openChannelSync(
-                data.simpleTaprootChannel
-                    ? {
-                          private: data.privateChannel,
-                          scid_alias: data.scidAlias,
-                          local_funding_amount: data.local_funding_amount,
-                          min_confs: data.min_confs,
-                          node_pubkey_string: data.node_pubkey_string,
-                          sat_per_vbyte: data.sat_per_vbyte,
-                          spend_unconfirmed: data.spend_unconfirmed,
-                          fund_max: data.fundMax ? data.fundMax : undefined,
-                          outpoints:
-                              data.utxos && data.utxos.length > 0
-                                  ? data.utxos.map((utxo: string) => {
-                                        const [txid_str, output_index] =
-                                            utxo.split(':');
-                                        return {
-                                            txid_str,
-                                            output_index: Number(output_index)
-                                        };
-                                    })
-                                  : undefined,
-                          commitment_type:
-                              lnrpc.CommitmentType['SIMPLE_TAPROOT']
-                      }
-                    : {
-                          private: data.privateChannel,
-                          scid_alias: data.scidAlias,
-                          local_funding_amount: data.local_funding_amount,
-                          min_confs: data.min_confs,
-                          node_pubkey_string: data.node_pubkey_string,
-                          sat_per_vbyte: data.sat_per_vbyte,
-                          spend_unconfirmed: data.spend_unconfirmed,
-                          fund_max: data.fundMax ? data.fundMax : undefined,
-                          outpoints:
-                              data.utxos && data.utxos.length > 0
-                                  ? data.utxos.map((utxo: string) => {
-                                        const [txid_str, output_index] =
-                                            utxo.split(':');
-                                        return {
-                                            txid_str,
-                                            output_index: Number(output_index)
-                                        };
-                                    })
-                                  : undefined
-                      }
-            )
+    openChannel = async (data: OpenChannelRequest) => {
+        let request: lnrpc.OpenChannelRequest = {
+            private: data.privateChannel,
+            scid_alias: data.scidAlias,
+            local_funding_amount: data.local_funding_amount,
+            min_confs: data.min_confs,
+            node_pubkey_string: data.node_pubkey_string,
+            sat_per_vbyte: data.sat_per_vbyte,
+            spend_unconfirmed: data.spend_unconfirmed
+        };
+
+        if (data.fundMax) {
+            request.fund_max = true;
+        }
+
+        if (data.simpleTaprootChannel) {
+            request.commitment_type = lnrpc.CommitmentType['SIMPLE_TAPROOT'];
+        }
+
+        if (data.utxos && data.utxos.length > 0) {
+            request.outpoints = data.utxos.map((utxo: string) => {
+                const [txid_str, output_index] = utxo.split(':');
+                return {
+                    txid_str,
+                    output_index: Number(output_index)
+                };
+            });
+        }
+        return await this.lnc.lnd.lightning
+            .openChannelSync(request)
             .then((data: lnrpc.ChannelPoint) => snakeize(data));
+    };
+
     // TODO add with external accounts
     // openChannelStream = (data: OpenChannelRequest) =>
     //     this.wsReq('/v1/channels/stream', 'POST', data);
@@ -380,6 +363,8 @@ export default class LightningNodeConnect {
     supportsMPP = () => this.supports('v0.10.0');
     supportsAMP = () => this.supports('v0.13.0');
     supportsCoinControl = () => this.permNewAddress;
+    supportsChannelCoinControl = () =>
+        this.permNewAddress && this.supports('v0.17.0');
     supportsHopPicking = () => this.permOpenChannel;
     supportsAccounts = () => this.permImportAccount;
     supportsRouting = () => this.permForwardingHistory;

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -132,6 +132,7 @@ export default class LndHub extends LND {
     supportsMPP = () => false;
     supportsAMP = () => false;
     supportsCoinControl = () => false;
+    supportsChannelCoinControl = () => false;
     supportsHopPicking = () => false;
     supportsAccounts = () => false;
     supportsRouting = () => false;

--- a/backends/Spark.ts
+++ b/backends/Spark.ts
@@ -363,6 +363,7 @@ export default class Spark {
     supportsMPP = () => false;
     supportsAMP = () => false;
     supportsCoinControl = () => false;
+    supportsChannelCoinControl = () => false;
     supportsHopPicking = () => false;
     supportsAccounts = () => false;
     supportsRouting = () => true;

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -124,6 +124,7 @@ class BackendUtils {
     supportsMPP = () => this.call('supportsMPP');
     supportsAMP = () => this.call('supportsAMP');
     supportsCoinControl = () => this.call('supportsCoinControl');
+    supportsChannelCoinControl = () => this.call('supportsChannelCoinControl');
     supportsHopPicking = () => this.call('supportsHopPicking');
     supportsAccounts = () => this.call('supportsAccounts');
     supportsRouting = () => this.call('supportsRouting');

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -459,7 +459,7 @@ export default class OpenChannel extends React.Component<
 
                         {!connectPeerOnly && (
                             <>
-                                {BackendUtils.supportsCoinControl() && (
+                                {BackendUtils.supportsChannelCoinControl() && (
                                     <UTXOPicker
                                         onValueChange={this.selectUTXOs}
                                         UTXOsStore={UTXOsStore}


### PR DESCRIPTION
# Description

This PR adds a new `supportsChannelCoinControl` check to the backends. Changes here will allow LND v0.16.4 and lower users to continue using the app, and open channels, even when their instances have strict API param checking.

- [ ] New feature
- [X] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
