### PR TITLE
POS: Display 'sats' in CHARGE button when fiat is not enabled

### DIFF
--- a/views/Wallet/StandalonePosPane.tsx
+++ b/views/Wallet/StandalonePosPane.tsx
@@ -748,7 +748,12 @@ export default class StandalonePosPane extends React.PureComponent<
                                 title={`${localeString('general.charge')} (${
                                     currentOrder
                                         ? (itemQty > 0 ? `${itemQty} - ` : '') +
-                                          (this.state.totalMoneyDisplay || 0)
+                                          (fiatEnabled
+                                              ? this.state.totalMoneyDisplay
+                                              : ` ${this.props.UnitsStore.getAmountFromSats(
+                                                    currentOrder?.total_money
+                                                        ?.sats
+                                                )}`)
                                         : '0'
                                 })`}
                                 containerStyle={{


### PR DESCRIPTION
https://github.com/ZeusLN/zeus/issues/2128

Earlier we used to get $0 when we try to checkout POS orders if fiat are disabled in settings. instead of that we should have the `sats` as currency in that case



Before:

https://github.com/ZeusLN/zeus/assets/50761978/94713b15-54c5-41ff-8aa3-9e781c3e1886




After:

https://github.com/ZeusLN/zeus/assets/50761978/fcb1d988-0fc0-4559-a82e-1c3baac41abe




