### PR TITLE
Add CLN.jpg to selection for CLNRest in SetNodePicture.tsx

### DIFF
--- a/views/Settings/SetNodePicture.tsx
+++ b/views/Settings/SetNodePicture.tsx
@@ -73,7 +73,10 @@ export default class SetNodePicture extends React.Component<
             ],
             'embedded-lnd': [require('../../assets/images/LND.jpg')],
             'lightning-node-connect': [require('../../assets/images/LND.jpg')],
-            'cln-rest: [require('../../assets/images/CLN.jpg')]
+            'cln-rest': [
+                require('../../assets/images/CLN.jpg'),
+                require('../../assets/images/BTCpay.jpg')
+            ]
         };
 
         if (implementation && implementation in implementationImagesMap) {

--- a/views/Settings/SetNodePicture.tsx
+++ b/views/Settings/SetNodePicture.tsx
@@ -72,7 +72,8 @@ export default class SetNodePicture extends React.Component<
                 require('../../assets/images/LND.jpg')
             ],
             'embedded-lnd': [require('../../assets/images/LND.jpg')],
-            'lightning-node-connect': [require('../../assets/images/LND.jpg')]
+            'lightning-node-connect': [require('../../assets/images/LND.jpg')],
+            'cln-rest: [require('../../assets/images/CLN.jpg')]
         };
 
         if (implementation && implementation in implementationImagesMap) {


### PR DESCRIPTION
# Description

Add CLN.jpg to selection for the CLNRest implementation. This existing image is used today for c-lightning-REST.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [x] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [x] CLNRest
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
