### PR TITLE
Save language key instead of value in settings

### DIFF
--- a/views/Settings/Language.tsx
+++ b/views/Settings/Language.tsx
@@ -111,7 +111,7 @@ export default class Language extends React.Component<
                                 }}
                                 onPress={async () => {
                                     await updateSettings({
-                                        locale: item.value
+                                        locale: item.key
                                     }).then(() => {
                                         navigation.goBack();
                                     });
@@ -123,7 +123,7 @@ export default class Language extends React.Component<
                                             color:
                                                 selectedLocale === item.key ||
                                                 (!selectedLocale &&
-                                                    item.value === 'English')
+                                                    item.key === 'en')
                                                     ? themeColor('highlight')
                                                     : themeColor('text')
                                         }}
@@ -132,8 +132,7 @@ export default class Language extends React.Component<
                                     </ListItem.Title>
                                 </ListItem.Content>
                                 {(selectedLocale === item.key ||
-                                    (!selectedLocale &&
-                                        item.value === 'English')) && (
+                                    (!selectedLocale && item.key === 'en')) && (
                                     <View style={{ textAlign: 'right' }}>
                                         <Icon
                                             name="check"


### PR DESCRIPTION
# Description

This fixes #1790. This was caused because the language value (e. g. English) instead of the key (e. g. en) was saved and then migrated to the key.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
