### PR TITLE
c-lightning-REST: OpenChannel: fix fee rate

### DIFF
--- a/backends/CLightningREST.ts
+++ b/backends/CLightningREST.ts
@@ -5,6 +5,7 @@ import OpenChannelRequest from './../models/OpenChannelRequest';
 import VersionUtils from './../utils/VersionUtils';
 import Base64Utils from './../utils/Base64Utils';
 import { Hash as sha256Hash } from 'fast-sha256';
+import BigNumber from 'bignumber.js';
 
 export default class CLightningREST extends LND {
     getHeaders = (macaroonHex: string): any => {
@@ -169,11 +170,14 @@ export default class CLightningREST extends LND {
     getNewAddress = () => this.getRequest('/v1/newaddr?addrType=bech32');
     openChannel = (data: OpenChannelRequest) => {
         let request: any;
+        const feeRate = `${new BigNumber(data.sat_per_vbyte)
+            .times(1000)
+            .toString()}perkb`;
         if (data.utxos && data.utxos.length > 0) {
             request = {
                 id: data.id,
                 satoshis: data.satoshis,
-                feeRate: data.sat_per_vbyte,
+                feeRate,
                 announce: !data.privateChannel ? 'true' : 'false',
                 minfConf: data.min_confs,
                 utxos: data.utxos
@@ -182,7 +186,7 @@ export default class CLightningREST extends LND {
             request = {
                 id: data.id,
                 satoshis: data.satoshis,
-                feeRate: data.sat_per_vbyte,
+                feeRate,
                 announce: !data.privateChannel ? 'true' : 'false',
                 minfConf: data.min_confs
             };

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -376,7 +376,10 @@ export default class ChannelView extends React.Component<
                             }
                         />
                     )}
-                    {(pendingOpen || pendingClose || closing) &&
+                    {(pendingOpen ||
+                        pendingClose ||
+                        closing ||
+                        !BackendUtils.isLNDBased()) &&
                         channel_point && (
                             <KeyValue
                                 keyValue={localeString(


### PR DESCRIPTION
# Description

As [reported by Bitcoin Puerto Rico](https://njump.me/nevent1qqs28wvlkju30rsjhepesqywdphz2s7s83hcv250pazc4fnzd9pjn9cpp4mhxue69uhkummn9ekx7mqpzfmhxue69uhk7enxvd5xz6tw9ec82cspzemhxue69uhhyetvv9ujumn0wd68ytnzv9hxgqgkwaehxw309aex2mrp0yh8qunfd4skctnwv46qygx2d9khak62s6l8clvcw27jlxjygsx03ck70pf4xm9m8fs2aztyrud8m503), it appears the c-lightning-REST interface is opening channels at 1 sat/vbyte no matter what fee rate you set.

It appears that the c-lightning-REST backend does not accept sats/vbyte as a unit as [detailed here](https://github.com/Ride-The-Lightning/c-lightning-REST/blob/master/controllers/channel.js#L32C61-L32C66). This change has the interface submit the fee rate using `perkb` formatting.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
