### PR TITLE
ZEUS-2042: add feedback to manual SCB recovery process

### DIFF
--- a/views/Settings/EmbeddedNode/DisasterRecoveryAdvanced.tsx
+++ b/views/Settings/EmbeddedNode/DisasterRecoveryAdvanced.tsx
@@ -6,14 +6,15 @@ import moment from 'moment';
 import { StackNavigationProp } from '@react-navigation/stack';
 
 import Button from '../../../components/Button';
-import Screen from '../../../components/Screen';
 import Header from '../../../components/Header';
+import LoadingIndicator from '../../../components/LoadingIndicator';
+import Screen from '../../../components/Screen';
+import { ErrorMessage } from '../../../components/SuccessErrorMessage';
 
 import ChannelBackupStore from '../../../stores/ChannelBackupStore';
 
 import { localeString } from '../../../utils/LocaleUtils';
 import { themeColor } from '../../../utils/ThemeUtils';
-import LoadingIndicator from '../../../components/LoadingIndicator';
 
 interface DisasterRecoveryAdvancedProps {
     navigation: StackNavigationProp<any, any>;
@@ -35,7 +36,9 @@ export default class DisasterRecoveryAdvanced extends React.Component<
     };
 
     UNSAFE_componentWillMount(): void {
-        this.props.ChannelBackupStore.advancedRecoveryList();
+        const { ChannelBackupStore } = this.props;
+        ChannelBackupStore.reset();
+        ChannelBackupStore.advancedRecoveryList();
     }
 
     render() {
@@ -46,7 +49,8 @@ export default class DisasterRecoveryAdvanced extends React.Component<
             triggerRecovery,
             backups,
             loading,
-            error
+            error,
+            error_msg
         } = ChannelBackupStore;
 
         const noneSelected = Object.keys(selected).length === 0;
@@ -110,14 +114,19 @@ export default class DisasterRecoveryAdvanced extends React.Component<
                                     disabled={noneSelected}
                                     onPress={async () => {
                                         if (selected.backup) {
-                                            await triggerRecovery(
-                                                selected.backup
-                                            );
-                                            navigation.popTo('Wallet');
+                                            try {
+                                                await triggerRecovery(
+                                                    selected.backup
+                                                );
+                                                navigation.popTo('Wallet');
+                                            } catch (e) {}
                                         }
                                     }}
                                 />
                             </View>
+                        )}
+                        {!loading && error_msg && (
+                            <ErrorMessage message={error_msg} />
                         )}
                         {!loading && backups.length > 0 && (
                             <FlatList


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2042**](https://github.com/ZeusLN/zeus/issues/2042)

When manually recovering SCB data, a loading indicator will now be shown and an error message will be displayed properly on error.

![simulator_screenshot_C93AE1E9-428B-4BE9-A1D9-0DE5352823F9](https://github.com/ZeusLN/zeus/assets/1878621/38e9405c-b721-467e-9e2b-9c3b34001fee)

This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- x ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
