### PR TITLE
ZEUS-1686: ModalBox: take fontScale into account when setting height

### DIFF
--- a/components/ModalBox.tsx
+++ b/components/ModalBox.tsx
@@ -17,7 +17,12 @@ import {
     Keyboard
 } from 'react-native';
 
-const { height: SCREEN_HEIGHT, width: SCREEN_WIDTH } = Dimensions.get('window');
+const {
+    height: SCREEN_HEIGHT,
+    width: SCREEN_WIDTH,
+    fontScale: FONT_SCALE
+} = Dimensions.get('window');
+
 const styles = StyleSheet.create({
     wrapper: {
         backgroundColor: 'white'
@@ -518,6 +523,9 @@ export default class ModalBox extends React.PureComponent {
                     styles.wrapper,
                     size,
                     this.props.style,
+                    this.props.style.height
+                        ? { height: this.props.style.height * FONT_SCALE }
+                        : undefined,
                     {
                         transform: [
                             { translateY: this.state.position },


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1686**](https://github.com/ZeusLN/zeus/issues/1686)

This was causing the address type picker to be cut off when using higher than default font size settings on Android.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
