### PR TITLE
Currency Converter: Fix flags position in input boxes

### DIFF
--- a/views/Settings/CurrencyConverter.tsx
+++ b/views/Settings/CurrencyConverter.tsx
@@ -554,7 +554,7 @@ export default class CurrencyConverter extends React.Component<
                                                         style={{
                                                             position:
                                                                 'absolute',
-                                                            left: [
+                                                            right: [
                                                                 'BTC',
                                                                 'sats'
                                                             ].includes(item)


### PR DESCRIPTION
Fixed the flags position in Currency Converter input boxes which broke due to our recent update to react native `0.74.2`