### PR TITLE
AddNotes: Transparent background in all themes

### DIFF
--- a/views/AddNotes.tsx
+++ b/views/AddNotes.tsx
@@ -129,7 +129,8 @@ export default class AddNotes extends React.Component<
                         style={{
                             padding: 20,
                             flexGrow: 1,
-                            flexShrink: 1
+                            flexShrink: 1,
+                            backgroundColor: 'none'
                         }}
                         textInputStyle={{
                             height: '100%',


### PR DESCRIPTION
We were getting the dark background in light themes as well, so I made the background transparent for all themes.

Before:
![Simulator Screenshot - iPhone 14 Plus - 2023-11-06 at 14 31 08](https://github.com/ZeusLN/zeus/assets/50761978/a0ee8f4f-259e-4514-b8b0-f4a84906d3f3)

After:
![Simulator Screenshot - iPhone 14 Plus - 2023-11-06 at 14 21 41](https://github.com/ZeusLN/zeus/assets/50761978/ccb563f4-9b55-4a85-a7f1-30d0c3ab4537)
