### PR TITLE
LSP settings: set testnet host based on node info

### DIFF
--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -3,7 +3,7 @@ import ReactNativeBlobUtil from 'react-native-blob-util';
 
 import SettingsStore from './SettingsStore';
 import ChannelsStore from './ChannelsStore';
-import stores from './Stores';
+import NodeInfoStore from './NodeInfoStore';
 
 import lndMobile from '../lndmobile/LndMobileInjection';
 const { channel } = lndMobile;
@@ -24,10 +24,16 @@ export default class LSPStore {
 
     settingsStore: SettingsStore;
     channelsStore: ChannelsStore;
+    nodeInfoStore: NodeInfoStore;
 
-    constructor(settingsStore: SettingsStore, channelsStore: ChannelsStore) {
+    constructor(
+        settingsStore: SettingsStore,
+        channelsStore: ChannelsStore,
+        nodeInfoStore: NodeInfoStore
+    ) {
         this.settingsStore = settingsStore;
         this.channelsStore = channelsStore;
+        this.nodeInfoStore = nodeInfoStore;
     }
 
     @action
@@ -37,9 +43,7 @@ export default class LSPStore {
         this.error = false;
         this.error_msg = '';
         this.showLspSettings = false;
-        // TODO Pegasus clear channel acceptor when
-        // it's supported by other backends
-        // this.channelAcceptor = undefined;
+        this.channelAcceptor = undefined;
     };
 
     @action
@@ -48,9 +52,9 @@ export default class LSPStore {
     };
 
     getLSPHost = () =>
-        this.settingsStore.embeddedLndNetwork === 'Mainnet'
-            ? this.settingsStore.settings.lspMainnet
-            : this.settingsStore.settings.lspTestnet;
+        this.nodeInfoStore!.nodeInfo.isTestNet
+            ? this.settingsStore.settings.lspTestnet
+            : this.settingsStore.settings.lspMainnet;
 
     @action
     public getLSPInfo = () => {
@@ -127,7 +131,7 @@ export default class LSPStore {
                       },
                 JSON.stringify({
                     amount_msat,
-                    pubkey: stores.nodeInfoStore.nodeInfo.nodeId
+                    pubkey: this.nodeInfoStore.nodeInfo.nodeId
                 })
             )
                 .then((response: any) => {

--- a/stores/Stores.ts
+++ b/stores/Stores.ts
@@ -54,7 +54,11 @@ class Stores {
             this.channelsStore,
             this.settingsStore
         );
-        this.lspStore = new LSPStore(this.settingsStore, this.channelsStore);
+        this.lspStore = new LSPStore(
+            this.settingsStore,
+            this.channelsStore,
+            this.nodeInfoStore
+        );
         this.lightningAddressStore = new LightningAddressStore(
             this.nodeInfoStore,
             this.settingsStore

--- a/views/Settings/LSP.tsx
+++ b/views/Settings/LSP.tsx
@@ -43,15 +43,14 @@ export default class LSP extends React.Component<LSPProps, LSPState> {
     };
 
     async UNSAFE_componentWillMount() {
-        const { SettingsStore } = this.props;
-        const { settings, embeddedLndNetwork } = SettingsStore;
+        const { SettingsStore, NodeInfoStore } = this.props;
+        const { settings } = SettingsStore;
 
         this.setState({
             enableLSP: settings.enableLSP,
-            lsp:
-                embeddedLndNetwork === 'Mainnet'
-                    ? settings.lspMainnet
-                    : settings.lspTestnet,
+            lsp: NodeInfoStore!.nodeInfo.isTestNet
+                ? settings.lspTestnet
+                : settings.lspMainnet,
             accessKey: settings.lspAccessKey,
             requestSimpleTaproot: settings.requestSimpleTaproot
         });


### PR DESCRIPTION
# Description

Previously, we would use the embedded node's network config flag to determine whether to use the mainnet or testnet LSP host. This PR changes this test to leverage the testnet flag from the `NodeInfo` call.

Furthermore, this PR clears the channel acceptor when changing active nodes now that multiple backends are supported.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
