### PR TITLE
New fee limit defaults and behavior

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -649,6 +649,7 @@
     "views.Settings.Payments.defaultFeeLimit": "Default Fee Limit",
     "views.Settings.Payments.timeoutSeconds": "Timeout (seconds)",
     "views.Settings.Payments.preferredMempoolRate": "Preferred Mempool Rate",
+    "views.Settings.Payments.feeLimitMethodExplainer": "Fee limit method will default to fixed for amounts up to 1000 sats and percentage for amounts greater than 1000 sats. You'll be able to change which method and values to use though, under the Settings section of the Payment Request view.",
     "views.Settings.Invoices.title": "Invoices settings",
     "views.Settings.Invoices.showCustomPreimageField": "Show custom preimage field",
     "views.Settings.Privacy.blockExplorer": "Default Block explorer",

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -53,7 +53,7 @@ interface PosSettings {
 }
 
 interface PaymentsSettings {
-    defaultFeeMethod?: string;
+    defaultFeeMethod?: string; // deprecated
     defaultFeePercentage?: string;
     defaultFeeFixed?: string;
     timeoutSeconds?: string;
@@ -734,9 +734,9 @@ export default class SettingsStore {
             squareDevMode: false
         },
         payments: {
-            defaultFeeMethod: 'fixed',
-            defaultFeePercentage: '0.5',
-            defaultFeeFixed: '100',
+            defaultFeeMethod: 'fixed', // deprecated
+            defaultFeePercentage: '5.0',
+            defaultFeeFixed: '1000',
             timeoutSeconds: '60',
             preferredMempoolRate: 'fastestFee'
         },

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -106,9 +106,9 @@ export default class PaymentRequest extends React.Component<
         enableAtomicMultiPathPayment: false,
         maxParts: '16',
         maxShardAmt: '',
-        feeLimitSat: '100',
+        feeLimitSat: '1000',
         feeOption: 'fixed',
-        maxFeePercent: '0.5',
+        maxFeePercent: '5.0',
         timeoutSeconds: '60',
         outgoingChanId: null,
         lastHopPubkey: null,
@@ -119,14 +119,24 @@ export default class PaymentRequest extends React.Component<
 
     async UNSAFE_componentWillMount() {
         this.isComponentMounted = true;
-        const { SettingsStore } = this.props;
+        const { SettingsStore, InvoicesStore } = this.props;
         const { getSettings, implementation } = SettingsStore;
         const settings = await getSettings();
 
+        let feeOption = 'fixed';
+        const { pay_req } = InvoicesStore;
+        const requestAmount = pay_req && pay_req.getRequestAmount;
+
+        if (requestAmount && requestAmount != 0) {
+            if (requestAmount > 1000) {
+                feeOption = 'percent';
+            }
+        }
+
         this.setState({
-            feeOption: settings?.payments?.defaultFeeMethod || 'fixed',
+            feeOption,
             feeLimitSat: settings?.payments?.defaultFeeFixed || '100',
-            maxFeePercent: settings?.payments?.defaultFeePercentage || '0.5',
+            maxFeePercent: settings?.payments?.defaultFeePercentage || '5.0',
             timeoutSeconds: settings?.payments?.timeoutSeconds || '60'
         });
 
@@ -870,7 +880,7 @@ export default class PaymentRequest extends React.Component<
                                             </Text>
                                             <TextInput
                                                 keyboardType="numeric"
-                                                placeholder={'0.5'}
+                                                placeholder={'5.0'}
                                                 value={maxFeePercent}
                                                 onChangeText={(text: string) =>
                                                     this.setState({

--- a/views/Settings/PaymentsSettings.tsx
+++ b/views/Settings/PaymentsSettings.tsx
@@ -38,8 +38,8 @@ export default class PaymentsSettings extends React.Component<
 > {
     state = {
         feeLimitMethod: 'fixed',
-        feeLimit: '100',
-        feePercentage: '0.5',
+        feeLimit: '1000',
+        feePercentage: '5.0',
         timeoutSeconds: '60',
         enableMempoolRates: false,
         preferredMempoolRate: 'fastestFee'
@@ -52,8 +52,8 @@ export default class PaymentsSettings extends React.Component<
 
         this.setState({
             feeLimitMethod: settings?.payments?.defaultFeeMethod || 'fixed',
-            feeLimit: settings?.payments?.defaultFeeFixed || '100',
-            feePercentage: settings?.payments?.defaultFeePercentage || '0.5',
+            feeLimit: settings?.payments?.defaultFeeFixed || '1000',
+            feePercentage: settings?.payments?.defaultFeePercentage || '5.0',
             enableMempoolRates: settings?.privacy?.enableMempoolRates || false,
             timeoutSeconds: settings?.payments?.timeoutSeconds || '60',
             preferredMempoolRate:
@@ -103,7 +103,7 @@ export default class PaymentsSettings extends React.Component<
                     }}
                 >
                     {BackendUtils.isLNDBased() && (
-                        <>
+                        <View style={{ marginBottom: 20 }}>
                             <Text
                                 style={{
                                     fontFamily: 'PPNeueMontreal-Book',
@@ -121,9 +121,7 @@ export default class PaymentsSettings extends React.Component<
                                     flex: 1,
                                     flexWrap: 'wrap',
                                     flexDirection: 'row',
-                                    justifyContent: 'flex-end',
-                                    opacity:
-                                        feeLimitMethod == 'percent' ? 1 : 0.25
+                                    justifyContent: 'flex-end'
                                 }}
                             ></View>
                             <View
@@ -134,9 +132,7 @@ export default class PaymentsSettings extends React.Component<
                             >
                                 <TextInput
                                     style={{
-                                        width: '50%',
-                                        opacity:
-                                            feeLimitMethod == 'fixed' ? 1 : 0.25
+                                        width: '50%'
                                     }}
                                     keyboardType="numeric"
                                     value={feeLimit}
@@ -167,9 +163,7 @@ export default class PaymentsSettings extends React.Component<
                                         paddingTop: 5,
                                         color: themeColor('text'),
                                         top: 28,
-                                        right: 30,
-                                        opacity:
-                                            feeLimitMethod == 'fixed' ? 1 : 0.25
+                                        right: 30
                                     }}
                                 >
                                     {localeString('general.sats')}
@@ -177,10 +171,6 @@ export default class PaymentsSettings extends React.Component<
                                 <TextInput
                                     style={{
                                         width: '50%',
-                                        opacity:
-                                            feeLimitMethod == 'percent'
-                                                ? 1
-                                                : 0.25,
                                         right: 5
                                     }}
                                     keyboardType="numeric"
@@ -211,17 +201,18 @@ export default class PaymentsSettings extends React.Component<
                                         paddingTop: 5,
                                         color: themeColor('text'),
                                         top: 28,
-                                        right: 25,
-                                        opacity:
-                                            feeLimitMethod == 'percent'
-                                                ? 1
-                                                : 0.25
+                                        right: 25
                                     }}
                                 >
                                     {'%'}
                                 </Text>
                             </View>
-                        </>
+                            <Text style={{ color: themeColor('text') }}>
+                                {localeString(
+                                    'views.Settings.Payments.feeLimitMethodExplainer'
+                                )}
+                            </Text>
+                        </View>
                     )}
                     {BackendUtils.isLNDBased() && (
                         <>


### PR DESCRIPTION
# Description

This PR makes two changes to how fee limits for LN payments work in ZEUS:

1. The default values are changed:
- Fee limit fixed: 100 sats -> 1000 sats
- Fee limit percentage: 0.5% -> 5%
- Fee limit method setting is effectively removed

2. The default fee limit method logic has been changed.

**Previously**: the method (percentage or fixed) would be chosen based on what the user had in their settings (default: fixed) - regardless of the payment size.
**Now**: Fee limit method will default to fixed for amounts up to 1000 sats and percentage for amounts greater than 1000 sats. You'll be able to change which method and values to use though, under the Settings section of the Payment Request view.

New explainer has been added to the Payment settings view:

![simulator_screenshot_270EC7FE-6A58-424C-9983-04C422220E8B](https://github.com/ZeusLN/zeus/assets/1878621/49745d3a-b300-4a0b-90d2-4adfcb3faf0c)


This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [X] Code refactor
- [X] Configuration change
- [ ] Locales update
- [ ] Quality assurance 
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
