### PR TITLE
Activity Filter: In transit payments

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -802,6 +802,7 @@
     "views.ActivityFilter.lightningPayments": "Lightning payments",
     "views.ActivityFilter.onChainPayments": "On-chain payments",
     "views.ActivityFilter.minimumAmount": "Minimum Amount (sats)",
+    "views.ActivityFilter.inTransit": "In transit payments",
     "general.clearChanges": "Clear changes",
     "views.Routing.RoutingEvent.sourceChannel": "Source Channel",
     "views.Routing.RoutingEvent.destinationChannel": "Destination Channel",

--- a/stores/ActivityStore.ts
+++ b/stores/ActivityStore.ts
@@ -24,6 +24,7 @@ export interface Filter {
     sent: boolean;
     received: boolean;
     unpaid: boolean;
+    inTransit: boolean;
     minimumAmount: number;
     startDate?: Date;
     endDate?: Date;
@@ -35,6 +36,7 @@ export const DEFAULT_FILTERS = {
     sent: true,
     received: true,
     unpaid: true,
+    inTransit: false,
     minimumAmount: 0,
     startDate: undefined,
     endDate: undefined
@@ -83,6 +85,7 @@ export default class ActivityStore {
             sent: false,
             received: true,
             unpaid: false,
+            inTransit: false,
             minimumAmount: 0,
             startDate: undefined,
             endDate: undefined

--- a/utils/ActivityFilterUtils.ts
+++ b/utils/ActivityFilterUtils.ts
@@ -70,6 +70,17 @@ class ActivityFilterUtils {
             );
         }
 
+        if (filter.inTransit == false) {
+            filteredActivity = filteredActivity.filter(
+                (activity: any) =>
+                    !(
+                        activity.model ===
+                            localeString('views.Payment.title') &&
+                        activity.isInTransit
+                    )
+            );
+        }
+
         if (filter.minimumAmount > 0) {
             filteredActivity = filteredActivity.filter(
                 (activity: any) =>

--- a/views/Activity/ActivityFilter.tsx
+++ b/views/Activity/ActivityFilter.tsx
@@ -73,6 +73,7 @@ export default class ActivityFilter extends React.Component<
             sent,
             received,
             unpaid,
+            inTransit,
             minimumAmount,
             startDate,
             endDate
@@ -183,6 +184,12 @@ export default class ActivityFilter extends React.Component<
                 label: localeString('views.Wallet.Invoices.unpaid'),
                 value: unpaid,
                 var: 'unpaid',
+                type: 'Toggle'
+            },
+            {
+                label: localeString('views.ActivityFilter.inTransit'),
+                value: inTransit,
+                var: 'inTransit',
                 type: 'Toggle'
             },
             {


### PR DESCRIPTION
# Description

This PR adds a settings in `Activity filter` for in transit payments. It is off by default so users will need to opt in to see them.

![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-11-11 at 20 11 05](https://github.com/ZeusLN/zeus/assets/1878621/931477b0-d4c3-436a-b770-d02cf9117231)

This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
