### PR TITLE
RNFS: account for changing DocumentDirectoryPath

### DIFF
--- a/models/Contact.ts
+++ b/models/Contact.ts
@@ -1,5 +1,6 @@
 import { computed } from 'mobx';
 import BaseModel from './BaseModel';
+import RNFS from 'react-native-fs';
 
 export default class Contact extends BaseModel {
     id: string; // deprecated
@@ -82,5 +83,21 @@ export default class Contact extends BaseModel {
 
     @computed public get hasNpub(): boolean {
         return this.nostrNpub?.length > 0 && this.nostrNpub[0] !== '';
+    }
+
+    @computed public get getPhoto(): string {
+        if (this.photo?.includes('rnfs://')) {
+            const fileName = this.photo.replace('rnfs://', '');
+            return `file://${RNFS.DocumentDirectoryPath}/${fileName}`;
+        }
+        return this.photo || '';
+    }
+
+    @computed public get getBanner(): string {
+        if (this.banner?.includes('rnfs://')) {
+            const fileName = this.banner.replace('rnfs://', '');
+            return `file://${RNFS.DocumentDirectoryPath}/${fileName}`;
+        }
+        return this.banner || '';
     }
 }

--- a/utils/ContactUtils.ts
+++ b/utils/ContactUtils.ts
@@ -51,8 +51,6 @@ const transformContactData = async (contact: any) => {
             }
         }
 
-        console.log('Transformed contact:', transformedContact);
-
         if (contact?.picture) {
             console.log('Downloading image...');
             const fileName =
@@ -72,6 +70,8 @@ const transformContactData = async (contact: any) => {
                 console.error('Error downloading photo:', photoError);
             }
         }
+
+        console.log('Transformed contact:', transformedContact);
 
         return transformedContact;
     } catch (error) {

--- a/utils/ContactUtils.ts
+++ b/utils/ContactUtils.ts
@@ -45,7 +45,7 @@ const transformContactData = async (contact: any) => {
                 }).promise;
 
                 console.log('Banner download successful!');
-                transformedContact.banner = 'file://' + bannerFilePath;
+                transformedContact.banner = 'rnfs://' + bannerFileName;
             } catch (bannerError) {
                 console.error('Error downloading banner:', bannerError);
             }
@@ -67,7 +67,7 @@ const transformContactData = async (contact: any) => {
                 }).promise;
 
                 console.log('Download successful!');
-                transformedContact.photo = 'file://' + filePath;
+                transformedContact.photo = 'rnfs://' + fileName;
             } catch (photoError) {
                 console.error('Error downloading photo:', photoError);
             }

--- a/views/ContactDetails.tsx
+++ b/views/ContactDetails.tsx
@@ -338,7 +338,7 @@ export default class ContactDetails extends React.Component<
                         >
                             {contact.banner && (
                                 <Image
-                                    source={{ uri: contact.banner }}
+                                    source={{ uri: contact.getBanner }}
                                     style={{
                                         width: '100%',
                                         height: 150,
@@ -348,7 +348,7 @@ export default class ContactDetails extends React.Component<
                             )}
                             {contact.photo && (
                                 <Image
-                                    source={{ uri: contact.photo }}
+                                    source={{ uri: contact.getPhoto }}
                                     style={{
                                         width: 150,
                                         height: 150,

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -479,9 +479,9 @@ export default class Send extends React.Component<SendProps, SendState> {
                         alignItems: 'center'
                     }}
                 >
-                    {item.photo && (
+                    {contact.photo && (
                         <Image
-                            source={{ uri: item.photo }}
+                            source={{ uri: contact.getPhoto }}
                             style={{
                                 width: 40,
                                 height: 40,

--- a/views/Settings/AddContact.tsx
+++ b/views/Settings/AddContact.tsx
@@ -276,7 +276,7 @@ export default class AddContact extends React.Component<
 
                             // Set the local file path in the state
                             this.setState({
-                                photo: 'file://' + filePath
+                                photo: 'rnfs://' + fileName
                             });
                         } catch (error) {
                             console.error('Error saving file: ', error);
@@ -371,6 +371,14 @@ export default class AddContact extends React.Component<
         }
     }
 
+    getPhoto(photo): string {
+        if (photo?.includes('rnfs://')) {
+            const fileName = photo.replace('rnfs://', '');
+            return `file://${RNFS.DocumentDirectoryPath}/${fileName}`;
+        }
+        return photo || '';
+    }
+
     render() {
         const { navigation } = this.props;
         const {
@@ -381,6 +389,7 @@ export default class AddContact extends React.Component<
             pubkey,
             name,
             description,
+            photo,
             isValidOnchainAddress,
             isValidLightningAddress,
             isValidNIP05,
@@ -487,10 +496,10 @@ export default class AddContact extends React.Component<
                                         justifyContent: 'center'
                                     }}
                                 >
-                                    {this.state.photo ? (
+                                    {photo ? (
                                         <Image
                                             source={{
-                                                uri: this.state.photo
+                                                uri: this.getPhoto(photo)
                                             }}
                                             style={styles.photo}
                                         />

--- a/views/Settings/Contacts.tsx
+++ b/views/Settings/Contacts.tsx
@@ -167,9 +167,9 @@ export default class Contacts extends React.Component<
                         alignItems: 'center'
                     }}
                 >
-                    {item.photo && (
+                    {contact.photo && (
                         <Image
-                            source={{ uri: item.photo }}
+                            source={{ uri: contact.getPhoto }}
                             style={{
                                 width: 40,
                                 height: 40,


### PR DESCRIPTION
This addresses an issue with Contacts images on iOS. With iOS design, the `DocumentDirectoryPath` changes with each update. This would cause our saved images to break upon update.

Related issue: https://github.com/itinance/react-native-fs/issues/528

This PR ensures that images persist across app updates.