### PR TITLE
Tap-to-confirm logic for deleting passphrase / themeColor instead of red

### DIFF
--- a/views/Settings/SetDuressPassword.tsx
+++ b/views/Settings/SetDuressPassword.tsx
@@ -23,6 +23,7 @@ interface SetDuressPassphraseState {
     savedDuressPassphrase: string;
     duressPassphraseMismatchError: boolean;
     duressPassphraseInvalidError: boolean;
+    confirmDelete: boolean;
 }
 
 @inject('SettingsStore')
@@ -36,7 +37,8 @@ export default class SetDuressPassphrase extends React.Component<
         duressPassphraseConfirm: '',
         savedDuressPassphrase: '',
         duressPassphraseMismatchError: false,
-        duressPassphraseInvalidError: false
+        duressPassphraseInvalidError: false,
+        confirmDelete: false
     };
 
     async componentDidMount() {
@@ -210,15 +212,26 @@ export default class SetDuressPassphrase extends React.Component<
                     {!!savedDuressPassphrase && (
                         <View style={{ paddingTop: 10, margin: 10 }}>
                             <Button
-                                title={localeString(
-                                    'views.Settings.SetDuressPassword.deletePassword'
-                                )}
-                                onPress={() => this.deleteDuressPassword()}
-                                containerStyle={{
-                                    borderColor: 'red'
+                                title={
+                                    this.state.confirmDelete
+                                        ? localeString(
+                                              'views.Settings.AddEditNode.tapToConfirm'
+                                          )
+                                        : localeString(
+                                              'views.Settings.SetDuressPassword.deletePassword'
+                                          )
+                                }
+                                onPress={() => {
+                                    if (!this.state.confirmDelete) {
+                                        this.setState({
+                                            confirmDelete: true
+                                        });
+                                    } else {
+                                        this.deleteDuressPassword();
+                                    }
                                 }}
                                 titleStyle={{
-                                    color: 'red'
+                                    color: themeColor('delete')
                                 }}
                                 secondary
                             />

--- a/views/Settings/SetPassword.tsx
+++ b/views/Settings/SetPassword.tsx
@@ -23,6 +23,7 @@ interface SetPassphraseState {
     savedPassphrase: string;
     passphraseMismatchError: boolean;
     passphraseInvalidError: boolean;
+    confirmDelete: boolean;
 }
 
 @inject('SettingsStore')
@@ -36,7 +37,8 @@ export default class SetPassphrase extends React.Component<
         passphraseConfirm: '',
         savedPassphrase: '',
         passphraseMismatchError: false,
-        passphraseInvalidError: false
+        passphraseInvalidError: false,
+        confirmDelete: false
     };
 
     async componentDidMount() {
@@ -205,15 +207,26 @@ export default class SetPassphrase extends React.Component<
                     {!!savedPassphrase && (
                         <View style={{ paddingTop: 10, margin: 10 }}>
                             <Button
-                                title={localeString(
-                                    'views.Settings.SetPassword.deletePassword'
-                                )}
-                                onPress={() => this.deletePassword()}
-                                containerStyle={{
-                                    borderColor: 'red'
+                                title={
+                                    this.state.confirmDelete
+                                        ? localeString(
+                                              'views.Settings.AddEditNode.tapToConfirm'
+                                          )
+                                        : localeString(
+                                              'views.Settings.SetPassword.deletePassword'
+                                          )
+                                }
+                                onPress={() => {
+                                    if (!this.state.confirmDelete) {
+                                        this.setState({
+                                            confirmDelete: true
+                                        });
+                                    } else {
+                                        this.deletePassword();
+                                    }
                                 }}
                                 titleStyle={{
-                                    color: 'red'
+                                    color: themeColor('delete')
                                 }}
                                 secondary
                             />


### PR DESCRIPTION
# Description
- Added Tap-to-confirm logic for deleting passphrase and deleting duress passphrase
- Using themeColor instead of red

I cannot see any effect for this: `containerStyle={{ borderColor: themeColor('delete') }}`
-> so I deleted it.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [x] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the Zeus [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
