### PR TITLE
SendingLightning/SendingOnChain: Slightly bigger Wordmark logo

### DIFF
--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -162,7 +162,7 @@ export default class SendingLightning extends React.Component<
                     >
                         {(!!success || !!inTransit) && !error && (
                             <Wordmark
-                                height={windowSize.width * 0.2}
+                                height={windowSize.width * 0.25}
                                 width={windowSize.width}
                                 fill={themeColor('highlight')}
                             />

--- a/views/SendingOnChain.tsx
+++ b/views/SendingOnChain.tsx
@@ -90,7 +90,7 @@ export default class SendingOnChain extends React.Component<
                         {publishSuccess && (
                             <>
                                 <Wordmark
-                                    height={windowSize.width * 0.2}
+                                    height={windowSize.width * 0.25}
                                     width={windowSize.width}
                                     fill={themeColor('highlight')}
                                 />


### PR DESCRIPTION
# Description

As discussed with @kaloudis, Wordmark logo is now a bit bigger.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
