### PR TITLE
Extend Zaplocker warning to zaps

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -562,7 +562,7 @@
     "views.Send.lookup": "Look Up Payment Request",
     "views.Send.noOnchainBalance": "No on-chain balance available. Close a channel or receive an on-chain transaction first.",
     "views.Send.noLightningBalance": "No lightning balance available. Open a channel or receive a lightning payment first.",
-    "views.Send.zaplockerWarning": "It currently is not recommended to pay Zaplocker invoices with nodes that aren't online 24/7. Not coming online during the period between the payment completion and the final expiration may result in a force closed channel. Open ZEUS regularly to mitigate the issue. Proceed at your own risk.",
+    "views.Send.zaplockerWarning": "This is a Zaplocker invoices that will hold payment up to 24 hours. Open ZEUS regularly after payment to help mitigate the risk of a force closed channel. Proceed at your own risk.",
     "views.SendingLightning.sending": "Sending Transaction",
     "views.SendingLightning.success": "Transaction successfully sent",
     "views.SendingLightning.paymentHash": "Payment Hash",

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -45,6 +45,12 @@ import CaretRight from '../assets/images/SVG/Caret Right.svg';
 import QR from '../assets/images/SVG/QR.svg';
 import Conversion from '../components/Conversion';
 
+const zaplockerDestinations = [
+    // OLYMPUS
+    '031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581'
+    // TODO add Zaplocker.com
+];
+
 interface InvoiceProps {
     exitSetup: any;
     navigation: any;
@@ -354,6 +360,13 @@ export default class PaymentRequest extends React.Component<
 
         const noBalance = this.props.BalanceStore.lightningBalance === 0;
 
+        const showZaplockerWarning =
+            isZaplocker ||
+            (destination &&
+                zaplockerDestinations.includes(destination) &&
+                cltv_expiry &&
+                Number(cltv_expiry) > 200);
+
         const QRButton = () => (
             <TouchableOpacity
                 onPress={() =>
@@ -406,7 +419,7 @@ export default class PaymentRequest extends React.Component<
                     {!loading && !loadingFeeEstimate && !!pay_req && (
                         <View style={styles.content}>
                             <>
-                                {isZaplocker &&
+                                {showZaplockerWarning &&
                                     implementation === 'embedded-lnd' && (
                                         <View
                                             style={{


### PR DESCRIPTION
# Description

Currently, the Zaplocker warning will only show when paying someone's lightning address from within the app (the `user_pubkey` property is used on the payment endpoint, although perhaps we should switch over to `hodl_invoice`).

This change will allow the warning to be displayed even if the payment request is loaded by a user's Nostr client.

This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
