### PR TITLE
Embedded LND: remove listeners when changing to other connection

### DIFF
--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -1,6 +1,7 @@
 import LND from './LND';
 import OpenChannelRequest from '../models/OpenChannelRequest';
 import Base64Utils from './../utils/Base64Utils';
+import { removeListeners } from '../utils/LndMobileUtils';
 
 import lndMobile from '../lndmobile/LndMobileInjection';
 
@@ -167,6 +168,7 @@ export default class EmbeddedLND extends LND {
     // subscribeTransactions = () => this.getRequest('/v1/transactions/subscribe');
     // initChannelAcceptor = async (callback: any) =>
     //     await channelAcceptor(callback);
+    disconnect = () => removeListeners();
 
     supportsMessageSigning = () => true;
     supportsLnurlAuth = () => true;

--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -191,6 +191,11 @@ export async function initializeLnd(isTestnet?: boolean, rescan?: boolean) {
     await initialize();
 }
 
+export function removeListeners() {
+    LndMobileEventEmitter.removeAllListeners &&
+        LndMobileEventEmitter.removeAllListeners('SubscribeState');
+}
+
 export async function startLnd(walletPassword: string) {
     const { checkStatus, startLnd, decodeState, subscribeState } =
         lndMobile.index;

--- a/views/Settings/Nodes.tsx
+++ b/views/Settings/Nodes.tsx
@@ -182,7 +182,9 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                                         }).then(() => {
                                             if (
                                                 currentImplementation ===
-                                                'lightning-node-connect'
+                                                    'lightning-node-connect' ||
+                                                currentImplementation ===
+                                                    'embedded-lnd'
                                             ) {
                                                 BackendUtils.disconnect();
                                             }


### PR DESCRIPTION
# Description

Mixmaster noticed that we get more and more console logs/debugs when switching from embedded node to another node and back.

this is the first time:

```
 DEBUG  utils/LndMobileUtils.ts: SubscribeState
  {"data":"CAQ="}
 LOG  name SubscribeState
 LOG  checkLndStreamErrorResponse error_desc: undefined
 LOG  utils/LndMobileUtils.ts: Current lnd state
  {"state":"SERVER_ACTIVE"}
 DEBUG  utils/LndMobileUtils.ts: Got lnrpc.WalletState.SERVER_ACTIVE
 DEBUG  utils/LndMobileUtils.ts: SubscribeState
  {"data":"CAQ="}
 LOG  name SubscribeState
 LOG  checkLndStreamErrorResponse error_desc: undefined
 LOG  utils/LndMobileUtils.ts: Current lnd state
  {"state":"SERVER_ACTIVE"}
 DEBUG  utils/LndMobileUtils.ts: Got lnrpc.WalletState.SERVER_ACTIVE
```

Next time it is double, then triple etc. It appears we never remove our `SubscribeState` listener. This does so leveraging the `BackendUtils`' `disconnect` function that we use to explicitly close LNC connections.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
