### PR TITLE
Close Channel: Force Close: fee rate fix

### DIFF
--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -190,7 +190,9 @@ export default class EmbeddedLND extends LND {
             urlParams && urlParams[1] ? Number(urlParams[1]) : 0;
         const force = urlParams && urlParams[2] ? true : false;
         const sat_per_vbyte =
-            urlParams && urlParams[3] ? Number(urlParams[3]) : undefined;
+            urlParams && urlParams[3] && !urlParams[2]
+                ? Number(urlParams[3])
+                : undefined;
         const delivery_address =
             urlParams && urlParams[4] ? urlParams[4] : undefined;
 

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -479,7 +479,7 @@ export default class LND {
             urlParams && urlParams[1]
         }?force=${urlParams && urlParams[2]}`;
 
-        if (urlParams && urlParams[3]) {
+        if (urlParams && !urlParams[2] && urlParams[3]) {
             requestString += `&sat_per_vbyte=${urlParams && urlParams[3]}`;
         }
 

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -297,7 +297,7 @@ export default class LightningNodeConnect {
             force: urlParams && urlParams[2]
         };
 
-        if (urlParams && urlParams[3]) {
+        if (urlParams && urlParams[3] && !urlParams[2]) {
             params.sat_per_vbyte = Number(urlParams[3]);
         }
 

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -705,25 +705,51 @@ export default class ChannelView extends React.Component<
                             )}
                             {BackendUtils.isLNDBased() && (
                                 <>
-                                    <Text
-                                        style={{
-                                            ...styles.text,
-                                            color: themeColor('text')
-                                        }}
-                                    >
-                                        {localeString(
-                                            'views.Channel.closingRate'
-                                        )}
-                                    </Text>
-                                    <OnchainFeeInput
-                                        fee={satPerByte}
-                                        onChangeFee={(text: string) => {
-                                            this.setState({
-                                                satPerByte: text
-                                            });
-                                        }}
-                                        navigation={navigation}
-                                    />
+                                    <View style={{ marginBottom: 10 }}>
+                                        <Text
+                                            style={{
+                                                ...styles.text,
+                                                color: themeColor('text'),
+                                                top: 20
+                                            }}
+                                        >
+                                            {localeString(
+                                                'views.Channel.forceClose'
+                                            )}
+                                        </Text>
+                                        <Switch
+                                            value={forceCloseChannel}
+                                            onValueChange={() =>
+                                                this.setState({
+                                                    forceCloseChannel:
+                                                        !forceCloseChannel
+                                                })
+                                            }
+                                        />
+                                    </View>
+                                    {!forceCloseChannel && (
+                                        <>
+                                            <Text
+                                                style={{
+                                                    ...styles.text,
+                                                    color: themeColor('text')
+                                                }}
+                                            >
+                                                {localeString(
+                                                    'views.Channel.closingRate'
+                                                )}
+                                            </Text>
+                                            <OnchainFeeInput
+                                                fee={satPerByte}
+                                                onChangeFee={(text: string) => {
+                                                    this.setState({
+                                                        satPerByte: text
+                                                    });
+                                                }}
+                                                navigation={navigation}
+                                            />
+                                        </>
+                                    )}
                                     <>
                                         <Text
                                             style={{
@@ -749,28 +775,6 @@ export default class ChannelView extends React.Component<
                                             locked={closingChannel}
                                         />
                                     </>
-                                    <View style={{ marginBottom: 10 }}>
-                                        <Text
-                                            style={{
-                                                ...styles.text,
-                                                color: themeColor('text'),
-                                                top: 20
-                                            }}
-                                        >
-                                            {localeString(
-                                                'views.Channel.forceClose'
-                                            )}
-                                        </Text>
-                                        <Switch
-                                            value={forceCloseChannel}
-                                            onValueChange={() =>
-                                                this.setState({
-                                                    forceCloseChannel:
-                                                        !forceCloseChannel
-                                                })
-                                            }
-                                        />
-                                    </View>
                                 </>
                             )}
                             <View style={styles.button}>


### PR DESCRIPTION
# Description

In Lightning, force closes used pre-negotiated fee rates.

In a recent release of LND (v0.18.0?), force channel closes with fee rates provided now throw the following error:
`[ERR] RPCS: [/lnrpc.Lightning/CloseChannel]: force closing a channel uses a pre-defined fee`

This PR:
- On the backend, on the Close channel call, ensures fee rates are not passed in if the force close flag is.
- On the frontend, moves the force close toggle above the other close channel fields, and hides the fee rate field if force close is switched on.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
