### PR TITLE
Transaction details: do not show fee percentage if amount is 0

### DIFF
--- a/models/Transaction.ts
+++ b/models/Transaction.ts
@@ -53,7 +53,7 @@ export default class Transaction extends BaseModel {
     @computed public get getFeePercentage(): string {
         const amount = this.getAmount;
         const fee = this.getFee;
-        if (!fee || !amount || fee == '0') return '';
+        if (!fee || !amount || fee == '0' || amount == '0') return '';
 
         // use at most 3 decimal places and remove trailing 0s
         return (


### PR DESCRIPTION
# Description

If amount is 0 and fee is not (e. g. channel operation tx), fee percentage is shown as "Infitity%":

![grafik](https://github.com/ZeusLN/zeus/assets/77545287/3b39900c-b798-4b85-80bc-14e8b10b7f84)

Now, the percentage is hidden if amount is 0.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
