### PR TITLE
ZEUS-2443: LNURL-Pay: retain currency unit state

### DIFF
--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -17,7 +17,6 @@ import { Row } from '../..//components/layout/Row';
 
 import InvoicesStore from '../../stores/InvoicesStore';
 import LnurlPayStore from '../../stores/LnurlPayStore';
-import UnitsStore from '../../stores/UnitsStore';
 
 import LnurlPayMetadata from './Metadata';
 
@@ -29,7 +28,6 @@ interface LnurlPayProps {
     navigation: StackNavigationProp<any, any>;
     InvoicesStore: InvoicesStore;
     LnurlPayStore: LnurlPayStore;
-    UnitsStore: UnitsStore;
     route: Route<'LnurlPay', { lnurlParams: any; amount: any }>;
 }
 
@@ -40,7 +38,7 @@ interface LnurlPayState {
     comment: string;
 }
 
-@inject('InvoicesStore', 'LnurlPayStore', 'UnitsStore')
+@inject('InvoicesStore', 'LnurlPayStore')
 @observer
 export default class LnurlPay extends React.Component<
     LnurlPayProps,
@@ -69,10 +67,8 @@ export default class LnurlPay extends React.Component<
     }
 
     stateFromProps(props: LnurlPayProps) {
-        const { UnitsStore, route } = props;
+        const { route } = props;
         const { lnurlParams: lnurl, amount } = route.params ?? {};
-
-        UnitsStore.resetUnits();
 
         return {
             amount:


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2443**](https://github.com/ZeusLN/zeus/issues/2443)

Retain currency unit state when paying a LNURL-pay or lightning address.

Unsure why we were resetting units previously - perhaps for the range not displaying correctly?

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
