### PR TITLE
CLNRest: add QR format

### DIFF
--- a/utils/ConnectionFormatUtils.test.ts
+++ b/utils/ConnectionFormatUtils.test.ts
@@ -152,4 +152,48 @@ describe('ConnectionFormatUtils', () => {
             });
         });
     });
+
+    describe('processCLNRestConnectUrl', () => {
+        it('handles plainnet properly - w/o http forced', () => {
+            expect(
+                ConnectionFormatUtils.processCLNRestConnectUrl(
+                    'clnrest://8.8.0.0:2056?&rune=OSqc7ixY6F-gjcigBfxtzKUI54uzgFSA6YfBQoWGDV89MA==&protocol=http'
+                )
+            ).toEqual({
+                host: 'https://8.8.0.0',
+                rune: 'OSqc7ixY6F-gjcigBfxtzKUI54uzgFSA6YfBQoWGDV89MA==',
+                port: '2056',
+                enableTor: false,
+                implementation: 'cln-rest'
+            });
+        });
+
+        it('handles plainnet properly - with http forced', () => {
+            expect(
+                ConnectionFormatUtils.processCLNRestConnectUrl(
+                    'clnrest://http://8.8.0.0:2056?&rune=OSqc7ixY6F-gjcigBfxtzKUI54uzgFSA6YfBQoWGDV89MA==&protocol=http'
+                )
+            ).toEqual({
+                host: 'http://8.8.0.0',
+                rune: 'OSqc7ixY6F-gjcigBfxtzKUI54uzgFSA6YfBQoWGDV89MA==',
+                port: '2056',
+                enableTor: false,
+                implementation: 'cln-rest'
+            });
+        });
+
+        it('handles Tor properly', () => {
+            expect(
+                ConnectionFormatUtils.processCLNRestConnectUrl(
+                    'clnrest://http://y7enfk2mdfawf.onion:2056?&rune=OSqc7ixY6F-gjcigBfxtzKUI54uzgFSA6YfBQoWGDV89MA==&protocol=http'
+                )
+            ).toEqual({
+                host: 'http://y7enfk2mdfawf.onion',
+                rune: 'OSqc7ixY6F-gjcigBfxtzKUI54uzgFSA6YfBQoWGDV89MA==',
+                port: '2056',
+                enableTor: true,
+                implementation: 'cln-rest'
+            });
+        });
+    });
 });

--- a/utils/ConnectionFormatUtils.ts
+++ b/utils/ConnectionFormatUtils.ts
@@ -110,6 +110,58 @@ class ConnectionFormatUtils {
             implementation: 'c-lightning-REST'
         };
     };
+
+    processCLNRestConnectUrl = (input: string) => {
+        let host, port;
+        const forceHttp = input.includes('clnrest://http://');
+        const clrConnectionString = forceHttp
+            ? input.replace('clnrest://http://', '')
+            : input.split('clnrest://')[1];
+        const params = input.split('?')[1];
+
+        const result: any = {};
+        if (params) {
+            params.split('&').forEach(function (part) {
+                // split on only the first = sign
+                const item = part.split(/=(.*)/s);
+                result[item[0]] = decodeURIComponent(item[1]);
+            });
+        }
+
+        // is IPv6
+        if (input.includes('[')) {
+            host =
+                clrConnectionString && clrConnectionString.split(']:')[0] + ']';
+            port =
+                clrConnectionString &&
+                clrConnectionString.split(']:')[1] &&
+                clrConnectionString.split(']:')[1].split('?')[0];
+        } else {
+            host = clrConnectionString && clrConnectionString.split(':')[0];
+            port =
+                clrConnectionString &&
+                clrConnectionString.split(':')[1] &&
+                clrConnectionString.split(':')[1].split('?')[0];
+        }
+        const rune = result.rune;
+
+        // prepend https by default
+        host = host.includes('://')
+            ? host
+            : forceHttp
+            ? 'http://' + host
+            : 'https://' + host;
+
+        const enableTor: boolean = host.includes('.onion');
+
+        return {
+            host,
+            port,
+            rune,
+            enableTor,
+            implementation: 'cln-rest'
+        };
+    };
 }
 
 const connectionFormatUtils = new ConnectionFormatUtils();

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -226,6 +226,33 @@ const handleAnything = async (
                 { cancelable: false }
             );
         }
+    } else if (value.includes('clnrest://')) {
+        if (isClipboardValue) return true;
+        const { host, port, rune, implementation, enableTor } =
+            ConnectionFormatUtils.processCLNRestConnectUrl(value);
+
+        if (host && port && rune) {
+            return [
+                'NodeConfiguration',
+                {
+                    node: {
+                        host,
+                        port,
+                        rune,
+                        implementation,
+                        enableTor
+                    },
+                    isValid: true
+                }
+            ];
+        } else {
+            Alert.alert(
+                localeString('general.error'),
+                localeString('views.LNDConnectConfigQRScanner.error'),
+                [{ text: localeString('general.ok'), onPress: () => void 0 }],
+                { cancelable: false }
+            );
+        }
     } else if (
         value.includes('https://terminal.lightning.engineering#/connect/pair/')
     ) {


### PR DESCRIPTION
# Description

This PR adds a QR decoder specifically for CLNRest connections. It is inspired by the format used for c-lightning-REST connections.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (c-lightning-REST)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
