### PR TITLE
[bug fix] LND (REST): incorrectly displayed failed payment

### DIFF
--- a/models/Payment.ts
+++ b/models/Payment.ts
@@ -21,7 +21,7 @@ export default class Payment extends BaseModel {
     bolt: string;
     status: string;
     payment_request: string;
-    failure_reason?: string;
+    failure_reason?: string | number;
     // c-lightning
     id?: string;
     destination?: string;
@@ -146,7 +146,13 @@ export default class Payment extends BaseModel {
                 }
             }
         }
-        if (this.failure_reason) isFailed = true;
+        if (
+            this.failure_reason &&
+            this.failure_reason !== 'FAILURE_REASON_NONE' &&
+            this.failure_reason !==
+                lnrpc.PaymentFailureReason.FAILURE_REASON_NONE
+        )
+            isFailed = true;
         return isFailed;
     }
 


### PR DESCRIPTION
# Description

A regression was added in https://github.com/ZeusLN/zeus/commit/77bcc7cd481f35dce27bd78197f185b6d3627e66 that causes payments in LND (REST) interfaces to all show as failed payments.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
