### PR TITLE
CLNRest: performance improvements using sql query

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -157,7 +157,7 @@ export default class CLNRest {
         route: string,
         ws?: boolean
     ) => {
-        const hostPath = host.includes('://') ? host : `http://${host}`;
+        const hostPath = host.includes('://') ? host : `https://${host}`;
         let baseUrl = `${hostPath}${port ? ':' + port : ''}`;
 
         if (ws) {

--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -157,7 +157,7 @@ export default class CLNRest {
         route: string,
         ws?: boolean
     ) => {
-        const hostPath = host.includes('://') ? host : `https://${host}`;
+        const hostPath = host.includes('://') ? host : `http://${host}`;
         let baseUrl = `${hostPath}${port ? ':' + port : ''}`;
 
         if (ws) {
@@ -210,7 +210,8 @@ export default class CLNRest {
         return this.postRequest('/v1/withdraw', request);
     };
     getMyNodeInfo = () => this.postRequest('/v1/getinfo');
-    getInvoices = () => this.postRequest('/v1/listinvoices');
+    getInvoices = () =>
+        this.postRequest('/v1/listinvoices', { limit: 150, index: 'created' });
     createInvoice = (data: any) =>
         this.postRequest('/v1/invoice', {
             description: data.memo,

--- a/backends/CoreLightningRequestHandler.ts
+++ b/backends/CoreLightningRequestHandler.ts
@@ -147,7 +147,8 @@ export const getChainTransactions = async () => {
     }
 
     const getinfo = getinfoResult.value;
-    const allTxs = sqlResult.status === 'fulfilled' ? sqlResult.value : [];
+    const allTxs =
+        sqlResult.status === 'fulfilled' ? sqlResult.value : { rows: [] };
 
     const walletTxs = allTxs.rows.filter(
         (tx: any) =>

--- a/backends/CoreLightningRequestHandler.ts
+++ b/backends/CoreLightningRequestHandler.ts
@@ -131,13 +131,15 @@ export const listPeers = async (data: any) => {
 
 // Get all chain transactions from your core-lightnig node
 export const getChainTransactions = async () => {
+    const sqlQuery =
+        `SELECT * FROM bkpr_accountevents WHERE (tag='deposit' OR tag='to_them' OR tag='channel_open' OR tag='channel_close') ORDER BY timestamp DESC LIMIT 5`.trim();
+
     const results = await Promise.allSettled([
-        api.postRequest('/v1/bkpr-listaccountevents'),
+        api.postRequest('/v1/sql', { query: sqlQuery.trim() }),
         api.postRequest('/v1/listtransactions'),
         api.postRequest('/v1/getinfo')
     ]);
-
-    const [walletTxsResult, listTxsResult, getinfoResult] = results;
+    const [sqlResult, listTxsResult, getinfoResult] = results;
 
     // If getinfo fails, return blank txs
     if (getinfoResult.status !== 'fulfilled') {
@@ -145,27 +147,17 @@ export const getChainTransactions = async () => {
     }
 
     const getinfo = getinfoResult.value;
+    const allTxs = sqlResult.status === 'fulfilled' ? sqlResult.value : [];
 
-    const allTxs =
-        walletTxsResult.status === 'fulfilled'
-            ? walletTxsResult.value.events.filter(
-                  (tx: any) => tx.type !== 'onchain_fee'
-              )
-            : { events: [] };
+    const walletTxs = allTxs.rows.filter(
+        (tx: any) =>
+            !!tx[3] && tx[3] === 'deposit' && !!tx[1] && tx[1] === 'wallet'
+    );
 
-    const walletTxs =
-        walletTxsResult.status === 'fulfilled'
-            ? walletTxsResult.value.events.filter(
-                  (tx: any) => tx.tag === 'deposit' && tx.account === 'wallet'
-              )
-            : { events: [] };
-
-    const externalTxs =
-        walletTxsResult.status === 'fulfilled'
-            ? walletTxsResult.value.events.filter(
-                  (tx: any) => tx.tag === 'deposit' && tx.account === 'external'
-              )
-            : { events: [] };
+    const externalTxs = allTxs.rows.filter(
+        (tx: any) =>
+            !!tx[3] && tx[3] === 'deposit' && !!tx[1] && tx[1] === 'external'
+    );
 
     const listTxs =
         listTxsResult.status === 'fulfilled'
@@ -175,17 +167,17 @@ export const getChainTransactions = async () => {
     const transactions = listTxs.transactions
         .map((tx: any) => {
             const withdrawal = externalTxs.find((n: any) => {
-                const txid = n.outpoint ? n.outpoint.split(':')[0] : null;
+                const txid = n[8] ? n[8].split(':')[0] : null;
 
                 // Check if the deposit is associated with a channel open or close
-                const isChannelChange = allTxs.find((c: any) => {
-                    if (!c.outpoint) {
+                const isChannelChange = allTxs.rows.find((c: any) => {
+                    if (!c[8]) {
                         return undefined;
                     }
 
                     return (
-                        c.outpoint.split(':')[0] === tx.hash &&
-                        (c.tag === 'channel_open' || c.tag === 'channel_close')
+                        c[8].split(':')[0] === tx.hash &&
+                        (c[3] === 'channel_open' || c[3] === 'channel_close')
                     );
                 });
 
@@ -197,16 +189,17 @@ export const getChainTransactions = async () => {
             });
 
             const deposit = walletTxs.find((n: any) => {
-                const txid = n.outpoint ? n.outpoint.split(':')[0] : null;
+                const txid = n[8] ? n[8].split(':')[0] : null;
 
                 // Check if the deposit is associated with a channel open or close
-                const isChannelChange = allTxs.find((c: any) => {
-                    if (!c.outpoint) {
+                const isChannelChange = allTxs.rows.find((c: any) => {
+                    if (!c[8]) {
                         return undefined;
                     }
+
                     return (
-                        c.outpoint.split(':')[0] === tx.hash &&
-                        (c.tag === 'channel_open' || c.tag === 'channel_close')
+                        c[8].split(':')[0] === tx.hash &&
+                        (c[3] === 'channel_open' || c[3] === 'channel_close')
                     );
                 });
 
@@ -219,11 +212,10 @@ export const getChainTransactions = async () => {
 
             if (withdrawal) {
                 return {
-                    amount: -Math.abs(withdrawal.credit_msat) / 1000,
-                    block_height: withdrawal.blockheight,
-                    num_confirmations:
-                        getinfo.blockheight - withdrawal.blockheight,
-                    time_stamp: withdrawal.timestamp,
+                    amount: -Math.abs(withdrawal[4]) / 1000,
+                    block_height: withdrawal[9],
+                    num_confirmations: getinfo.blockheight - withdrawal[9],
+                    time_stamp: withdrawal[7],
                     txid: tx.hash,
                     note: 'on-chain withdrawal'
                 };
@@ -231,11 +223,10 @@ export const getChainTransactions = async () => {
 
             if (deposit) {
                 return {
-                    amount: deposit.credit_msat / 1000,
-                    block_height: deposit.blockheight,
-                    num_confirmations:
-                        getinfo.blockheight - deposit.blockheight,
-                    time_stamp: deposit.timestamp,
+                    amount: deposit[4] / 1000,
+                    block_height: deposit[9],
+                    num_confirmations: getinfo.blockheight - deposit[9],
+                    time_stamp: deposit[7],
                     txid: tx.hash,
                     note: 'on-chain deposit'
                 };

--- a/backends/CoreLightningRequestHandler.ts
+++ b/backends/CoreLightningRequestHandler.ts
@@ -132,7 +132,7 @@ export const listPeers = async (data: any) => {
 // Get all chain transactions from your core-lightnig node
 export const getChainTransactions = async () => {
     const sqlQuery =
-        `SELECT * FROM bkpr_accountevents WHERE (tag='deposit' OR tag='to_them' OR tag='channel_open' OR tag='channel_close') ORDER BY timestamp DESC LIMIT 5`.trim();
+        `SELECT * FROM bkpr_accountevents WHERE (tag='deposit' OR tag='to_them' OR tag='channel_open' OR tag='channel_close') ORDER BY timestamp DESC LIMIT 150`.trim();
 
     const results = await Promise.allSettled([
         api.postRequest('/v1/sql', { query: sqlQuery.trim() }),


### PR DESCRIPTION
# Description

Relates to issue: #1637

We spoke about this a bit on the telegram chat, to begin with we will limit the list of transactions to 150. Right now I was able to limit the expensive `bkpr-listaccountevents` and `listinvoices`. I couldn't restrict `listpays` because it doesn't take a limit argument. There is a `listsendpays` that can take a limit but it doesn't return bolt12 payments (classic CLN). 

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [X] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [X] Core Lightning (CLNRest)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair