### PR TITLE
Make LightningSvg and OnChainSvg components dynamic with width and height props

### DIFF
--- a/assets/images/SVG/DynamicSVG/LightningSvg.tsx
+++ b/assets/images/SVG/DynamicSVG/LightningSvg.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { Svg, Circle, Polygon } from 'react-native-svg';
 import { themeColor } from '../../../../utils/ThemeUtils';
 
-export default function LightningSvg() {
+export default function LightningSvg({ width = 70, height = 70 }) {
     const svgProps = {
-        width: '70',
-        height: '70',
+        width: `${width}`,
+        height: `${height}`,
         viewBox: '0 0 50 50',
         fill: 'none',
         xmlns: 'http://www.w3.org/2000/svg'

--- a/assets/images/SVG/DynamicSVG/OnChainSvg.tsx
+++ b/assets/images/SVG/DynamicSVG/OnChainSvg.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { Svg, Circle, Path } from 'react-native-svg';
 import { themeColor } from '../../../../utils/ThemeUtils';
 
-export default function OnChainSvg() {
+export default function OnChainSvg({ width = 70, height = 70 }) {
     const svgProps = {
-        width: '70',
-        height: '70',
+        width: `${width}`,
+        height: `${height}`,
         viewBox: '0 0 50 50',
         fill: 'none',
         xmlns: 'http://www.w3.org/2000/svg'

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -1018,7 +1018,7 @@ export default class Receive extends React.Component<
 
         const lightningButton = () => (
             <React.Fragment>
-                <LightningSvg />
+                <LightningSvg width={50} height={50} />
                 <Text
                     style={{
                         color:
@@ -1035,7 +1035,7 @@ export default class Receive extends React.Component<
 
         const onChainButton = () => (
             <React.Fragment>
-                <OnChainSvg />
+                <OnChainSvg width={50} height={50} />
                 <Text
                     style={{
                         color:


### PR DESCRIPTION
# Description

Different width and height is needed for the icons in swipeable row and on receive screen, so it is dynamic now.

Before:
![grafik](https://github.com/ZeusLN/zeus/assets/77545287/4cd8bc94-9841-4a1e-8daf-ff4faa472987)

After:
![grafik](https://github.com/ZeusLN/zeus/assets/77545287/230c73a4-8f30-418b-afb4-2bed794b4978)


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
