### PR TITLE
Do not require login after setting new PIN or password

### DIFF
--- a/views/Settings/SetPassword.tsx
+++ b/views/Settings/SetPassword.tsx
@@ -93,7 +93,7 @@ export default class SetPassphrase extends React.Component<
         }
 
         await updateSettings({ passphrase }).then(() => {
-            setLoginStatus(false);
+            setLoginStatus(true);
             getSettings();
             navigation.navigate('Settings', {
                 refresh: true
@@ -254,10 +254,7 @@ export default class SetPassphrase extends React.Component<
                                         this.deletePassword();
                                     }
                                 }}
-                                titleStyle={{
-                                    color: themeColor('delete')
-                                }}
-                                secondary
+                                warning
                             />
                         </View>
                     )}

--- a/views/Settings/SetPin.tsx
+++ b/views/Settings/SetPin.tsx
@@ -92,7 +92,7 @@ export default class SetPin extends React.Component<SetPinProps, SetPinState> {
         }
 
         await updateSettings({ pin }).then(() => {
-            setLoginStatus(false);
+            setLoginStatus(true);
             getSettings();
             navigation.navigate('Settings', {
                 refresh: true


### PR DESCRIPTION
# Description

This fixes #1757. After setting a new PIN or password, no additional login is required now. Also improved color of 'Delete Password' button:

![grafik](https://github.com/ZeusLN/zeus/assets/77545287/5a000b92-fa87-434e-9366-66375aca3a21)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
