### PR TITLE
Sending Lightning: Success: display preimage

### DIFF
--- a/models/Payment.ts
+++ b/models/Payment.ts
@@ -74,7 +74,21 @@ export default class Payment extends BaseModel {
     }
 
     @computed public get getPreimage(): string {
-        return this.preimage || this.payment_preimage;
+        if (this.preimage) {
+            if (this.preimage?.type === 'Buffer') {
+                this.preimage = Base64Utils.bytesToHex(this.preimage.data);
+            }
+            return this.preimage;
+        }
+        if (this.payment_preimage) {
+            if (this.payment_preimage?.type === 'Buffer') {
+                this.payment_preimage = Base64Utils.bytesToHex(
+                    this.payment_preimage.data
+                );
+            }
+            return this.payment_preimage;
+        }
+        return '';
     }
 
     @computed public get isIncomplete(): boolean {

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -39,6 +39,7 @@ export default class TransactionsStore {
     @observable transaction: Transaction | null;
     @observable payment_route: any; // Route
     @observable payment_preimage: string | null;
+    @observable isIncomplete: boolean | null;
     @observable payment_hash: any;
     @observable payment_error: any;
     @observable onchain_address: string;
@@ -70,6 +71,7 @@ export default class TransactionsStore {
         this.transaction = null;
         this.payment_route = null;
         this.payment_preimage = null;
+        this.isIncomplete = null;
         this.payment_hash = null;
         this.payment_error = null;
         this.onchain_address = '';
@@ -209,6 +211,7 @@ export default class TransactionsStore {
         this.error = false;
         this.payment_route = null;
         this.payment_preimage = null;
+        this.isIncomplete = null;
         this.payment_hash = null;
         this.payment_error = null;
         this.status = null;
@@ -306,8 +309,11 @@ export default class TransactionsStore {
     public handlePayment = (result: any) => {
         this.loading = false;
         this.payment_route = result.payment_route;
-        this.payment_preimage = result.payment_preimage;
-        this.payment_hash = new Payment(result).paymentHash;
+
+        const payment = new Payment(result);
+        this.payment_preimage = payment.getPreimage;
+        this.payment_hash = payment.paymentHash;
+        this.isIncomplete = payment.isIncomplete;
 
         const implementation = this.settingsStore.implementation;
 

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -113,7 +113,8 @@ export default class SendingLightning extends React.Component<
             error_msg,
             payment_hash,
             payment_preimage,
-            payment_error
+            payment_error,
+            isIncomplete
         } = TransactionsStore;
         const { storedNotes } = this.state;
 
@@ -317,22 +318,25 @@ export default class SendingLightning extends React.Component<
                                     />
                                 </View>
                             )}
-                        {!!payment_preimage && !error && !payment_error && (
-                            <View style={{ width: '90%' }}>
-                                <CopyBox
-                                    heading={localeString(
-                                        'views.Payment.paymentPreimage'
-                                    )}
-                                    headingCopied={`${localeString(
-                                        'views.Payment.paymentPreimage'
-                                    )} ${localeString(
-                                        'components.ExternalLinkModal.copied'
-                                    )}`}
-                                    theme="dark"
-                                    URL={payment_preimage}
-                                />
-                            </View>
-                        )}
+                        {!!payment_preimage &&
+                            !isIncomplete &&
+                            !error &&
+                            !payment_error && (
+                                <View style={{ width: '90%' }}>
+                                    <CopyBox
+                                        heading={localeString(
+                                            'views.Payment.paymentPreimage'
+                                        )}
+                                        headingCopied={`${localeString(
+                                            'views.Payment.paymentPreimage'
+                                        )} ${localeString(
+                                            'components.ExternalLinkModal.copied'
+                                        )}`}
+                                        theme="dark"
+                                        URL={payment_preimage}
+                                    />
+                                </View>
+                            )}
                         {
                             <View
                                 style={[

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -317,19 +317,19 @@ export default class SendingLightning extends React.Component<
                                     />
                                 </View>
                             )}
-                        {!!payment_hash && !error && !payment_error && (
+                        {!!payment_preimage && !error && !payment_error && (
                             <View style={{ width: '90%' }}>
                                 <CopyBox
                                     heading={localeString(
-                                        'views.SendingLightning.paymentHash'
+                                        'views.Payment.paymentPreimage'
                                     )}
                                     headingCopied={`${localeString(
-                                        'views.SendingLightning.paymentHash'
+                                        'views.Payment.paymentPreimage'
                                     )} ${localeString(
                                         'components.ExternalLinkModal.copied'
                                     )}`}
                                     theme="dark"
-                                    URL={payment_hash}
+                                    URL={payment_preimage}
                                 />
                             </View>
                         )}


### PR DESCRIPTION
# Description

When completing a payment, display the payment preimage instead of the payment hash, if possible. The preimage has some caveats in being used as a receipt but functions better than the payment hash.

Before:
![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-01 at 23 49 32](https://github.com/ZeusLN/zeus/assets/1878621/d3d5b0e9-f2c8-4dd3-8482-439b92fb957f)


After:
![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-01 at 23 46 32](https://github.com/ZeusLN/zeus/assets/1878621/a1806b79-ea76-4827-97d2-c2662807dcb2)


This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
