### PR TITLE
Keep navigation state when resuming from background and login is required

### DIFF
--- a/components/PinPad.tsx
+++ b/components/PinPad.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useMemo, useState } from 'react';
-import { StyleSheet, Text, Pressable, View } from 'react-native';
+import { StyleSheet, Text, Pressable, View, AppState } from 'react-native';
 import { themeColor } from '../utils/ThemeUtils';
 import { Row } from './layout/Row';
 import Success from '../assets/images/SVG/Success.svg';
@@ -35,6 +35,20 @@ export default function PinPad({
     // PinPad state only depends on pin value length, not the actual pin/amount value
     // Parent component to PinPad can store pin/amount value
     const [pinValueLength, setPinValueLength] = useState(0);
+
+    React.useEffect(() => {
+        const subscription = AppState.addEventListener(
+            'change',
+            (nextAppState) => {
+                if (nextAppState === 'background') {
+                    clearPinValueLength();
+                    clearValue();
+                }
+            }
+        );
+
+        return () => subscription.remove();
+    }, []);
 
     const bigKeypadButtons =
         Stores.settingsStore.settings &&

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -1,6 +1,14 @@
 import { inject, observer } from 'mobx-react';
 import * as React from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+    AppState,
+    AppStateStatus,
+    NativeEventSubscription,
+    ScrollView,
+    StyleSheet,
+    Text,
+    View
+} from 'react-native';
 
 import Button from '../components/Button';
 import Header from '../components/Header';
@@ -45,6 +53,8 @@ export default class Lockscreen extends React.Component<
     LockscreenProps,
     LockscreenState
 > {
+    private subscription: NativeEventSubscription;
+
     constructor(props: any) {
         super(props);
         this.state = {
@@ -63,13 +73,15 @@ export default class Lockscreen extends React.Component<
         };
     }
 
-    proceed = () => {
+    proceed = (navigationTarget?: string) => {
         const { SettingsStore, navigation } = this.props;
         SettingsStore.setInitialStart(false);
-        if (SettingsStore.settings.selectNodeOnStartup) {
+        if (navigationTarget) {
+            navigation.navigate(navigationTarget);
+        } else if (SettingsStore.settings.selectNodeOnStartup) {
             navigation.navigate('Nodes');
         } else {
-            navigation.navigate('Wallet');
+            navigation.pop();
         }
     };
 
@@ -119,7 +131,7 @@ export default class Lockscreen extends React.Component<
             !deleteDuressPin
         ) {
             SettingsStore.setLoginStatus(true);
-            this.proceed();
+            this.proceed('Wallet');
         }
 
         if (settings.authenticationAttempts) {
@@ -156,12 +168,29 @@ export default class Lockscreen extends React.Component<
                     duressPin: settings.duressPin
                 });
             }
-        } else if (settings && settings.nodes && settings.nodes.length > 0) {
+        } else if (settings && settings.nodes && settings?.nodes?.length > 0) {
             this.proceed();
         } else {
             navigation.navigate('IntroSplash');
         }
     }
+
+    componentDidMount() {
+        this.subscription = AppState.addEventListener(
+            'change',
+            this.handleAppStateChange
+        );
+    }
+
+    componentWillUnmount() {
+        this.subscription?.remove();
+    }
+
+    handleAppStateChange = (nextAppState: AppStateStatus) => {
+        if (nextAppState === 'background') {
+            this.setState({ passphraseAttempt: '' });
+        }
+    };
 
     onInputLabelPressed = () => {
         this.setState({ hidden: !this.state.hidden });
@@ -280,7 +309,7 @@ export default class Lockscreen extends React.Component<
             selectedNode: undefined,
             authenticationAttempts: 0
         }).then(() => {
-            this.proceed();
+            this.proceed('IntroSplash');
         });
     };
 
@@ -297,7 +326,7 @@ export default class Lockscreen extends React.Component<
             duressPin: '',
             authenticationAttempts: 0
         }).then(() => {
-            this.proceed();
+            this.proceed('IntroSplash');
         });
     };
 

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -75,10 +75,13 @@ export default class Lockscreen extends React.Component<
 
     proceed = (navigationTarget?: string) => {
         const { SettingsStore, navigation } = this.props;
-        SettingsStore.setInitialStart(false);
         if (navigationTarget) {
             navigation.navigate(navigationTarget);
-        } else if (SettingsStore.settings.selectNodeOnStartup) {
+        } else if (
+            SettingsStore.settings.selectNodeOnStartup &&
+            SettingsStore.initialStart
+        ) {
+            SettingsStore.setInitialStart(false);
             navigation.navigate('Nodes');
         } else {
             navigation.pop();

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -225,10 +225,6 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             SettingsStore.loginMethodConfigured() &&
             loginBackground
         ) {
-            // In case the lock screen is visible and a valid PIN is entered and home button is pressed,
-            // unauthorized access would be possible because the PIN is not cleared on next launch.
-            // By calling pop, the lock screen is closed to clear the PIN.
-            this.props.navigation.pop();
             SettingsStore.setLoginStatus(false);
         } else if (nextAppState === 'active' && SettingsStore.loginRequired()) {
             this.props.navigation.navigate('Lockscreen');


### PR DESCRIPTION
# Description

This fixes #1880.

In Lockscreen, after successful login, we navigated to Wallet. Also, when going to background, we called `navigation.pop()` to close a possibly open PIN screen. Both caused that the navigation state was lost.

Instead we now call `navigation.pop()` after successful login in Lockscreen and clear the entered pin in PinPad when going to background.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
