### PR TITLE
External account workflow fixes

### DIFF
--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -923,9 +923,13 @@ export default class ChannelsStore {
                 };
                 BackendUtils.openChannelStream(request)
                     .then((data: any) => {
-                        const { pending_chan_id } = data.result;
+                        const { psbt_fund, pending_chan_id } = data.result;
                         this.pending_chan_ids.push(pending_chan_id);
-                        this.handleChannelOpen(request);
+                        if (psbt_fund?.funding_address) {
+                            outputs[psbt_fund.funding_address] =
+                                psbt_fund.funding_amount;
+                        }
+                        this.handleChannelOpen(request, outputs);
                     })
                     .catch((error: Error) => {
                         this.handleChannelOpenError(error);


### PR DESCRIPTION
# Description

While testing our external account workflows against the Foundation Passport we found a few issues.

- LND now requires outputs to be defined when verifying a PSBT with `FundingStateStep`. Previously we were able to skip passing them in when only funding a single channel. We now pass them in/
- Passport (like the Krux) always returns back a signed PSBT instead of a TX hex, even dealing with a single sig wallet. We've now added formal handling for UR `bytes` and `crypto-psbt` formats.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
