### PR TITLE
Channels: fixed aliases

### DIFF
--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -37,6 +37,15 @@ export enum ChannelsType {
     Closed = 2
 }
 
+interface aliases {
+    [index: string]: string;
+}
+
+const fixedAliases: aliases = {
+    '031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581':
+        'Olympus by ZEUS'
+};
+
 export default class ChannelsStore {
     @observable public loading = false;
     @observable public error = false;
@@ -338,15 +347,17 @@ export default class ChannelsStore {
 
         for (const channel of channelsWithMissingAliases) {
             const nodeInfo = this.nodes[channel.remotePubkey];
-            if (!nodeInfo) continue;
-            this.aliasesById[channel.channelId!] = nodeInfo.alias;
+            const alias = nodeInfo?.alias || fixedAliases[channel.remotePubkey];
+            if (alias) this.aliasesById[channel.channelId!] = alias;
         }
 
         if (setPendingHtlcs) this.pendingHTLCs = [];
 
         for (const channel of channels) {
             if (channel.alias == null) {
-                channel.alias = this.nodes[channel.remotePubkey]?.alias;
+                channel.alias =
+                    this.nodes[channel.remotePubkey]?.alias ||
+                    this.aliasesById[channel.channelId!];
             }
             channel.displayName =
                 channel.alias ||


### PR DESCRIPTION
# Description

Sometimes our embedded nodes have issues displaying our LSP's node alias from the graph data. This PR adds an index of predefined aliases to fall back on in case the alias cannot be fetched.

This pull request is categorized as a:

- [x] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
