### PR TITLE
Receive: Blinded Paths: turn off and disable AMP and Route Hints

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -2504,6 +2504,7 @@ export default class Receive extends React.Component<
                                                                     !routeHints
                                                             })
                                                         }
+                                                        disabled={blindedPaths}
                                                     />
                                                 </>
                                             )}
@@ -2638,6 +2639,7 @@ export default class Receive extends React.Component<
                                                                     !ampInvoice
                                                             })
                                                         }
+                                                        disabled={blindedPaths}
                                                     />
                                                 </>
                                             )}
@@ -2670,10 +2672,22 @@ export default class Receive extends React.Component<
                                                     <Switch
                                                         value={blindedPaths}
                                                         onValueChange={() =>
-                                                            this.setState({
-                                                                blindedPaths:
-                                                                    !blindedPaths
-                                                            })
+                                                            this.setState(
+                                                                (
+                                                                    prevState
+                                                                ) => ({
+                                                                    blindedPaths:
+                                                                        !blindedPaths,
+                                                                    ampInvoice:
+                                                                        !blindedPaths
+                                                                            ? false
+                                                                            : prevState.ampInvoice,
+                                                                    routeHints:
+                                                                        !blindedPaths
+                                                                            ? false
+                                                                            : prevState.routeHints
+                                                                })
+                                                            )
                                                         }
                                                     />
                                                 </>

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -2672,22 +2672,14 @@ export default class Receive extends React.Component<
                                                     <Switch
                                                         value={blindedPaths}
                                                         onValueChange={() =>
-                                                            this.setState(
-                                                                (
-                                                                    prevState
-                                                                ) => ({
-                                                                    blindedPaths:
-                                                                        !blindedPaths,
-                                                                    ampInvoice:
-                                                                        !blindedPaths
-                                                                            ? false
-                                                                            : prevState.ampInvoice,
-                                                                    routeHints:
-                                                                        !blindedPaths
-                                                                            ? false
-                                                                            : prevState.routeHints
-                                                                })
-                                                            )
+                                                            this.setState({
+                                                                blindedPaths:
+                                                                    !blindedPaths,
+                                                                ampInvoice:
+                                                                    false,
+                                                                routeHints:
+                                                                    false
+                                                            })
                                                         }
                                                     />
                                                 </>

--- a/views/Settings/InvoicesSettings.tsx
+++ b/views/Settings/InvoicesSettings.tsx
@@ -371,6 +371,7 @@ export default class InvoicesSettings extends React.Component<
                                         }
                                     });
                                 }}
+                                disabled={blindedPaths}
                             />
                         </>
                     )}
@@ -413,6 +414,7 @@ export default class InvoicesSettings extends React.Component<
                                         }
                                     });
                                 }}
+                                disabled={blindedPaths}
                             />
                         </>
                     )}
@@ -440,8 +442,11 @@ export default class InvoicesSettings extends React.Component<
                                 value={blindedPaths}
                                 onValueChange={async () => {
                                     this.setState({
-                                        blindedPaths: !blindedPaths
+                                        blindedPaths: !blindedPaths,
+                                        ampInvoice: false,
+                                        routeHints: false
                                     });
+
                                     await updateSettings({
                                         invoices: {
                                             addressType,
@@ -449,8 +454,8 @@ export default class InvoicesSettings extends React.Component<
                                             expiry,
                                             timePeriod,
                                             expirySeconds,
-                                            routeHints,
-                                            ampInvoice,
+                                            routeHints: false,
+                                            ampInvoice: false,
                                             blindedPaths: !blindedPaths,
                                             showCustomPreimageField
                                         }


### PR DESCRIPTION
# Description

When using Blinded Paths with LND, route hints are incompatible and AMP invoice are not support _yet_. This PR toggles these settings off and disables the switches when Blinded Paths are enabled on the `Receive` view and under `Settings`.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
