### PR TITLE
Send: Confirm before proceeding to the address

### DIFF
--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -184,12 +184,6 @@ export default class Send extends React.Component<SendProps, SendState> {
         }
     }
 
-    async componentDidUpdate(prevProps, prevState) {
-        if (this.state.destination !== prevState.destination) {
-            this.validateAddress(this.state.destination);
-        }
-    }
-
     subscribePayment = (streamingCall: string) => {
         const { handlePayment, handlePaymentError } =
             this.props.TransactionsStore;
@@ -532,9 +526,9 @@ export default class Send extends React.Component<SendProps, SendState> {
                             value={!contactName && destination}
                             onChangeText={(text: string) => {
                                 this.setState({
-                                    destination: text
+                                    destination: text,
+                                    error_msg: !text && ''
                                 });
-                                this.validateAddress(text);
                             }}
                             style={{
                                 flex: 1,
@@ -608,7 +602,7 @@ export default class Send extends React.Component<SendProps, SendState> {
                             <ErrorMessage message={error_msg} />
                         </View>
                     )}
-                    {!isValid && !!destination && (
+                    {!isValid && !!destination && error_msg && (
                         <Text
                             style={{
                                 ...styles.text,
@@ -955,7 +949,18 @@ export default class Send extends React.Component<SendProps, SendState> {
                         </View>
                     )}
 
-                    <View style={styles.button}>
+                    {destination && (
+                        <View style={styles.button}>
+                            <Button
+                                title={localeString('general.proceed')}
+                                onPress={() =>
+                                    this.validateAddress(destination)
+                                }
+                            />
+                        </View>
+                    )}
+
+                    <View style={{ ...styles.button, paddingTop: 20 }}>
                         <Button
                             title={localeString('general.enableNfc')}
                             icon={{


### PR DESCRIPTION
# Description

This relates to issue: #1811 

_We added a `Proceed` button on the Send screen, so we will have to tap it to confirm before going with the entered address_ 

![Simulator Screenshot - iPhone 14 Plus - 2023-11-02 at 23 12 18](https://github.com/ZeusLN/zeus/assets/50761978/c1a79014-810d-46d9-a9e7-4a1df7cee6d6)
