### PR TITLE
Harmonize back/close icons

### DIFF
--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -220,7 +220,7 @@ export default class Activity extends React.PureComponent<
         return (
             <Screen>
                 <Header
-                    leftComponent="Close"
+                    leftComponent="Back"
                     centerComponent={{
                         text: localeString('general.activity'),
                         style: {

--- a/views/Activity/ActivityFilter.tsx
+++ b/views/Activity/ActivityFilter.tsx
@@ -255,7 +255,7 @@ export default class ActivityFilter extends React.Component<
         return (
             <Screen>
                 <Header
-                    leftComponent="Close"
+                    leftComponent="Back"
                     centerComponent={{
                         text: localeString('views.ActivityFilter.title'),
                         style: {

--- a/views/UTXOs/CoinControl.tsx
+++ b/views/UTXOs/CoinControl.tsx
@@ -47,7 +47,7 @@ export default class CoinControl extends React.Component<CoinControlProps, {}> {
         return (
             <Screen>
                 <Header
-                    leftComponent="Close"
+                    leftComponent="Back"
                     centerComponent={{
                         text:
                             utxos.length > 0


### PR DESCRIPTION
# Description

Most screens use the Back icon to go back/close the current view. Now also using this icon for the three remaining screens (Activity, ActivityFilter, CoinControl).

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
