### PR TITLE
ZEUS-1934: Payment: Move noteKey logic to model

### DIFF
--- a/models/Payment.ts
+++ b/models/Payment.ts
@@ -293,4 +293,8 @@ export default class Payment extends BaseModel {
             .replace(/(\d+) /g, '$1 ')
             .replace(/ (\d+)/g, ' $1');
     }
+
+    @computed public get noteKey(): string {
+        return this.paymentHash || this.getPreimage;
+    }
 }

--- a/views/Payment.tsx
+++ b/views/Payment.tsx
@@ -56,10 +56,7 @@ export default class PaymentView extends React.Component<PaymentProps> {
             this.setState({ lnurlpaytx });
         }
         navigation.addListener('didFocus', () => {
-            const noteKey =
-                payment.paymentHash ?? typeof payment.getPreimage === 'string'
-                    ? payment.getPreimage
-                    : null;
+            const noteKey = payment.noteKey;
 
             EncryptedStorage.getItem('note-' + noteKey)
                 .then((storedNotes) => {
@@ -92,11 +89,11 @@ export default class PaymentView extends React.Component<PaymentProps> {
             getMemo,
             isIncomplete,
             isInTransit,
-            isFailed
+            isFailed,
+            noteKey
         } = payment;
         const date = getDisplayTime;
-        const noteKey =
-            paymentHash ?? typeof getPreimage === 'string' ? getPreimage : null;
+
         const EditNotesButton = () => (
             <TouchableOpacity
                 onPress={() =>


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1934**](https://github.com/ZeusLN/zeus/issues/1934)

Moves the `noteKey` logic for payment objects to the model.

This remedies a regression where notes added on the `SendingLightning` success screen were not being saved properly - may have been a regression from https://github.com/ZeusLN/zeus/pull/1920

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [X] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
