### PR TITLE
Layer Balances: prompt user to open channel if they only have on-chain funds

### DIFF
--- a/components/LayerBalances/index.tsx
+++ b/components/LayerBalances/index.tsx
@@ -13,6 +13,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 
 import { inject, observer } from 'mobx-react';
 import Amount from '../Amount';
+import Button from '../Button';
 import { Spacer } from '../layout/Spacer';
 import OnchainSwipeableRow from './OnchainSwipeableRow';
 import LightningSwipeableRow from './LightningSwipeableRow';
@@ -331,6 +332,15 @@ export default class LayerBalances extends Component<LayerBalancesProps, {}> {
 
         return (
             <View style={{ flex: 1 }}>
+                {lightningBalance === 0 && totalBlockchainBalance !== 0 && (
+                    <Button
+                        title={localeString(
+                            'components.LayerBalances.moveFundsToLn'
+                        )}
+                        onPress={() => navigation.navigate('OpenChannel')}
+                        secondary
+                    />
+                )}
                 <FlatList
                     data={DATA}
                     ItemSeparatorComponent={() => (

--- a/locales/en.json
+++ b/locales/en.json
@@ -1022,6 +1022,7 @@
     "components.ChannelPicker.modal.description": "Select the channel to be used in this operation. You may want to only use specific channels to preserve your privacy.",
     "components.ChannelPicker.modal.description.multiple": "Select the channel(s) to be used in this operation. You may want to only use specific channels to preserve your privacy.",
     "components.LayerBalances.moreAccounts": "More accounts",
+    "components.LayerBalances.moveFundsToLn": "Move on-chain funds to lightning",
     "backends.LND.wsReq.warning": "You may have to enable Certificate Verification to make these kind of calls",
     "backends.LND.restReq.connectionError": "Connection error",
     "utils.handleAnything.lightningAddressError": "Error fetching Lightning Address data",


### PR DESCRIPTION
# Description

We've received some reports of users that are confused on how to 'move funds to lightning' after depositing on-chain funds in the wallet.

This PR aims to improve the UX by prompting users to `Move on-chain funds to lightning` if they have a lightning balance of 0 and a non-zero on-chain balance.

![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-08 at 11 53 11](https://github.com/user-attachments/assets/fa9a4486-3e0d-418a-95bb-216843b3e309)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
