### PR TITLE
Embedded node: add additional restore warning

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -878,6 +878,7 @@
     "views.Settings.NodeConfiguration.backUpWallet": "Back up wallet",
     "views.Settings.NodeConfiguration.restoreWarning": "Restoring a wallet will trigger a force close of all your channels. Consider closing your channels on your original device first, if possible, to save on fees and recover your funds more quickly.",
     "views.Settings.NodeConfiguration.embeddedDelete": "For now, Embedded LND nodes cannot be deleted within the app. You must uninstall and reinstall the app to create or restore an Embedded LND wallet.",
+    "views.Settings.NodeConfiguration.embeddedDelete2": "It is recommended to close all your channels manually before moving to another device. Restoring without closing out channels beforehand will trigger force closes, which will result in higher fees and can take up to two weeks to recover your funds.",
     "views.Settings.LightningAddress.create": "Create lightning address",
     "views.Settings.LightningAddress.redeemAll": "Redeem all",
     "views.Settings.LightningAddress.change": "Change lightning address",

--- a/views/Settings/NodeConfiguration.tsx
+++ b/views/Settings/NodeConfiguration.tsx
@@ -1651,17 +1651,30 @@ export default class NodeConfiguration extends React.Component<
                     )}
 
                     {implementation === 'embedded-lnd' && saved && (
-                        <Text
-                            style={{
-                                color: themeColor('text'),
-                                textAlign: 'center',
-                                marginTop: 20
-                            }}
-                        >
-                            {localeString(
-                                'views.Settings.NodeConfiguration.embeddedDelete'
-                            )}
-                        </Text>
+                        <>
+                            <Text
+                                style={{
+                                    color: themeColor('text'),
+                                    textAlign: 'center',
+                                    marginTop: 20
+                                }}
+                            >
+                                {localeString(
+                                    'views.Settings.NodeConfiguration.embeddedDelete'
+                                )}
+                            </Text>
+                            <Text
+                                style={{
+                                    color: themeColor('text'),
+                                    textAlign: 'center',
+                                    marginTop: 20
+                                }}
+                            >
+                                {localeString(
+                                    'views.Settings.NodeConfiguration.embeddedDelete2'
+                                )}
+                            </Text>
+                        </>
                     )}
                 </ScrollView>
             </Screen>


### PR DESCRIPTION
# Description

Adds an additional restore warning to the Node Configuration view for Embedded LND nodes.

![simulator_screenshot_C60E6B6C-171A-4BFA-871A-534FE6CEAAC7](https://github.com/ZeusLN/zeus/assets/1878621/3f78ac09-aaa5-4750-a97c-f30f9d7871f7)


This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
