### PR TITLE
this should fix lnaddress handling with .onion domains . lnurl on onion should be called by http:// instead of https://

### DIFF
--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -388,7 +388,11 @@ const handleAnything = async (
         }
 
         const [username, domain] = value.split('@');
-        const url = `https://${domain}/.well-known/lnurlp/${username.toLowerCase()}`;
+        if domain.includes('.onion') {
+          const url = `http://${domain}/.well-known/lnurlp/${username.toLowerCase()}`;
+        }else{
+          const url = `https://${domain}/.well-known/lnurlp/${username.toLowerCase()}`;
+        }
         const error = localeString(
             'utils.handleAnything.lightningAddressError'
         );

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -388,7 +388,7 @@ const handleAnything = async (
         }
 
         const [username, domain] = value.split('@');
-        if domain.includes('.onion') {
+        if (domain.includes('.onion')) {
           const url = `http://${domain}/.well-known/lnurlp/${username.toLowerCase()}`;
         }else{
           const url = `https://${domain}/.well-known/lnurlp/${username.toLowerCase()}`;


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This pull request is categorized as a:

- [ ] New feature
- [ x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [x] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
