### PR TITLE
Back up wallet: order seed phrase in columns and center

### DIFF
--- a/views/Settings/Seed.tsx
+++ b/views/Settings/Seed.tsx
@@ -50,17 +50,19 @@ const MnemonicWord = ({ index, word }) => {
                 flexDirection: 'row'
             }}
         >
-            <Text
-                style={{
-                    flex: 1,
-                    fontFamily: 'Lato-Regular',
-                    color: themeColor('secondaryText'),
-                    fontSize: 18,
-                    alignSelf: 'flex-start'
-                }}
-            >
-                {index + 1}
-            </Text>
+            <View style={{ width: 35 }}>
+                <Text
+                    style={{
+                        flex: 1,
+                        fontFamily: 'Lato-Regular',
+                        color: themeColor('secondaryText'),
+                        fontSize: 18,
+                        alignSelf: 'flex-start'
+                    }}
+                >
+                    {index + 1}
+                </Text>
+            </View>
             <Text
                 style={{
                     flex: 1,
@@ -72,7 +74,7 @@ const MnemonicWord = ({ index, word }) => {
                     padding: 0
                 }}
             >
-                {isRevealed ? word : '*******'}
+                {isRevealed ? word : '********'}
             </Text>
         </TouchableOpacity>
     );

--- a/views/Settings/Seed.tsx
+++ b/views/Settings/Seed.tsx
@@ -251,7 +251,7 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                                 alignSelf: 'center',
                                 position: 'absolute',
                                 bottom: 35,
-                                width: '90%'
+                                width: '100%'
                             }}
                         >
                             <Button
@@ -264,16 +264,21 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                     </>
                 )}
                 {understood && (
-                    <>
-                        <ScrollView style={{ flex: 1, marginBottom: 80 }}>
+                    <View style={{ flex: 1, justifyContent: 'center' }}>
+                        <ScrollView
+                            contentContainerStyle={{
+                                flexGrow: 1,
+                                justifyContent: 'center'
+                            }}
+                        >
                             <View
                                 style={{
-                                    flex: 1,
                                     marginTop: 8,
-                                    maxHeight: 720,
+                                    maxHeight: 620,
                                     flexWrap: 'wrap',
                                     alignItems: 'flex-start',
-                                    flexDirection: 'row'
+                                    alignSelf: 'center',
+                                    flexDirection: 'column'
                                 }}
                             >
                                 {seedPhrase &&
@@ -293,9 +298,10 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                         <View
                             style={{
                                 alignSelf: 'center',
-                                position: 'absolute',
+                                marginTop: 45,
                                 bottom: 35,
-                                width: '90%'
+                                width: '100%',
+                                backgroundColor: themeColor('background')
                             }}
                         >
                             <Button
@@ -311,7 +317,7 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                                 )}
                             />
                         </View>
-                    </>
+                    </View>
                 )}
             </Screen>
         );


### PR DESCRIPTION
# Description

This PR takes the seed phrase on the Back up wallet view, lays it out in columns instead of rows, and centers it all.

Columns is the far more common layout that I've seen across hardware wallets and seed plates.

iPhone 15 Pro Max - Before

![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-17 at 22 07 41](https://github.com/ZeusLN/zeus/assets/1878621/4b6cc7b6-fc62-43e4-9814-8078cbc8010b)

iPhone 15 Pro Max - After

![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-17 at 22 07 53](https://github.com/ZeusLN/zeus/assets/1878621/54b9e422-8ff4-48a3-975e-d54be0bd0f73)

iPhone SE (3rd generation) - Before

![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-17 at 22 06 43](https://github.com/ZeusLN/zeus/assets/1878621/2b72c9d7-51b6-46ea-be95-08a73d116889)

iPhone SE (3rd generation) - After

![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-17 at 22 06 26](https://github.com/ZeusLN/zeus/assets/1878621/3165eb8f-2d3b-4eeb-bc47-419ed5553f94)

iPad Pro (12.9-inch) (6th generation) - Before

![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-10-17 at 22 02 07](https://github.com/ZeusLN/zeus/assets/1878621/371a2939-1752-4fa8-a101-cc7d0309589b)

iPad Pro (12.9-inch) (6th generation) - After

![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-10-17 at 22 01 50](https://github.com/ZeusLN/zeus/assets/1878621/f9c629c7-fb7c-484e-bbe0-5810e67abaf1)

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
