### PR TITLE
Embedded LND: conf: payments-expiration-grace-period

### DIFF
--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -91,6 +91,7 @@ const writeLndConfig = async (
     tlsdisableautofill=1
     maxpendingchannels=1000
     max-commit-fee-rate-anchors=100
+    payments-expiration-grace-period=336h
     ${rescan ? 'reset-wallet-transactions=true' : ''}
     
     [db]


### PR DESCRIPTION
```; A period to wait before for closing channels with outgoing htlcs that have
; timed out and are a result of this nodes initiated payments. In addition to
; our current block based deadline, if specified this grace period will also be
; taken into account. Valid time units are {s, m, h}.
; Default:
;   payments-expiration-grace-period=0s
; Example:
;   payments-expiration-grace-period=30s
```

Set to 336h, or two weeks.