### PR TITLE
ZEUS-2026: Embedded LND: Express Graph Sync: add skip

### DIFF
--- a/android/app/src/main/java/com/zeus/LndMobile.java
+++ b/android/app/src/main/java/com/zeus/LndMobile.java
@@ -386,13 +386,17 @@ class LndMobile extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void gossipSync(String networkType, Promise promise) {
+  public void gossipSync(String serviceUrl, String networkType, Promise promise) {
     int req = new Random().nextInt();
     requests.put(req, promise);
 
     Message message = Message.obtain(null, LndMobileService.MSG_GOSSIP_SYNC, req, 0);
     message.replyTo = messenger;
     Bundle bundle = new Bundle();
+    bundle.putString(
+      "serviceUrl",
+      serviceUrl
+    );
     bundle.putString(
       "networkType",
       networkType
@@ -403,6 +407,21 @@ class LndMobile extends ReactContextBaseJavaModule {
       lndMobileServiceMessenger.send(message);
     } catch (RemoteException e) {
       promise.reject(TAG, "Could not Send MSG_GOSSIP_SYNC to LndMobileService", e);
+    }
+  }
+
+  @ReactMethod
+  public void cancelGossipSync(Promise promise) {
+    int req = new Random().nextInt();
+    requests.put(req, promise);
+
+    Message message = Message.obtain(null, LndMobileService.MSG_CANCEL_GOSSIP_SYNC, req, 0);
+    message.replyTo = messenger;
+
+    try {
+      lndMobileServiceMessenger.send(message);
+    } catch (RemoteException e) {
+      promise.reject(TAG, "Could not Send MSG_CANCEL_GOSSIP_SYNC to LndMobileService", e);
     }
   }
 

--- a/android/app/src/main/java/com/zeus/LndMobileService.java
+++ b/android/app/src/main/java/com/zeus/LndMobileService.java
@@ -73,6 +73,8 @@ public class LndMobileService extends Service {
   static final int MSG_GRPC_STREAM_WRITE_RESULT = 22;
   static final int MSG_GOSSIP_SYNC = 23;
   static final int MSG_GOSSIP_SYNC_RESULT = 24;
+  static final int MSG_CANCEL_GOSSIP_SYNC = 25;
+  static final int MSG_CANCEL_GOSSIP_SYNC_RESULT = 26;
 
   private Map<String, Method> syncMethods = new HashMap<>();
   private Map<String, Method> streamMethods = new HashMap<>();
@@ -236,8 +238,13 @@ public class LndMobileService extends Service {
             break;
 
           case MSG_GOSSIP_SYNC:
+            final String serviceUrl = bundle.getString("serviceUrl", "");
             final String networkType = bundle.getString("networkType", "");
-            gossipSync(msg.replyTo, networkType, request);
+            gossipSync(msg.replyTo, serviceUrl, networkType, request);
+            break;
+
+          case MSG_CANCEL_GOSSIP_SYNC:
+            cancelGossipSync(msg.replyTo, request);
             break;
 
           case MSG_PING:
@@ -367,10 +374,11 @@ public class LndMobileService extends Service {
     }
   }
 
-  void gossipSync(Messenger recipient, String networkType, int request) {
+  void gossipSync(Messenger recipient, String serviceUrl, String networkType, int request) {
     Runnable gossipSync = new Runnable() {
       public void run() {
         Lndmobile.gossipSync(
+          serviceUrl,
           getApplicationContext().getCacheDir().getAbsolutePath(),
           getApplicationContext().getFilesDir().getAbsolutePath(),
           networkType,
@@ -630,5 +638,12 @@ public class LndMobileService extends Service {
         }
       }
     );
+  }
+
+  private void cancelGossipSync(Messenger recipient, int request) {
+    if (notificationManager != null) {
+      notificationManager.cancelAll();
+    }
+    Lndmobile.cancelGossipSync();
   }
 }

--- a/fetch-libraries.sh
+++ b/fetch-libraries.sh
@@ -1,10 +1,10 @@
-VERSION=v0.17.4-beta-zeus.2
+VERSION=v0.17.4-beta-zeus.3
 
 ANDROID_FILE=Lndmobile.aar
 IOS_FILE=Lndmobile.xcframework
 
-ANDROID_SHA256='a913226224ff02fadb4a2b0ccc069df132c7b9eaba48c8d27f02c8090dbb5f12'
-IOS_SHA256='6defcda62b5ab9eb147a7fb6f5e3c136d3b24bc93887981e612af280ecd85471'
+ANDROID_SHA256='4b224ffca0ffc1432033799fd2715c3487b314ae0f2a525b2b785050a3c0df41'
+IOS_SHA256='ef934a7866cbfc026711b3b5b0fbd6b3457b3b57897bf647890034e25a5c04dd'
 
 FILE_PATH=https://github.com/ZeusLN/lnd/releases/download/$VERSION/
 

--- a/ios/LndMobile/Lnd.swift
+++ b/ios/LndMobile/Lnd.swift
@@ -302,7 +302,17 @@ open class Lnd {
     }
   }
 
- func gossipSync(_ cacheDir: String, dataDir: String, networkType: String, callback: @escaping Callback) {
-   LndmobileGossipSync(cacheDir, dataDir, networkType, LndmobileCallback(method: "zeus_gossipSync", callback: callback))
- }
+  func gossipSync(_ serviceUrl: String, cacheDir: String, dataDir: String, networkType: String, callback: @escaping Callback) {
+    LndmobileGossipSync(serviceUrl, cacheDir, dataDir, networkType, LndmobileCallback(method: "zeus_gossipSync", callback: callback))
+  }
+  
+  func cancelGossipSync(_ callback: @escaping Callback) {
+    do {
+      let stopRequest = Lnrpc_StopRequest()
+      let payload = try stopRequest.serializedData()
+      LndmobileCancelGossipSync()
+    } catch let error {
+      callback(nil, error)
+    }
+  }
 }

--- a/ios/LndMobile/LndMobile.m
+++ b/ios/LndMobile/LndMobile.m
@@ -71,8 +71,14 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-  gossipSync: (NSString *)networkType
+  gossipSync: (NSString *)serviceUrl
+  networkType: (NSString *)networkType
   resolver: (RCTPromiseResolveBlock)resolve
+  rejecter: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
+  cancelGossipSync: (RCTPromiseResolveBlock)resolve
   rejecter: (RCTPromiseRejectBlock)reject
 )
 

--- a/ios/LndMobile/LndMobile.swift
+++ b/ios/LndMobile/LndMobile.swift
@@ -276,13 +276,13 @@ class LndMobile: RCTEventEmitter {
     }
   }
 
- @objc(gossipSync:resolver:rejecter:)
- func gossipSync(networkType: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+@objc(gossipSync:networkType:resolver:rejecter:)
+  func gossipSync(serviceUrl: String, networkType: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
    let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
    let lndPath = applicationSupport.appendingPathComponent("lnd", isDirectory: true)
    let cachePath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
 
-   Lnd.shared.gossipSync(cachePath.path, dataDir: lndPath.path, networkType: networkType, callback: { (data, error) in
+    Lnd.shared.gossipSync(serviceUrl, cacheDir: cachePath.path, dataDir: lndPath.path, networkType: networkType, callback: { (data, error) in
      if let e = error {
        reject("error", e.localizedDescription, e)
        return
@@ -292,4 +292,17 @@ class LndMobile: RCTEventEmitter {
      ])
    })
  }
+
+  @objc(cancelGossipSync:rejecter:)
+  func cancelGossipSync(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject:@escaping RCTPromiseRejectBlock) {
+    Lnd.shared.cancelGossipSync() { (data, error) in
+      if let e = error {
+        reject("error", e.localizedDescription, e)
+        return
+      }
+      resolve([
+        "data": data?.base64EncodedString()
+      ])
+    }
+  }
 }

--- a/lndmobile/LndMobile.d.ts
+++ b/lndmobile/LndMobile.d.ts
@@ -39,11 +39,17 @@ export interface ILndMobile {
     ): Promise<'done'>;
     writeToStream(method: string, payload: string): Promise<boolean>;
 
+    // Express Graph Sync / Speedloader
+    gossipSync(
+        serviceUrl: string,
+        networkType: string
+    ): Promise<{ data: string }>;
+    cancelGossipSync(): void;
+
     // Android-specific
     unbindLndMobileService(): Promise<void>; // TODO(hsjoberg): function looks broken
     sendPongToLndMobileservice(): Promise<{ data: string }>;
     checkLndMobileServiceConnected(): Promise<boolean>;
-    gossipSync(networkType: string): Promise<{ data: string }>;
 }
 
 export interface ILndMobileTools {

--- a/lndmobile/LndMobileInjection.ts
+++ b/lndmobile/LndMobileInjection.ts
@@ -13,6 +13,7 @@ import {
     checkLndFolderExists,
     createIOSApplicationSupportAndLndDirectories,
     gossipSync,
+    cancelGossipSync,
     TEMP_moveLndToApplicationSupport,
     excludeLndICloudBackup,
     queryRoutes,
@@ -105,7 +106,11 @@ export interface ILndMobileInjections {
             isTestnet?: boolean
         ) => Promise<string>;
         stopLnd: () => Promise<string>;
-        gossipSync: (networkType: string) => Promise<{ data: string }>;
+        gossipSync: (
+            serviceUrl: string,
+            networkType: string
+        ) => Promise<{ data: string }>;
+        cancelGossipSync: () => void;
         checkICloudEnabled: () => Promise<boolean>;
         checkApplicationSupportExists: () => Promise<boolean>;
         checkLndFolderExists: () => Promise<boolean>;
@@ -377,6 +382,7 @@ export default {
         startLnd,
         stopLnd,
         gossipSync,
+        cancelGossipSync,
         checkICloudEnabled,
         checkApplicationSupportExists,
         checkLndFolderExists,

--- a/lndmobile/index.ts
+++ b/lndmobile/index.ts
@@ -87,9 +87,17 @@ export const startLnd = async (
  * @throws
  */
 export const gossipSync = async (
+    serviceUrl: string,
     networkType: string
 ): Promise<{ data: string }> => {
-    return await LndMobile.gossipSync(networkType);
+    return await LndMobile.gossipSync(serviceUrl, networkType);
+};
+
+/**
+ * @throws
+ */
+export const cancelGossipSync = async () => {
+    return LndMobile.cancelGossipSync();
 };
 
 export const checkICloudEnabled = async (): Promise<boolean> => {

--- a/locales/en.json
+++ b/locales/en.json
@@ -102,6 +102,7 @@
     "general.advanced": "Advanced",
     "general.clearChanges": "Clear changes",
     "general.destination": "Destination",
+    "general.skip": "Skip",
     "restart.title": "Restart required",
     "restart.msg": "ZEUS has to be restarted before the new configuration is applied.",
     "restart.msg1": "Would you like to restart now?",

--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -15,7 +15,11 @@ import { sleep } from './SleepUtils';
 import Base64Utils from './Base64Utils';
 
 import lndMobile from '../lndmobile/LndMobileInjection';
-import { ELndMobileStatusCodes, gossipSync } from '../lndmobile/index';
+import {
+    ELndMobileStatusCodes,
+    gossipSync,
+    cancelGossipSync
+} from '../lndmobile/index';
 
 import stores from '../stores/Stores';
 
@@ -151,9 +155,25 @@ const writeLndConfig = async (
 };
 
 export async function expressGraphSync() {
-    if (stores.settingsStore.embeddedLndNetwork === 'Mainnet') {
-        const start = new Date();
+    return await new Promise(async (resolve) => {
         stores.syncStore.setExpressGraphSyncStatus(true);
+
+        const start = new Date();
+
+        const timer = setInterval(async () => {
+            console.log('Express graph sync is running...');
+            // Check if the cancellation token is set
+            if (!stores.syncStore.isInExpressGraphSync) {
+                clearInterval(timer);
+                // call cancellation to LND here
+                console.log('Express graph sync cancelling...');
+                cancelGossipSync();
+
+                console.log('Express graph sync cancelled...');
+                resolve(true);
+            }
+        }, 1000);
+
         if (stores.settingsStore?.settings?.resetExpressGraphSyncOnStartup) {
             log.d('Clearing speedloader files');
             try {
@@ -166,17 +186,24 @@ export async function expressGraphSync() {
 
         try {
             const connectionState = await NetInfo.fetch();
-            const gossipStatus = await gossipSync(connectionState.type);
+            const gossipStatus = await gossipSync(
+                'https://speedloader.lnolymp.us/',
+                connectionState.type
+            );
+
+            clearInterval(timer);
+
             const completionTime =
                 (new Date().getTime() - start.getTime()) / 1000 + 's';
             console.log('gossipStatus', `${gossipStatus} - ${completionTime}`);
+            stores.syncStore.setExpressGraphSyncStatus(false);
+            resolve(true);
         } catch (e) {
             log.e('GossipSync exception!', [e]);
+            stores.syncStore.setExpressGraphSyncStatus(false);
+            resolve(true);
         }
-
-        stores.syncStore.setExpressGraphSyncStatus(false);
-    }
-    return;
+    });
 }
 
 export async function initializeLnd(

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -319,9 +319,12 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             embeddedTor,
             initialLoad
         } = settings;
-        const expressGraphSyncEnabled = settings.expressGraphSync;
+        const expressGraphSyncEnabled =
+            settings.expressGraphSync && embeddedLndNetwork === 'Mainnet';
 
+        let start;
         if (connecting) {
+            start = new Date().getTime();
             NodeInfoStore.reset();
             BalanceStore.reset();
             ChannelsStore.reset();
@@ -454,6 +457,9 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         }
 
         if (connecting) {
+            console.log(
+                'connect time: ' + (new Date().getTime() - start) / 1000 + 's'
+            );
             setConnectingStatus(false);
         }
 
@@ -789,9 +795,35 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                                     </View>
                                 </View>
                             </View>
+                            {isInExpressGraphSync && (
+                                <View
+                                    style={{
+                                        bottom: 70,
+                                        position: 'absolute',
+                                        alignSelf: 'center'
+                                    }}
+                                >
+                                    <Button
+                                        title={localeString('general.skip')}
+                                        containerStyle={{
+                                            width: 320
+                                        }}
+                                        titleStyle={{
+                                            color: themeColor('text')
+                                        }}
+                                        onPress={() => {
+                                            SyncStore.setExpressGraphSyncStatus(
+                                                false
+                                            );
+                                        }}
+                                        adaptiveWidth
+                                        iconOnly
+                                    />
+                                </View>
+                            )}
                             <View
                                 style={{
-                                    bottom: 56,
+                                    bottom: 15,
                                     position: 'absolute',
                                     alignSelf: 'center'
                                 }}


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2026**](https://github.com/ZeusLN/zeus/issues/2026)

This PR adds a button on the startup screen to allow users to skip the Express Graph Sync process. In building out the frontend, it was discovered that a cancel function will have to be added to the [Speedloader library](https://github.com/djkazic/speedloader) as well, otherwise the LND node continues to pull the graph data even though the UI is indicating that the node is now starting.

Speedloader PR can be found [here](https://github.com/djkazic/speedloader/pull/3). Changes are reflected in tag `v0.17.4-beta-zeus.3` of our LND fork

This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
