### PR TITLE
LSP Settings: add reset button

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -88,6 +88,7 @@
     "general.content": "Content",
     "general.lightningInvoice": "Lightning invoice",
     "general.or": "or",
+    "general.reset": "Reset",
     "views.Settings.Support.title": "Support ZEUS",
     "views.Settings.Support.titleAlt": "Merch and Support",
     "views.Settings.SocialMedia.title": "Social media",

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -666,8 +666,8 @@ export const LNDHUB_AUTH_MODES = [
     { key: 'Alby', value: 'Alby' }
 ];
 
-const DEFAULT_LSP_MAINNET = 'https://0conf.lnolymp.us';
-const DEFAULT_LSP_TESTNET = 'https://testnet-0conf.lnolymp.us';
+export const DEFAULT_LSP_MAINNET = 'https://0conf.lnolymp.us';
+export const DEFAULT_LSP_TESTNET = 'https://testnet-0conf.lnolymp.us';
 
 export const DEFAULT_NOSTR_RELAYS = [
     'wss://nostr.mutinywallet.com',

--- a/views/Settings/LSP.tsx
+++ b/views/Settings/LSP.tsx
@@ -7,11 +7,15 @@ import Screen from '../../components/Screen';
 import Header from '../../components/Header';
 import TextInput from '../../components/TextInput';
 
-import SettingsStore from '../../stores/SettingsStore';
+import SettingsStore, {
+    DEFAULT_LSP_MAINNET,
+    DEFAULT_LSP_TESTNET
+} from '../../stores/SettingsStore';
 
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import Switch from '../../components/Switch';
+import Button from '../../components/Button';
 
 interface LSPProps {
     navigation: any;
@@ -54,6 +58,13 @@ export default class LSP extends React.Component<LSPProps, LSPState> {
         const { navigation, SettingsStore } = this.props;
         const { enableLSP, lsp, accessKey, requestSimpleTaproot } = this.state;
         const { updateSettings, embeddedLndNetwork }: any = SettingsStore;
+
+        const showReset: boolean =
+            !enableLSP ||
+            accessKey !== '' ||
+            requestSimpleTaproot ||
+            (embeddedLndNetwork === 'Mainnet' && lsp !== DEFAULT_LSP_MAINNET) ||
+            (embeddedLndNetwork === 'Testnet' && lsp !== DEFAULT_LSP_TESTNET);
 
         return (
             <Screen>
@@ -222,6 +233,35 @@ export default class LSP extends React.Component<LSPProps, LSPState> {
                             />
                         </View>
                     </ListItem>
+
+                    {showReset && (
+                        <View style={{ marginTop: 20 }}>
+                            <Button
+                                title={localeString('general.reset')}
+                                accessibilityLabel={localeString(
+                                    'general.reset'
+                                )}
+                                onPress={async () => {
+                                    this.setState({
+                                        enableLSP: true,
+                                        lsp:
+                                            embeddedLndNetwork === 'Mainnet'
+                                                ? DEFAULT_LSP_MAINNET
+                                                : DEFAULT_LSP_TESTNET,
+                                        accessKey: '',
+                                        requestSimpleTaproot: false
+                                    });
+                                    await updateSettings({
+                                        enableLSP: true,
+                                        lspMainnet: DEFAULT_LSP_MAINNET,
+                                        lspTestnet: DEFAULT_LSP_TESTNET,
+                                        lspAccessKey: '',
+                                        requestSimpleTaproot: false
+                                    });
+                                }}
+                            />
+                        </View>
+                    )}
                 </View>
             </Screen>
         );


### PR DESCRIPTION
# Description

This PR adds a reset button to the LSP settings page when the default settings are changed. This is particularly helpful for users who change their default LSP and want to change back to the defaults.

With no settings changed:
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-11-11 at 19 55 13](https://github.com/ZeusLN/zeus/assets/1878621/e326e0b5-4dbc-44a5-9346-a59a87621f08)

With settings changed:
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-11-11 at 19 55 20](https://github.com/ZeusLN/zeus/assets/1878621/ec04d7b3-d3c7-4ef1-9a57-fdb95e5f6f67)

This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
