### PR TITLE
Persist chosen units across app restarts

### DIFF
--- a/components/AmountInput.tsx
+++ b/components/AmountInput.tsx
@@ -25,10 +25,6 @@ interface AmountInputProps {
     FiatStore?: FiatStore;
     SettingsStore?: SettingsStore;
     UnitsStore?: UnitsStore;
-    // Quick fix for ZEUS-1580
-    // Prevents unit reset when Keysend is initiated from Keypad
-    // since unit depends on user selection and is not necessarily sats
-    preventUnitReset?: boolean;
 }
 
 interface AmountInputState {
@@ -85,13 +81,9 @@ export default class AmountInput extends React.Component<
     constructor(props: any) {
         super(props);
 
-        const { amount, onAmountChange, preventUnitReset } = props;
+        const { amount, onAmountChange } = props;
         let satAmount = '0';
-        if (amount && !preventUnitReset) {
-            // reset units to sats if amount is passed in
-            this.props.UnitsStore?.resetUnits();
-            satAmount = getSatAmount(amount).toString();
-        }
+        if (amount) satAmount = getSatAmount(amount).toString();
 
         onAmountChange(amount, satAmount);
         this.state = {

--- a/stores/UnitsStore.ts
+++ b/stores/UnitsStore.ts
@@ -1,4 +1,6 @@
 import { action, observable } from 'mobx';
+import EncryptedStorage from 'react-native-encrypted-storage';
+
 import SettingsStore from './SettingsStore';
 import FiatStore from './FiatStore';
 import FeeUtils from './../utils/FeeUtils';
@@ -7,6 +9,8 @@ type Units = 'sats' | 'BTC' | 'fiat';
 
 // 100_000_000
 export const SATS_PER_BTC = 100000000;
+
+const UNIT_KEY = 'zeus-units';
 
 interface ValueDisplayProps {
     amount: string;
@@ -19,17 +23,26 @@ interface ValueDisplayProps {
 }
 
 export default class UnitsStore {
-    @observable public units: Units = 'sats';
+    @observable public units: Units | string = 'sats';
     settingsStore: SettingsStore;
     fiatStore: FiatStore;
 
     constructor(settingsStore: SettingsStore, fiatStore: FiatStore) {
         this.settingsStore = settingsStore;
         this.fiatStore = fiatStore;
+        this.getUnits();
     }
 
+    getUnits = async () => {
+        const units = await EncryptedStorage.getItem(UNIT_KEY);
+        if (units) this.units = units;
+    };
+
     @action
-    public changeUnits = () => (this.units = this.getNextUnit());
+    public changeUnits = async () => {
+        this.units = this.getNextUnit();
+        await EncryptedStorage.setItem(UNIT_KEY, this.units);
+    };
 
     public getNextUnit = () => {
         const { settings } = this.settingsStore;

--- a/utils/AddressUtils.test.ts
+++ b/utils/AddressUtils.test.ts
@@ -1,3 +1,10 @@
+jest.mock('react-native-encrypted-storage', () => ({
+    setItem: jest.fn(() => Promise.resolve()),
+    getItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+    clear: jest.fn(() => Promise.resolve())
+}));
+
 import AddressUtils from './AddressUtils';
 
 describe('AddressUtils', () => {

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -10,7 +10,7 @@ import NodeUriUtils from './NodeUriUtils';
 import { localeString } from './LocaleUtils';
 import BackendUtils from './BackendUtils';
 
-const { nodeInfoStore, invoicesStore, settingsStore } = stores;
+const { nodeInfoStore, invoicesStore, unitsStore, settingsStore } = stores;
 
 const isClipboardValue = (data: string) =>
     handleAnything(data, undefined, true);
@@ -56,6 +56,7 @@ const handleAnything = async (
         AddressUtils.isValidBitcoinAddress(value, isTestNet || isRegTest)
     ) {
         if (isClipboardValue) return true;
+        if (amount) unitsStore?.resetUnits();
         return [
             'Send',
             {

--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -276,7 +276,6 @@ export default class LnurlPay extends React.Component<
                         <View style={{ marginTop: -20 }}>
                             <AmountInput
                                 amount={amount}
-                                preventUnitReset={true}
                                 locked={
                                     lnurl &&
                                     lnurl.minSendable === lnurl.maxSendable

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -84,7 +84,6 @@ interface SendState {
     enableAtomicMultiPathPayment: boolean;
     clipboard: string;
     loading: boolean;
-    preventUnitReset: boolean;
     contactName: string;
 }
 
@@ -107,7 +106,6 @@ export default class Send extends React.Component<SendProps, SendState> {
         const amount = navigation.getParam('amount', null);
         const transactionType = navigation.getParam('transactionType', null);
         const isValid = navigation.getParam('isValid', false);
-        const preventUnitReset = navigation.getParam('preventUnitReset', false);
         const contactName = navigation.getParam('contactName', null);
 
         if (transactionType === 'Lightning') {
@@ -132,7 +130,6 @@ export default class Send extends React.Component<SendProps, SendState> {
             enableAtomicMultiPathPayment: false,
             clipboard: '',
             loading: false,
-            preventUnitReset,
             contactName
         };
     }
@@ -405,7 +402,6 @@ export default class Send extends React.Component<SendProps, SendState> {
             enableAtomicMultiPathPayment,
             clipboard,
             loading,
-            preventUnitReset,
             contactName
         } = this.state;
         const {
@@ -724,7 +720,6 @@ export default class Send extends React.Component<SendProps, SendState> {
                             <React.Fragment>
                                 <AmountInput
                                     amount={amount}
-                                    preventUnitReset={preventUnitReset}
                                     title={localeString('views.Send.amount')}
                                     onAmountChange={(
                                         amount: string,

--- a/views/Wallet/KeypadPane.tsx
+++ b/views/Wallet/KeypadPane.tsx
@@ -444,8 +444,7 @@ export default class KeypadPane extends React.PureComponent<
                                     noUppercase
                                     onPress={() => {
                                         navigation.navigate('Send', {
-                                            amount,
-                                            preventUnitReset: true
+                                            amount
                                         });
                                     }}
                                     buttonStyle={{ height: 40 }}


### PR DESCRIPTION
# Description

Relates to issues: [**ZEUS-1417**](https://github.com/ZeusLN/zeus/issues/1417), **ZEUS-1580**, **ZEUS-1527**, **ZEUS-1871**

The primary purpose of this PR is to ensure that chosen units persist across app restarts. This is particularly helpful for shops that ring up sales based in fiat currencies.

This PR also makes a change to `AmountInput` that ensures that the units are not reset when a generated invoice is cleared (hitting the X button).

As a result, I believe [ZEUS-1580](https://github.com/ZeusLN/zeus/issues/1580) is now resolved.

I've also ensured that [ZEUS-1527](https://github.com/ZeusLN/zeus/issues/1527) and [ZEUS-1871](https://github.com/ZeusLN/zeus/issues/1871) remain corrected.

This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
