### PR TITLE
Bug Fix: Prevent Currency input to display '0' when it is empty

### DIFF
--- a/views/Settings/CurrencyConverter.tsx
+++ b/views/Settings/CurrencyConverter.tsx
@@ -189,7 +189,20 @@ export default class CurrencyConverter extends React.Component<
 
         const convertedValues: { [key: string]: string } = { ...inputValues };
 
-        // Apply formatting to the input value before conversion for all currencies
+        // If the input is empty, clear the corresponding currency values
+        if (sanitizedValue === '') {
+            convertedValues[currency] = '';
+            Object.keys(convertedValues).forEach((key) => {
+                if (key !== currency) {
+                    convertedValues[key] = ''; // Clear all other currencies
+                }
+            });
+
+            this.setState({ inputValues: convertedValues });
+            return;
+        }
+
+        // Apply formatting to the input value before conversion
         const formattedValue = formatNumber(sanitizedValue, currency);
 
         // Set the input value
@@ -199,78 +212,72 @@ export default class CurrencyConverter extends React.Component<
         Object.keys(convertedValues).forEach((key) => {
             if (key !== currency) {
                 let convertedValue = '';
+                // Conversion from sats to currency
+                if (currency === 'sats') {
+                    // Convert sats to BTC first
+                    const btcValue = (
+                        parseFloat(sanitizedValue) / 100000000
+                    ).toFixed(8);
 
-                // Check if the value is empty
-                if (sanitizedValue === '') {
-                    convertedValues[key] = ''; // Set the converted value to empty string
-                } else {
-                    // Conversion from sats to currency
-                    if (currency === 'sats') {
-                        // Convert sats to BTC first
-                        const btcValue = (
-                            parseFloat(sanitizedValue) / 100000000
-                        ).toFixed(8);
-
-                        if (key === 'BTC') {
-                            convertedValue = btcValue;
-                        } else {
-                            // Then convert BTC to the target currency
-                            const btcConversionRate = fiatRates.find(
-                                (rate) => rate.currencyPair === `BTC_${key}`
-                            )?.rate;
-
-                            if (btcConversionRate) {
-                                convertedValue = (
-                                    parseFloat(btcValue) * btcConversionRate
-                                ).toFixed(2);
-                            }
-                        }
-                    } else if (currency === 'BTC') {
-                        // Conversion from BTC to currency
-                        const directRate = fiatRates.find(
-                            (rate) => rate.currencyPair === `${currency}_${key}`
-                        );
-                        if (key === 'sats') {
-                            convertedValue = (
-                                parseFloat(sanitizedValue) * 100000000
-                            ).toFixed(0);
-                        }
-                        if (directRate) {
-                            convertedValue = (
-                                parseFloat(sanitizedValue) * directRate.rate
-                            ).toFixed(2);
-                        }
+                    if (key === 'BTC') {
+                        convertedValue = btcValue;
                     } else {
-                        // Conversion from currency to currency
-                        const btcToRate = fiatRates.find(
+                        // Then convert BTC to the target currency
+                        const btcConversionRate = fiatRates.find(
                             (rate) => rate.currencyPair === `BTC_${key}`
                         )?.rate;
-                        const btcFromRate: any = fiatRates.find(
-                            (rate) => rate.currencyPair === `BTC_${currency}`
-                        )?.rate;
 
-                        if (btcFromRate) {
-                            const btcValue = (
-                                parseFloat(sanitizedValue) / btcFromRate
-                            ).toFixed(8);
-                            if (key === 'BTC') {
-                                convertedValue =
-                                    sanitizedValue === '' ? '' : btcValue;
-                            } else if (key === 'sats') {
-                                convertedValue =
-                                    sanitizedValue === ''
-                                        ? ''
-                                        : (
-                                              parseFloat(btcValue) * 100000000
-                                          ).toFixed(0); // Convert BTC to sats if sats is present
-                            }
+                        if (btcConversionRate) {
+                            convertedValue = (
+                                parseFloat(btcValue) * btcConversionRate
+                            ).toFixed(2);
                         }
+                    }
+                } else if (currency === 'BTC') {
+                    // Conversion from BTC to currency
+                    const directRate = fiatRates.find(
+                        (rate) => rate.currencyPair === `${currency}_${key}`
+                    );
+                    if (key === 'sats') {
+                        convertedValue = (
+                            parseFloat(sanitizedValue) * 100000000
+                        ).toFixed(0);
+                    }
+                    if (directRate) {
+                        convertedValue = (
+                            parseFloat(sanitizedValue) * directRate.rate
+                        ).toFixed(2);
+                    }
+                } else {
+                    // Conversion from currency to currency
+                    const btcToRate = fiatRates.find(
+                        (rate) => rate.currencyPair === `BTC_${key}`
+                    )?.rate;
+                    const btcFromRate: any = fiatRates.find(
+                        (rate) => rate.currencyPair === `BTC_${currency}`
+                    )?.rate;
 
-                        if (btcToRate && btcFromRate) {
-                            const btcValue =
-                                parseFloat(sanitizedValue) / btcFromRate;
-                            convertedValue = (btcValue * btcToRate).toFixed(2);
+                    if (btcFromRate) {
+                        const btcValue = (
+                            parseFloat(sanitizedValue) / btcFromRate
+                        ).toFixed(8);
+                        if (key === 'BTC') {
+                            convertedValue =
+                                sanitizedValue === '' ? '' : btcValue;
+                        } else if (key === 'sats') {
+                            convertedValue =
+                                sanitizedValue === ''
+                                    ? ''
+                                    : (
+                                          parseFloat(btcValue) * 100000000
+                                      ).toFixed(0); // Convert BTC to sats if sats is present
                         }
+                    }
+
+                    if (btcToRate && btcFromRate) {
+                        const btcValue =
+                            parseFloat(sanitizedValue) / btcFromRate;
+                        convertedValue = (btcValue * btcToRate).toFixed(2);
                     }
                 }
 


### PR DESCRIPTION
https://github.com/ZeusLN/zeus/issues/2437

To fix this issue, we made the following changes:
   - We added a check that immediately stops the conversion process if the input field is cleared. This prevents the input from converting an empty value into `0`.

   - When the input is cleared, we made sure all related converted values in the other currency fields are also cleared, instead of showing incorrect conversions.
