### PR TITLE
Button: simplify style, fix Android NFC modal display

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -12,7 +12,6 @@ interface ButtonProps {
     tertiary?: boolean;
     quaternary?: boolean;
     warning?: boolean;
-    quinary?: boolean;
     iconOnly?: boolean;
     adaptiveWidth?: boolean;
     containerStyle?: any;
@@ -32,7 +31,6 @@ function Button(props: ButtonProps) {
         tertiary,
         quaternary,
         warning,
-        quinary,
         iconOnly,
         adaptiveWidth,
         containerStyle,
@@ -83,10 +81,8 @@ function Button(props: ButtonProps) {
             buttonStyle={{
                 backgroundColor: iconOnly
                     ? 'transparent'
-                    : quinary
-                    ? themeColor('buttonBackground') || themeColor('secondary')
                     : quaternary
-                    ? themeColor('background')
+                    ? themeColor('buttonBackground') || themeColor('secondary')
                     : tertiary
                     ? themeColor('highlight')
                     : secondary
@@ -104,10 +100,6 @@ function Button(props: ButtonProps) {
                     : {
                           color: iconOnly
                               ? textColor
-                              : quinary
-                              ? warning
-                                  ? themeColor('warning')
-                                  : textColor
                               : quaternary
                               ? warning
                                   ? themeColor('warning')

--- a/components/Channels/SortButton.tsx
+++ b/components/Channels/SortButton.tsx
@@ -72,7 +72,7 @@ export default class SortButton extends React.Component<SortButtonProps, {}> {
                             }}
                             adaptiveWidth
                             buttonStyle={{ width: 50 }}
-                            quinary
+                            quaternary
                             onPress={() =>
                                 ActionSheetIOS.showActionSheetWithOptions(
                                     {

--- a/components/UnitToggle.tsx
+++ b/components/UnitToggle.tsx
@@ -30,7 +30,7 @@ export default class UnitToggle extends React.Component<UnitToggleProps, {}> {
                         size: 25
                     }}
                     adaptiveWidth
-                    quinary
+                    quaternary
                     noUppercase
                     onPress={() => {
                         if (onToggle) onToggle();

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -629,7 +629,7 @@ export default class ChannelView extends React.Component<
                                             forceCloseChannel
                                         )
                                     }
-                                    quinary
+                                    quaternary
                                     warning
                                 />
                             </View>

--- a/views/Wallet/KeypadPane.tsx
+++ b/views/Wallet/KeypadPane.tsx
@@ -364,7 +364,7 @@ export default class KeypadPane extends React.PureComponent<
                                 <View style={{ width: '25%' }}>
                                     <Button
                                         title={'50k'}
-                                        quinary
+                                        quaternary
                                         noUppercase
                                         onPress={() => {
                                             UnitsStore.resetUnits();
@@ -379,7 +379,7 @@ export default class KeypadPane extends React.PureComponent<
                                 <View style={{ width: '25%' }}>
                                     <Button
                                         title={'100k'}
-                                        quinary
+                                        quaternary
                                         noUppercase
                                         onPress={() => {
                                             UnitsStore.resetUnits();
@@ -394,7 +394,7 @@ export default class KeypadPane extends React.PureComponent<
                                 <View style={{ width: '25%' }}>
                                     <Button
                                         title={'1m'}
-                                        quinary
+                                        quaternary
                                         noUppercase
                                         onPress={() => {
                                             UnitsStore.resetUnits();
@@ -409,7 +409,7 @@ export default class KeypadPane extends React.PureComponent<
                                 <View style={{ width: '25%' }}>
                                     <Button
                                         title={localeString('general.other')}
-                                        quinary
+                                        quaternary
                                         noUppercase
                                         onPress={() => {
                                             UnitsStore.resetUnits();
@@ -435,7 +435,7 @@ export default class KeypadPane extends React.PureComponent<
                             <View style={{ width: '40%' }}>
                                 <Button
                                     title={localeString('general.request')}
-                                    quinary
+                                    quaternary
                                     noUppercase
                                     onPress={() => {
                                         navigation.navigate('Receive', {
@@ -456,7 +456,7 @@ export default class KeypadPane extends React.PureComponent<
                                             themeColor('buttonText') ||
                                             themeColor('text')
                                     }}
-                                    quinary
+                                    quaternary
                                     noUppercase
                                     onPress={() => {
                                         navigation.navigate('Receive', {
@@ -469,7 +469,7 @@ export default class KeypadPane extends React.PureComponent<
                             <View style={{ width: '40%' }}>
                                 <Button
                                     title={localeString('general.send')}
-                                    quinary
+                                    quaternary
                                     noUppercase
                                     onPress={() => {
                                         navigation.navigate('Send', {

--- a/views/Wallet/StandalonePosKeypadPane.tsx
+++ b/views/Wallet/StandalonePosKeypadPane.tsx
@@ -278,7 +278,7 @@ export default class PosKeypadPane extends React.PureComponent<
                                 title={localeString(
                                     'general.request'
                                 ).toUpperCase()}
-                                quinary
+                                quaternary
                                 noUppercase
                                 onPress={() => {
                                     this.addItemAndCheckout();


### PR DESCRIPTION
# Description

This PR simplifies the `Button` component by folding the uncommonly used `quinary` boolean style into `quaternary`. It also fixes the style of the `AndroidNfcModal` whose button text was hard to read.

Before:
![Screenshot_1711216397](https://github.com/ZeusLN/zeus/assets/1878621/7356efa2-cbee-45cf-ae72-de5559c5fffd)

After:
![Screenshot_1711216372](https://github.com/ZeusLN/zeus/assets/1878621/d71d46ed-5bb7-4079-b089-0996032f574a)


This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
