### PR TITLE
ZEUS-1981: LNURL payment amount defaults to current currency

### DIFF
--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -15,6 +15,7 @@ import { Row } from '../..//components/layout/Row';
 
 import InvoicesStore from '../../stores/InvoicesStore';
 import LnurlPayStore from '../../stores/LnurlPayStore';
+import UnitsStore from '../../stores/UnitsStore';
 
 import LnurlPayMetadata from './Metadata';
 
@@ -26,6 +27,7 @@ interface LnurlPayProps {
     navigation: any;
     InvoicesStore: InvoicesStore;
     LnurlPayStore: LnurlPayStore;
+    UnitsStore: UnitsStore;
 }
 
 interface LnurlPayState {
@@ -35,7 +37,7 @@ interface LnurlPayState {
     comment: string;
 }
 
-@inject('InvoicesStore', 'LnurlPayStore')
+@inject('InvoicesStore', 'LnurlPayStore', 'UnitsStore')
 @observer
 export default class LnurlPay extends React.Component<
     LnurlPayProps,
@@ -64,9 +66,11 @@ export default class LnurlPay extends React.Component<
     }
 
     stateFromProps(props: LnurlPayProps) {
-        const { navigation } = props;
+        const { UnitsStore, navigation } = props;
         const lnurl = navigation.getParam('lnurlParams');
         const amount = navigation.getParam('amount');
+
+        UnitsStore.resetUnits();
 
         return {
             amount:


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1981**](https://github.com/ZeusLN/zeus/issues/1981)

This approach resets the selected currency to sats when loading the LNURL-Pay view.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
