### PR TITLE
ContactDetails: Decrease font-size of name

### DIFF
--- a/views/ContactDetails.tsx
+++ b/views/ContactDetails.tsx
@@ -360,7 +360,7 @@ export default class ContactDetails extends React.Component<
                             )}
                             <Text
                                 style={{
-                                    fontSize: 44,
+                                    fontSize: 40,
                                     fontWeight: 'bold',
                                     marginBottom: 10,
                                     color: 'white'


### PR DESCRIPTION
Slightly decreased the font-size of name from `ContactDetails` view from **44** to **40**

Before:
![Simulator Screenshot - iPhone 15 - 2024-01-24 at 11 45 01](https://github.com/ZeusLN/zeus/assets/50761978/5ffaae78-77ac-48f7-a3fa-efdd893b9a6e)

After:
![Simulator Screenshot - iPhone 15 - 2024-01-24 at 11 41 04](https://github.com/ZeusLN/zeus/assets/50761978/4b226915-25d8-424e-89ba-2f08c14bef0e)
