### PR TITLE
[Display bug] Seed: explicitly create two columns

### DIFF
--- a/views/Settings/Seed.tsx
+++ b/views/Settings/Seed.tsx
@@ -43,10 +43,10 @@ const MnemonicWord = ({ index, word }) => {
             style={{
                 padding: 8,
                 backgroundColor: themeColor('secondary'),
-                width: '45%',
                 borderRadius: 5,
-                margin: 9,
+                margin: 6,
                 marginTop: 4,
+                marginBottom: 4,
                 flexDirection: 'row'
             }}
         >
@@ -71,6 +71,7 @@ const MnemonicWord = ({ index, word }) => {
                     fontSize: 18,
                     alignSelf: 'flex-end',
                     margin: 0,
+                    marginLeft: 10,
                     padding: 0
                 }}
             >
@@ -270,22 +271,14 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                         <ScrollView
                             contentContainerStyle={{
                                 flexGrow: 1,
-                                justifyContent: 'center'
+                                flexDirection: 'row'
                             }}
                         >
-                            <View
-                                style={{
-                                    marginTop: 8,
-                                    maxHeight: 620,
-                                    flexWrap: 'wrap',
-                                    alignItems: 'flex-start',
-                                    alignSelf: 'center',
-                                    flexDirection: 'column'
-                                }}
-                            >
+                            <View style={styles.column}>
                                 {seedPhrase &&
-                                    seedPhrase.map(
-                                        (word: string, index: number) => {
+                                    seedPhrase
+                                        .slice(0, 12)
+                                        .map((word: string, index: number) => {
                                             return (
                                                 <MnemonicWord
                                                     index={index}
@@ -293,8 +286,21 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                                                     key={`mnemonic-${index}`}
                                                 />
                                             );
-                                        }
-                                    )}
+                                        })}
+                            </View>
+                            <View style={styles.column}>
+                                {seedPhrase &&
+                                    seedPhrase
+                                        .slice(12, 24)
+                                        .map((word: string, index: number) => {
+                                            return (
+                                                <MnemonicWord
+                                                    index={index + 12}
+                                                    word={word}
+                                                    key={`mnemonic-${index}`}
+                                                />
+                                            );
+                                        })}
                             </View>
                         </ScrollView>
                         <View
@@ -302,8 +308,8 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                                 alignSelf: 'center',
                                 marginTop: 45,
                                 bottom: 35,
-                                width: '100%',
-                                backgroundColor: themeColor('background')
+                                backgroundColor: themeColor('background'),
+                                width: '100%'
                             }}
                         >
                             <Button
@@ -364,5 +370,13 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
         alignItems: 'center',
         marginTop: 22
+    },
+    column: {
+        marginTop: 8,
+        flexWrap: 'wrap',
+        alignItems: 'flex-start',
+        alignSelf: 'center',
+        flexDirection: 'column',
+        width: '50%'
     }
 });


### PR DESCRIPTION
# Description

On some devices, the seed phrase would continue on to a third column. This was because a fixed `maxHeight` was determining where the columns were split - which can vary based on resolution density.

This fix explicitly defines two columns 1-12, and 13-24 of the seed phrase and adjusts some margins.

Before:

![Screenshot_1698161817](https://github.com/ZeusLN/zeus/assets/1878621/8c473c4a-ba93-4541-bb90-df5686c16466)

After: 

![Screenshot_1698161921](https://github.com/ZeusLN/zeus/assets/1878621/3b1703da-469f-4832-852c-6839233b24e7)

iPad check:

![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-10-24 at 11 43 46](https://github.com/ZeusLN/zeus/assets/1878621/f13e6113-3063-4af2-b3fb-5e9b07c3f826)

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [X] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
