### PR TITLE
Display info when clicking on swipeable rows while sync

### DIFF
--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { getParams as getlnurlParams } from 'js-lnurl';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { inject, observer } from 'mobx-react';
 
 import { RectButton } from 'react-native-gesture-handler';
 import Swipeable from 'react-native-gesture-handler/Swipeable';
@@ -18,6 +19,7 @@ import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
 
 import stores from './../../stores/Stores';
+import SyncStore from '../../stores/SyncStore';
 const { invoicesStore } = stores;
 
 import Receive from './../../assets/images/SVG/Receive.svg';
@@ -31,8 +33,11 @@ interface LightningSwipeableRowProps {
     locked?: boolean;
     children: React.ReactNode;
     disabled?: boolean;
+    SyncStore?: SyncStore;
 }
 
+@inject('SyncStore')
+@observer
 export default class LightningSwipeableRow extends Component<
     LightningSwipeableRowProps,
     {}
@@ -259,7 +264,23 @@ export default class LightningSwipeableRow extends Component<
     };
 
     render() {
-        const { children, lightning, offer, locked, disabled } = this.props;
+        const { children, lightning, offer, locked, disabled, SyncStore } =
+            this.props;
+        const { isSyncing } = SyncStore!;
+        if (isSyncing) {
+            return (
+                <TouchableOpacity
+                    onPress={() =>
+                        stores.modalStore.toggleInfoModal(
+                            localeString('views.Wallet.waitForSync')
+                        )
+                    }
+                    activeOpacity={1}
+                >
+                    {children}
+                </TouchableOpacity>
+            );
+        }
         if (locked && (lightning || offer)) {
             return (
                 <TouchableOpacity

--- a/components/LayerBalances/OnchainSwipeableRow.tsx
+++ b/components/LayerBalances/OnchainSwipeableRow.tsx
@@ -10,10 +10,14 @@ import {
 import { RectButton } from 'react-native-gesture-handler';
 import Swipeable from 'react-native-gesture-handler/Swipeable';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { inject, observer } from 'mobx-react';
 
 import BackendUtils from './../../utils/BackendUtils';
 import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
+
+import stores from './../../stores/Stores';
+import SyncStore from '../../stores/SyncStore';
 
 import Coins from './../../assets/images/SVG/Coins.svg';
 import Receive from './../../assets/images/SVG/Receive.svg';
@@ -28,8 +32,11 @@ interface OnchainSwipeableRowProps {
     hidden?: boolean;
     children?: React.ReactNode;
     disabled?: boolean;
+    SyncStore?: SyncStore;
 }
 
+@inject('SyncStore')
+@observer
 export default class OnchainSwipeableRow extends Component<
     OnchainSwipeableRowProps,
     {}
@@ -171,7 +178,25 @@ export default class OnchainSwipeableRow extends Component<
     };
 
     render() {
-        const { children, value, locked, hidden, disabled } = this.props;
+        const { children, value, locked, hidden, disabled, SyncStore } =
+            this.props;
+        const { isSyncing } = SyncStore!;
+        if (isSyncing) {
+            return (
+                <TouchableOpacity
+                    onPress={() =>
+                        stores.modalStore.toggleInfoModal(
+                            localeString('views.Wallet.waitForSync')
+                        )
+                    }
+                    activeOpacity={1}
+                >
+                    <View style={{ width: '100%', opacity: hidden ? 0.25 : 1 }}>
+                        {children}
+                    </View>
+                </TouchableOpacity>
+            );
+        }
         if (locked && value) {
             return (
                 <TouchableOpacity

--- a/locales/en.json
+++ b/locales/en.json
@@ -317,6 +317,7 @@
     "views.OpenChannel.removeAdditionalChannel": "Remove additional channel",
     "views.Wallet.BalancePane.sync.title": "Finishing sync",
     "views.Wallet.BalancePane.sync.text": "Hang on tight! You will be ready to use Zeus soon.",
+    "views.Wallet.waitForSync": "Your node must be fully synced before you can send or receive payments. Please wait.",
     "views.Wallet.BalancePane.recovery.title": "Recovery mode",
     "views.Wallet.BalancePane.recovery.text": "Please leave ZEUS open until the process completes.",
     "views.Wallet.BalancePane.recovery.textAlt": "Leave ZEUS open until completion.",


### PR DESCRIPTION
# Description

This fixes #2560.

![grafik](https://github.com/user-attachments/assets/f2deed2f-6dc6-4197-9ee5-5fb607af712f)


This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
