### PR TITLE
Channels pane: Added clock icon to Button in WalletHeader in case there are pending channels

### DIFF
--- a/components/WalletHeader.tsx
+++ b/components/WalletHeader.tsx
@@ -201,6 +201,7 @@ export default class WalletHeader extends React.Component<
             PosStore,
             SyncStore
         } = this.props;
+        const { filteredPendingChannels } = ChannelsStore!;
         const { settings, posStatus, setPosStatus } = SettingsStore!;
         const { paid } = LightningAddressStore!;
         const { isSyncing } = SyncStore!;
@@ -387,6 +388,18 @@ export default class WalletHeader extends React.Component<
                                         title={title}
                                         noUppercase
                                         buttonStyle={{ alignSelf: 'center' }}
+                                        icon={
+                                            filteredPendingChannels?.length > 0
+                                                ? {
+                                                      name: 'clockcircle',
+                                                      type: 'antdesign',
+                                                      size: 20,
+                                                      color: themeColor(
+                                                          'background'
+                                                      )
+                                                  }
+                                                : null
+                                        }
                                     />
                                 </View>
                             ) : (


### PR DESCRIPTION
# Description

This fixes #1607.

Before, you could not know there are pending channels:
![grafik](https://github.com/ZeusLN/zeus/assets/77545287/2ee2dd08-bb85-40d8-a591-7cb4c306c052)


Now:
![grafik](https://github.com/ZeusLN/zeus/assets/77545287/98f62821-026d-4731-bf86-46594e185ce1)

Different theme:
![grafik](https://github.com/ZeusLN/zeus/assets/77545287/2f47d5f7-63f4-4434-9444-822bacb55521)


This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
