### PR TITLE
Add ability to select node on start-up

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -677,6 +677,7 @@
     "views.Settings.Display.displayNickname": "Display node nickname on main views",
     "views.Settings.Display.bigKeypadButtons": "Big keypad buttons",
     "views.Settings.Display.showAllDecimalPlaces": "Show all decimal places",
+    "views.Settings.Display.selectNodeOnStartup": "Select node on startup",
     "views.Settings.privacy": "Privacy",
     "views.Settings.payments": "Payments",
     "views.Settings.Privacy.title": "Privacy settings",

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -146,6 +146,7 @@ export interface Settings {
     requestSimpleTaproot: boolean;
     // Lightning Address
     lightningAddress: LightningAddressSettings;
+    selectNodeOnStartup: boolean;
 }
 
 export const FIAT_RATES_SOURCE_KEYS = [
@@ -1033,7 +1034,8 @@ export default class SettingsStore {
             nostrPrivateKey: '',
             nostrRelays: DEFAULT_NOSTR_RELAYS,
             notifications: 0
-        }
+        },
+        selectNodeOnStartup: false
     };
     @observable public posStatus: string = 'unselected';
     @observable public loading = false;
@@ -1073,6 +1075,12 @@ export default class SettingsStore {
     @observable public walletPassword: string;
     @observable public adminMacaroon: string;
     @observable public embeddedLndNetwork: string;
+    @observable public initialStart: boolean = true;
+
+    @action
+    public setInitialStart = (status: boolean) => {
+        this.initialStart = status;
+    };
 
     @action
     public changeLocale = (locale: string) => {

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -63,6 +63,16 @@ export default class Lockscreen extends React.Component<
         };
     }
 
+    proceed = () => {
+        const { SettingsStore, navigation } = this.props;
+        SettingsStore.setInitialStart(false);
+        if (SettingsStore.settings.selectNodeOnStartup) {
+            navigation.navigate('Nodes');
+        } else {
+            navigation.navigate('Wallet');
+        }
+    };
+
     async UNSAFE_componentWillMount() {
         const { SettingsStore, navigation } = this.props;
         const { settings } = SettingsStore;
@@ -97,7 +107,7 @@ export default class Lockscreen extends React.Component<
             if (isVerified) {
                 this.resetAuthenticationAttempts();
                 SettingsStore.setLoginStatus(true);
-                navigation.navigate('Wallet');
+                this.proceed();
                 return;
             }
         }
@@ -109,7 +119,7 @@ export default class Lockscreen extends React.Component<
             !deleteDuressPin
         ) {
             SettingsStore.setLoginStatus(true);
-            navigation.navigate('Wallet');
+            this.proceed();
         }
 
         if (settings.authenticationAttempts) {
@@ -147,7 +157,7 @@ export default class Lockscreen extends React.Component<
                 });
             }
         } else if (settings && settings.nodes && settings.nodes.length > 0) {
-            navigation.navigate('Wallet');
+            this.proceed();
         } else {
             navigation.navigate('IntroSplash');
         }
@@ -192,7 +202,7 @@ export default class Lockscreen extends React.Component<
             } else {
                 setPosStatus('inactive');
                 this.resetAuthenticationAttempts();
-                navigation.navigate('Wallet');
+                this.proceed();
             }
         } else if (
             (duressPassphrase && passphraseAttempt === duressPassphrase) ||
@@ -262,7 +272,7 @@ export default class Lockscreen extends React.Component<
     };
 
     deleteNodes = () => {
-        const { SettingsStore, navigation } = this.props;
+        const { SettingsStore } = this.props;
         const { updateSettings } = SettingsStore;
 
         updateSettings({
@@ -270,12 +280,12 @@ export default class Lockscreen extends React.Component<
             selectedNode: undefined,
             authenticationAttempts: 0
         }).then(() => {
-            navigation.navigate('Wallet');
+            this.proceed();
         });
     };
 
     authenticationFailure = () => {
-        const { SettingsStore, navigation } = this.props;
+        const { SettingsStore } = this.props;
         const { updateSettings } = SettingsStore;
 
         updateSettings({
@@ -287,7 +297,7 @@ export default class Lockscreen extends React.Component<
             duressPin: '',
             authenticationAttempts: 0
         }).then(() => {
-            navigation.navigate('Wallet');
+            this.proceed();
         });
     };
 

--- a/views/Settings/Display.tsx
+++ b/views/Settings/Display.tsx
@@ -25,6 +25,7 @@ interface DisplayState {
     displayNickname: boolean;
     bigKeypadButtons: boolean;
     showAllDecimalPlaces: boolean;
+    selectNodeOnStartup: boolean;
 }
 
 @inject('SettingsStore')
@@ -38,7 +39,8 @@ export default class Display extends React.Component<
         defaultView: 'Keypad',
         displayNickname: false,
         bigKeypadButtons: false,
-        showAllDecimalPlaces: false
+        showAllDecimalPlaces: false,
+        selectNodeOnStartup: false
     };
 
     async UNSAFE_componentWillMount() {
@@ -57,7 +59,8 @@ export default class Display extends React.Component<
                 false,
             showAllDecimalPlaces:
                 (settings.display && settings.display.showAllDecimalPlaces) ||
-                false
+                false,
+            selectNodeOnStartup: settings.selectNodeOnStartup || false
         });
     }
 
@@ -77,7 +80,8 @@ export default class Display extends React.Component<
             displayNickname,
             bigKeypadButtons,
             theme,
-            showAllDecimalPlaces
+            showAllDecimalPlaces,
+            selectNodeOnStartup
         } = this.state;
         const { updateSettings }: any = SettingsStore;
 
@@ -268,6 +272,45 @@ export default class Display extends React.Component<
                                             showAllDecimalPlaces:
                                                 !showAllDecimalPlaces
                                         }
+                                    });
+                                }}
+                            />
+                        </View>
+                    </ListItem>
+                    <ListItem
+                        containerStyle={{
+                            borderBottomWidth: 0,
+                            backgroundColor: 'transparent'
+                        }}
+                    >
+                        <ListItem.Title
+                            style={{
+                                color: themeColor('secondaryText'),
+                                fontFamily: 'PPNeueMontreal-Book',
+                                left: -10
+                            }}
+                        >
+                            {localeString(
+                                'views.Settings.Display.selectNodeOnStartup'
+                            )}
+                        </ListItem.Title>
+                        <View
+                            style={{
+                                flex: 1,
+                                flexDirection: 'row',
+                                justifyContent: 'flex-end'
+                            }}
+                        >
+                            <Switch
+                                value={selectNodeOnStartup}
+                                onValueChange={async () => {
+                                    this.setState({
+                                        selectNodeOnStartup:
+                                            !selectNodeOnStartup
+                                    });
+                                    await updateSettings({
+                                        selectNodeOnStartup:
+                                            !selectNodeOnStartup
                                     });
                                 }}
                             />

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -241,7 +241,8 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
 
     async getSettingsAndNavigate() {
         const { SettingsStore, navigation } = this.props;
-        const { posStatus, setPosStatus } = SettingsStore;
+        const { posStatus, setPosStatus, initialStart, setInitialStart } =
+            SettingsStore;
 
         // This awaits on settings, so should await on Tor being bootstrapped before making requests
         await SettingsStore.getSettings().then(async (settings: Settings) => {
@@ -268,6 +269,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 settings.nodes &&
                 settings.nodes.length > 0
             ) {
+                if (settings.selectNodeOnStartup && initialStart) {
+                    setInitialStart(false);
+                    navigation.navigate('Nodes');
+                }
                 if (!this.state.unlocked) {
                     this.startListeners();
                     this.setState({ unlocked: true });


### PR DESCRIPTION
# Description

This PR adds the ability for users to select which node/wallet to use on start-up.

Currently the setting is presented under `Settings` > `Display`

![simulator_screenshot_151E68F5-54FB-42C3-AC55-B25C70732090](https://github.com/ZeusLN/zeus/assets/1878621/64b9bead-2e47-4df1-86c6-a1e90a9ada80)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [x] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
