### PR TITLE
[bug fix] ErrorUtils: handle edge cases 

### DIFF
--- a/utils/ErrorUtils.test.ts
+++ b/utils/ErrorUtils.test.ts
@@ -102,5 +102,11 @@ describe('ErrorUtils', () => {
                 )
             ).toEqual('Random message');
         });
+
+        it('Return string if error is sent as a string', () => {
+            expect(errorToUserFriendly('Payment timed out', false)).toEqual(
+                'Payment timed out'
+            );
+        });
     });
 });

--- a/utils/ErrorUtils.ts
+++ b/utils/ErrorUtils.ts
@@ -11,11 +11,12 @@ const userFriendlyErrors: any = {
     FAILURE_REASON_INCORRECT_PAYMENT_DETAILS:
         'error.failureReasonIncorrectPaymentDetails',
     FAILURE_REASON_INSUFFICIENT_BALANCE:
-        'error.failureReasonInsufficientBalance'
+        'error.failureReasonInsufficientBalance',
+    Error: 'general.error'
 };
 
 const errorToUserFriendly = (error: Error, localize = true) => {
-    let errorMessage: string = error.message;
+    let errorMessage: string = error?.message;
     let errorObject: any;
 
     try {


### PR DESCRIPTION
# Description

We got some report of this error message being thrown frequently. Turns out there's a regression in `ErrorUtils` that causes errors passed in as strings, such as the payment timeout message to be handled incorrectly.

This also adds a generic error message in the edge case that the error is undefined.

![image](https://github.com/ZeusLN/zeus/assets/1878621/161ff4c4-37a3-4bd5-aaec-d20db7a46e3b)

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
