### PR TITLE
ZEUS-2062: LSP peer connect: make silent on Open Channel view

### DIFF
--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -85,6 +85,7 @@ export default class LSPStore {
                                     local_funding_amount: ''
                                 },
                                 false,
+                                true,
                                 true
                             );
                         } catch (e) {}


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2062**](https://github.com/ZeusLN/zeus/issues/2062)

In investigating the issue linked above, we discovered that peer connect errors from the LSP were displayed on the `OpenChannel` view. This PR adds a `silent` flag to the `connectPeer` call to be used in the `LSPStore` so that users do not see errors from calls they do not manually initiate.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
