### PR TITLE
Neutrino: auto-select peers on wallet creation

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -497,6 +497,7 @@
     "views.Intro.lightningLiquidity": "Learn about lightning liquidity",
     "views.Intro.advancedSetUp": "Advanced set-up",
     "views.Intro.creatingWallet": "Zeus is creating your wallet.",
+    "views.Intro.choosingPeers": "ZEUS is choosing your peers.",
     "views.Intro.carousel1.title": "Payments you can trust",
     "views.Intro.carousel1.text": "ZEUS runs a Bitcoin and Lightning node to verify and keep your transactions private.",
     "views.Intro.carousel2.title": "On-chain transfers",

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -976,6 +976,12 @@ export const DEFAULT_NEUTRINO_PEERS_MAINNET = [
     'sg.lnolymp.us'
 ];
 
+export const SECONDARY_NEUTRINO_PEERS_MAINNET = [
+    'node.blixtwallet.com',
+    'bb1.breez.technology',
+    'bb2.breez.technology'
+];
+
 export const DEFAULT_NEUTRINO_PEERS_TESTNET = [
     'testnet.lnolymp.us',
     'btcd-testnet.lightning.computer',

--- a/views/Intro.tsx
+++ b/views/Intro.tsx
@@ -18,7 +18,7 @@ import LoadingIndicator from '../components/LoadingIndicator';
 import Screen from '../components/Screen';
 import { ErrorMessage } from '../components/SuccessErrorMessage';
 
-import { createLndWallet } from '../utils/LndMobileUtils';
+import { chooseNeutrinoPeers, createLndWallet } from '../utils/LndMobileUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
 import UrlUtils from '../utils/UrlUtils';
@@ -36,6 +36,7 @@ interface IntroProps {
 
 const Intro: React.FC<IntroProps> = (props) => {
     const [creatingWallet, setCreatingWallet] = useState(false);
+    const [choosingPeers, setChoosingPeers] = useState(false);
     const [error, setError] = useState(false);
 
     let screenWidth: number;
@@ -171,12 +172,19 @@ const Intro: React.FC<IntroProps> = (props) => {
                             <Button
                                 title={localeString('views.Intro.quickStart')}
                                 onPress={async () => {
-                                    setCreatingWallet(true);
                                     const { settingsStore } = stores;
                                     const {
                                         setConnectingStatus,
                                         updateSettings
                                     } = settingsStore;
+
+                                    setChoosingPeers(true);
+
+                                    await chooseNeutrinoPeers(undefined);
+
+                                    setCreatingWallet(true);
+                                    setChoosingPeers(false);
+
                                     const response = await createLndWallet(
                                         undefined
                                     );
@@ -203,6 +211,7 @@ const Intro: React.FC<IntroProps> = (props) => {
                                         });
                                     } else {
                                         setCreatingWallet(false);
+                                        setChoosingPeers(false);
                                         setError(true);
                                     }
                                 }}
@@ -282,7 +291,7 @@ const Intro: React.FC<IntroProps> = (props) => {
         );
     };
 
-    if (creatingWallet) {
+    if (choosingPeers || creatingWallet) {
         return (
             <Screen>
                 <View
@@ -312,10 +321,11 @@ const Intro: React.FC<IntroProps> = (props) => {
                             padding: 8
                         }}
                     >
-                        {localeString('views.Intro.creatingWallet').replace(
-                            'Zeus',
-                            'ZEUS'
-                        )}
+                        {choosingPeers
+                            ? localeString('views.Intro.choosingPeers')
+                            : localeString(
+                                  'views.Intro.creatingWallet'
+                              ).replace('Zeus', 'ZEUS')}
                     </Text>
                     <View style={{ marginTop: 40 }}>
                         <LoadingIndicator />

--- a/views/Settings/NodeConfiguration.tsx
+++ b/views/Settings/NodeConfiguration.tsx
@@ -51,7 +51,10 @@ import Scan from '../../assets/images/SVG/Scan.svg';
 import AddIcon from '../../assets/images/SVG/Add.svg';
 
 import { getPhoto } from '../../utils/PhotoUtils';
-import { createLndWallet } from '../../utils/LndMobileUtils';
+import {
+    chooseNeutrinoPeers,
+    createLndWallet
+} from '../../utils/LndMobileUtils';
 
 interface NodeConfigurationProps {
     navigation: StackNavigationProp<any, any>;
@@ -596,6 +599,8 @@ export default class NodeConfiguration extends React.Component<
         this.setState({
             creatingWallet: true
         });
+
+        await chooseNeutrinoPeers(network === 'Testnet');
 
         const response = await createLndWallet(
             recoveryCipherSeed,

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -21,7 +21,10 @@ import TextInput from '../../components/TextInput';
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
 
-import { createLndWallet } from '../../utils/LndMobileUtils';
+import {
+    chooseNeutrinoPeers,
+    createLndWallet
+} from '../../utils/LndMobileUtils';
 
 import { BIP39_WORD_LIST } from '../../utils/Bip39Utils';
 
@@ -876,6 +879,10 @@ export default class SeedRecovery extends React.PureComponent<
                                     this.setState({
                                         loading: true
                                     });
+
+                                    await chooseNeutrinoPeers(
+                                        network === 'testnet'
+                                    );
 
                                     try {
                                         const response = await createLndWallet(


### PR DESCRIPTION
# Description

This PR optimizes the Neutrino peers selected by default for users, by pinging predefined sets of peers and setting the user's peers to be only those with pings of under 200ms

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
