### PR TITLE
ZEUS-2491: force user to set rate on mempool fee suggestion error

### DIFF
--- a/components/OnchainFeeInput.tsx
+++ b/components/OnchainFeeInput.tsx
@@ -47,8 +47,6 @@ export default function OnchainFeeInput(props: OnchainFeeInputProps) {
                     setErrorOccurredLoadingFees(true);
                     setLoading(false);
                 });
-        } else {
-            onChangeFee(DEFAULT_FEE);
         }
     }, []);
 
@@ -107,6 +105,7 @@ export default function OnchainFeeInput(props: OnchainFeeInputProps) {
                         setNewFee(text);
                         onChangeFee(text);
                     }}
+                    error={!newFee || newFee === '0'}
                 />
             )}
         </>

--- a/components/OnchainFeeInput.tsx
+++ b/components/OnchainFeeInput.tsx
@@ -14,6 +14,8 @@ interface OnchainFeeInputProps {
     onChangeFee: (fee: string) => void;
 }
 
+const DEFAULT_FEE = '2';
+
 export default function OnchainFeeInput(props: OnchainFeeInputProps) {
     const { fee, onChangeFee, navigation } = props;
 
@@ -45,6 +47,8 @@ export default function OnchainFeeInput(props: OnchainFeeInputProps) {
                     setErrorOccurredLoadingFees(true);
                     setLoading(false);
                 });
+        } else {
+            onChangeFee(DEFAULT_FEE);
         }
     }, []);
 
@@ -97,7 +101,7 @@ export default function OnchainFeeInput(props: OnchainFeeInputProps) {
             ) : (
                 <TextInput
                     keyboardType="numeric"
-                    placeholder="2"
+                    placeholder={DEFAULT_FEE}
                     value={newFee}
                     onChangeText={(text: string) => {
                         setNewFee(text);

--- a/components/OnchainFeeInput.tsx
+++ b/components/OnchainFeeInput.tsx
@@ -41,6 +41,7 @@ export default function OnchainFeeInput(props: OnchainFeeInputProps) {
                     setLoading(false);
                 })
                 .catch(() => {
+                    onChangeFee('0');
                     setErrorOccurredLoadingFees(true);
                     setLoading(false);
                 });

--- a/components/OnchainFeeInput.tsx
+++ b/components/OnchainFeeInput.tsx
@@ -14,7 +14,7 @@ interface OnchainFeeInputProps {
     onChangeFee: (fee: string) => void;
 }
 
-const DEFAULT_FEE = '2';
+const DEFAULT_FEE = '10';
 
 export default function OnchainFeeInput(props: OnchainFeeInputProps) {
     const { fee, onChangeFee, navigation } = props;

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -800,7 +800,6 @@ export default class ChannelView extends React.Component<
                                             deliveryAddress
                                         )
                                     }
-                                    disabled={satPerByte === '0'}
                                     warning
                                 />
                             </View>

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -800,6 +800,7 @@ export default class ChannelView extends React.Component<
                                             deliveryAddress
                                         )
                                     }
+                                    disabled={satPerByte === '0'}
                                     warning
                                 />
                             </View>

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -808,6 +808,28 @@ export default class OpenChannel extends React.Component<
                                         </View>
                                     )}
 
+                                <View style={{ marginTop: 10 }}>
+                                    <Text
+                                        style={{
+                                            ...styles.text,
+                                            color: themeColor('secondaryText')
+                                        }}
+                                    >
+                                        {localeString(
+                                            'views.OpenChannel.satsPerVbyte'
+                                        )}
+                                    </Text>
+                                    <OnchainFeeInput
+                                        fee={sat_per_vbyte}
+                                        onChangeFee={(text: string) => {
+                                            this.setState({
+                                                sat_per_vbyte: text
+                                            });
+                                        }}
+                                        navigation={navigation}
+                                    />
+                                </View>
+
                                 <TouchableOpacity
                                     onPress={() => {
                                         this.setState({
@@ -818,7 +840,6 @@ export default class OpenChannel extends React.Component<
                                 >
                                     <View
                                         style={{
-                                            marginTop: 10,
                                             marginBottom: 10
                                         }}
                                     >
@@ -864,30 +885,6 @@ export default class OpenChannel extends React.Component<
                                                 />
                                             </View>
                                         )}
-
-                                        <>
-                                            <Text
-                                                style={{
-                                                    ...styles.text,
-                                                    color: themeColor(
-                                                        'secondaryText'
-                                                    )
-                                                }}
-                                            >
-                                                {localeString(
-                                                    'views.OpenChannel.satsPerVbyte'
-                                                )}
-                                            </Text>
-                                            <OnchainFeeInput
-                                                fee={sat_per_vbyte}
-                                                onChangeFee={(text: string) => {
-                                                    this.setState({
-                                                        sat_per_vbyte: text
-                                                    });
-                                                }}
-                                                navigation={navigation}
-                                            />
-                                        </>
 
                                         <>
                                             <Text
@@ -1029,7 +1026,10 @@ export default class OpenChannel extends React.Component<
                                 icon={{
                                     name: 'swap-horiz',
                                     size: 25,
-                                    color: 'white'
+                                    color:
+                                        sat_per_vbyte === '0'
+                                            ? themeColor('secondaryText')
+                                            : themeColor('background')
                                 }}
                                 onPress={() => {
                                     this.scrollViewRef.current?.scrollTo({
@@ -1046,6 +1046,9 @@ export default class OpenChannel extends React.Component<
                                         connectPeerOnly
                                     );
                                 }}
+                                disabled={
+                                    !connectPeerOnly && sat_per_vbyte === '0'
+                                }
                             />
                         </View>
 

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -111,7 +111,7 @@ export default class OpenChannel extends React.Component<
             satAmount: '',
             min_confs: 1,
             spend_unconfirmed: false,
-            sat_per_vbyte: '2',
+            sat_per_vbyte: '',
             privateChannel: true,
             scidAlias: true,
             simpleTaprootChannel: false,
@@ -1027,7 +1027,7 @@ export default class OpenChannel extends React.Component<
                                     name: 'swap-horiz',
                                     size: 25,
                                     color:
-                                        sat_per_vbyte === '0'
+                                        sat_per_vbyte === '0' || !sat_per_vbyte
                                             ? themeColor('secondaryText')
                                             : themeColor('background')
                                 }}
@@ -1047,7 +1047,8 @@ export default class OpenChannel extends React.Component<
                                     );
                                 }}
                                 disabled={
-                                    !connectPeerOnly && sat_per_vbyte === '0'
+                                    !connectPeerOnly &&
+                                    (sat_per_vbyte === '0' || !sat_per_vbyte)
                                 }
                             />
                         </View>

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -158,7 +158,7 @@ export default class Send extends React.Component<SendProps, SendState> {
             destination: destination || '',
             amount: amount || '',
             satAmount: '',
-            fee: '2',
+            fee: '',
             utxos: [],
             utxoBalance: 0,
             confirmationTarget: '60',
@@ -1250,7 +1250,9 @@ export default class Send extends React.Component<SendProps, SendState> {
                                             size: 25,
                                             color:
                                                 totalBlockchainBalanceAccounts ===
-                                                    0 || fee === '0'
+                                                    0 ||
+                                                fee === '0' ||
+                                                !fee
                                                     ? themeColor(
                                                           'secondaryText'
                                                       )
@@ -1261,7 +1263,9 @@ export default class Send extends React.Component<SendProps, SendState> {
                                         }
                                         disabled={
                                             totalBlockchainBalanceAccounts ===
-                                                0 || fee === '0'
+                                                0 ||
+                                            fee === '0' ||
+                                            !fee
                                         }
                                     />
                                 </View>

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -1250,7 +1250,7 @@ export default class Send extends React.Component<SendProps, SendState> {
                                             size: 25,
                                             color:
                                                 totalBlockchainBalanceAccounts ===
-                                                0
+                                                    0 || fee === '0'
                                                     ? themeColor(
                                                           'secondaryText'
                                                       )
@@ -1260,7 +1260,8 @@ export default class Send extends React.Component<SendProps, SendState> {
                                             this.sendCoins(satAmount)
                                         }
                                         disabled={
-                                            totalBlockchainBalanceAccounts === 0
+                                            totalBlockchainBalanceAccounts ===
+                                                0 || fee === '0'
                                         }
                                     />
                                 </View>


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2491**](https://github.com/ZeusLN/zeus/issues/2491)

- Users must now manually set a fee rate when mempool fee suggestion fails, when opening a channel, closing a channel, or making an on-onchain transaction
- Opening a channel, closing a channel, and making an on-onchain transaction is blocked when the fee rate is set to 0 sats/vbyte
- On the `Open Channel` view the fee input form is now moved out and above the `Advanced settings` section
- Fixes display of the icon on the `Open Channel` button on the `Open Channel` view
- `OnchainFeeInput`: when suggestions are disabled, force users to manually set the fee rate before proceeding

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
