### PR TITLE
ZEUS-2214: LNURL-channel: default to unannounced channel

### DIFF
--- a/views/LnurlChannel.tsx
+++ b/views/LnurlChannel.tsx
@@ -57,7 +57,7 @@ export default class LnurlChannel extends React.Component<
         } catch (err) {
             this.state = {
                 domain: '',
-                privateChannel: false,
+                privateChannel: true,
                 node_pubkey_string: '',
                 host: '',
                 k1: '',
@@ -89,7 +89,7 @@ export default class LnurlChannel extends React.Component<
             k1: lnurl.k1,
             localnodeids: [],
             localnodeid: '',
-            privateChannel: false,
+            privateChannel: true,
             connectingToPeer: false,
             peerSuccess: false,
             lnurlChannelSuccess: false,
@@ -246,10 +246,12 @@ export default class LnurlChannel extends React.Component<
                                     fontFamily: 'PPNeueMontreal-Book'
                                 }}
                             >
-                                {localeString('views.OpenChannel.private')}
+                                {localeString(
+                                    'views.Wallet.Channels.announced'
+                                )}
                             </Text>
                             <Switch
-                                value={privateChannel}
+                                value={!privateChannel}
                                 onValueChange={() =>
                                     this.setState({
                                         privateChannel: !privateChannel


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2214**](https://github.com/ZeusLN/zeus/issues/2214)

This PR changes to the behavior for LNURL-channel to default to private (unannounced) channels. It also updated the toggle to label to match that of the `Open Channel` view and use the label "Announced"

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
