### PR TITLE
PaidIndicator: changed color for better contrast

### DIFF
--- a/components/PaidIndicator.tsx
+++ b/components/PaidIndicator.tsx
@@ -34,147 +34,147 @@ function PaidIndicator() {
                 colorFilters={[
                     {
                         keypath: '81 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '79 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '77 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '75 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '72 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '70 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '68 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '66 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '64 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '46 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '44 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '43 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '42 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '41 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '40 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '39 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '38 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '37 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '36 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '35 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '34 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '33 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '32 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '25 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '23 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '21 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '19 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '16 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '14 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '12 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '10 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '08 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '06 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '33 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '04 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     },
                     {
                         keypath: '02 Outlines 2',
-                        color: themeColor('highlight')
+                        color: themeColor('text')
                     }
                 ]}
             />


### PR DESCRIPTION
# Description

Since new Zeus logo led to bad contrast, color is now themeColor('text') which has good contrast.

Before:
![grafik](https://github.com/ZeusLN/zeus/assets/77545287/210ff25b-53e0-410f-95f0-2be94f701332)

After:
![dark](https://github.com/ZeusLN/zeus/assets/77545287/08ef3db3-d09b-412a-a293-a8b226722f27)
![grafik](https://github.com/ZeusLN/zeus/assets/77545287/ca87dd68-4683-4a04-ad80-ea970bf4b600)


This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [x] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
