### PR TITLE
Send/receive: hide select buttons when loading

### DIFF
--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -1045,52 +1045,55 @@ export default class PaymentRequest extends React.Component<
                     </ScrollView>
                 </View>
 
-                {!!pay_req && BackendUtils.supportsLightningSends() && (
-                    <View style={{ bottom: 10 }}>
-                        <View style={styles.button}>
-                            <Button
-                                title={localeString(
-                                    'views.PaymentRequest.payInvoice'
-                                )}
-                                icon={
-                                    lightningReadyToSend
-                                        ? {
-                                              name: 'send',
-                                              size: 25
-                                          }
-                                        : undefined
-                                }
-                                onPress={() => {
-                                    if (isZaplocker)
-                                        LnurlPayStore.broadcastAttestation();
-                                    this.sendPayment({
-                                        payment_request: paymentRequest,
-                                        amount: satAmount
-                                            ? satAmount.toString()
-                                            : undefined,
-                                        max_parts: enableMultiPathPayment
-                                            ? maxParts
-                                            : null,
-                                        max_shard_amt: enableMultiPathPayment
-                                            ? maxShardAmt
-                                            : null,
-                                        fee_limit_sat: isLnd
-                                            ? feeLimitSat
-                                            : null,
-                                        max_fee_percent: isCLightning
-                                            ? maxFeePercentFormatted
-                                            : null,
-                                        outgoing_chan_id: outgoingChanId,
-                                        last_hop_pubkey: lastHopPubkey,
-                                        amp: enableAmp,
-                                        timeout_seconds: timeoutSeconds
-                                    });
-                                }}
-                                disabled={!lightningReadyToSend}
-                            />
+                {!!pay_req &&
+                    !loading &&
+                    BackendUtils.supportsLightningSends() && (
+                        <View style={{ bottom: 10 }}>
+                            <View style={styles.button}>
+                                <Button
+                                    title={localeString(
+                                        'views.PaymentRequest.payInvoice'
+                                    )}
+                                    icon={
+                                        lightningReadyToSend
+                                            ? {
+                                                  name: 'send',
+                                                  size: 25
+                                              }
+                                            : undefined
+                                    }
+                                    onPress={() => {
+                                        if (isZaplocker)
+                                            LnurlPayStore.broadcastAttestation();
+                                        this.sendPayment({
+                                            payment_request: paymentRequest,
+                                            amount: satAmount
+                                                ? satAmount.toString()
+                                                : undefined,
+                                            max_parts: enableMultiPathPayment
+                                                ? maxParts
+                                                : null,
+                                            max_shard_amt:
+                                                enableMultiPathPayment
+                                                    ? maxShardAmt
+                                                    : null,
+                                            fee_limit_sat: isLnd
+                                                ? feeLimitSat
+                                                : null,
+                                            max_fee_percent: isCLightning
+                                                ? maxFeePercentFormatted
+                                                : null,
+                                            outgoing_chan_id: outgoingChanId,
+                                            last_hop_pubkey: lastHopPubkey,
+                                            amp: enableAmp,
+                                            timeout_seconds: timeoutSeconds
+                                        });
+                                    }}
+                                    disabled={!lightningReadyToSend}
+                                />
+                            </View>
                         </View>
-                    </View>
-                )}
+                    )}
             </Screen>
         );
     }

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -1285,9 +1285,8 @@ export default class Receive extends React.Component<
                         posStatus === 'active' ? null : haveInvoice ? (
                             <ClearButton />
                         ) : (
-                            BackendUtils.supportsAddressTypeSelection() && (
-                                <SettingsButton />
-                            )
+                            BackendUtils.supportsAddressTypeSelection() &&
+                            !creatingInvoice && <SettingsButton />
                         )
                     }
                     navigation={navigation}


### PR DESCRIPTION
# Description

- [Receive: hide settings icon when creating invoice](https://github.com/ZeusLN/zeus/commit/5fe5e76cde907c0901b4a2593b022a4853537c61)
- [PaymentRequest: hide pay button when invoice loading](https://github.com/ZeusLN/zeus/commit/5ee16805582a1855d4110af7b36c43c3e536107c)

##

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
