### PR TITLE
Startup: wait for node selection to load invoice

### DIFF
--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -92,7 +92,6 @@ export default class Lockscreen extends React.Component<
             SettingsStore.settings.selectNodeOnStartup &&
             SettingsStore.initialStart
         ) {
-            SettingsStore.setInitialStart(false);
             navigation.navigate('Nodes');
         } else {
             navigation.pop();
@@ -234,7 +233,14 @@ export default class Lockscreen extends React.Component<
             (pinAttempt && pinAttempt === pin)
         ) {
             SettingsStore.setLoginStatus(true);
-            LinkingUtils.handleInitialUrl(navigation);
+            if (
+                !(
+                    SettingsStore.settings.selectNodeOnStartup &&
+                    SettingsStore.initialStart
+                )
+            ) {
+                LinkingUtils.handleInitialUrl(navigation);
+            }
             if (modifySecurityScreen) {
                 this.resetAuthenticationAttempts();
                 navigation.navigate(modifySecurityScreen);
@@ -252,7 +258,14 @@ export default class Lockscreen extends React.Component<
             (duressPin && pinAttempt === duressPin)
         ) {
             SettingsStore.setLoginStatus(true);
-            LinkingUtils.handleInitialUrl(navigation);
+            if (
+                !(
+                    SettingsStore.settings.selectNodeOnStartup &&
+                    SettingsStore.initialStart
+                )
+            ) {
+                LinkingUtils.handleInitialUrl(navigation);
+            }
             this.deleteNodes();
         } else {
             // need to fetch updated settings to get incremented value of
@@ -268,7 +281,14 @@ export default class Lockscreen extends React.Component<
             });
             if (authenticationAttempts >= maxAuthenticationAttempts) {
                 SettingsStore.setLoginStatus(true);
-                LinkingUtils.handleInitialUrl(navigation);
+                if (
+                    !(
+                        SettingsStore.settings.selectNodeOnStartup &&
+                        SettingsStore.initialStart
+                    )
+                ) {
+                    LinkingUtils.handleInitialUrl(navigation);
+                }
                 // wipe node configs, passwords, and pins
                 this.authenticationFailure();
             } else {

--- a/views/Settings/Nodes.tsx
+++ b/views/Settings/Nodes.tsx
@@ -106,8 +106,12 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
             SettingsStore
         } = this.props;
         const { loading, nodes, selectedNode } = this.state;
-        const { updateSettings, setConnectingStatus, implementation }: any =
-            SettingsStore;
+        const {
+            updateSettings,
+            setConnectingStatus,
+            setInitialStart,
+            implementation
+        }: any = SettingsStore;
 
         const implementationDisplayValue = {};
         INTERFACE_KEYS.forEach((item) => {
@@ -242,6 +246,7 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                                                 NodeInfoStore.reset();
                                                 ChannelsStore.reset();
                                                 setConnectingStatus(true);
+                                                setInitialStart(false);
                                                 navigation.popTo('Wallet', {
                                                     refresh: true
                                                 });

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -237,8 +237,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
 
     async getSettingsAndNavigate() {
         const { SettingsStore, navigation } = this.props;
-        const { posStatus, setPosStatus, initialStart, setInitialStart } =
-            SettingsStore;
+        const { posStatus, setPosStatus, initialStart } = SettingsStore;
 
         // This awaits on settings, so should await on Tor being bootstrapped before making requests
         await SettingsStore.getSettings().then(async (settings: Settings) => {
@@ -273,7 +272,6 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 settings.nodes.length > 0
             ) {
                 if (settings.selectNodeOnStartup && initialStart) {
-                    setInitialStart(false);
                     navigation.navigate('Nodes');
                 }
                 if (!this.state.unlocked) {
@@ -507,7 +505,13 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         }
 
         // only navigate to initial url after connection and main calls are made
-        if (this.state.initialLoad) {
+        if (
+            this.state.initialLoad &&
+            !(
+                SettingsStore.settings.selectNodeOnStartup &&
+                SettingsStore.initialStart
+            )
+        ) {
             this.setState({
                 initialLoad: false
             });


### PR DESCRIPTION
# Description

This PR fixes an issue with loading invoices when `Select node on start-up` is enable under Display settings.

Previously, when the app was being opened to pay an invoice, it would skip the `Nodes` view. This PR ensures that a node is selected by the user before the invoice is loaded.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
