### PR TITLE
Embedded LND: conf: max-commit-fee-rate-anchors

### DIFF
--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -90,7 +90,7 @@ const writeLndConfig = async (
     accept-keysend=1
     tlsdisableautofill=1
     maxpendingchannels=1000
-    max-commit-fee-rate-anchors=100
+    max-commit-fee-rate-anchors=50
     payments-expiration-grace-period=336h
     ${rescan ? 'reset-wallet-transactions=true' : ''}
     


### PR DESCRIPTION
Halve the maximum force close fee rate set by clients. Still at a healthy rate but should help the LSP save on fees.