### PR TITLE
[Bug fix] Sending Lightning: fix wrong display of Zaplocker warning

### DIFF
--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -196,7 +196,7 @@ export default class SendingLightning extends React.Component<
                                 </Text>
                             </View>
                         )}
-                        {!loading && LnurlPayStore.isZaplocker && (
+                        {!loading && LnurlPayStore.isZaplocker && !success && (
                             <View
                                 style={{
                                     padding: 20,

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -280,7 +280,6 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             ChannelsStore,
             ChannelBackupStore,
             LightningAddressStore,
-            LnurlPayStore,
             LSPStore,
             SyncStore,
             SettingsStore
@@ -295,8 +294,6 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             LSPStore.reset();
             ChannelBackupStore.reset();
         }
-
-        LnurlPayStore.reset();
 
         this.getSettingsAndNavigate();
     }
@@ -313,7 +310,8 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             LSPStore,
             ChannelBackupStore,
             SyncStore,
-            LightningAddressStore
+            LightningAddressStore,
+            LnurlPayStore
         } = this.props;
         const {
             settings,
@@ -333,6 +331,8 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         const { fiatEnabled, pos, rescan, recovery, lightningAddress } =
             settings;
         const expressGraphSyncEnabled = settings.expressGraphSync;
+
+        LnurlPayStore.reset();
 
         if (pos && pos.squareEnabled && posStatus === 'active')
             PosStore.getOrders();


### PR DESCRIPTION
# Description

Discovered by mix:

![image](https://github.com/ZeusLN/zeus/assets/1878621/e6ffb53d-1102-454c-a959-c23a0a9bf3bf)

This bug occurs when you've previously paid a Zaplocker payment (in transit) then make a successful payment.

This was caused by two things:

- Zaplocker error still being rendered on the view, despite payment success
- LnurlPay reset call being called on the `refresh` function of the main wallet view, instead of the `fetchData` call

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
