### PR TITLE
LSPS1: default to REST interface for remote LND nodes

### DIFF
--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -689,8 +689,8 @@ export default class LND {
     supportsOnchainSendMax = () => this.supports('v0.18.3');
     supportsOnchainBatching = () => true;
     supportsChannelBatching = () => true;
-    supportsLSPS1customMessage = () => true;
-    supportsLSPS1rest = () => false;
+    supportsLSPS1customMessage = () => false;
+    supportsLSPS1rest = () => true;
     supportsOffers = (): Promise<boolean> | boolean => false;
     supportsBolt11BlindedRoutes = () => this.supports('v0.18.3');
     supportsAddressesWithDerivationPaths = () => this.supports('v0.18.0');

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -527,8 +527,8 @@ export default class LightningNodeConnect {
     supportsOnchainSendMax = () => this.supports('v0.18.3');
     supportsOnchainBatching = () => true;
     supportsChannelBatching = () => true;
-    supportsLSPS1customMessage = () => true;
-    supportsLSPS1rest = () => false;
+    supportsLSPS1customMessage = () => false;
+    supportsLSPS1rest = () => true;
     supportsOffers = () => false;
     supportsBolt11BlindedRoutes = () => this.supports('v0.18.3');
     supportsAddressesWithDerivationPaths = () => this.supports('v0.18.0');


### PR DESCRIPTION
# Description

Something we overlooked when implementing LSPS1 for remote LND nodes: on the [`SubscribeCustomMessages`](https://lightning.engineering/api-docs/api/lnd/lightning/subscribe-custom-messages/) endpoint, LND must be built with `devrpc` tags for messages with type outside of the custom range (>= 32768). The LSP spec uses messages with type 37913.

Since many remote node users do not have their LND instances built with the `devrpc` tag, we'll point them to use the HTTP interface instead.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
