### PR TITLE
Close channel: display error message

### DIFF
--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -223,9 +223,8 @@ export default class LightningNodeConnect {
             },
             force: urlParams && urlParams[2]
         };
-        return await this.lnc.lnd.lightning
-            .closeChannel(params)
-            .then((data: lnrpc.CloseStatusUpdate) => snakeize(data));
+
+        return this.lnc.lnd.lightning.closeChannel(params);
     };
     getNodeInfo = async (urlParams?: Array<string>) =>
         await this.lnc.lnd.lightning

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -467,15 +467,18 @@ export default class ChannelsStore {
         if (this.settingsStore.implementation === 'lightning-node-connect') {
             return BackendUtils.closeChannel(urlParams);
         } else {
+            let resolved = false;
             return await Promise.race([
                 new Promise((resolve) => {
                     BackendUtils.closeChannel(urlParams)
                         .then(() => {
                             this.handleChannelClose();
+                            resolved = true;
                             resolve(true);
                         })
                         .catch((error: Error) => {
                             this.handleChannelCloseError(error);
+                            resolved = true;
                             resolve(true);
                         });
                 }),
@@ -484,7 +487,7 @@ export default class ChannelsStore {
                 // before that time
                 new Promise(async (resolve) => {
                     await new Promise((res) => setTimeout(res, 6000));
-                    this.handleChannelClose();
+                    if (!resolved) this.handleChannelClose();
                     resolve(true);
                 })
             ]);


### PR DESCRIPTION
# Description

Previously, closing channels would not display errors if any occurred, which would cause some user confusion. This PR adds the display of those errors on the singular `Channel` view, instead of automatically redirecting the user back to the `Channels` list.

![Simulator Screenshot - iPhone 8 Plus - 2024-03-27 at 13 06 30](https://github.com/ZeusLN/zeus/assets/1878621/9e578f2e-7116-41a0-8d2f-25b56bdb3cb9)

![Simulator Screenshot - iPhone 8 Plus - 2024-03-27 at 13 03 53](https://github.com/ZeusLN/zeus/assets/1878621/999cbb59-565e-41c6-a44a-289c2c667b79)


This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
