### PR TITLE
Neutrino: increase ping threshold, 200->1000ms

### DIFF
--- a/components/Modals/AlertModal.tsx
+++ b/components/Modals/AlertModal.tsx
@@ -10,6 +10,7 @@ import ModalStore from '../../stores/ModalStore';
 import NodeInfoStore from '../../stores/NodeInfoStore';
 import SettingsStore from '../../stores/SettingsStore';
 
+import { NEUTRINO_PING_THRESHOLD_MS } from '../../utils/LndMobileUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { restartNeeded } from '../../utils/RestartUtils';
 import { themeColor } from '../../utils/ThemeUtils';
@@ -153,9 +154,9 @@ export default class AlertModal extends React.Component<AlertModalProps, {}> {
                                         color: themeColor('text')
                                     }}
                                 >
-                                    {localeString(
+                                    {`${localeString(
                                         'components.AlertModal.neutrinoExplainer'
-                                    )}
+                                    )} (>${NEUTRINO_PING_THRESHOLD_MS}ms)`}
                                 </Text>
 
                                 <Text

--- a/locales/en.json
+++ b/locales/en.json
@@ -1193,7 +1193,7 @@
     "components.AlertModal.zombieExplainer": "Zombie channels indicate stale data on your downloaded network graph.",
     "components.AlertModal.resetEGS": "Reset express graph sync data",
     "components.AlertModal.neutrinoPeers": "Problematic neutrino peers",
-    "components.AlertModal.neutrinoExplainer": "Neutrino peers with over 200ms ping time can cause performance issues in the app.",
+    "components.AlertModal.neutrinoExplainer": "Neutrino peers with high ping times can cause performance issues in the app.",
     "components.AlertModal.reviewPeers": "Review neutrino peers list",
     "views.PendingHTLCs.title": "Pending HTLCs",
     "views.PendingHTLCs.noPendingHTLCs": "No pending HTLCs",

--- a/stores/AlertStore.ts
+++ b/stores/AlertStore.ts
@@ -5,6 +5,11 @@ import SettingsStore from './SettingsStore';
 import NodeInfoStore from './NodeInfoStore';
 import { localeString } from '../utils/LocaleUtils';
 
+import {
+    NEUTRINO_PING_TIMEOUT_MS,
+    NEUTRINO_PING_THRESHOLD_MS
+} from '../utils/LndMobileUtils';
+
 const ZOMBIE_CHAN_THRESHOLD = 21000;
 
 interface Peer {
@@ -60,7 +65,7 @@ export default class AlertStore {
             await new Promise(async (resolve) => {
                 try {
                     const ms = await Ping.start(peer, {
-                        timeout: 1000
+                        timeout: NEUTRINO_PING_TIMEOUT_MS
                     });
                     console.log(`# ${peer} - ${ms}`);
                     results.push({
@@ -87,7 +92,8 @@ export default class AlertStore {
                     localeString(
                         'views.Settings.EmbeddedNode.NeutrinoPeers.timedOut'
                     ) ||
-                (Number.isInteger(result.ms) && result.ms > 200)
+                (Number.isInteger(result.ms) &&
+                    result.ms > NEUTRINO_PING_THRESHOLD_MS)
             );
         });
 

--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -70,6 +70,9 @@ export function checkLndStreamErrorResponse(
     return null;
 }
 
+export const NEUTRINO_PING_TIMEOUT_MS = 1500;
+export const NEUTRINO_PING_THRESHOLD_MS = 1000;
+
 const writeLndConfig = async (
     isTestnet?: boolean,
     rescan?: boolean,
@@ -287,7 +290,9 @@ export async function startLnd(
 }
 
 export async function chooseNeutrinoPeers(isTestnet?: boolean) {
-    console.log('Selecting Neutrino peers with ping times <200ms');
+    console.log(
+        `Selecting Neutrino peers with ping times <${NEUTRINO_PING_THRESHOLD_MS}ms`
+    );
     let peers = isTestnet
         ? DEFAULT_NEUTRINO_PEERS_TESTNET
         : DEFAULT_NEUTRINO_PEERS_MAINNET;
@@ -298,7 +303,7 @@ export async function chooseNeutrinoPeers(isTestnet?: boolean) {
         await new Promise(async (resolve) => {
             try {
                 const ms = await Ping.start(peer, {
-                    timeout: 1000
+                    timeout: NEUTRINO_PING_TIMEOUT_MS
                 });
                 console.log(`# ${peer} - ${ms}`);
                 results.push({
@@ -318,7 +323,10 @@ export async function chooseNeutrinoPeers(isTestnet?: boolean) {
     }
 
     let filteredResults = results.filter((result: any) => {
-        return Number.isInteger(result.ms) && result.ms < 200;
+        return (
+            Number.isInteger(result.ms) &&
+            result.ms < NEUTRINO_PING_THRESHOLD_MS
+        );
     });
 
     if (filteredResults.length < 3 && !isTestnet) {
@@ -328,7 +336,7 @@ export async function chooseNeutrinoPeers(isTestnet?: boolean) {
             await new Promise(async (resolve) => {
                 try {
                     const ms = await Ping.start(peer, {
-                        timeout: 1000
+                        timeout: NEUTRINO_PING_TIMEOUT_MS
                     });
                     console.log(`# ${peer} - ${ms}`);
                     results.push({
@@ -349,7 +357,10 @@ export async function chooseNeutrinoPeers(isTestnet?: boolean) {
     }
 
     filteredResults = results.filter((result: any) => {
-        return Number.isInteger(result.ms) && result.ms < 200;
+        return (
+            Number.isInteger(result.ms) &&
+            result.ms < NEUTRINO_PING_THRESHOLD_MS
+        );
     });
 
     const selectedPeers: string[] = [];

--- a/views/Settings/EmbeddedNode/Peers/NeutrinoPeers.tsx
+++ b/views/Settings/EmbeddedNode/Peers/NeutrinoPeers.tsx
@@ -17,6 +17,7 @@ import {
     WarningMessage,
     ErrorMessage
 } from '../../../../components/SuccessErrorMessage';
+import LoadingIndicator from '../../../../components/LoadingIndicator';
 
 import SettingsStore, {
     DEFAULT_NEUTRINO_PEERS_MAINNET,
@@ -26,7 +27,10 @@ import SettingsStore, {
 import { localeString } from '../../../../utils/LocaleUtils';
 import { restartNeeded } from '../../../../utils/RestartUtils';
 import { themeColor } from '../../../../utils/ThemeUtils';
-import LoadingIndicator from '../../../../components/LoadingIndicator';
+import {
+    NEUTRINO_PING_THRESHOLD_MS,
+    NEUTRINO_PING_TIMEOUT_MS
+} from '../../../../utils/LndMobileUtils';
 
 import Stopwatch from '../../../../assets/images/SVG/Stopwatch.svg';
 
@@ -128,7 +132,7 @@ export default class NeutrinoPeers extends React.Component<
                         {!pingTimeout &&
                             !pinging &&
                             pingHost &&
-                            pingTime <= 100 && (
+                            pingTime <= 200 && (
                                 <SuccessMessage
                                     message={pingTimeMsg}
                                     dismissable
@@ -137,8 +141,8 @@ export default class NeutrinoPeers extends React.Component<
                         {!pingTimeout &&
                             !pinging &&
                             pingHost &&
-                            pingTime < 200 &&
-                            pingTime > 100 && (
+                            pingTime < NEUTRINO_PING_THRESHOLD_MS &&
+                            pingTime > 200 && (
                                 <WarningMessage
                                     message={pingTimeMsg}
                                     dismissable
@@ -147,7 +151,7 @@ export default class NeutrinoPeers extends React.Component<
                         {!pingTimeout &&
                             !pinging &&
                             pingHost &&
-                            pingTime >= 200 && (
+                            pingTime >= NEUTRINO_PING_THRESHOLD_MS && (
                                 <ErrorMessage
                                     message={pingTimeMsg}
                                     dismissable
@@ -275,7 +279,8 @@ export default class NeutrinoPeers extends React.Component<
                                                             await Ping.start(
                                                                 addPeer,
                                                                 {
-                                                                    timeout: 1000
+                                                                    timeout:
+                                                                        NEUTRINO_PING_TIMEOUT_MS
                                                                 }
                                                             );
                                                         this.setState({
@@ -390,7 +395,8 @@ export default class NeutrinoPeers extends React.Component<
                                                                         await Ping.start(
                                                                             item,
                                                                             {
-                                                                                timeout: 1000
+                                                                                timeout:
+                                                                                    NEUTRINO_PING_TIMEOUT_MS
                                                                             }
                                                                         );
                                                                     this.setState(


### PR DESCRIPTION
# Description

This PR changes the upper threshold for what we consider an acceptable Neutrino ping from 200ms to 1000ms. This will be taken into consideration when auto-selecting Neutrino peers on wallet creation/recovery, on our new alerts system, and in the manual ping test system on the Neutrino peers settings page.

Related Neutrino commits:

https://github.com/ZeusLN/lnd/commit/41ce36eec3bb2d3bce8aa3a7bd102126381bed81

https://github.com/djkazic/neutrino/commit/c8fd04d4f772fec06ae5f71da5c641dd37db34c8

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
