### PR TITLE
ZEUS Pay: update relay sig when Nostr key updated

### DIFF
--- a/views/Settings/LightningAddress/NostrKeys.tsx
+++ b/views/Settings/LightningAddress/NostrKeys.tsx
@@ -5,6 +5,9 @@ import { inject, observer } from 'mobx-react';
 import { generatePrivateKey, getPublicKey, nip19 } from 'nostr-tools';
 import { Route } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { schnorr } from '@noble/curves/secp256k1';
+import { bytesToHex } from '@noble/hashes/utils';
+import hashjs from 'hash.js';
 
 import Button from '../../../components/Button';
 import KeyValue from '../../../components/KeyValue';
@@ -352,9 +355,28 @@ export default class NostrKey extends React.Component<
                                                     { nostrPrivateKey }
                                                 );
                                             } else {
+                                                const relays =
+                                                    settings.lightningAddress
+                                                        .nostrRelays;
+                                                const relays_sig = bytesToHex(
+                                                    schnorr.sign(
+                                                        hashjs
+                                                            .sha256()
+                                                            .update(
+                                                                JSON.stringify(
+                                                                    relays
+                                                                )
+                                                            )
+                                                            .digest('hex'),
+                                                        nostrPrivateKey
+                                                    )
+                                                );
                                                 try {
                                                     update({
-                                                        nostr_pk: nostrPublicKey
+                                                        nostr_pk:
+                                                            nostrPublicKey,
+                                                        relays,
+                                                        relays_sig
                                                     }).then(async () => {
                                                         this.setState({
                                                             existingNostrPrivateKey:


### PR DESCRIPTION
# Description

This PR fixes two bugs with ZEUS Pay lightning addresses.
- Nostr relay sigs were not being updated when Nostr keys were changed
- The user's saved relay list was not being used for attestation lookup

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
