### PR TITLE
[Bug fix] Lightning Address Settings: Nostr relays: update relays_sig on relay deletion

### DIFF
--- a/views/Settings/LightningAddress/NostrRelays.tsx
+++ b/views/Settings/LightningAddress/NostrRelays.tsx
@@ -257,9 +257,26 @@ export default class NostrRelays extends React.Component<
                                                                 relays: newNostrRelays
                                                             });
                                                         } else {
+                                                            const relays_sig =
+                                                                bytesToHex(
+                                                                    schnorr.sign(
+                                                                        hashjs
+                                                                            .sha256()
+                                                                            .update(
+                                                                                JSON.stringify(
+                                                                                    newNostrRelays
+                                                                                )
+                                                                            )
+                                                                            .digest(
+                                                                                'hex'
+                                                                            ),
+                                                                        nostrPrivateKey
+                                                                    )
+                                                                );
                                                             try {
                                                                 await update({
-                                                                    relays: newNostrRelays
+                                                                    relays: newNostrRelays,
+                                                                    relays_sig
                                                                 }).then(
                                                                     async () => {
                                                                         this.setState(


### PR DESCRIPTION
# Description

When deleting a ZEUS PAY Nostr relay, the client does not submit an updated `relays_sig`. This can lead to invalid Zaplocker checks on the payment request view.

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
