### PR TITLE
Fixed handling of unified bitcoin URIs with lnurl

### DIFF
--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -186,12 +186,10 @@ export default class LightningSwipeableRow extends Component<
                     switch (params.tag) {
                         case 'payRequest':
                             params.lnurlText = lightning;
-                            return [
-                                'LnurlPay',
-                                {
-                                    lnurlParams: params
-                                }
-                            ];
+                            this.props.navigation.navigate('LnurlPay', {
+                                lnurlParams: params
+                            });
+                            return;
                         default:
                             Alert.alert(
                                 localeString('general.error'),

--- a/utils/handleAnything.test.ts
+++ b/utils/handleAnything.test.ts
@@ -5,18 +5,22 @@ jest.mock('./AddressUtils', () => ({
     isValidLightningPaymentRequest: () => mockIsValidLightningPaymentRequest
 }));
 jest.mock('./TorUtils', () => ({}));
-jest.mock('./BackendUtils', () => ({}));
+jest.mock('./BackendUtils', () => ({
+    supportsOnchainSends: () => mockSupportsOnchainSends
+}));
 jest.mock('../stores/Stores', () => ({
     nodeInfoStore: { nodeInfo: {} },
     invoicesStore: { getPayReq: jest.fn() }
 }));
 jest.mock('react-native-blob-util', () => ({}));
+// jest.mock('', () => ({ getParams: () => ({}) }));
 import stores from '../stores/Stores';
 import handleAnything from './handleAnything';
 let mockProcessedSendAddress = {};
 let mockIsValidBitcoinAddress = false;
 let mockIsValidLightningPubKey = false;
 let mockIsValidLightningPaymentRequest = false;
+let mockSupportsOnchainSends = true;
 
 describe('handleAnything', () => {
     beforeEach(() => {
@@ -102,6 +106,98 @@ describe('handleAnything', () => {
             const data = 'test data';
             mockProcessedSendAddress = { value: 'some payment request' };
             mockIsValidLightningPaymentRequest = true;
+
+            const result = await handleAnything(data, undefined, true);
+
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('bitcoin URI with lnurl and backend not supporting on-chain sends', () => {
+        it('should return LnurlPay screen if not from clipboard', async () => {
+            const data =
+                'bitcoin:BC1QUXCS7V556UTNUKU93HSZ7LHHFFLWN9NF2UTQ6N?pj=https://ts.dergigi.com/BTC/pj&lightning=LNURL1DP68GURN8GHJ7ARN9EJX2UN8D9NKJTNRDAKJ7SJ5GVH42J2VFE24YNP0WPSHJTMF9ATKWD622CE953JGWV6XXUMRDPXNVCJ8X4G9GF2CHDF';
+            mockProcessedSendAddress = {
+                value: 'BC1QUXCS7V556UTNUKU93HSZ7LHHFFLWN9NF2UTQ6N',
+                lightning:
+                    'LNURL1DP68GURN8GHJ7ARN9EJX2UN8D9NKJTNRDAKJ7SJ5GVH42J2VFE24YNP0WPSHJTMF9ATKWD622CE953JGWV6XXUMRDPXNVCJ8X4G9GF2CHDF'
+            };
+            mockIsValidBitcoinAddress = true;
+            mockSupportsOnchainSends = false;
+
+            const result = await handleAnything(data);
+
+            expect(result).toEqual([
+                'LnurlPay',
+                {
+                    lnurlParams: {
+                        callback:
+                            'https://ts.dergigi.com/BTC/UILNURL/pay/i/Wg7JV2ZFHs4cschM6bG5PT',
+                        commentAllowed: 2000,
+                        decodedMetadata: [
+                            [
+                                'text/plain',
+                                'Paid to dergigi.com (Order ID: V4V-reader)'
+                            ]
+                        ],
+                        domain: 'ts.dergigi.com',
+                        maxSendable: 612000000000,
+                        metadata:
+                            '[["text/plain","Paid to dergigi.com (Order ID: V4V-reader)"]]',
+                        minSendable: 1000,
+                        tag: 'payRequest'
+                    }
+                }
+            ]);
+        });
+
+        it('should return true if from clipboard', async () => {
+            const data =
+                'bitcoin:BC1QUXCS7V556UTNUKU93HSZ7LHHFFLWN9NF2UTQ6N?pj=https://ts.dergigi.com/BTC/pj&lightning=LNURL1DP68GURN8GHJ7ARN9EJX2UN8D9NKJTNRDAKJ7SJ5GVH42J2VFE24YNP0WPSHJTMF9ATKWD622CE953JGWV6XXUMRDPXNVCJ8X4G9GF2CHDF';
+            mockProcessedSendAddress = {
+                value: 'BC1QUXCS7V556UTNUKU93HSZ7LHHFFLWN9NF2UTQ6N',
+                lightning:
+                    'LNURL1DP68GURN8GHJ7ARN9EJX2UN8D9NKJTNRDAKJ7SJ5GVH42J2VFE24YNP0WPSHJTMF9ATKWD622CE953JGWV6XXUMRDPXNVCJ8X4G9GF2CHDF'
+            };
+            mockIsValidBitcoinAddress = true;
+            mockSupportsOnchainSends = false;
+
+            const result = await handleAnything(data, undefined, true);
+
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('bitcoin URI with bolt11 and backend not supporting on-chain sends', () => {
+        it('should return PaymentRequest screen and call getPayReq if not from clipboard', async () => {
+            const data =
+                'bitcoin:BC1QYLH3U67J673H6Y6ALV70M0PL2YZ53TZHVXGG7U?amount=0.00001&label=sbddesign%3A%20For%20lunch%20Tuesday&message=For%20lunch%20Tuesday&lightning=LNBC10U1P3PJ257PP5YZTKWJCZ5FTL5LAXKAV23ZMZEKAW37ZK6KMV80PK4XAEV5QHTZ7QDPDWD3XGER9WD5KWM36YPRX7U3QD36KUCMGYP282ETNV3SHJCQZPGXQYZ5VQSP5USYC4LK9CHSFP53KVCNVQ456GANH60D89REYKDNGSMTJ6YW3NHVQ9QYYSSQJCEWM5CJWZ4A6RFJX77C490YCED6PEMK0UPKXHY89CMM7SCT66K8GNEANWYKZGDRWRFJE69H9U5U0W57RRCSYSAS7GADWMZXC8C6T0SPJAZUP6';
+            mockProcessedSendAddress = {
+                value: 'BC1QYLH3U67J673H6Y6ALV70M0PL2YZ53TZHVXGG7U',
+                lightning:
+                    'LNBC10U1P3PJ257PP5YZTKWJCZ5FTL5LAXKAV23ZMZEKAW37ZK6KMV80PK4XAEV5QHTZ7QDPDWD3XGER9WD5KWM36YPRX7U3QD36KUCMGYP282ETNV3SHJCQZPGXQYZ5VQSP5USYC4LK9CHSFP53KVCNVQ456GANH60D89REYKDNGSMTJ6YW3NHVQ9QYYSSQJCEWM5CJWZ4A6RFJX77C490YCED6PEMK0UPKXHY89CMM7SCT66K8GNEANWYKZGDRWRFJE69H9U5U0W57RRCSYSAS7GADWMZXC8C6T0SPJAZUP6'
+            };
+            mockIsValidBitcoinAddress = true;
+            mockSupportsOnchainSends = false;
+
+            const result = await handleAnything(data);
+
+            expect(stores.invoicesStore.getPayReq).toHaveBeenCalledWith(
+                'LNBC10U1P3PJ257PP5YZTKWJCZ5FTL5LAXKAV23ZMZEKAW37ZK6KMV80PK4XAEV5QHTZ7QDPDWD3XGER9WD5KWM36YPRX7U3QD36KUCMGYP282ETNV3SHJCQZPGXQYZ5VQSP5USYC4LK9CHSFP53KVCNVQ456GANH60D89REYKDNGSMTJ6YW3NHVQ9QYYSSQJCEWM5CJWZ4A6RFJX77C490YCED6PEMK0UPKXHY89CMM7SCT66K8GNEANWYKZGDRWRFJE69H9U5U0W57RRCSYSAS7GADWMZXC8C6T0SPJAZUP6'
+            );
+            expect(result).toEqual(['PaymentRequest', {}]);
+        });
+
+        it('should return true if from clipboard', async () => {
+            const data =
+                'bitcoin:BC1QYLH3U67J673H6Y6ALV70M0PL2YZ53TZHVXGG7U?amount=0.00001&label=sbddesign%3A%20For%20lunch%20Tuesday&message=For%20lunch%20Tuesday&lightning=LNBC10U1P3PJ257PP5YZTKWJCZ5FTL5LAXKAV23ZMZEKAW37ZK6KMV80PK4XAEV5QHTZ7QDPDWD3XGER9WD5KWM36YPRX7U3QD36KUCMGYP282ETNV3SHJCQZPGXQYZ5VQSP5USYC4LK9CHSFP53KVCNVQ456GANH60D89REYKDNGSMTJ6YW3NHVQ9QYYSSQJCEWM5CJWZ4A6RFJX77C490YCED6PEMK0UPKXHY89CMM7SCT66K8GNEANWYKZGDRWRFJE69H9U5U0W57RRCSYSAS7GADWMZXC8C6T0SPJAZUP6';
+            mockProcessedSendAddress = {
+                value: 'BC1QYLH3U67J673H6Y6ALV70M0PL2YZ53TZHVXGG7U',
+                lightning:
+                    'LNBC10U1P3PJ257PP5YZTKWJCZ5FTL5LAXKAV23ZMZEKAW37ZK6KMV80PK4XAEV5QHTZ7QDPDWD3XGER9WD5KWM36YPRX7U3QD36KUCMGYP282ETNV3SHJCQZPGXQYZ5VQSP5USYC4LK9CHSFP53KVCNVQ456GANH60D89REYKDNGSMTJ6YW3NHVQ9QYYSSQJCEWM5CJWZ4A6RFJX77C490YCED6PEMK0UPKXHY89CMM7SCT66K8GNEANWYKZGDRWRFJE69H9U5U0W57RRCSYSAS7GADWMZXC8C6T0SPJAZUP6'
+            };
+            mockIsValidBitcoinAddress = true;
+            mockSupportsOnchainSends = false;
 
             const result = await handleAnything(data, undefined, true);
 

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -40,8 +40,32 @@ const handleAnything = async (
     ) {
         if (isClipboardValue) return true;
         if (!BackendUtils.supportsOnchainSends()) {
-            invoicesStore.getPayReq(lightning);
-            return ['PaymentRequest', {}];
+            if (lightning?.toLowerCase().startsWith('lnurl')) {
+                try {
+                    const params = await getlnurlParams(lightning);
+                    if ('tag' in params && params.tag === 'payRequest') {
+                        return [
+                            'LnurlPay',
+                            {
+                                lnurlParams: params
+                            }
+                        ];
+                    } else {
+                        throw new Error(
+                            localeString(
+                                'utils.handleAnything.invalidLnurlParams'
+                            )
+                        );
+                    }
+                } catch {
+                    throw new Error(
+                        localeString('utils.handleAnything.invalidLnurlParams')
+                    );
+                }
+            } else {
+                invoicesStore.getPayReq(lightning);
+                return ['PaymentRequest', {}];
+            }
         }
         return [
             'Accounts',


### PR DESCRIPTION
# Description

There were issues when scanning a QR code with a unified bitcoin URI containing an lnurl part (example: `bitcoin:BC1QUXCS7V556UTNUKU93HSZ7LHHFFLWN9NF2UTQ6N?pj=https://ts.dergigi.com/BTC/pj&lightning=LNURL1DP68GURN8GHJ7ARN9EJX2UN8D9NKJTNRDAKJ7SJ5GVH42J2VFE24YNP0WPSHJTMF9ATKWD622CE953JGWV6XXUMRDPXNVCJ8X4G9GF2CHDF`).

When using a backend supporting on-chain sends, the lightning swipeable row was non-functional.

When using a backend not supporting on-chain sends, the lightning part was interpreted as bolt11.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [x] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
