### PR TITLE
Sending Lightning: always display Try Again button on error

### DIFF
--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -372,46 +372,21 @@ export default class SendingLightning extends React.Component<
                                     localeString(
                                         'error.failureReasonNoRoute'
                                     )) && (
-                                <>
-                                    <Text
-                                        style={{
-                                            textAlign: 'center',
-                                            color: 'white',
-                                            fontFamily: 'PPNeueMontreal-Book',
-                                            padding: 20,
-                                            fontSize: 14
-                                        }}
-                                    >
-                                        {localeString(
-                                            'views.SendingLightning.lowFeeLimitMessage'
-                                        )}
-                                    </Text>
-                                    <Button
-                                        title={localeString(
-                                            'views.SendingLightning.tryAgain'
-                                        )}
-                                        icon={{
-                                            name: 'return-up-back',
-                                            type: 'ionicon',
-                                            size: 25
-                                        }}
-                                        onPress={() => navigation.goBack()}
-                                        buttonStyle={{
-                                            backgroundColor: 'white',
-                                            height: 40
-                                        }}
-                                        containerStyle={{
-                                            width: '100%',
-                                            margin: 10
-                                        }}
-                                    />
-                                </>
+                                <Text
+                                    style={{
+                                        textAlign: 'center',
+                                        color: 'white',
+                                        fontFamily: 'PPNeueMontreal-Book',
+                                        padding: 20,
+                                        fontSize: 14
+                                    }}
+                                >
+                                    {localeString(
+                                        'views.SendingLightning.lowFeeLimitMessage'
+                                    )}
+                                </Text>
                             )}
-                            {(payment_error == 'FAILURE_REASON_TIMEOUT' ||
-                                payment_error ==
-                                    localeString(
-                                        'error.failureReasonTimeout'
-                                    )) && (
+                            {payment_error && (
                                 <Button
                                     title={localeString(
                                         'views.SendingLightning.tryAgain'


### PR DESCRIPTION
# Description

Previously, we would only display the button on timeout or no route found errors.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
