### PR TITLE
ZEUS-2053: Android: Tooltip text hidden in Dark Theme mode

### DIFF
--- a/components/Modals/InfoModal.tsx
+++ b/components/Modals/InfoModal.tsx
@@ -11,6 +11,7 @@ import ModalStore from '../../stores/ModalStore';
 
 import { localeString } from '../../utils/LocaleUtils';
 import UrlUtils from '../../utils/UrlUtils';
+import { themeColor } from '../../utils/ThemeUtils';
 
 interface InfoModalProps {
     ModalStore: ModalStore;
@@ -48,7 +49,7 @@ export default class InfoModal extends React.Component<InfoModalProps, {}> {
                 >
                     <View
                         style={{
-                            backgroundColor: 'white',
+                            backgroundColor: themeColor('secondary'),
                             borderRadius: 30,
                             padding: 30,
                             width: '100%',
@@ -63,6 +64,7 @@ export default class InfoModal extends React.Component<InfoModalProps, {}> {
                             <Text
                                 style={{
                                     fontFamily: 'PPNeueMontreal-Book',
+                                    color: themeColor('text'),
                                     fontSize: 20,
                                     marginBottom: 40
                                 }}
@@ -77,6 +79,7 @@ export default class InfoModal extends React.Component<InfoModalProps, {}> {
                                     key={index}
                                     style={{
                                         fontFamily: 'PPNeueMontreal-Book',
+                                        color: themeColor('text'),
                                         fontSize: 20,
                                         marginBottom: 40
                                     }}


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2053**](https://github.com/ZeusLN/zeus/issues/2053)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
