### PR TITLE
Channel details: smaller line spacing

### DIFF
--- a/components/FeeBreakdown.tsx
+++ b/components/FeeBreakdown.tsx
@@ -113,6 +113,7 @@ export default class FeeBreakdown extends React.Component<
                                     sensitive
                                 />
                             }
+                            compact
                         />
                         <KeyValue
                             keyValue={localeString(
@@ -122,6 +123,7 @@ export default class FeeBreakdown extends React.Component<
                                 Number(localPolicy.fee_rate_milli_msat) / 10000
                             }%`}
                             sensitive
+                            compact
                         />
                         <KeyValue
                             keyValue={localeString(
@@ -137,6 +139,7 @@ export default class FeeBreakdown extends React.Component<
                                     sensitive
                                 />
                             }
+                            compact
                         />
                         <KeyValue
                             keyValue={localeString(
@@ -146,6 +149,7 @@ export default class FeeBreakdown extends React.Component<
                                 Number(remotePolicy.fee_rate_milli_msat) / 10000
                             }%`}
                             sensitive
+                            compact
                         />
                         {BackendUtils.supportInboundFees() && (
                             <>
@@ -165,6 +169,7 @@ export default class FeeBreakdown extends React.Component<
                                                 sensitive
                                             />
                                         }
+                                        compact
                                     />
                                 )}
                                 {!!localPolicy.inbound_fee_rate_milli_msat && (
@@ -178,6 +183,7 @@ export default class FeeBreakdown extends React.Component<
                                             ) / 10000
                                         }%`}
                                         sensitive
+                                        compact
                                     />
                                 )}
                                 {!!remotePolicy.inbound_fee_base_msat && (
@@ -196,6 +202,7 @@ export default class FeeBreakdown extends React.Component<
                                                 sensitive
                                             />
                                         }
+                                        compact
                                     />
                                 )}
                                 {!!remotePolicy.inbound_fee_rate_milli_msat && (
@@ -209,6 +216,7 @@ export default class FeeBreakdown extends React.Component<
                                             ) / 10000
                                         }%`}
                                         sensitive
+                                        compact
                                     />
                                 )}
                             </>
@@ -264,6 +272,7 @@ export default class FeeBreakdown extends React.Component<
                                     sensitive
                                 />
                             }
+                            compact
                         />
                         <KeyValue
                             keyValue={localeString('views.Channel.remoteMin')}
@@ -274,6 +283,7 @@ export default class FeeBreakdown extends React.Component<
                                     sensitive
                                 />
                             }
+                            compact
                         />
                         <KeyValue
                             keyValue={localeString('views.Channel.localMax')}
@@ -286,6 +296,7 @@ export default class FeeBreakdown extends React.Component<
                                     sensitive
                                 />
                             }
+                            compact
                         />
                         <KeyValue
                             keyValue={localeString('views.Channel.remoteMax')}
@@ -299,6 +310,7 @@ export default class FeeBreakdown extends React.Component<
                                     sensitive
                                 />
                             }
+                            compact
                         />
 
                         <KeyValue
@@ -308,6 +320,7 @@ export default class FeeBreakdown extends React.Component<
                             value={`${
                                 localPolicy.time_lock_delta
                             } ${localeString('general.blocks')}`}
+                            compact
                         />
                         <KeyValue
                             keyValue={localeString(
@@ -316,6 +329,7 @@ export default class FeeBreakdown extends React.Component<
                             value={`${
                                 remotePolicy.time_lock_delta
                             } ${localeString('general.blocks')}`}
+                            compact
                         />
                         <Divider
                             orientation="horizontal"
@@ -333,6 +347,7 @@ export default class FeeBreakdown extends React.Component<
                             value={DateTimeUtils.listFormattedDate(
                                 localPolicy.last_update
                             )}
+                            compact
                         />
                         <KeyValue
                             keyValue={localeString(
@@ -341,6 +356,7 @@ export default class FeeBreakdown extends React.Component<
                             value={DateTimeUtils.listFormattedDate(
                                 remotePolicy.last_update
                             )}
+                            compact
                         />
                         <KeyValue
                             keyValue={localeString('views.Channel.peerStatus')}
@@ -349,6 +365,7 @@ export default class FeeBreakdown extends React.Component<
                                     ? localeString('views.Channel.active')
                                     : localeString('views.Channel.inactive')
                             }
+                            compact
                         />
                         {total_satoshis_received && (
                             <KeyValue
@@ -362,6 +379,7 @@ export default class FeeBreakdown extends React.Component<
                                         toggleable
                                     />
                                 }
+                                compact
                             />
                         )}
 
@@ -377,6 +395,7 @@ export default class FeeBreakdown extends React.Component<
                                         toggleable
                                     />
                                 }
+                                compact
                             />
                         )}
                         <Divider
@@ -396,6 +415,7 @@ export default class FeeBreakdown extends React.Component<
                                     ? localeString('views.Channel.yourNode')
                                     : peerDisplay
                             }
+                            compact
                         />
 
                         {commit_fee && (
@@ -411,6 +431,7 @@ export default class FeeBreakdown extends React.Component<
                                     />
                                 }
                                 sensitive
+                                compact
                             />
                         )}
 
@@ -420,6 +441,7 @@ export default class FeeBreakdown extends React.Component<
                                     'views.Channel.commitWeight'
                                 )}
                                 value={commit_weight}
+                                compact
                             />
                         )}
 
@@ -437,6 +459,7 @@ export default class FeeBreakdown extends React.Component<
                                     ),
                                     localeString('views.Channel.csvDelay.info2')
                                 ]}
+                                compact
                             />
                         )}
 
@@ -454,6 +477,7 @@ export default class FeeBreakdown extends React.Component<
                                         testnet
                                     )
                                 }
+                                compact
                             />
                         )}
                         {channelPoint && (
@@ -470,6 +494,7 @@ export default class FeeBreakdown extends React.Component<
                                         testnet
                                     )
                                 }
+                                compact
                             />
                         )}
                     </React.Fragment>

--- a/components/KeyValue.tsx
+++ b/components/KeyValue.tsx
@@ -34,6 +34,7 @@ interface KeyValueProps {
     disableCopy?: boolean;
     ModalStore?: ModalStore;
     SettingsStore?: SettingsStore;
+    compact?: boolean;
 }
 
 @inject('ModalStore', 'SettingsStore')
@@ -52,7 +53,8 @@ export default class KeyValue extends React.Component<KeyValueProps, {}> {
             mempoolLink,
             disableCopy,
             ModalStore,
-            SettingsStore
+            SettingsStore,
+            compact
         } = this.props;
         const { toggleInfoModal } = ModalStore!;
 
@@ -167,7 +169,12 @@ export default class KeyValue extends React.Component<KeyValueProps, {}> {
         );
 
         return (
-            <View style={{ paddingTop: 10, paddingBottom: 10 }}>
+            <View
+                style={{
+                    paddingTop: compact ? 5 : 10,
+                    paddingBottom: compact ? 5 : 10
+                }}
+            >
                 <KeyValueRow />
             </View>
         );

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -396,12 +396,14 @@ export default class ChannelView extends React.Component<
                         <KeyValue
                             keyValue={localeString('views.Channel.channelId')}
                             value={channelId}
+                            compact
                         />
                     )}
                     {shortChannelId && (
                         <KeyValue
                             keyValue={localeString('views.Channel.scid')}
                             value={shortChannelId}
+                            compact
                         />
                     )}
                     {!!alias_scids && alias_scids.length > 0 && (
@@ -414,12 +416,14 @@ export default class ChannelView extends React.Component<
                             value={PrivacyUtils.sensitiveValue(
                                 alias_scids.join(', ')
                             )}
+                            compact
                         />
                     )}
                     {zero_conf && (
                         <KeyValue
                             keyValue={localeString('views.Channel.zeroConf')}
                             value={localeString('general.true')}
+                            compact
                         />
                     )}
                     {!(closeHeight || closeType) && (
@@ -431,6 +435,7 @@ export default class ChannelView extends React.Component<
                                     : localeString('general.false')
                             }
                             color={privateChannel ? 'green' : '#808000'}
+                            compact
                         />
                     )}
                     {getCommitmentType && (
@@ -439,6 +444,7 @@ export default class ChannelView extends React.Component<
                                 'views.Channel.commitmentType'
                             )}
                             value={getCommitmentType}
+                            compact
                         />
                     )}
                     {chain_hash && (
@@ -446,6 +452,7 @@ export default class ChannelView extends React.Component<
                             keyValue={localeString('views.Channel.chainHash')}
                             value={chain_hash}
                             sensitive
+                            compact
                         />
                     )}
                     {!!closeHeight && (
@@ -460,6 +467,7 @@ export default class ChannelView extends React.Component<
                                     testnet
                                 )
                             }
+                            compact
                         />
                     )}
                     {closeType && (
@@ -467,6 +475,7 @@ export default class ChannelView extends React.Component<
                             keyValue={localeString('views.Channel.closeType')}
                             value={closeType}
                             sensitive
+                            compact
                         />
                     )}
                     {getOpenInitiator && (
@@ -476,6 +485,7 @@ export default class ChannelView extends React.Component<
                             )}
                             value={getOpenInitiator}
                             sensitive
+                            compact
                         />
                     )}
                     {getCloseInitiator && (
@@ -485,6 +495,7 @@ export default class ChannelView extends React.Component<
                             )}
                             value={getCloseInitiator}
                             sensitive
+                            compact
                         />
                     )}
                     {closing_txid && (
@@ -499,6 +510,7 @@ export default class ChannelView extends React.Component<
                                     testnet
                                 )
                             }
+                            compact
                         />
                     )}
                     {closing_tx_hash && (
@@ -515,6 +527,7 @@ export default class ChannelView extends React.Component<
                                     testnet
                                 )
                             }
+                            compact
                         />
                     )}
                     {(pendingOpen ||
@@ -535,6 +548,7 @@ export default class ChannelView extends React.Component<
                                         testnet
                                     )
                                 }
+                                compact
                             />
                         )}
                     {!!pending_htlcs && pending_htlcs.length > 0 && (
@@ -595,6 +609,7 @@ export default class ChannelView extends React.Component<
                                 />
                             }
                             sensitive
+                            compact
                         />
                     )}
                     {time_locked_balance && (
@@ -610,6 +625,7 @@ export default class ChannelView extends React.Component<
                                 />
                             }
                             sensitive
+                            compact
                         />
                     )}
                     <KeyValue
@@ -626,12 +642,14 @@ export default class ChannelView extends React.Component<
                                 }
                             />
                         }
+                        compact
                     />
                     <KeyValue
                         keyValue={localeString('views.Channel.remoteBalance')}
                         value={
                             <Amount sats={remoteBalance} sensitive toggleable />
                         }
+                        compact
                     />
                     {unsettled_balance !== '0' && (
                         <KeyValue
@@ -645,10 +663,13 @@ export default class ChannelView extends React.Component<
                                     toggleable
                                 />
                             }
+                            compact
                         />
                     )}
                     <KeyValue
-                        keyValue={localeString('views.Channel.Total.outbound')}
+                        keyValue={` ${localeString(
+                            'views.Channel.Total.outbound'
+                        )}`}
                         value={
                             <Amount
                                 sats={sendingCapacity}
@@ -657,9 +678,12 @@ export default class ChannelView extends React.Component<
                             />
                         }
                         indicatorColor={themeColor('outbound')}
+                        compact
                     />
                     <KeyValue
-                        keyValue={localeString('views.Channel.Total.inbound')}
+                        keyValue={` ${localeString(
+                            'views.Channel.Total.inbound'
+                        )}`}
                         value={
                             <Amount
                                 sats={receivingCapacity}
@@ -668,12 +692,13 @@ export default class ChannelView extends React.Component<
                             />
                         }
                         indicatorColor={themeColor('inbound')}
+                        compact
                     />
                     {!!local_chan_reserve_sat && (
                         <KeyValue
-                            keyValue={localeString(
+                            keyValue={` ${localeString(
                                 'views.Channel.localReserve'
-                            )}
+                            )}`}
                             value={
                                 <Amount
                                     sats={local_chan_reserve_sat}
@@ -691,13 +716,14 @@ export default class ChannelView extends React.Component<
                             )}
                             infoModalLink="https://bitcoin.design/guide/how-it-works/liquidity/#what-is-a-channel-reserve"
                             indicatorColor={themeColor('outboundReserve')}
+                            compact
                         />
                     )}
                     {!!remote_chan_reserve_sat && (
                         <KeyValue
-                            keyValue={localeString(
+                            keyValue={` ${localeString(
                                 'views.Channel.remoteReserve'
-                            )}
+                            )}`}
                             value={
                                 <Amount
                                     sats={remote_chan_reserve_sat}
@@ -710,6 +736,7 @@ export default class ChannelView extends React.Component<
                             )}
                             infoModalLink="https://bitcoin.design/guide/how-it-works/liquidity/#what-is-a-channel-reserve"
                             indicatorColor={themeColor('inboundReserve')}
+                            compact
                         />
                     )}
                     {capacity && (
@@ -718,6 +745,7 @@ export default class ChannelView extends React.Component<
                             value={
                                 <Amount sats={capacity} sensitive toggleable />
                             }
+                            compact
                         />
                     )}
 


### PR DESCRIPTION
# Description

- There is a lot of information in channel details, so I made a compact mode for KeyValue component.
- Added a missing divider between "Commitment Type" and "Channel balance" headline.
- Added space between capacity/reserve indicator and label

Before:
![grafik](https://github.com/user-attachments/assets/e26bf327-31ce-4e30-b4ac-9590d7ea2757)

After:
![grafik](https://github.com/user-attachments/assets/34cfc4cd-012c-42bd-8cb7-cce54ac9a6d5)

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
