### PR TITLE
ZEUS-2069: Settings: automatically upgrade users on old LSP host 

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1277,6 +1277,25 @@ export default class SettingsStore {
                     await EncryptedStorage.setItem(MOD_KEY, 'true');
                 }
 
+                const MOD_KEY2 = 'lsp-preview-mod';
+                const mod2 = await EncryptedStorage.getItem(MOD_KEY2);
+                if (!mod2) {
+                    if (
+                        this.settings?.lspMainnet ===
+                        'https://lsp-preview.lnolymp.us'
+                    ) {
+                        this.settings.lspMainnet = DEFAULT_LSP_MAINNET;
+                    }
+                    if (
+                        this.settings?.lspTestnet ===
+                        'https://testnet-lsp.lnolymp.us'
+                    ) {
+                        this.settings.lspTestnet = DEFAULT_LSP_TESTNET;
+                    }
+                    this.setSettings(JSON.stringify(this.settings));
+                    await EncryptedStorage.setItem(MOD_KEY2, 'true');
+                }
+
                 // migrate old POS squareEnabled setting to posEnabled
                 if (this.settings?.pos?.squareEnabled) {
                     this.settings.pos.posEnabled = PosEnabled.Square;

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -453,15 +453,15 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             }
         }
 
+        if (connecting) {
+            setConnectingStatus(false);
+        }
+
         if (BackendUtils.supportsLSPs()) {
             if (SettingsStore.settings.enableLSP) {
                 await LSPStore.getLSPInfo();
             }
             LSPStore.initChannelAcceptor();
-        }
-
-        if (connecting) {
-            setConnectingStatus(false);
         }
 
         // only navigate to initial url after connection and main calls are made


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2069**](https://github.com/ZeusLN/zeus/issues/2069)

Properly upgrade beta tester users to new LSP hosts and make sure wallet does not stall out if a connection to the LSP cannot be reached.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
