### PR TITLE
Settings: LSP: request Simple Taproot Channels by default

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -998,7 +998,7 @@ export default class SettingsStore {
         lspMainnet: DEFAULT_LSP_MAINNET,
         lspTestnet: DEFAULT_LSP_TESTNET,
         lspAccessKey: '',
-        requestSimpleTaproot: false,
+        requestSimpleTaproot: true,
         // Lightning Address
         lightningAddress: {
             enabled: false,
@@ -1233,25 +1233,10 @@ export default class SettingsStore {
                         localeMigrationMapping[this.settings.locale];
                 }
 
-                // TODO PEGASUS
-                // temporarily toggle all beta users settings for now
-                const MOD_KEY = 'beta5-mod';
+                const MOD_KEY = 'lsp-taproot-mod';
                 const mod = await EncryptedStorage.getItem(MOD_KEY);
                 if (!mod) {
-                    this.settings.expressGraphSync = true;
-                    if (this.settings.payments) {
-                        this.settings.payments.defaultFeePercentage = '5.0';
-                        this.settings.payments.defaultFeeFixed = '1000';
-                    } else {
-                        this.settings.payments = {
-                            defaultFeeMethod: 'fixed', // deprecated
-                            defaultFeePercentage: '5.0',
-                            defaultFeeFixed: '1000',
-                            timeoutSeconds: '60',
-                            preferredMempoolRate: 'fastestFee'
-                        };
-                    }
-                    this.settings.automaticDisasterRecoveryBackup = true;
+                    this.settings.requestSimpleTaproot = true;
                     this.setSettings(JSON.stringify(this.settings));
                     await EncryptedStorage.setItem(MOD_KEY, 'true');
                 }

--- a/views/Settings/LSP.tsx
+++ b/views/Settings/LSP.tsx
@@ -36,7 +36,7 @@ export default class LSP extends React.Component<LSPProps, LSPState> {
         enableLSP: true,
         lsp: '',
         accessKey: '',
-        requestSimpleTaproot: false
+        requestSimpleTaproot: true
     };
 
     async UNSAFE_componentWillMount() {
@@ -50,7 +50,10 @@ export default class LSP extends React.Component<LSPProps, LSPState> {
                     ? settings.lspMainnet
                     : settings.lspTestnet,
             accessKey: settings.lspAccessKey,
-            requestSimpleTaproot: settings.requestSimpleTaproot
+            requestSimpleTaproot:
+                settings?.requestSimpleTaproot !== null
+                    ? settings.requestSimpleTaproot
+                    : true
         });
     }
 


### PR DESCRIPTION
# Description

This PR changes the LSP settings to request Simple Taproot Channels by default.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [X] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
