### PR TITLE
ZEUS-2472: Unable to Add Lightning Node Connect Node When No Nodes are Present

### DIFF
--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -85,7 +85,7 @@ export default class LightningNodeConnect {
         );
     };
     isConnected = async () => await this.lnc.isConnected();
-    disconnect = () => this.lnc.disconnect();
+    disconnect = () => this.lnc && this.lnc.disconnect();
 
     getTransactions = async () =>
         await this.lnc.lnd.lightning

--- a/views/Settings/Nodes.tsx
+++ b/views/Settings/Nodes.tsx
@@ -237,8 +237,9 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                                                 selectedNode: index
                                             }).then(() => {
                                                 if (
+                                                    currentImplementation &&
                                                     currentImplementation ===
-                                                    'lightning-node-connect'
+                                                        'lightning-node-connect'
                                                 ) {
                                                     BackendUtils.disconnect();
                                                 }


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2472**](https://github.com/ZeusLN/zeus/issues/2472)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
