### PR TITLE
Note buttons: fix to bottom of views

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -499,7 +499,6 @@
     "views.Payment.creationDate": "Creation Date",
     "views.Payment.path": "Path",
     "views.Payment.paths": "Paths",
-    "views.Payment.notes": "Notes",
     "views.Payment.writeNote": "Write your note here",
     "views.PaymentRequest.title": "Lightning Invoice",
     "views.PaymentRequest.error": "Error loading invoice",

--- a/views/AddNotes.tsx
+++ b/views/AddNotes.tsx
@@ -151,15 +151,9 @@ export default class AddNotes extends React.Component<
                         }}
                     >
                         <Button
-                            title={
-                                isNoteStored
-                                    ? localeString(
-                                          'views.SendingLightning.UpdateNote'
-                                      )
-                                    : localeString(
-                                          'views.SendingLightning.AddANote'
-                                      )
-                            }
+                            title={localeString(
+                                'views.Settings.SetPassword.save'
+                            )}
                             onPress={() => saveNote()}
                             buttonStyle={{
                                 padding: 15

--- a/views/Invoice.tsx
+++ b/views/Invoice.tsx
@@ -288,7 +288,7 @@ export default class InvoiceView extends React.Component<InvoiceProps> {
 
                         {storedNotes && (
                             <KeyValue
-                                keyValue={localeString('views.Payment.notes')}
+                                keyValue={localeString('general.note')}
                                 value={storedNotes}
                                 sensitive
                                 mempoolLink={() =>
@@ -298,30 +298,30 @@ export default class InvoiceView extends React.Component<InvoiceProps> {
                                 }
                             />
                         )}
-
-                        {noteKey && (
-                            <Button
-                                title={
-                                    storedNotes
-                                        ? localeString(
-                                              'views.SendingLightning.UpdateNote'
-                                          )
-                                        : localeString(
-                                              'views.SendingLightning.AddANote'
-                                          )
-                                }
-                                onPress={() =>
-                                    navigation.navigate('AddNotes', {
-                                        getRPreimage: noteKey
-                                    })
-                                }
-                                containerStyle={{ marginTop: 15 }}
-                                secondary
-                                noUppercase
-                            />
-                        )}
                     </View>
                 </ScrollView>
+                <View style={{ bottom: 15 }}>
+                    {noteKey && (
+                        <Button
+                            title={
+                                storedNotes
+                                    ? localeString(
+                                          'views.SendingLightning.UpdateNote'
+                                      )
+                                    : localeString(
+                                          'views.SendingLightning.AddANote'
+                                      )
+                            }
+                            onPress={() =>
+                                navigation.navigate('AddNotes', {
+                                    getRPreimage: noteKey
+                                })
+                            }
+                            containerStyle={{ marginTop: 15 }}
+                            noUppercase
+                        />
+                    )}
+                </View>
             </Screen>
         );
     }

--- a/views/Payment.tsx
+++ b/views/Payment.tsx
@@ -277,7 +277,7 @@ export default class PaymentView extends React.Component<PaymentProps> {
                         )}
                         {storedNotes && (
                             <KeyValue
-                                keyValue={localeString('views.Payment.notes')}
+                                keyValue={localeString('general.note')}
                                 value={storedNotes}
                                 sensitive
                                 mempoolLink={() =>
@@ -287,29 +287,30 @@ export default class PaymentView extends React.Component<PaymentProps> {
                                 }
                             />
                         )}
-                        {noteKey && (
-                            <Button
-                                title={
-                                    storedNotes
-                                        ? localeString(
-                                              'views.SendingLightning.UpdateNote'
-                                          )
-                                        : localeString(
-                                              'views.SendingLightning.AddANote'
-                                          )
-                                }
-                                onPress={() =>
-                                    navigation.navigate('AddNotes', {
-                                        payment_hash: noteKey
-                                    })
-                                }
-                                containerStyle={{ marginTop: 15 }}
-                                secondary
-                                noUppercase
-                            />
-                        )}
                     </View>
                 </ScrollView>
+                <View style={{ bottom: 15 }}>
+                    {noteKey && (
+                        <Button
+                            title={
+                                storedNotes
+                                    ? localeString(
+                                          'views.SendingLightning.UpdateNote'
+                                      )
+                                    : localeString(
+                                          'views.SendingLightning.AddANote'
+                                      )
+                            }
+                            onPress={() =>
+                                navigation.navigate('AddNotes', {
+                                    payment_hash: noteKey
+                                })
+                            }
+                            containerStyle={{ marginTop: 15 }}
+                            noUppercase
+                        />
+                    )}
+                </View>
             </Screen>
         );
     }

--- a/views/Transaction.tsx
+++ b/views/Transaction.tsx
@@ -356,25 +356,25 @@ export default class TransactionView extends React.Component<
                             }
                         >
                             <KeyValue
-                                keyValue={localeString('views.Payment.notes')}
+                                keyValue={localeString('general.note')}
                                 value={storedNotes}
                                 sensitive
                             />
                         </TouchableOpacity>
                     )}
-
+                </ScrollView>
+                <View style={{ bottom: 15 }}>
                     {!isConfirmed && BackendUtils.supportsBumpFee() && (
-                        <View style={{ marginTop: 20 }}>
-                            <Button
-                                title={localeString('views.BumpFee.title')}
-                                onPress={() =>
-                                    navigation.navigate('BumpFee', {
-                                        outpoint: getOutpoint
-                                    })
-                                }
-                                noUppercase
-                            />
-                        </View>
+                        <Button
+                            title={localeString('views.BumpFee.title')}
+                            onPress={() =>
+                                navigation.navigate('BumpFee', {
+                                    outpoint: getOutpoint
+                                })
+                            }
+                            noUppercase
+                            containerStyle={{ marginTop: 20 }}
+                        />
                     )}
 
                     {tx && (
@@ -395,7 +395,7 @@ export default class TransactionView extends React.Component<
                             noUppercase
                         />
                     )}
-                </ScrollView>
+                </View>
             </Screen>
         );
     }


### PR DESCRIPTION
# Description

This PR affixes the buttons on the `Transaction`, `Payment`, and `Invoice` views to the bottom of the page and gives them a uniform style. It also modifies the `AddNotes` view slightly, fixing a casing issue and simplifying the save button.

Before and afters:

<img width="1049" alt="Screenshot 2024-04-20 at 00 27 51" src="https://github.com/ZeusLN/zeus/assets/1878621/99d44827-ac3f-474e-8011-d5794d7b0b47">

<img width="1086" alt="Screenshot 2024-04-20 at 00 28 24" src="https://github.com/ZeusLN/zeus/assets/1878621/acfd2cee-d670-4f1d-96fa-a4f4a57bb3bf">

<img width="1065" alt="Screenshot 2024-04-20 at 00 30 11" src="https://github.com/ZeusLN/zeus/assets/1878621/5a95a833-d383-4726-832f-c2a1eb1a9b95">

<img width="1087" alt="Screenshot 2024-04-20 at 00 30 59" src="https://github.com/ZeusLN/zeus/assets/1878621/c110537a-1974-4a5a-aaa0-f284e88e9fca">

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
