### PR TITLE
Tests for DateTimeUtils, DateTimeUtils Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "<rootDir>/node_modules"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!(react-native|@react-native|react-native-blob-util|react-native-randombytes)/)"
+      "node_modules/(?!(react-native|@react-native|react-native-blob-util|react-native-randombytes|dateformat)/)"
     ],
     "testPathIgnorePatterns": [
       "check-styles.test.ts"

--- a/utils/DateTimeUtils.test.ts
+++ b/utils/DateTimeUtils.test.ts
@@ -1,0 +1,121 @@
+import DateTimeUtils from './DateTimeUtils';
+
+describe('listDate', () => {
+    it('returns date for timestamp as number', () => {
+        const date = new Date(2024, 11, 26, 21, 21);
+        const timestamp = date.getTime() / 1000;
+
+        const result = DateTimeUtils.listDate(timestamp);
+
+        expect(result).toEqual(date);
+    });
+
+    it('returns date for timestamp as string', () => {
+        const date = new Date(2024, 11, 26, 21, 21);
+        const timestamp = date.getTime() / 1000;
+
+        const result = DateTimeUtils.listDate(timestamp.toString());
+
+        expect(result).toEqual(date);
+    });
+});
+
+describe('listFormattedDate', () => {
+    it('returns timestamp with custom format and string as input', () => {
+        const date = new Date(2024, 11, 26, 21, 21);
+        const timestamp = date.getTime() / 1000;
+
+        const result = DateTimeUtils.listFormattedDate(
+            timestamp.toString(),
+            "mmm d 'yy, HH:MM"
+        );
+
+        expect(result).toEqual("Dec 26 '24, 21:21");
+    });
+
+    it('returns timestamp with default format if no format is given', () => {
+        const date = new Date(2024, 11, 26, 21, 21);
+        const timestamp = date.getTime() / 1000;
+
+        const result = DateTimeUtils.listFormattedDate(timestamp);
+
+        expect(result).toMatch(/^Thu, Dec 26 '24, 21:21/);
+    });
+});
+
+describe('listFormattedDateShort', () => {
+    it('returns timestamp without year if timestamp is current year', () => {
+        const timestamp =
+            new Date(new Date().getFullYear(), 0, 1, 5, 6).getTime() / 1000;
+
+        const result = DateTimeUtils.listFormattedDateShort(timestamp);
+
+        expect(result).toEqual('Jan 1, 05:06');
+    });
+
+    it('returns timestamp with year if timestamp is next year', () => {
+        const year = new Date().getFullYear() + 1;
+        const timestamp = new Date(year, 0, 1, 5, 6).getTime() / 1000;
+
+        const result = DateTimeUtils.listFormattedDateShort(timestamp);
+
+        expect(result).toEqual(`Jan 1, '${year % 100}, 05:06`);
+    });
+
+    it('returns timestamp with year if timestamp is last year', () => {
+        const year = new Date().getFullYear() - 1;
+        const timestamp = new Date(year, 0, 1, 5, 6).getTime() / 1000;
+
+        const result = DateTimeUtils.listFormattedDateShort(timestamp);
+
+        expect(result).toEqual(`Jan 1, '${year % 100}, 05:06`);
+    });
+
+    it('returns timestamp if input is string', () => {
+        const timestamp =
+            new Date(new Date().getFullYear(), 0, 1, 5, 6).getTime() / 1000;
+
+        const result = DateTimeUtils.listFormattedDateShort(
+            timestamp.toString()
+        );
+
+        expect(result).toEqual('Jan 1, 05:06');
+    });
+});
+
+describe('listFormattedDateOrder', () => {
+    it('returns timestamp without year if timestamp is current year', () => {
+        const timestamp = new Date(new Date().getFullYear(), 0, 1, 5, 6);
+        const dayName = timestamp.toLocaleDateString('en-US', {
+            weekday: 'short'
+        });
+
+        const result = DateTimeUtils.listFormattedDateOrder(timestamp);
+
+        expect(result).toEqual(`05:06 am | ${dayName}, Jan 01`);
+    });
+
+    it('returns timestamp with year if timestamp is next year', () => {
+        const year = new Date().getFullYear() + 1;
+        const timestamp = new Date(year, 0, 1, 5, 6);
+        const dayName = timestamp.toLocaleDateString('en-US', {
+            weekday: 'short'
+        });
+
+        const result = DateTimeUtils.listFormattedDateOrder(timestamp);
+
+        expect(result).toEqual(`05:06 am | ${dayName}, Jan 01, '${year % 100}`);
+    });
+
+    it('returns timestamp with year if timestamp is last year', () => {
+        const year = new Date().getFullYear() - 1;
+        const timestamp = new Date(year, 0, 1, 5, 6);
+        const dayName = timestamp.toLocaleDateString('en-US', {
+            weekday: 'short'
+        });
+
+        const result = DateTimeUtils.listFormattedDateOrder(timestamp);
+
+        expect(result).toEqual(`05:06 am | ${dayName}, Jan 01, '${year % 100}`);
+    });
+});

--- a/utils/DateTimeUtils.ts
+++ b/utils/DateTimeUtils.ts
@@ -1,8 +1,9 @@
 import dateFormat from 'dateformat';
 
 class DateTimeUtils {
-    listDate = (timestamp: number | string | Date) =>
+    listDate = (timestamp: number | string) =>
         new Date(Number(timestamp) * 1000);
+
     listFormattedDate = (
         timestamp: number | string,
         format = "ddd, mmm d 'yy, HH:MM Z"
@@ -21,7 +22,7 @@ class DateTimeUtils {
         const dateYear = date.getFullYear();
 
         const format =
-            dateYear < currentYear ? "mmm d, 'yy, HH:MM" : 'mmm d, HH:MM';
+            dateYear !== currentYear ? "mmm d, 'yy, HH:MM" : 'mmm d, HH:MM';
 
         return this.listFormattedDate(timestamp, format);
     };
@@ -30,10 +31,10 @@ class DateTimeUtils {
         const currentYear = new Date().getFullYear();
         const dateYear = timestamp.getFullYear();
 
-        const time = dateFormat(timestamp, 'hh:mm tt');
+        const time = dateFormat(timestamp, 'HH:MM tt');
         const monthAndDay = dateFormat(timestamp, 'ddd, mmm dd');
         const year =
-            dateYear < currentYear ? `, '${dateFormat(timestamp, 'yy')}` : '';
+            dateYear !== currentYear ? `, '${dateFormat(timestamp, 'yy')}` : '';
 
         return `${time} | ${monthAndDay}${year}`;
     };


### PR DESCRIPTION
# Description

- Created DateTimeUtils.test.ts
- fixed/improved DateTimeUtils

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [x] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
