### PR TITLE
Currency Converter: error handling for rate fetch failure

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1025,6 +1025,7 @@
     "views.Settings.Nostr.relays": "Relays",
     "views.Settings.CurrencyConverter.title": "Currency Converter",
     "views.Settings.CurrencyConverter.enterAmount": "Enter amount",
+    "views.Settings.CurrencyConverter.error": "Error fetching rates. Tap to try again.",
     "views.LspExplanation.title": "What are these fees?",
     "views.Settings.CustodialWalletWarning.graph1": "The wallet you are using is custodial. This means that the funds here are not fully in your control, and can be stolen by the operator of the service.",
     "views.Settings.CustodialWalletWarning.graph2": "This wallet is more akin to a bank account than a bitcoin wallet. You don't have access to the bitcoin keys, but rather credentials that can be revoked at any moment.",

--- a/views/Settings/CurrencyConverter.tsx
+++ b/views/Settings/CurrencyConverter.tsx
@@ -15,6 +15,7 @@ import EncryptedStorage from 'react-native-encrypted-storage';
 
 import Screen from '../../components/Screen';
 import Header from '../../components/Header';
+import LoadingIndicator from '../../components/LoadingIndicator';
 import TextInput from '../../components/TextInput';
 import { ErrorMessage } from '../../components/SuccessErrorMessage';
 import { Row } from '../../components/layout/Row';
@@ -28,6 +29,7 @@ import Add from '../../assets/images/SVG/Add.svg';
 import Edit from '../../assets/images/SVG/Pen.svg';
 import DragDots from '../../assets/images/SVG/DragDots.svg';
 import BitcoinIcon from '../../assets/images/SVG/bitcoin-icon.svg';
+import { isEmpty } from 'lodash';
 
 interface CurrencyConverterProps {
     navigation: any;
@@ -356,10 +358,14 @@ export default class CurrencyConverter extends React.Component<
     };
 
     render() {
-        const { navigation, SettingsStore } = this.props;
+        const { navigation, SettingsStore, FiatStore } = this.props;
         const { inputValues, editMode, fadeAnim } = this.state;
         const { settings }: any = SettingsStore;
         const { fiatEnabled } = settings;
+        const { fiatRates, loading, getFiatRates } = FiatStore!;
+
+        let ratesNotFetched;
+        if (isEmpty(fiatRates)) ratesNotFetched = true;
 
         const AddButton = () => (
             <TouchableOpacity
@@ -460,6 +466,25 @@ export default class CurrencyConverter extends React.Component<
                             keyboardShouldPersistTaps="handled"
                             keyboardDismissMode="on-drag"
                         >
+                            {loading && (
+                                <View style={{ flex: 1, padding: 15 }}>
+                                    <LoadingIndicator />
+                                </View>
+                            )}
+                            {ratesNotFetched && !loading && (
+                                <TouchableOpacity
+                                    style={{ flex: 1, padding: 15 }}
+                                    onPress={() => {
+                                        getFiatRates();
+                                    }}
+                                >
+                                    <ErrorMessage
+                                        message={localeString(
+                                            'views.Settings.CurrencyConverter.error'
+                                        )}
+                                    />
+                                </TouchableOpacity>
+                            )}
                             <View
                                 style={{
                                     marginHorizontal: 16,


### PR DESCRIPTION
# Description

This PR adds some error handling for the `CurrencyConverter` view for when the rates haven't been fetched. Previously, 

Before:

![image](https://github.com/ZeusLN/zeus/assets/1878621/dc7aa0ca-4fda-4f22-88a8-2f414ae3c2fb)
![image](https://github.com/ZeusLN/zeus/assets/1878621/b44c0d1a-7ff7-4288-b921-887a0200665a)

After:

![Simulator Screenshot - iPhone 15 Pro - 2024-04-09 at 11 33 52](https://github.com/ZeusLN/zeus/assets/1878621/cc175c49-9fa3-4fc5-9ab6-a940881e6546)
![Simulator Screenshot - iPhone 15 Pro - 2024-04-09 at 11 34 15](https://github.com/ZeusLN/zeus/assets/1878621/881f5da4-5027-45cf-b4b4-6bda1b1d1470)


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
