### PR TITLE
ZEUS-2189: Node Configuration: some buttons should be labels

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -239,7 +239,6 @@
     "views.Settings.AddEditNode.certificateVerification": "Certificate Verification",
     "views.Settings.AddEditNode.createLndhub": "Create LNDHub account",
     "views.Settings.AddEditNode.saveNode": "Save Node Config",
-    "views.Settings.AddEditNode.nodeSaved": "Node Config Saved",
     "views.Settings.AddEditNode.setNodeActive": "Set Node Config as Active",
     "views.Settings.AddEditNode.nodeActive": "Node Active",
     "views.Settings.AddEditNode.scanLndconnect": "Scan lndconnect config",

--- a/views/Settings/NodeConfiguration.tsx
+++ b/views/Settings/NodeConfiguration.tsx
@@ -30,6 +30,7 @@ import DropdownSetting from '../../components/DropdownSetting';
 import Header from '../../components/Header';
 import KeyValue from '../../components/KeyValue';
 import LoadingIndicator from '../../components/LoadingIndicator';
+import Pill from '../../components/Pill';
 import Screen from '../../components/Screen';
 import {
     SuccessMessage,
@@ -1695,6 +1696,17 @@ export default class NodeConfiguration extends React.Component<
                             />
                         )}
 
+                    {active && (
+                        <View style={{ alignItems: 'center' }}>
+                            <Pill
+                                title={localeString(
+                                    'views.Settings.AddEditNode.nodeActive'
+                                )}
+                                backgroundColor="transparent"
+                            />
+                        </View>
+                    )}
+
                     {implementation === 'embedded-lnd' && (
                         <View style={{ ...styles.button, marginTop: 20 }}>
                             {!adminMacaroon && !creatingWallet && (
@@ -1761,18 +1773,13 @@ export default class NodeConfiguration extends React.Component<
                     {!creatingWallet &&
                         !(
                             implementation === 'embedded-lnd' && !adminMacaroon
-                        ) && (
+                        ) &&
+                        !saved && (
                             <View style={{ ...styles.button }}>
                                 <Button
-                                    title={
-                                        saved
-                                            ? localeString(
-                                                  'views.Settings.AddEditNode.nodeSaved'
-                                              )
-                                            : localeString(
-                                                  'views.Settings.AddEditNode.saveNode'
-                                              )
-                                    }
+                                    title={localeString(
+                                        'views.Settings.AddEditNode.saveNode'
+                                    )}
                                     onPress={() => {
                                         if (
                                             !saved &&
@@ -1812,18 +1819,12 @@ export default class NodeConfiguration extends React.Component<
                         <CertInstallInstructions />
                     )}
 
-                    {saved && !newEntry && (
+                    {saved && !active && !newEntry && (
                         <View style={styles.button}>
                             <Button
-                                title={
-                                    active
-                                        ? localeString(
-                                              'views.Settings.AddEditNode.nodeActive'
-                                          )
-                                        : localeString(
-                                              'views.Settings.AddEditNode.setNodeActive'
-                                          )
-                                }
+                                title={localeString(
+                                    'views.Settings.AddEditNode.setNodeActive'
+                                )}
                                 onPress={() =>
                                     this.setNodeConfigurationAsActive()
                                 }


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2189**](https://github.com/ZeusLN/zeus/issues/2189)

This includes two changes:

- NODE CONFIG SAVED is now never be displayed. If there are no changes, the Save button is hidden
- NODE ACTIVE is now a label, and placed above the action buttons

Before:
![Simulator Screenshot - iPhone 15 Plus - 2024-08-26 at 14 10 06](https://github.com/user-attachments/assets/cbd08124-c09c-4215-9780-aff7b75f99f6)

After:
![Simulator Screenshot - iPhone 15 Plus - 2024-08-26 at 14 20 04](https://github.com/user-attachments/assets/0b472d7e-e1b8-496a-8ad8-f2bf066cc6ca)


This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
