### PR TITLE
Visualize channel reserve capacity

### DIFF
--- a/components/BalanceSlider.tsx
+++ b/components/BalanceSlider.tsx
@@ -5,7 +5,7 @@ import { ChannelItem } from '../components/Channels/ChannelItem';
 interface BalanceSliderProps {
     localBalance: string | number;
     remoteBalance: string | number;
-    reserveBalance: string | number;
+    reserveBalance?: string | number;
     list?: boolean;
 }
 

--- a/components/BalanceSlider.tsx
+++ b/components/BalanceSlider.tsx
@@ -5,6 +5,7 @@ import { ChannelItem } from '../components/Channels/ChannelItem';
 interface BalanceSliderProps {
     localBalance: string | number;
     remoteBalance: string | number;
+    reserveBalance: string | number;
     list?: boolean;
 }
 
@@ -13,12 +14,13 @@ export default class BalanceSlider extends React.Component<
     {}
 > {
     render() {
-        const { localBalance, remoteBalance } = this.props;
+        const { localBalance, remoteBalance, reserveBalance } = this.props;
         return (
             <View style={styles.slider}>
                 <ChannelItem
                     inbound={remoteBalance}
                     outbound={localBalance}
+                    reserve={reserveBalance}
                     noBorder
                     hideLabels
                 />

--- a/components/BalanceSlider.tsx
+++ b/components/BalanceSlider.tsx
@@ -5,7 +5,8 @@ import { ChannelItem } from '../components/Channels/ChannelItem';
 interface BalanceSliderProps {
     localBalance: string | number;
     remoteBalance: string | number;
-    reserveBalance?: string | number;
+    localReserveBalance?: string | number;
+    remoteReserveBalance?: string | number;
     list?: boolean;
 }
 
@@ -14,13 +15,19 @@ export default class BalanceSlider extends React.Component<
     {}
 > {
     render() {
-        const { localBalance, remoteBalance, reserveBalance } = this.props;
+        const {
+            localBalance,
+            remoteBalance,
+            localReserveBalance,
+            remoteReserveBalance
+        } = this.props;
         return (
             <View style={styles.slider}>
                 <ChannelItem
                     inbound={remoteBalance}
                     outbound={localBalance}
-                    reserve={reserveBalance}
+                    inboundReserve={localReserveBalance}
+                    outboundReserve={remoteReserveBalance}
                     noBorder
                     hideLabels
                 />

--- a/components/Channels/BalanceBar.tsx
+++ b/components/Channels/BalanceBar.tsx
@@ -33,7 +33,7 @@ export function BalanceBar({
                 style={{
                     height: 8,
                     flex: outboundReserve / total,
-                    backgroundColor: '#E5E5E5',
+                    backgroundColor: themeColor('outboundReserve'),
                     marginRight: 1
                 }}
             />
@@ -61,7 +61,7 @@ export function BalanceBar({
                 style={{
                     height: 8,
                     flex: inboundReserve / total,
-                    backgroundColor: '#A7A9AC',
+                    backgroundColor: themeColor('inboundReserve'),
                     marginRight: 1
                 }}
             />

--- a/components/Channels/BalanceBar.tsx
+++ b/components/Channels/BalanceBar.tsx
@@ -1,26 +1,28 @@
 import React from 'react';
 import { View } from 'react-native';
 import { Row } from '../layout/Row';
-import { themeColor, hexAverage } from '../../utils/ThemeUtils';
+import { themeColor } from '../../utils/ThemeUtils';
 
 export function BalanceBar({
-    left,
-    center = 0,
-    right,
+    outbound,
+    inbound,
+    outboundReserve = 0,
+    inboundReserve = 0,
     offline,
     percentOfLargest,
     showProportionally = true
 }: {
-    left: number;
-    center: number;
-    right: number;
+    outbound: number;
+    inbound: number;
+    outboundReserve: number;
+    inboundReserve: number;
     offline: boolean;
     // How big is this channel relative to the largest channel
     // A float from 0.0 -> 1.0, 1 being the largest channel
     percentOfLargest: number;
     showProportionally: boolean;
 }) {
-    const total = left + center + right;
+    const total = outboundReserve + outbound + inbound + inboundReserve;
 
     // If we're supposed to show proportionally set the miniumum to 20% of the width
     // Otherwise take the full width
@@ -30,7 +32,15 @@ export function BalanceBar({
             <View
                 style={{
                     height: 8,
-                    flex: left / total,
+                    flex: outboundReserve / total,
+                    backgroundColor: '#E5E5E5',
+                    marginRight: 1
+                }}
+            />
+            <View
+                style={{
+                    height: 8,
+                    flex: outbound / total,
                     backgroundColor: offline
                         ? '#E5E5E5'
                         : themeColor('outbound'),
@@ -40,21 +50,19 @@ export function BalanceBar({
             <View
                 style={{
                     height: 8,
-                    flex: center / total,
+                    flex: inbound / total,
                     backgroundColor: offline
-                        ? '#C6C7C9'
-                        : hexAverage([
-                              themeColor('outbound'),
-                              themeColor('inbound')
-                          ]),
+                        ? '#A7A9AC'
+                        : themeColor('inbound'),
                     marginRight: 1
                 }}
             />
             <View
                 style={{
                     height: 8,
-                    flex: right / total,
-                    backgroundColor: offline ? '#A7A9AC' : themeColor('inbound')
+                    flex: inboundReserve / total,
+                    backgroundColor: '#A7A9AC',
+                    marginRight: 1
                 }}
             />
         </Row>

--- a/components/Channels/BalanceBar.tsx
+++ b/components/Channels/BalanceBar.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { View } from 'react-native';
 import { Row } from '../layout/Row';
-import { themeColor } from '../../utils/ThemeUtils';
+import { themeColor, hexAverage } from '../../utils/ThemeUtils';
 
 export function BalanceBar({
     left,
+    center = 0,
     right,
     offline,
     percentOfLargest,
     showProportionally = true
 }: {
     left: number;
+    center: number;
     right: number;
     offline: boolean;
     // How big is this channel relative to the largest channel
@@ -18,7 +20,7 @@ export function BalanceBar({
     percentOfLargest: number;
     showProportionally: boolean;
 }) {
-    const total = left + right;
+    const total = left + center + right;
 
     // If we're supposed to show proportionally set the miniumum to 20% of the width
     // Otherwise take the full width
@@ -32,6 +34,19 @@ export function BalanceBar({
                     backgroundColor: offline
                         ? '#E5E5E5'
                         : themeColor('outbound'),
+                    marginRight: 1
+                }}
+            />
+            <View
+                style={{
+                    height: 8,
+                    flex: center / total,
+                    backgroundColor: offline
+                        ? '#C6C7C9'
+                        : hexAverage([
+                              themeColor('outbound'),
+                              themeColor('inbound')
+                          ]),
                     marginRight: 1
                 }}
             />

--- a/components/Channels/ChannelItem.tsx
+++ b/components/Channels/ChannelItem.tsx
@@ -22,7 +22,8 @@ export function ChannelItem({
     secondTitle,
     inbound,
     outbound,
-    reserve = 0,
+    inboundReserve = 0,
+    outboundReserve = 0,
     largestTotal,
     status,
     pendingHTLCs,
@@ -36,7 +37,8 @@ export function ChannelItem({
     secondTitle?: string;
     inbound: string | number;
     outbound: string | number;
-    reserve?: string | number;
+    inboundReserve?: string | number;
+    outboundReserve?: string | number;
     largestTotal?: number;
     status?: Status;
     pendingHTLCs?: boolean;
@@ -130,9 +132,12 @@ export function ChannelItem({
             {inbound && outbound && !(inbound == 0 && outbound == 0) && (
                 <Row style={{ marginTop: 15, marginBottom: 15 }}>
                     <BalanceBar
-                        left={lurkerMode ? 50 : Number(outbound)}
-                        center={lurkerMode ? 0 : Number(reserve)}
-                        right={lurkerMode ? 50 : Number(inbound)}
+                        outbound={lurkerMode ? 50 : Number(outbound)}
+                        inbound={lurkerMode ? 50 : Number(inbound)}
+                        outboundReserve={
+                            lurkerMode ? 0 : Number(outboundReserve)
+                        }
+                        inboundReserve={lurkerMode ? 0 : Number(inboundReserve)}
                         offline={isOffline}
                         percentOfLargest={percentOfLargest}
                         showProportionally={lurkerMode ? false : true}

--- a/components/Channels/ChannelItem.tsx
+++ b/components/Channels/ChannelItem.tsx
@@ -22,6 +22,7 @@ export function ChannelItem({
     secondTitle,
     inbound,
     outbound,
+    reserve = 0,
     largestTotal,
     status,
     pendingHTLCs,
@@ -35,6 +36,7 @@ export function ChannelItem({
     secondTitle?: string;
     inbound: string | number;
     outbound: string | number;
+    reserve?: string | number;
     largestTotal?: number;
     status?: Status;
     pendingHTLCs?: boolean;
@@ -129,6 +131,7 @@ export function ChannelItem({
                 <Row style={{ marginTop: 15, marginBottom: 15 }}>
                     <BalanceBar
                         left={lurkerMode ? 50 : Number(outbound)}
+                        center={lurkerMode ? 0 : Number(reserve)}
                         right={lurkerMode ? 50 : Number(inbound)}
                         offline={isOffline}
                         percentOfLargest={percentOfLargest}

--- a/components/HopPicker.tsx
+++ b/components/HopPicker.tsx
@@ -146,6 +146,7 @@ export default class ChannelPicker extends React.Component<
                         title={item.displayName}
                         inbound={item.remoteBalance}
                         outbound={item.localBalance}
+                        reserve={item.totalReserveBalance}
                         largestTotal={largestChannelSats}
                         selected={selected}
                     />
@@ -159,6 +160,7 @@ export default class ChannelPicker extends React.Component<
                     title={item.displayName}
                     inbound={item.remoteBalance}
                     outbound={item.localBalance}
+                    reserve={item.totalReserveBalance}
                     selected={selected}
                 />
             </TouchableHighlight>

--- a/components/HopPicker.tsx
+++ b/components/HopPicker.tsx
@@ -146,7 +146,8 @@ export default class ChannelPicker extends React.Component<
                         title={item.displayName}
                         inbound={item.remoteBalance}
                         outbound={item.localBalance}
-                        reserve={item.totalReserveBalance}
+                        inboundReserve={item.remoteReserveBalance}
+                        outboundReserve={item.localReserveBalance}
                         largestTotal={largestChannelSats}
                         selected={selected}
                     />
@@ -160,7 +161,8 @@ export default class ChannelPicker extends React.Component<
                     title={item.displayName}
                     inbound={item.remoteBalance}
                     outbound={item.localBalance}
-                    reserve={item.totalReserveBalance}
+                    inboundReserve={item.remoteReserveBalance}
+                    outboundReserve={item.localReserveBalance}
                     selected={selected}
                 />
             </TouchableHighlight>

--- a/components/KeyValue.tsx
+++ b/components/KeyValue.tsx
@@ -22,6 +22,7 @@ interface KeyValueProps {
     keyValue: string;
     value?: any;
     color?: string;
+    indicatorColor?: string;
     sensitive?: boolean;
     infoText?: string | Array<string>;
     infoLink?: string;
@@ -40,6 +41,7 @@ export default class KeyValue extends React.Component<KeyValueProps, {}> {
             keyValue,
             value,
             color,
+            indicatorColor,
             sensitive,
             infoText,
             infoLink,
@@ -63,6 +65,17 @@ export default class KeyValue extends React.Component<KeyValueProps, {}> {
         const rtl = false;
         const KeyBase = (
             <Body>
+                {indicatorColor && (
+                    <View
+                        style={{
+                            width: 12,
+                            height: 12,
+                            borderRadius: 12 / 2,
+                            backgroundColor: indicatorColor,
+                            marginRight: 7
+                        }}
+                    ></View>
+                )}
                 <Text
                     style={{
                         color:

--- a/models/Channel.ts
+++ b/models/Channel.ts
@@ -95,18 +95,21 @@ export default class Channel extends BaseModel {
 
     @computed
     public get localBalance(): string {
-        return this.to_us
+        const totalLocalBalance = this.to_us
             ? (Number(this.to_us) / 1000).toString()
             : this.to_us_msat
             ? (Number(this.to_us_msat) / 1000).toString()
             : this.msatoshi_to_us
             ? (Number(this.msatoshi_to_us) / 1000).toString()
             : this.local_balance || '0';
+        return (
+            Number(totalLocalBalance) - Number(this.localReserveBalance)
+        ).toString();
     }
 
     @computed
     public get remoteBalance(): string {
-        return this.total
+        const totalRemoteBalance = this.total
             ? ((Number(this.total) - Number(this.to_us)) / 1000).toString()
             : this.total_msat
             ? (
@@ -119,6 +122,30 @@ export default class Channel extends BaseModel {
                   1000
               ).toString()
             : this.remote_balance || '0';
+        return (
+            Number(totalRemoteBalance) - Number(this.remoteReserveBalance)
+        ).toString();
+    }
+
+    @computed
+    public get localReserveBalance(): string {
+        return this.local_chan_reserve_sat
+            ? Number(this.local_chan_reserve_sat).toString()
+            : '0';
+    }
+
+    @computed
+    public get remoteReserveBalance(): string {
+        return this.remote_chan_reserve_sat
+            ? Number(this.remote_chan_reserve_sat).toString()
+            : '0';
+    }
+
+    @computed
+    public get totalReserveBalance(): string {
+        return (
+            Number(this.localReserveBalance) + Number(this.remoteReserveBalance)
+        ).toString();
     }
 
     /** Channel id

--- a/utils/ThemeUtils.ts
+++ b/utils/ThemeUtils.ts
@@ -440,32 +440,3 @@ export function isLightTheme() {
     var L = 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
     return L > 0.179;
 }
-
-const padToTwo = (numberString: string) => {
-    if (numberString.length < 2) {
-        numberString = '0' + numberString;
-    }
-    return numberString;
-};
-
-export const hexAverage = (args: string[] = []) => {
-    return args
-        .reduce(
-            function (previousValue, currentValue) {
-                // @ts-ignore:next-line
-                return currentValue
-                    .replace(/^#/, '')
-                    .match(/.{2}/g)
-                    .map(function (value, index) {
-                        return previousValue[index] + parseInt(value, 16);
-                    });
-            },
-            [0, 0, 0]
-        )
-        .reduce(function (previousValue, currentValue) {
-            return (
-                previousValue +
-                padToTwo(Math.floor(currentValue / args.length).toString(16))
-            );
-        }, '#');
-};

--- a/utils/ThemeUtils.ts
+++ b/utils/ThemeUtils.ts
@@ -64,6 +64,8 @@ const Dark: { [key: string]: any } = {
     separator: '#31363F',
     outbound: '#FFD93F',
     inbound: '#FFF0CA',
+    outboundReserve: '#B7B7B7',
+    inboundReserve: '#636569',
     success: '#46BE43',
     warning: '#E14C4C',
     bitcoin: '#FFB040',

--- a/utils/ThemeUtils.ts
+++ b/utils/ThemeUtils.ts
@@ -440,3 +440,32 @@ export function isLightTheme() {
     var L = 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
     return L > 0.179;
 }
+
+const padToTwo = (numberString: string) => {
+    if (numberString.length < 2) {
+        numberString = '0' + numberString;
+    }
+    return numberString;
+};
+
+export const hexAverage = (args: string[] = []) => {
+    return args
+        .reduce(
+            function (previousValue, currentValue) {
+                // @ts-ignore:next-line
+                return currentValue
+                    .replace(/^#/, '')
+                    .match(/.{2}/g)
+                    .map(function (value, index) {
+                        return previousValue[index] + parseInt(value, 16);
+                    });
+            },
+            [0, 0, 0]
+        )
+        .reduce(function (previousValue, currentValue) {
+            return (
+                previousValue +
+                padToTwo(Math.floor(currentValue / args.length).toString(16))
+            );
+        }, '#');
+};

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -34,7 +34,7 @@ import TextInput from '../../components/TextInput';
 import PrivacyUtils from '../../utils/PrivacyUtils';
 import BackendUtils from '../../utils/BackendUtils';
 import { localeString } from '../../utils/LocaleUtils';
-import { themeColor } from '../../utils/ThemeUtils';
+import { themeColor, hexAverage } from '../../utils/ThemeUtils';
 import UrlUtils from '../../utils/UrlUtils';
 import { getPhoto } from '../../utils/PhotoUtils';
 
@@ -230,6 +230,7 @@ export default class ChannelView extends React.Component<
             channel_point,
             commit_weight,
             localBalance,
+            totalReserveBalance,
             commit_fee,
             csv_delay,
             total_satoshis_received,
@@ -276,6 +277,11 @@ export default class ChannelView extends React.Component<
         const bumpable: boolean = pendingOpen;
 
         const peerDisplay = PrivacyUtils.sensitiveValue(displayName, 8);
+
+        const reserveColor = hexAverage([
+            themeColor('outbound'),
+            themeColor('inbound')
+        ]);
 
         const EditFees = () => (
             <TouchableOpacity
@@ -358,6 +364,7 @@ export default class ChannelView extends React.Component<
                     <BalanceSlider
                         localBalance={lurkerMode ? 50 : localBalance}
                         remoteBalance={lurkerMode ? 50 : remoteBalance}
+                        reserveBalance={lurkerMode ? 50 : totalReserveBalance}
                     />
                     <Text
                         style={{ ...styles.status, color: themeColor('text') }}
@@ -572,12 +579,14 @@ export default class ChannelView extends React.Component<
                         value={
                             <Amount sats={localBalance} sensitive toggleable />
                         }
+                        indicatorColor={themeColor('outbound')}
                     />
                     <KeyValue
                         keyValue={localeString('views.Channel.Total.inbound')}
                         value={
                             <Amount sats={remoteBalance} sensitive toggleable />
                         }
+                        indicatorColor={themeColor('inbound')}
                     />
                     {unsettled_balance && (
                         <KeyValue
@@ -621,6 +630,7 @@ export default class ChannelView extends React.Component<
                                 'views.Channel.localReserve.info'
                             )}
                             infoLink="https://bitcoin.design/guide/how-it-works/liquidity/#what-is-a-channel-reserve"
+                            indicatorColor={reserveColor}
                         />
                     )}
                     {!!remote_chan_reserve_sat && (
@@ -639,6 +649,7 @@ export default class ChannelView extends React.Component<
                                 'views.Channel.remoteReserve.info'
                             )}
                             infoLink="https://bitcoin.design/guide/how-it-works/liquidity/#what-is-a-channel-reserve"
+                            indicatorColor={reserveColor}
                         />
                     )}
                     {capacity && (

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -631,7 +631,7 @@ export default class ChannelView extends React.Component<
                                 'views.Channel.localReserve.info'
                             )}
                             infoLink="https://bitcoin.design/guide/how-it-works/liquidity/#what-is-a-channel-reserve"
-                            indicatorColor="#E5E5E5"
+                            indicatorColor={themeColor('outboundReserve')}
                         />
                     )}
                     {!!remote_chan_reserve_sat && (
@@ -650,7 +650,7 @@ export default class ChannelView extends React.Component<
                                 'views.Channel.remoteReserve.info'
                             )}
                             infoLink="https://bitcoin.design/guide/how-it-works/liquidity/#what-is-a-channel-reserve"
-                            indicatorColor="#A7A9AC"
+                            indicatorColor={themeColor('inboundReserve')}
                         />
                     )}
                     {capacity && (

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -34,7 +34,7 @@ import TextInput from '../../components/TextInput';
 import PrivacyUtils from '../../utils/PrivacyUtils';
 import BackendUtils from '../../utils/BackendUtils';
 import { localeString } from '../../utils/LocaleUtils';
-import { themeColor, hexAverage } from '../../utils/ThemeUtils';
+import { themeColor } from '../../utils/ThemeUtils';
 import UrlUtils from '../../utils/UrlUtils';
 import { getPhoto } from '../../utils/PhotoUtils';
 
@@ -230,12 +230,13 @@ export default class ChannelView extends React.Component<
             channel_point,
             commit_weight,
             localBalance,
-            totalReserveBalance,
+            remoteBalance,
+            localReserveBalance,
+            remoteReserveBalance,
             commit_fee,
             csv_delay,
             total_satoshis_received,
             isActive,
-            remoteBalance,
             unsettled_balance,
             total_satoshis_sent,
             remotePubkey,
@@ -277,11 +278,6 @@ export default class ChannelView extends React.Component<
         const bumpable: boolean = pendingOpen;
 
         const peerDisplay = PrivacyUtils.sensitiveValue(displayName, 8);
-
-        const reserveColor = hexAverage([
-            themeColor('outbound'),
-            themeColor('inbound')
-        ]);
 
         const EditFees = () => (
             <TouchableOpacity
@@ -364,7 +360,12 @@ export default class ChannelView extends React.Component<
                     <BalanceSlider
                         localBalance={lurkerMode ? 50 : localBalance}
                         remoteBalance={lurkerMode ? 50 : remoteBalance}
-                        reserveBalance={lurkerMode ? 50 : totalReserveBalance}
+                        localReserveBalance={
+                            lurkerMode ? 50 : localReserveBalance
+                        }
+                        remoteReserveBalance={
+                            lurkerMode ? 50 : remoteReserveBalance
+                        }
                     />
                     <Text
                         style={{ ...styles.status, color: themeColor('text') }}
@@ -630,7 +631,7 @@ export default class ChannelView extends React.Component<
                                 'views.Channel.localReserve.info'
                             )}
                             infoLink="https://bitcoin.design/guide/how-it-works/liquidity/#what-is-a-channel-reserve"
-                            indicatorColor={reserveColor}
+                            indicatorColor="#E5E5E5"
                         />
                     )}
                     {!!remote_chan_reserve_sat && (
@@ -649,7 +650,7 @@ export default class ChannelView extends React.Component<
                                 'views.Channel.remoteReserve.info'
                             )}
                             infoLink="https://bitcoin.design/guide/how-it-works/liquidity/#what-is-a-channel-reserve"
-                            indicatorColor={reserveColor}
+                            indicatorColor="#A7A9AC"
                         />
                     )}
                     {capacity && (

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -121,6 +121,7 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
                         pendingHTLCs={item?.pending_htlcs?.length > 0}
                         inbound={item.remoteBalance}
                         outbound={item.localBalance}
+                        reserve={item.totalReserveBalance}
                         largestTotal={largestChannelSats}
                     />
                 </TouchableHighlight>
@@ -139,6 +140,7 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
                     title={item.displayName}
                     inbound={item.remoteBalance}
                     outbound={item.localBalance}
+                    reserve={item.totalReserveBalance}
                     status={getStatus()}
                     pendingHTLCs={item?.pending_htlcs?.length > 0}
                     pendingTimelock={

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -121,7 +121,6 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
                         pendingHTLCs={item?.pending_htlcs?.length > 0}
                         inbound={item.remoteBalance}
                         outbound={item.localBalance}
-                        reserve={item.totalReserveBalance}
                         largestTotal={largestChannelSats}
                     />
                 </TouchableHighlight>
@@ -140,7 +139,6 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
                     title={item.displayName}
                     inbound={item.remoteBalance}
                     outbound={item.localBalance}
-                    reserve={item.totalReserveBalance}
                     status={getStatus()}
                     pendingHTLCs={item?.pending_htlcs?.length > 0}
                     pendingTimelock={


### PR DESCRIPTION
# Description

This PR attempts to visualize the channel reserve capacity of a channel. This is the reserve both parties must retain on their side of the channel to prevent cheating. Read more here: https://bitcoin.design/guide/how-it-works/liquidity/#what-is-a-channel-reserve

To convey this. We
- Add a reserve segment to the `BalanceBar` component in between the inbound and outbound amounts that is the composite color of the two.
- Add a color indicator circle to the `KeyValue` component to be displayed on the single `Channel` view to give the user an additional visual cue.

![image](https://github.com/user-attachments/assets/0bc9ac0c-1316-42c3-832c-786c552d8de1)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
