### PR TITLE
[bug fix] SetFeesForm: allow iOS users to input negative amounts for inbound fees

### DIFF
--- a/components/SetFeesForm.tsx
+++ b/components/SetFeesForm.tsx
@@ -188,7 +188,7 @@ export default class SetFeesForm extends React.Component<
                             )} (${localeString('general.sats')})`}
                         </Text>
                         <TextInput
-                            keyboardType="numeric"
+                            keyboardType="decimal"
                             placeholder={baseFeeInbound || '1'}
                             value={newBaseFeeInbound}
                             onChangeText={(text: string) =>
@@ -212,7 +212,7 @@ export default class SetFeesForm extends React.Component<
                             )} (${localeString('general.percentage')})`}
                         </Text>
                         <TextInput
-                            keyboardType="numeric"
+                            keyboardType="decimal"
                             placeholder={feeRateInbound || '1'}
                             value={newFeeRateInbound}
                             onChangeText={(text: string) =>


### PR DESCRIPTION
# Description

In v0.9.1 we allow the setting of inbound fees for channels, which can be set to negative values.

The problem is that on Android, the `numeric` keyboard shows the `-` char, whereas on iOS, it does not.

Changing the keyboard type to `decimal` will result in no change for most Android systems, whereas iOS should have access to the full keyboard so that users can hit the `-` char.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
