### PR TITLE
Hide NFC buttons if not supported

### DIFF
--- a/components/CollapsedQR.tsx
+++ b/components/CollapsedQR.tsx
@@ -67,6 +67,7 @@ interface CollapsedQRProps {
     textBottom?: boolean;
     truncateLongValue?: boolean;
     logo?: any;
+    nfcSupported?: boolean;
 }
 
 interface CollapsedQRState {
@@ -259,7 +260,7 @@ export default class CollapsedQR extends React.Component<
                     />
                 )}
                 <CopyButton copyValue={copyValue || value} title={copyText} />
-                {Platform.OS === 'android' && (
+                {Platform.OS === 'android' && this.props.nfcSupported && (
                     <Button
                         title={
                             nfcBroadcast

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-native-keychain": "8.1.1",
     "react-native-level-fs": "3.0.1",
     "react-native-linear-gradient": "2.6.2",
-    "react-native-nfc-manager": "3.14.11",
+    "react-native-nfc-manager": "3.14.14",
     "react-native-notifications": "5.1.0",
     "react-native-os": "aprock/react-native-os#5/head",
     "react-native-ping": "1.2.8",

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -139,6 +139,7 @@ interface ReceiveState {
     routeHints: boolean;
     account: string;
     blindedPaths: boolean;
+    nfcSupported: boolean;
     // POS
     orderId: string;
     orderTotal: string;
@@ -195,6 +196,7 @@ export default class Receive extends React.Component<
         routeHints: false,
         account: 'default',
         blindedPaths: false,
+        nfcSupported: false,
         // POS
         orderId: '',
         orderTip: '',
@@ -426,6 +428,11 @@ export default class Receive extends React.Component<
                 needInbound
             });
         }
+    }
+
+    async componentDidMount() {
+        const nfcSupported = await NfcManager.isSupported();
+        this.setState({ nfcSupported });
     }
 
     clearListeners = () => {
@@ -1076,7 +1083,8 @@ export default class Receive extends React.Component<
             routeHintMode,
             selectedRouteHintChannels,
             blindedPaths,
-            hideRightHeaderComponent
+            hideRightHeaderComponent,
+            nfcSupported
         } = this.state;
 
         const { fontScale } = Dimensions.get('window');
@@ -1797,6 +1805,7 @@ export default class Receive extends React.Component<
                                                             ? ZIconWhite
                                                             : ZIcon
                                                     }
+                                                    nfcSupported={nfcSupported}
                                                 />
                                             )}
                                         {selectedIndex == 1 &&
@@ -1820,6 +1829,7 @@ export default class Receive extends React.Component<
                                                             ? LightningIconWhite
                                                             : LightningIcon
                                                     }
+                                                    nfcSupported={nfcSupported}
                                                 />
                                             )}
                                         {selectedIndex == 2 &&
@@ -1843,6 +1853,7 @@ export default class Receive extends React.Component<
                                                             ? OnChainIconWhite
                                                             : OnChainIcon
                                                     }
+                                                    nfcSupported={nfcSupported}
                                                 />
                                             )}
 
@@ -1911,6 +1922,7 @@ export default class Receive extends React.Component<
                                                             ? ZPayIconWhite
                                                             : ZPayIcon
                                                     }
+                                                    nfcSupported={nfcSupported}
                                                 />
                                             )}
 
@@ -1936,39 +1948,42 @@ export default class Receive extends React.Component<
                                                     expanded
                                                     textBottom
                                                     truncateLongValue
+                                                    nfcSupported={nfcSupported}
                                                 />
                                             )}
                                         {!(
                                             selectedIndex === 3 &&
                                             !lightningAddress
-                                        ) && (
-                                            <View
-                                                style={[
-                                                    styles.button,
-                                                    { paddingTop: 0 }
-                                                ]}
-                                            >
-                                                <Button
-                                                    title={
-                                                        posStatus === 'active'
-                                                            ? localeString(
-                                                                  'general.payNfc'
-                                                              )
-                                                            : localeString(
-                                                                  'general.receiveNfc'
-                                                              )
-                                                    }
-                                                    icon={{
-                                                        name: 'nfc',
-                                                        size: 25
-                                                    }}
-                                                    onPress={() =>
-                                                        this.enableNfc()
-                                                    }
-                                                    secondary
-                                                />
-                                            </View>
-                                        )}
+                                        ) &&
+                                            nfcSupported && (
+                                                <View
+                                                    style={[
+                                                        styles.button,
+                                                        { paddingTop: 0 }
+                                                    ]}
+                                                >
+                                                    <Button
+                                                        title={
+                                                            posStatus ===
+                                                            'active'
+                                                                ? localeString(
+                                                                      'general.payNfc'
+                                                                  )
+                                                                : localeString(
+                                                                      'general.receiveNfc'
+                                                                  )
+                                                        }
+                                                        icon={{
+                                                            name: 'nfc',
+                                                            size: 25
+                                                        }}
+                                                        onPress={() =>
+                                                            this.enableNfc()
+                                                        }
+                                                        secondary
+                                                    />
+                                                </View>
+                                            )}
                                     </View>
                                 )}
                                 {!loading && !haveInvoice && !creatingInvoice && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1572,14 +1572,15 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.44.0.tgz#961a5903c74139390478bdc808bcde3fc45ab7af"
   integrity sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==
 
-"@expo/config-plugins@~7.2.5":
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-7.2.5.tgz#b15f22878975fdc4ddcfa8cdc971937ddc4c0249"
-  integrity sha512-w+5ccu1IxBHgyQk9CPFKLZOk8yZQEyTjbJwOzESK1eR7QwosbcsLkN1c1WWUZYiCXwORu3UTwJYll4+X2xxJhQ==
+"@expo/config-plugins@~7.8.0":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-7.8.4.tgz#533b5d536c1dc8b5544d64878b51bda28f2e1a1f"
+  integrity sha512-hv03HYxb/5kX8Gxv/BTI8TLc9L06WzqAfHRRXdbar4zkLcP2oTzvsLEF4/L/TIpD3rsnYa0KU42d0gWRxzPCJg==
   dependencies:
-    "@expo/config-types" "^49.0.0-alpha.1"
-    "@expo/json-file" "~8.2.37"
-    "@expo/plist" "^0.0.20"
+    "@expo/config-types" "^50.0.0-alpha.1"
+    "@expo/fingerprint" "^0.6.0"
+    "@expo/json-file" "~8.3.0"
+    "@expo/plist" "^0.1.0"
     "@expo/sdk-runtime-versions" "^1.0.0"
     "@react-native/normalize-color" "^2.0.0"
     chalk "^4.1.2"
@@ -1590,27 +1591,41 @@
     resolve-from "^5.0.0"
     semver "^7.5.3"
     slash "^3.0.0"
+    slugify "^1.6.6"
     xcode "^3.0.1"
     xml2js "0.6.0"
 
-"@expo/config-types@^49.0.0-alpha.1":
-  version "49.0.0"
-  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-49.0.0.tgz#15ffef715285c06703f6fb7ec0cda853f645cc09"
-  integrity sha512-8eyREVi+K2acnMBe/rTIu1dOfyR2+AMnTLHlut+YpMV9OZPdeKV0Bs9BxAewGqBA2slslbQ9N39IS2CuTKpXkA==
+"@expo/config-types@^50.0.0-alpha.1":
+  version "50.0.1"
+  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-50.0.1.tgz#12d889214dedf64fbf2322c9d9e75c9d5ca7f695"
+  integrity sha512-EZHMgzkWRB9SMHO1e9m8s+OMahf92XYTnsCFjxhSfcDrcEoSdFPyJWDJVloHZPMGhxns7Fi2+A+bEVN/hD4NKA==
 
-"@expo/json-file@~8.2.37":
-  version "8.2.37"
-  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.37.tgz#9c02d3b42134907c69cc0a027b18671b69344049"
-  integrity sha512-YaH6rVg11JoTS2P6LsW7ybS2CULjf40AbnAHw2F1eDPuheprNjARZMnyHFPkKv7GuxCy+B9GPcbOKgc4cgA80Q==
+"@expo/fingerprint@^0.6.0":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@expo/fingerprint/-/fingerprint-0.6.1.tgz#763ae79b06f60e10853596bfa2bd730bfb13f2b0"
+  integrity sha512-ggLn6unI6qowlA1FihdQwPpLn16VJulYkvYAEL50gaqVahfNEglRQMSH2giZzjD0d6xq2/EQuUdFyHaJfyJwOQ==
+  dependencies:
+    "@expo/spawn-async" "^1.5.0"
+    chalk "^4.1.2"
+    debug "^4.3.4"
+    find-up "^5.0.0"
+    minimatch "^3.0.4"
+    p-limit "^3.1.0"
+    resolve-from "^5.0.0"
+
+"@expo/json-file@~8.3.0":
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.3.3.tgz#7926e3592f76030ce63d6b1308ac8f5d4d9341f4"
+  integrity sha512-eZ5dld9AD0PrVRiIWpRkm5aIoWBw3kAyd8VkuWEy92sEthBKDDDHAnK2a0dw0Eil6j7rK7lS/Qaq/Zzngv2h5A==
   dependencies:
     "@babel/code-frame" "~7.10.4"
     json5 "^2.2.2"
     write-file-atomic "^2.3.0"
 
-"@expo/plist@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.20.tgz#a6b3124438031c02b762bad5a47b70584d3c0072"
-  integrity sha512-UXQ4LXCfTZ580LDHGJ5q62jSTwJFFJ1GqBu8duQMThiHKWbMJ+gajJh6rsB6EJ3aLUr9wcauxneL5LVRFxwBEA==
+"@expo/plist@^0.1.0":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.1.3.tgz#b4fbee2c4f7a88512a4853d85319f4d95713c529"
+  integrity sha512-GW/7hVlAylYg1tUrEASclw1MMk9FP4ZwyFAY/SUTJIhPDQHtfOlXREyWV3hhrHdX/K+pS73GNgdfT6E/e+kBbg==
   dependencies:
     "@xmldom/xmldom" "~0.7.7"
     base64-js "^1.2.3"
@@ -1620,6 +1635,13 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz#d7ebd21b19f1c6b0395e50d78da4416941c57f7c"
   integrity sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==
+
+"@expo/spawn-async@^1.5.0":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@expo/spawn-async/-/spawn-async-1.7.2.tgz#fcfe66c3e387245e72154b1a7eae8cada6a47f58"
+  integrity sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==
+  dependencies:
+    cross-spawn "^7.0.3"
 
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
@@ -8864,12 +8886,12 @@ react-native-linear-gradient@2.6.2:
   resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.6.2.tgz#56598a76832724b2afa7889747635b5c80948f38"
   integrity sha512-Z8Xxvupsex+9BBFoSYS87bilNPWcRfRsGC0cpJk72Nxb5p2nEkGSBv73xZbEHnW2mUFvP+huYxrVvjZkr/gRjQ==
 
-react-native-nfc-manager@3.14.11:
-  version "3.14.11"
-  resolved "https://registry.yarnpkg.com/react-native-nfc-manager/-/react-native-nfc-manager-3.14.11.tgz#ed8e688793639bd36d4e42a309a054ede9c7fa04"
-  integrity sha512-h0qJOQ1P+xXK7dRbK4xnK80kQxgNfniwlsP0oj33cb8ML9XVntBlVjbcHUsf6iERDYT8xPpQdfviSYB/zJ+K1g==
+react-native-nfc-manager@3.14.14:
+  version "3.14.14"
+  resolved "https://registry.yarnpkg.com/react-native-nfc-manager/-/react-native-nfc-manager-3.14.14.tgz#ae0918bbc95e4a8e0dc8db6b9fc5a9e9e772cf73"
+  integrity sha512-e0MjBz1yDpIGCBUUxwbx25K51eaSS4cy0OQgCiA+EOlXHjwfmp5tFEyaBI/X4pI6ifpsUOBCUX0hqSCC7/IQDg==
   dependencies:
-    "@expo/config-plugins" "~7.2.5"
+    "@expo/config-plugins" "~7.8.0"
 
 react-native-notifications@5.1.0:
   version "5.1.0"
@@ -9680,6 +9702,11 @@ slice-ansi@^2.0.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+slugify@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.6.tgz#2d4ac0eacb47add6af9e04d3be79319cbcc7924b"
+  integrity sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==
 
 snake-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
# Description

- Hide NFC buttons if NFC is not supported on device
- Update react-native-nfc-manager 3.14.11 -> 3.14.14

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [x] Contributors will need to run `yarn` after this PR is merged in
- [x] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
