### PR TITLE
Several layout improvements

### DIFF
--- a/components/Text.tsx
+++ b/components/Text.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Text, TextStyle, TouchableOpacity } from 'react-native';
 import { inject, observer } from 'mobx-react';
-import { Row } from './layout/Row';
 
 import { themeColor } from './../utils/ThemeUtils';
 
@@ -34,16 +33,14 @@ export default class ZeusText extends React.Component<TextProps, {}> {
         const { toggleInfoModal } = ModalStore!;
 
         const CoreText = () => (
-            <Row>
-                <Text
-                    style={{
-                        fontFamily: 'PPNeueMontreal-Book',
-                        color: themeColor('text'),
-                        ...style
-                    }}
-                >
-                    {children}
-                </Text>
+            <Text
+                style={{
+                    fontFamily: 'PPNeueMontreal-Book',
+                    color: themeColor('text'),
+                    ...style
+                }}
+            >
+                {children}
                 {infoModalText && (
                     <Text
                         style={{
@@ -55,7 +52,7 @@ export default class ZeusText extends React.Component<TextProps, {}> {
                         {'  ⓘ'}
                     </Text>
                 )}
-            </Row>
+            </Text>
         );
 
         if (infoModalText) {

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -2019,59 +2019,73 @@ export default class Receive extends React.Component<
                                     <>
                                         {BackendUtils.supportsLSPs() &&
                                             !lspNotConfigured && (
-                                                <>
-                                                    <Text
-                                                        style={{
-                                                            ...styles.secondaryText,
-                                                            color: themeColor(
-                                                                'secondaryText'
-                                                            ),
-                                                            top: 20
-                                                        }}
-                                                        infoModalText={[
-                                                            localeString(
-                                                                'views.Receive.lspSwitchExplainer1'
-                                                            ),
-                                                            localeString(
-                                                                'views.Receive.lspSwitchExplainer2'
-                                                            )
-                                                        ]}
-                                                        infoModalAdditionalButtons={[
-                                                            {
-                                                                title: localeString(
-                                                                    'general.learnMore'
+                                                <View
+                                                    style={{
+                                                        flexDirection: 'row',
+                                                        marginBottom: 15
+                                                    }}
+                                                >
+                                                    <View style={{ flex: 1 }}>
+                                                        <Text
+                                                            style={{
+                                                                ...styles.secondaryText,
+                                                                color: themeColor(
+                                                                    'secondaryText'
+                                                                )
+                                                            }}
+                                                            infoModalText={[
+                                                                localeString(
+                                                                    'views.Receive.lspSwitchExplainer1'
                                                                 ),
-                                                                callback: () =>
-                                                                    navigation.navigate(
-                                                                        'LspExplanationOverview'
-                                                                    )
-                                                            }
-                                                        ]}
-                                                    >
-                                                        {localeString(
-                                                            'views.Settings.LSP.enableLSP'
-                                                        )}
-                                                    </Text>
-                                                    <Switch
-                                                        value={enableLSP}
-                                                        onValueChange={async () => {
-                                                            this.setState({
-                                                                enableLSP:
-                                                                    !enableLSP,
-                                                                lspIsActive:
-                                                                    !enableLSP &&
-                                                                    BackendUtils.supportsLSPs() &&
-                                                                    !lspNotConfigured
-                                                            });
-                                                            await updateSettings(
+                                                                localeString(
+                                                                    'views.Receive.lspSwitchExplainer2'
+                                                                )
+                                                            ]}
+                                                            infoModalAdditionalButtons={[
                                                                 {
-                                                                    enableLSP:
-                                                                        !enableLSP
+                                                                    title: localeString(
+                                                                        'general.learnMore'
+                                                                    ),
+                                                                    callback:
+                                                                        () =>
+                                                                            navigation.navigate(
+                                                                                'LspExplanationOverview'
+                                                                            )
                                                                 }
-                                                            );
+                                                            ]}
+                                                        >
+                                                            {localeString(
+                                                                'views.Settings.LSP.enableLSP'
+                                                            )}
+                                                        </Text>
+                                                    </View>
+                                                    <View
+                                                        style={{
+                                                            alignSelf: 'center',
+                                                            marginLeft: 5
                                                         }}
-                                                    />
-                                                </>
+                                                    >
+                                                        <Switch
+                                                            value={enableLSP}
+                                                            onValueChange={async () => {
+                                                                this.setState({
+                                                                    enableLSP:
+                                                                        !enableLSP,
+                                                                    lspIsActive:
+                                                                        !enableLSP &&
+                                                                        BackendUtils.supportsLSPs() &&
+                                                                        !lspNotConfigured
+                                                                });
+                                                                await updateSettings(
+                                                                    {
+                                                                        enableLSP:
+                                                                            !enableLSP
+                                                                    }
+                                                                );
+                                                            }}
+                                                        />
+                                                    </View>
+                                                </View>
                                             )}
 
                                         {(!enableLSP || lspNotConfigured) && (
@@ -2533,39 +2547,54 @@ export default class Receive extends React.Component<
 
                                         {BackendUtils.isLNDBased() &&
                                             !lspIsActive && (
-                                                <>
-                                                    <Text
+                                                <View
+                                                    style={{
+                                                        flexDirection: 'row',
+                                                        marginTop: 20
+                                                    }}
+                                                >
+                                                    <View style={{ flex: 1 }}>
+                                                        <Text
+                                                            style={{
+                                                                ...styles.secondaryText,
+                                                                color: themeColor(
+                                                                    'secondaryText'
+                                                                )
+                                                            }}
+                                                            infoModalText={[
+                                                                localeString(
+                                                                    'views.Receive.routeHintSwitchExplainer1'
+                                                                ),
+                                                                localeString(
+                                                                    'views.Receive.routeHintSwitchExplainer2'
+                                                                )
+                                                            ]}
+                                                        >
+                                                            {localeString(
+                                                                'views.Receive.routeHints'
+                                                            )}
+                                                        </Text>
+                                                    </View>
+                                                    <View
                                                         style={{
-                                                            ...styles.secondaryText,
-                                                            color: themeColor(
-                                                                'secondaryText'
-                                                            ),
-                                                            top: 20
+                                                            alignSelf: 'center',
+                                                            marginLeft: 5
                                                         }}
-                                                        infoModalText={[
-                                                            localeString(
-                                                                'views.Receive.routeHintSwitchExplainer1'
-                                                            ),
-                                                            localeString(
-                                                                'views.Receive.routeHintSwitchExplainer2'
-                                                            )
-                                                        ]}
                                                     >
-                                                        {localeString(
-                                                            'views.Receive.routeHints'
-                                                        )}
-                                                    </Text>
-                                                    <Switch
-                                                        value={routeHints}
-                                                        onValueChange={() =>
-                                                            this.setState({
-                                                                routeHints:
-                                                                    !routeHints
-                                                            })
-                                                        }
-                                                        disabled={blindedPaths}
-                                                    />
-                                                </>
+                                                        <Switch
+                                                            value={routeHints}
+                                                            onValueChange={() =>
+                                                                this.setState({
+                                                                    routeHints:
+                                                                        !routeHints
+                                                                })
+                                                            }
+                                                            disabled={
+                                                                blindedPaths
+                                                            }
+                                                        />
+                                                    </View>
+                                                </View>
                                             )}
 
                                         {BackendUtils.isLNDBased() &&
@@ -2667,81 +2696,109 @@ export default class Receive extends React.Component<
 
                                         {BackendUtils.supportsAMP() &&
                                             !lspIsActive && (
-                                                <>
-                                                    <Text
+                                                <View
+                                                    style={{
+                                                        flexDirection: 'row',
+                                                        marginTop: 20
+                                                    }}
+                                                >
+                                                    <View style={{ flex: 1 }}>
+                                                        <Text
+                                                            style={{
+                                                                ...styles.secondaryText,
+                                                                color: themeColor(
+                                                                    'secondaryText'
+                                                                )
+                                                            }}
+                                                            infoModalText={[
+                                                                localeString(
+                                                                    'views.Receive.ampSwitchExplainer1'
+                                                                ),
+                                                                localeString(
+                                                                    'views.Receive.ampSwitchExplainer2'
+                                                                )
+                                                            ]}
+                                                            infoModalLink="https://docs.lightning.engineering/lightning-network-tools/lnd/amp"
+                                                        >
+                                                            {localeString(
+                                                                'views.Receive.ampInvoice'
+                                                            )}
+                                                        </Text>
+                                                    </View>
+                                                    <View
                                                         style={{
-                                                            ...styles.secondaryText,
-                                                            color: themeColor(
-                                                                'secondaryText'
-                                                            ),
-                                                            top: 20
+                                                            alignSelf: 'center',
+                                                            marginLeft: 5
                                                         }}
-                                                        infoModalText={[
-                                                            localeString(
-                                                                'views.Receive.ampSwitchExplainer1'
-                                                            ),
-                                                            localeString(
-                                                                'views.Receive.ampSwitchExplainer2'
-                                                            )
-                                                        ]}
-                                                        infoModalLink="https://docs.lightning.engineering/lightning-network-tools/lnd/amp"
                                                     >
-                                                        {localeString(
-                                                            'views.Receive.ampInvoice'
-                                                        )}
-                                                    </Text>
-                                                    <Switch
-                                                        value={ampInvoice}
-                                                        onValueChange={() =>
-                                                            this.setState({
-                                                                ampInvoice:
-                                                                    !ampInvoice
-                                                            })
-                                                        }
-                                                        disabled={blindedPaths}
-                                                    />
-                                                </>
+                                                        <Switch
+                                                            value={ampInvoice}
+                                                            onValueChange={() =>
+                                                                this.setState({
+                                                                    ampInvoice:
+                                                                        !ampInvoice
+                                                                })
+                                                            }
+                                                            disabled={
+                                                                blindedPaths
+                                                            }
+                                                        />
+                                                    </View>
+                                                </View>
                                             )}
 
                                         {BackendUtils.supportsBolt11BlindedRoutes() &&
                                             !lspIsActive && (
-                                                <>
-                                                    <Text
+                                                <View
+                                                    style={{
+                                                        flexDirection: 'row',
+                                                        marginTop: 20
+                                                    }}
+                                                >
+                                                    <View style={{ flex: 1 }}>
+                                                        <Text
+                                                            style={{
+                                                                ...styles.secondaryText,
+                                                                color: themeColor(
+                                                                    'secondaryText'
+                                                                )
+                                                            }}
+                                                            infoModalText={[
+                                                                localeString(
+                                                                    'views.Receive.blindedPathsExplainer1'
+                                                                ),
+                                                                localeString(
+                                                                    'views.Receive.blindedPathsExplainer2'
+                                                                )
+                                                            ]}
+                                                            infoModalLink="https://lightningprivacy.com/en/blinded-trampoline"
+                                                        >
+                                                            {localeString(
+                                                                'views.Receive.blindedPaths'
+                                                            )}
+                                                        </Text>
+                                                    </View>
+                                                    <View
                                                         style={{
-                                                            ...styles.secondaryText,
-                                                            color: themeColor(
-                                                                'secondaryText'
-                                                            ),
-                                                            top: 20
+                                                            alignSelf: 'center',
+                                                            marginLeft: 5
                                                         }}
-                                                        infoModalText={[
-                                                            localeString(
-                                                                'views.Receive.blindedPathsExplainer1'
-                                                            ),
-                                                            localeString(
-                                                                'views.Receive.blindedPathsExplainer2'
-                                                            )
-                                                        ]}
-                                                        infoModalLink="https://lightningprivacy.com/en/blinded-trampoline"
                                                     >
-                                                        {localeString(
-                                                            'views.Receive.blindedPaths'
-                                                        )}
-                                                    </Text>
-                                                    <Switch
-                                                        value={blindedPaths}
-                                                        onValueChange={() =>
-                                                            this.setState({
-                                                                blindedPaths:
-                                                                    !blindedPaths,
-                                                                ampInvoice:
-                                                                    false,
-                                                                routeHints:
-                                                                    false
-                                                            })
-                                                        }
-                                                    />
-                                                </>
+                                                        <Switch
+                                                            value={blindedPaths}
+                                                            onValueChange={() =>
+                                                                this.setState({
+                                                                    blindedPaths:
+                                                                        !blindedPaths,
+                                                                    ampInvoice:
+                                                                        false,
+                                                                    routeHints:
+                                                                        false
+                                                                })
+                                                            }
+                                                        />
+                                                    </View>
+                                                </View>
                                             )}
 
                                         <View style={styles.button}>

--- a/views/Settings/ChannelsSettings.tsx
+++ b/views/Settings/ChannelsSettings.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, ScrollView } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { StackNavigationProp } from '@react-navigation/stack';
 
@@ -100,9 +100,11 @@ export default class ChannelsSettings extends React.Component<
                     }}
                     navigation={navigation}
                 />
-                <View
+                <ScrollView
                     style={{
-                        padding: 20
+                        flex: 1,
+                        paddingHorizontal: 15,
+                        marginTop: 5
                     }}
                 >
                     <Text
@@ -133,136 +135,162 @@ export default class ChannelsSettings extends React.Component<
                         }}
                     />
 
-                    <>
-                        <Text
-                            style={{
-                                top: 20,
-                                color: themeColor('secondaryText')
-                            }}
-                        >
-                            {localeString('views.OpenChannel.announceChannel')}
-                        </Text>
-                        <Switch
-                            value={!privateChannel}
-                            onValueChange={async () => {
-                                this.setState({
-                                    privateChannel: !privateChannel
-                                });
-                                await updateSettings({
-                                    channels: {
-                                        min_confs,
-                                        privateChannel: !privateChannel,
-                                        scidAlias,
-                                        simpleTaprootChannel
-                                    }
-                                });
-                            }}
-                            disabled={simpleTaprootChannel}
-                        />
-                    </>
-
-                    {BackendUtils.isLNDBased() && (
-                        <>
+                    <View style={{ flexDirection: 'row', marginTop: 20 }}>
+                        <View style={{ flex: 1 }}>
                             <Text
                                 style={{
-                                    top: 20,
-                                    color: themeColor('secondaryText')
+                                    color: themeColor('secondaryText'),
+                                    fontSize: 17
                                 }}
                             >
-                                {localeString('views.OpenChannel.scidAlias')}
+                                {localeString(
+                                    'views.OpenChannel.announceChannel'
+                                )}
                             </Text>
+                        </View>
+                        <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
-                                value={scidAlias}
+                                value={!privateChannel}
                                 onValueChange={async () => {
                                     this.setState({
-                                        scidAlias: !scidAlias
+                                        privateChannel: !privateChannel
                                     });
                                     await updateSettings({
                                         channels: {
                                             min_confs,
-                                            privateChannel,
-                                            scidAlias: !scidAlias,
+                                            privateChannel: !privateChannel,
+                                            scidAlias,
                                             simpleTaprootChannel
                                         }
                                     });
                                 }}
+                                disabled={simpleTaprootChannel}
                             />
-                        </>
+                        </View>
+                    </View>
+
+                    {BackendUtils.isLNDBased() && (
+                        <View style={{ flexDirection: 'row', marginTop: 20 }}>
+                            <View style={{ flex: 1 }}>
+                                <Text
+                                    style={{
+                                        color: themeColor('secondaryText'),
+                                        fontSize: 17
+                                    }}
+                                >
+                                    {localeString(
+                                        'views.OpenChannel.scidAlias'
+                                    )}
+                                </Text>
+                            </View>
+                            <View
+                                style={{ alignSelf: 'center', marginLeft: 5 }}
+                            >
+                                <Switch
+                                    value={scidAlias}
+                                    onValueChange={async () => {
+                                        this.setState({
+                                            scidAlias: !scidAlias
+                                        });
+                                        await updateSettings({
+                                            channels: {
+                                                min_confs,
+                                                privateChannel,
+                                                scidAlias: !scidAlias,
+                                                simpleTaprootChannel
+                                            }
+                                        });
+                                    }}
+                                />
+                            </View>
+                        </View>
                     )}
 
                     {BackendUtils.supportsSimpleTaprootChannels() && (
-                        <>
-                            <Text
-                                style={{
-                                    top: 20,
-                                    color: themeColor('secondaryText')
-                                }}
+                        <View style={{ flexDirection: 'row', marginTop: 20 }}>
+                            <View style={{ flex: 1 }}>
+                                <Text
+                                    style={{
+                                        color: themeColor('secondaryText'),
+                                        fontSize: 17
+                                    }}
+                                >
+                                    {localeString(
+                                        'views.OpenChannel.simpleTaprootChannel'
+                                    )}
+                                </Text>
+                            </View>
+                            <View
+                                style={{ alignSelf: 'center', marginLeft: 5 }}
                             >
-                                {localeString(
-                                    'views.OpenChannel.simpleTaprootChannel'
-                                )}
-                            </Text>
-                            <Switch
-                                value={simpleTaprootChannel}
-                                onValueChange={async () => {
-                                    this.setState({
-                                        simpleTaprootChannel:
-                                            !simpleTaprootChannel
-                                    });
-
-                                    if (!simpleTaprootChannel) {
+                                <Switch
+                                    value={simpleTaprootChannel}
+                                    onValueChange={async () => {
                                         this.setState({
-                                            privateChannel: true
-                                        });
-                                    }
-
-                                    await updateSettings({
-                                        channels: {
-                                            min_confs,
-                                            privateChannel:
-                                                !simpleTaprootChannel
-                                                    ? true
-                                                    : privateChannel,
-                                            scidAlias,
                                             simpleTaprootChannel:
                                                 !simpleTaprootChannel
+                                        });
+
+                                        if (!simpleTaprootChannel) {
+                                            this.setState({
+                                                privateChannel: true
+                                            });
                                         }
-                                    });
-                                }}
-                            />
-                        </>
+
+                                        await updateSettings({
+                                            channels: {
+                                                min_confs,
+                                                privateChannel:
+                                                    !simpleTaprootChannel
+                                                        ? true
+                                                        : privateChannel,
+                                                scidAlias,
+                                                simpleTaprootChannel:
+                                                    !simpleTaprootChannel
+                                            }
+                                        });
+                                    }}
+                                />
+                            </View>
+                        </View>
                     )}
 
                     {(BackendUtils.supportsLSPS1customMessage() ||
                         BackendUtils.supportsLSPS1rest()) && (
-                        <>
-                            <Text
-                                style={{
-                                    top: 20,
-                                    color: themeColor('secondaryText')
-                                }}
+                        <View style={{ flexDirection: 'row', marginTop: 20 }}>
+                            <View style={{ flex: 1 }}>
+                                <Text
+                                    style={{
+                                        color: themeColor('secondaryText'),
+                                        fontSize: 17
+                                    }}
+                                >
+                                    {localeString(
+                                        'views.Settings.Channels.lsps1ShowPurchaseButton'
+                                    )}
+                                </Text>
+                            </View>
+                            <View
+                                style={{ alignSelf: 'center', marginLeft: 5 }}
                             >
-                                {localeString(
-                                    'views.Settings.Channels.lsps1ShowPurchaseButton'
-                                )}
-                            </Text>
-                            <Switch
-                                value={lsps1ShowPurchaseButton}
-                                onValueChange={async () => {
-                                    this.setState({
-                                        lsps1ShowPurchaseButton:
-                                            !lsps1ShowPurchaseButton
-                                    });
+                                <Switch
+                                    value={lsps1ShowPurchaseButton}
+                                    onValueChange={async () => {
+                                        this.setState({
+                                            lsps1ShowPurchaseButton:
+                                                !lsps1ShowPurchaseButton
+                                        });
 
-                                    await updateSettings({
-                                        lsps1ShowPurchaseButton:
-                                            !lsps1ShowPurchaseButton
-                                    });
-                                }}
-                            />
-                        </>
+                                        await updateSettings({
+                                            lsps1ShowPurchaseButton:
+                                                !lsps1ShowPurchaseButton
+                                        });
+                                    }}
+                                />
+                            </View>
+                        </View>
                     )}
-                </View>
+                </ScrollView>
             </Screen>
         );
     }

--- a/views/Settings/Display.tsx
+++ b/views/Settings/Display.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { ScrollView, View } from 'react-native';
-import { ListItem } from 'react-native-elements';
 import { inject, observer } from 'mobx-react';
 import { StackNavigationProp } from '@react-navigation/stack';
 import SystemNavigationBar from 'react-native-system-navigation-bar';
@@ -12,6 +11,7 @@ import SettingsStore, {
 import { localeString } from '../../utils/LocaleUtils';
 import { isLightTheme, themeColor } from '../../utils/ThemeUtils';
 
+import Text from '../../components/Text';
 import DropdownSetting from '../../components/DropdownSetting';
 import Header from '../../components/Header';
 import Screen from '../../components/Screen';
@@ -115,7 +115,7 @@ export default class Display extends React.Component<
                     navigation={navigation}
                 />
                 <ScrollView
-                    style={{ flex: 1, padding: 15 }}
+                    style={{ flex: 1, paddingHorizontal: 15, marginTop: 5 }}
                     keyboardShouldPersistTaps="handled"
                 >
                     <DropdownSetting
@@ -171,30 +171,21 @@ export default class Display extends React.Component<
                         values={DEFAULT_VIEW_KEYS}
                     />
 
-                    <ListItem
-                        containerStyle={{
-                            borderBottomWidth: 0,
-                            backgroundColor: 'transparent'
-                        }}
-                    >
-                        <ListItem.Title
-                            style={{
-                                color: themeColor('secondaryText'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                left: -10
-                            }}
-                        >
-                            {localeString(
-                                'views.Settings.Display.displayNickname'
-                            )}
-                        </ListItem.Title>
-                        <View
-                            style={{
-                                flex: 1,
-                                flexDirection: 'row',
-                                justifyContent: 'flex-end'
-                            }}
-                        >
+                    <View style={{ flexDirection: 'row', marginTop: 20 }}>
+                        <View style={{ flex: 1 }}>
+                            <Text
+                                style={{
+                                    color: themeColor('secondaryText'),
+                                    fontSize: 17,
+                                    fontFamily: 'PPNeueMontreal-Book'
+                                }}
+                            >
+                                {localeString(
+                                    'views.Settings.Display.displayNickname'
+                                )}
+                            </Text>
+                        </View>
+                        <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={displayNickname}
                                 onValueChange={async () => {
@@ -215,32 +206,23 @@ export default class Display extends React.Component<
                                 }}
                             />
                         </View>
-                    </ListItem>
+                    </View>
 
-                    <ListItem
-                        containerStyle={{
-                            borderBottomWidth: 0,
-                            backgroundColor: 'transparent'
-                        }}
-                    >
-                        <ListItem.Title
-                            style={{
-                                color: themeColor('secondaryText'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                left: -10
-                            }}
-                        >
-                            {localeString(
-                                'views.Settings.Display.bigKeypadButtons'
-                            )}
-                        </ListItem.Title>
-                        <View
-                            style={{
-                                flex: 1,
-                                flexDirection: 'row',
-                                justifyContent: 'flex-end'
-                            }}
-                        >
+                    <View style={{ flexDirection: 'row', marginTop: 20 }}>
+                        <View style={{ flex: 1 }}>
+                            <Text
+                                style={{
+                                    color: themeColor('secondaryText'),
+                                    fontSize: 17,
+                                    fontFamily: 'PPNeueMontreal-Book'
+                                }}
+                            >
+                                {localeString(
+                                    'views.Settings.Display.bigKeypadButtons'
+                                )}
+                            </Text>
+                        </View>
+                        <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={bigKeypadButtons}
                                 onValueChange={async () => {
@@ -261,32 +243,23 @@ export default class Display extends React.Component<
                                 }}
                             />
                         </View>
-                    </ListItem>
+                    </View>
 
-                    <ListItem
-                        containerStyle={{
-                            borderBottomWidth: 0,
-                            backgroundColor: 'transparent'
-                        }}
-                    >
-                        <ListItem.Title
-                            style={{
-                                color: themeColor('secondaryText'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                left: -10
-                            }}
-                        >
-                            {localeString(
-                                'views.Settings.Display.showAllDecimalPlaces'
-                            )}
-                        </ListItem.Title>
-                        <View
-                            style={{
-                                flex: 1,
-                                flexDirection: 'row',
-                                justifyContent: 'flex-end'
-                            }}
-                        >
+                    <View style={{ flexDirection: 'row', marginTop: 20 }}>
+                        <View style={{ flex: 1 }}>
+                            <Text
+                                style={{
+                                    color: themeColor('secondaryText'),
+                                    fontSize: 17,
+                                    fontFamily: 'PPNeueMontreal-Book'
+                                }}
+                            >
+                                {localeString(
+                                    'views.Settings.Display.showAllDecimalPlaces'
+                                )}
+                            </Text>
+                        </View>
+                        <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={showAllDecimalPlaces}
                                 onValueChange={async () => {
@@ -309,32 +282,23 @@ export default class Display extends React.Component<
                                 }}
                             />
                         </View>
-                    </ListItem>
+                    </View>
 
-                    <ListItem
-                        containerStyle={{
-                            borderBottomWidth: 0,
-                            backgroundColor: 'transparent'
-                        }}
-                    >
-                        <ListItem.Title
-                            style={{
-                                color: themeColor('secondaryText'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                left: -10
-                            }}
-                        >
-                            {localeString(
-                                'views.Settings.Display.removeDecimalSpaces'
-                            )}
-                        </ListItem.Title>
-                        <View
-                            style={{
-                                flex: 1,
-                                flexDirection: 'row',
-                                justifyContent: 'flex-end'
-                            }}
-                        >
+                    <View style={{ flexDirection: 'row', marginTop: 20 }}>
+                        <View style={{ flex: 1 }}>
+                            <Text
+                                style={{
+                                    color: themeColor('secondaryText'),
+                                    fontSize: 17,
+                                    fontFamily: 'PPNeueMontreal-Book'
+                                }}
+                            >
+                                {localeString(
+                                    'views.Settings.Display.removeDecimalSpaces'
+                                )}
+                            </Text>
+                        </View>
+                        <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={removeDecimalSpaces}
                                 onValueChange={async () => {
@@ -357,32 +321,23 @@ export default class Display extends React.Component<
                                 }}
                             />
                         </View>
-                    </ListItem>
+                    </View>
 
-                    <ListItem
-                        containerStyle={{
-                            borderBottomWidth: 0,
-                            backgroundColor: 'transparent'
-                        }}
-                    >
-                        <ListItem.Title
-                            style={{
-                                color: themeColor('secondaryText'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                left: -10
-                            }}
-                        >
-                            {localeString(
-                                'views.Settings.Display.showMillisatoshiAmounts'
-                            )}
-                        </ListItem.Title>
-                        <View
-                            style={{
-                                flex: 1,
-                                flexDirection: 'row',
-                                justifyContent: 'flex-end'
-                            }}
-                        >
+                    <View style={{ flexDirection: 'row', marginTop: 20 }}>
+                        <View style={{ flex: 1 }}>
+                            <Text
+                                style={{
+                                    color: themeColor('secondaryText'),
+                                    fontSize: 17,
+                                    fontFamily: 'PPNeueMontreal-Book'
+                                }}
+                            >
+                                {localeString(
+                                    'views.Settings.Display.showMillisatoshiAmounts'
+                                )}
+                            </Text>
+                        </View>
+                        <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={showMillisatoshiAmounts}
                                 onValueChange={async () => {
@@ -405,31 +360,23 @@ export default class Display extends React.Component<
                                 }}
                             />
                         </View>
-                    </ListItem>
-                    <ListItem
-                        containerStyle={{
-                            borderBottomWidth: 0,
-                            backgroundColor: 'transparent'
-                        }}
-                    >
-                        <ListItem.Title
-                            style={{
-                                color: themeColor('secondaryText'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                left: -10
-                            }}
-                        >
-                            {localeString(
-                                'views.Settings.Display.selectNodeOnStartup'
-                            )}
-                        </ListItem.Title>
-                        <View
-                            style={{
-                                flex: 1,
-                                flexDirection: 'row',
-                                justifyContent: 'flex-end'
-                            }}
-                        >
+                    </View>
+
+                    <View style={{ flexDirection: 'row', marginTop: 20 }}>
+                        <View style={{ flex: 1 }}>
+                            <Text
+                                style={{
+                                    color: themeColor('secondaryText'),
+                                    fontSize: 17,
+                                    fontFamily: 'PPNeueMontreal-Book'
+                                }}
+                            >
+                                {localeString(
+                                    'views.Settings.Display.selectNodeOnStartup'
+                                )}
+                            </Text>
+                        </View>
+                        <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={selectNodeOnStartup}
                                 onValueChange={async () => {
@@ -444,7 +391,7 @@ export default class Display extends React.Component<
                                 }}
                             />
                         </View>
-                    </ListItem>
+                    </View>
                 </ScrollView>
             </Screen>
         );

--- a/views/Settings/InvoicesSettings.tsx
+++ b/views/Settings/InvoicesSettings.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, TouchableOpacity, ScrollView, View } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import BigNumber from 'bignumber.js';
 import _map from 'lodash/map';
@@ -173,9 +173,10 @@ export default class InvoicesSettings extends React.Component<
                     }
                     navigation={navigation}
                 />
-                <View
+                <ScrollView
                     style={{
-                        padding: 20
+                        paddingHorizontal: 15,
+                        marginTop: 5
                     }}
                 >
                     <Text
@@ -340,159 +341,244 @@ export default class InvoicesSettings extends React.Component<
                     )}
 
                     {BackendUtils.isLNDBased() && (
-                        <>
-                            <Text
-                                style={{
-                                    ...styles.secondaryText,
-                                    color: themeColor('secondaryText'),
-                                    top: 20
-                                }}
-                                infoModalText={[
-                                    localeString(
-                                        'views.Receive.routeHintSwitchExplainer1'
-                                    ),
-                                    localeString(
-                                        'views.Receive.routeHintSwitchExplainer2'
-                                    )
-                                ]}
+                        <View
+                            style={{
+                                flexDirection: 'row',
+                                marginTop: 20
+                            }}
+                        >
+                            <View style={{ flex: 1 }}>
+                                <Text
+                                    style={{
+                                        ...styles.secondaryText,
+                                        color: themeColor('secondaryText')
+                                    }}
+                                    infoModalText={[
+                                        localeString(
+                                            'views.Receive.routeHintSwitchExplainer1'
+                                        ),
+                                        localeString(
+                                            'views.Receive.routeHintSwitchExplainer2'
+                                        )
+                                    ]}
+                                >
+                                    {localeString('views.Receive.routeHints')}
+                                </Text>
+                            </View>
+                            <View
+                                style={{ alignSelf: 'center', marginLeft: 5 }}
                             >
-                                {localeString('views.Receive.routeHints')}
-                            </Text>
-                            <Switch
-                                value={routeHints}
-                                onValueChange={async () => {
-                                    this.setState({
-                                        routeHints: !routeHints
-                                    });
-                                    await updateSettings({
-                                        invoices: {
-                                            addressType,
-                                            memo,
-                                            expiry,
-                                            timePeriod,
-                                            expirySeconds,
-                                            routeHints: !routeHints,
-                                            ampInvoice,
-                                            blindedPaths,
-                                            showCustomPreimageField
-                                        }
-                                    });
-                                }}
-                                disabled={blindedPaths}
-                            />
-                        </>
+                                <Switch
+                                    value={routeHints}
+                                    onValueChange={async () => {
+                                        this.setState({
+                                            routeHints: !routeHints
+                                        });
+                                        await updateSettings({
+                                            invoices: {
+                                                addressType,
+                                                memo,
+                                                expiry,
+                                                timePeriod,
+                                                expirySeconds,
+                                                routeHints: !routeHints,
+                                                ampInvoice,
+                                                blindedPaths,
+                                                showCustomPreimageField
+                                            }
+                                        });
+                                    }}
+                                    disabled={blindedPaths}
+                                />
+                            </View>
+                        </View>
                     )}
 
                     {BackendUtils.supportsAMP() && (
-                        <>
-                            <Text
-                                style={{
-                                    ...styles.secondaryText,
-                                    color: themeColor('secondaryText'),
-                                    top: 20
-                                }}
-                                infoModalText={[
-                                    localeString(
-                                        'views.Receive.ampSwitchExplainer1'
-                                    ),
-                                    localeString(
-                                        'views.Receive.ampSwitchExplainer2'
-                                    )
-                                ]}
-                                infoModalLink="https://docs.lightning.engineering/lightning-network-tools/lnd/amp"
+                        <View
+                            style={{
+                                flexDirection: 'row',
+                                marginTop: 20
+                            }}
+                        >
+                            <View style={{ flex: 1 }}>
+                                <Text
+                                    style={{
+                                        ...styles.secondaryText,
+                                        color: themeColor('secondaryText')
+                                    }}
+                                    infoModalText={[
+                                        localeString(
+                                            'views.Receive.ampSwitchExplainer1'
+                                        ),
+                                        localeString(
+                                            'views.Receive.ampSwitchExplainer2'
+                                        )
+                                    ]}
+                                    infoModalLink="https://docs.lightning.engineering/lightning-network-tools/lnd/amp"
+                                >
+                                    {localeString('views.Receive.ampInvoice')}
+                                </Text>
+                            </View>
+                            <View
+                                style={{ alignSelf: 'center', marginLeft: 5 }}
                             >
-                                {localeString('views.Receive.ampInvoice')}
-                            </Text>
-                            <Switch
-                                value={ampInvoice}
-                                onValueChange={async () => {
-                                    this.setState({
-                                        ampInvoice: !ampInvoice
-                                    });
-                                    await updateSettings({
-                                        invoices: {
-                                            addressType,
-                                            memo,
-                                            expiry,
-                                            timePeriod,
-                                            expirySeconds,
-                                            routeHints,
-                                            ampInvoice: !ampInvoice,
-                                            showCustomPreimageField
-                                        }
-                                    });
-                                }}
-                                disabled={blindedPaths}
-                            />
-                        </>
+                                <Switch
+                                    value={ampInvoice}
+                                    onValueChange={async () => {
+                                        this.setState({
+                                            ampInvoice: !ampInvoice
+                                        });
+                                        await updateSettings({
+                                            invoices: {
+                                                addressType,
+                                                memo,
+                                                expiry,
+                                                timePeriod,
+                                                expirySeconds,
+                                                routeHints,
+                                                ampInvoice: !ampInvoice,
+                                                showCustomPreimageField
+                                            }
+                                        });
+                                    }}
+                                    disabled={blindedPaths}
+                                />
+                            </View>
+                        </View>
                     )}
 
                     {BackendUtils.supportsBolt11BlindedRoutes() && (
-                        <>
-                            <Text
-                                style={{
-                                    ...styles.secondaryText,
-                                    color: themeColor('secondaryText'),
-                                    top: 20
-                                }}
-                                infoModalText={[
-                                    localeString(
-                                        'views.Receive.blindedPathsExplainer1'
-                                    ),
-                                    localeString(
-                                        'views.Receive.blindedPathsExplainer2'
-                                    )
-                                ]}
+                        <View
+                            style={{
+                                flexDirection: 'row',
+                                marginTop: 20
+                            }}
+                        >
+                            <View style={{ flex: 1 }}>
+                                <Text
+                                    style={{
+                                        ...styles.secondaryText,
+                                        color: themeColor('secondaryText')
+                                    }}
+                                    infoModalText={[
+                                        localeString(
+                                            'views.Receive.blindedPathsExplainer1'
+                                        ),
+                                        localeString(
+                                            'views.Receive.blindedPathsExplainer2'
+                                        )
+                                    ]}
+                                >
+                                    {localeString('views.Receive.blindedPaths')}
+                                </Text>
+                            </View>
+                            <View
+                                style={{ alignSelf: 'center', marginLeft: 5 }}
                             >
-                                {localeString('views.Receive.blindedPaths')}
-                            </Text>
-                            <Switch
-                                value={blindedPaths}
-                                onValueChange={async () => {
-                                    this.setState({
-                                        blindedPaths: !blindedPaths,
-                                        ampInvoice: false,
-                                        routeHints: false
-                                    });
-
-                                    await updateSettings({
-                                        invoices: {
-                                            addressType,
-                                            memo,
-                                            expiry,
-                                            timePeriod,
-                                            expirySeconds,
-                                            routeHints: false,
-                                            ampInvoice: false,
+                                <Switch
+                                    value={blindedPaths}
+                                    onValueChange={async () => {
+                                        this.setState({
                                             blindedPaths: !blindedPaths,
-                                            showCustomPreimageField
-                                        }
-                                    });
-                                }}
-                            />
-                        </>
+                                            ampInvoice: false,
+                                            routeHints: false
+                                        });
+
+                                        await updateSettings({
+                                            invoices: {
+                                                addressType,
+                                                memo,
+                                                expiry,
+                                                timePeriod,
+                                                expirySeconds,
+                                                routeHints: false,
+                                                ampInvoice: false,
+                                                blindedPaths: !blindedPaths,
+                                                showCustomPreimageField
+                                            }
+                                        });
+                                    }}
+                                />
+                            </View>
+                        </View>
                     )}
 
                     {BackendUtils.supportsCustomPreimages() && (
-                        <>
+                        <View
+                            style={{
+                                flexDirection: 'row',
+                                marginTop: 20
+                            }}
+                        >
+                            <View style={{ flex: 1 }}>
+                                <Text
+                                    style={{
+                                        ...styles.secondaryText,
+                                        color: themeColor('secondaryText')
+                                    }}
+                                >
+                                    {localeString(
+                                        'views.Settings.Invoices.showCustomPreimageField'
+                                    )}
+                                    {}
+                                </Text>
+                            </View>
+                            <View
+                                style={{ alignSelf: 'center', marginLeft: 5 }}
+                            >
+                                <Switch
+                                    value={showCustomPreimageField}
+                                    onValueChange={async () => {
+                                        this.setState({
+                                            showCustomPreimageField:
+                                                !showCustomPreimageField
+                                        });
+                                        await updateSettings({
+                                            invoices: {
+                                                addressType,
+                                                memo,
+                                                expiry,
+                                                timePeriod,
+                                                expirySeconds,
+                                                routeHints,
+                                                ampInvoice,
+                                                showCustomPreimageField:
+                                                    !showCustomPreimageField
+                                            }
+                                        });
+                                    }}
+                                />
+                            </View>
+                        </View>
+                    )}
+
+                    <View
+                        style={{
+                            flexDirection: 'row',
+                            marginTop: 20
+                        }}
+                    >
+                        <View style={{ flex: 1 }}>
                             <Text
                                 style={{
                                     ...styles.secondaryText,
-                                    color: themeColor('secondaryText'),
-                                    top: 20
+                                    color: themeColor('secondaryText')
                                 }}
                             >
                                 {localeString(
-                                    'views.Settings.Invoices.showCustomPreimageField'
+                                    'views.Settings.Invoices.displayAmountOnInvoice'
                                 )}
                                 {}
                             </Text>
+                        </View>
+                        <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
-                                value={showCustomPreimageField}
+                                value={displayAmountOnInvoice}
                                 onValueChange={async () => {
                                     this.setState({
-                                        showCustomPreimageField:
-                                            !showCustomPreimageField
+                                        displayAmountOnInvoice:
+                                            !displayAmountOnInvoice
                                     });
                                     await updateSettings({
                                         invoices: {
@@ -503,53 +589,16 @@ export default class InvoicesSettings extends React.Component<
                                             expirySeconds,
                                             routeHints,
                                             ampInvoice,
-                                            showCustomPreimageField:
-                                                !showCustomPreimageField
+                                            showCustomPreimageField,
+                                            displayAmountOnInvoice:
+                                                !displayAmountOnInvoice
                                         }
                                     });
                                 }}
                             />
-                        </>
-                    )}
-
-                    <>
-                        <Text
-                            style={{
-                                ...styles.secondaryText,
-                                color: themeColor('secondaryText'),
-                                top: 20
-                            }}
-                        >
-                            {localeString(
-                                'views.Settings.Invoices.displayAmountOnInvoice'
-                            )}
-                            {}
-                        </Text>
-                        <Switch
-                            value={displayAmountOnInvoice}
-                            onValueChange={async () => {
-                                this.setState({
-                                    displayAmountOnInvoice:
-                                        !displayAmountOnInvoice
-                                });
-                                await updateSettings({
-                                    invoices: {
-                                        addressType,
-                                        memo,
-                                        expiry,
-                                        timePeriod,
-                                        expirySeconds,
-                                        routeHints,
-                                        ampInvoice,
-                                        showCustomPreimageField,
-                                        displayAmountOnInvoice:
-                                            !displayAmountOnInvoice
-                                    }
-                                });
-                            }}
-                        />
-                    </>
-                </View>
+                        </View>
+                    </View>
+                </ScrollView>
                 <ModalBox
                     style={{
                         backgroundColor: themeColor('background'),

--- a/views/Settings/LightningAddress/ChangeAddress.tsx
+++ b/views/Settings/LightningAddress/ChangeAddress.tsx
@@ -10,6 +10,7 @@ import Header from '../../../components/Header';
 import LoadingIndicator from '../../../components/LoadingIndicator';
 import TextInput from '../../../components/TextInput';
 import { ErrorMessage } from '../../../components/SuccessErrorMessage';
+import { Row } from '../../../components/layout/Row';
 
 import LightningAddressStore from '../../../stores/LightningAddressStore';
 
@@ -110,16 +111,20 @@ export default class ChangeAddress extends React.Component<
                                                     flexDirection: 'row'
                                                 }}
                                             />
-                                            <Text
-                                                style={{
-                                                    ...styles.text,
-                                                    color: themeColor('text'),
-                                                    fontSize: 20,
-                                                    marginLeft: 5
-                                                }}
-                                            >
-                                                @zeuspay.com
-                                            </Text>
+                                            <Row>
+                                                <Text
+                                                    style={{
+                                                        ...styles.text,
+                                                        color: themeColor(
+                                                            'text'
+                                                        ),
+                                                        fontSize: 20,
+                                                        marginLeft: 5
+                                                    }}
+                                                >
+                                                    @zeuspay.com
+                                                </Text>
+                                            </Row>
                                         </View>
                                     </View>
                                 </View>

--- a/views/Settings/LightningAddress/LightningAddressSettings.tsx
+++ b/views/Settings/LightningAddress/LightningAddressSettings.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import { Icon, ListItem } from 'react-native-elements';
 import { inject, observer } from 'mobx-react';
 
-import { Row } from '../../../components/layout/Row';
 import Text from '../../../components/Text';
 import DropdownSetting from '../../../components/DropdownSetting';
 import Screen from '../../../components/Screen';
@@ -110,28 +109,31 @@ export default class LightningAddressSettings extends React.Component<
                         }
                         navigation={navigation}
                     />
-                    <ScrollView style={{ margin: 5 }}>
+                    <ScrollView style={{ paddingHorizontal: 15, marginTop: 5 }}>
                         {error_msg && (
                             <ErrorMessage message={error_msg} dismissable />
                         )}
-                        <ListItem containerStyle={styles.listItem}>
-                            <ListItem.Title
-                                style={{
-                                    color: themeColor('text'),
-                                    fontFamily: 'PPNeueMontreal-Book',
-                                    width: '85%'
-                                }}
-                            >
-                                {localeString(
-                                    'views.Settings.LightningAddressSettings.automaticallyAccept'
-                                )}
-                            </ListItem.Title>
+                        <View
+                            style={{
+                                flexDirection: 'row',
+                                marginTop: 20
+                            }}
+                        >
+                            <View style={{ flex: 1 }}>
+                                <Text
+                                    style={{
+                                        color: themeColor('secondaryText'),
+                                        fontSize: 17,
+                                        fontFamily: 'PPNeueMontreal-Book'
+                                    }}
+                                >
+                                    {localeString(
+                                        'views.Settings.LightningAddressSettings.automaticallyAccept'
+                                    )}
+                                </Text>
+                            </View>
                             <View
-                                style={{
-                                    flex: 1,
-                                    flexDirection: 'row',
-                                    justifyContent: 'flex-end'
-                                }}
+                                style={{ alignSelf: 'center', marginLeft: 5 }}
                             >
                                 <Switch
                                     value={automaticallyAccept}
@@ -158,14 +160,8 @@ export default class LightningAddressSettings extends React.Component<
                                     }}
                                 />
                             </View>
-                        </ListItem>
-                        <View
-                            style={{
-                                margin: 5,
-                                marginLeft: 15,
-                                marginRight: 15
-                            }}
-                        >
+                        </View>
+                        <View style={{ marginTop: 20 }}>
                             <DropdownSetting
                                 title={localeString(
                                     'views.Settings.LightningAddressSettings.automaticallyAcceptAttestationLevel'
@@ -198,11 +194,16 @@ export default class LightningAddressSettings extends React.Component<
                                 disabled={!automaticallyAccept}
                             />
                         </View>
-                        <ListItem containerStyle={styles.listItem}>
-                            <Row align="flex-end">
+                        <View
+                            style={{
+                                flexDirection: 'row',
+                                marginTop: 20
+                            }}
+                        >
+                            <View style={{ flex: 1 }}>
                                 <Text
                                     style={{
-                                        color: themeColor('text'),
+                                        color: themeColor('secondaryText'),
                                         fontFamily: 'PPNeueMontreal-Book',
                                         fontSize: 17
                                     }}
@@ -217,50 +218,55 @@ export default class LightningAddressSettings extends React.Component<
                                 >
                                     {localeString('views.Receive.routeHints')}
                                 </Text>
-                                <View style={{ flex: 1 }}>
-                                    <Switch
-                                        value={routeHints}
-                                        onValueChange={async () => {
-                                            this.setState({
-                                                routeHints: !routeHints
-                                            });
-                                            await updateSettings({
-                                                lightningAddress: {
-                                                    enabled,
-                                                    automaticallyAccept,
-                                                    automaticallyAcceptAttestationLevel,
-                                                    automaticallyRequestOlympusChannels:
-                                                        false, // deprecated
-                                                    routeHints: !routeHints,
-                                                    allowComments,
-                                                    nostrPrivateKey,
-                                                    nostrRelays,
-                                                    notifications
-                                                }
-                                            });
-                                        }}
-                                    />
-                                </View>
-                            </Row>
-                        </ListItem>
-                        <ListItem containerStyle={styles.listItem}>
-                            <ListItem.Title
-                                style={{
-                                    color: themeColor('text'),
-                                    fontFamily: 'PPNeueMontreal-Book',
-                                    width: '85%'
-                                }}
-                            >
-                                {localeString(
-                                    'views.Settings.LightningAddressSettings.allowComments'
-                                )}
-                            </ListItem.Title>
+                            </View>
                             <View
-                                style={{
-                                    flex: 1,
-                                    flexDirection: 'row',
-                                    justifyContent: 'flex-end'
-                                }}
+                                style={{ alignSelf: 'center', marginLeft: 5 }}
+                            >
+                                <Switch
+                                    value={routeHints}
+                                    onValueChange={async () => {
+                                        this.setState({
+                                            routeHints: !routeHints
+                                        });
+                                        await updateSettings({
+                                            lightningAddress: {
+                                                enabled,
+                                                automaticallyAccept,
+                                                automaticallyAcceptAttestationLevel,
+                                                automaticallyRequestOlympusChannels:
+                                                    false, // deprecated
+                                                routeHints: !routeHints,
+                                                allowComments,
+                                                nostrPrivateKey,
+                                                nostrRelays,
+                                                notifications
+                                            }
+                                        });
+                                    }}
+                                />
+                            </View>
+                        </View>
+                        <View
+                            style={{
+                                flexDirection: 'row',
+                                marginTop: 20
+                            }}
+                        >
+                            <View style={{ flex: 1 }}>
+                                <Text
+                                    style={{
+                                        color: themeColor('secondaryText'),
+                                        fontFamily: 'PPNeueMontreal-Book',
+                                        fontSize: 17
+                                    }}
+                                >
+                                    {localeString(
+                                        'views.Settings.LightningAddressSettings.allowComments'
+                                    )}
+                                </Text>
+                            </View>
+                            <View
+                                style={{ alignSelf: 'center', marginLeft: 5 }}
                             >
                                 <Switch
                                     value={allowComments}
@@ -293,14 +299,8 @@ export default class LightningAddressSettings extends React.Component<
                                     }}
                                 />
                             </View>
-                        </ListItem>
-                        <View
-                            style={{
-                                margin: 5,
-                                marginLeft: 15,
-                                marginRight: 15
-                            }}
-                        >
+                        </View>
+                        <View style={{ marginTop: 20 }}>
                             <DropdownSetting
                                 title={localeString(
                                     'views.Settings.LightningAddressSettings.notifications'
@@ -336,14 +336,16 @@ export default class LightningAddressSettings extends React.Component<
                         </View>
                         <ListItem
                             containerStyle={{
-                                backgroundColor: 'transparent'
+                                backgroundColor: 'transparent',
+                                padding: 0,
+                                marginTop: 20
                             }}
                             onPress={() => navigation.navigate('NostrKeys')}
                         >
                             <ListItem.Content>
                                 <ListItem.Title
                                     style={{
-                                        color: themeColor('text'),
+                                        color: themeColor('secondaryText'),
                                         fontFamily: 'PPNeueMontreal-Book'
                                     }}
                                 >
@@ -357,14 +359,16 @@ export default class LightningAddressSettings extends React.Component<
                         </ListItem>
                         <ListItem
                             containerStyle={{
-                                backgroundColor: 'transparent'
+                                backgroundColor: 'transparent',
+                                padding: 0,
+                                marginTop: 20
                             }}
                             onPress={() => navigation.navigate('NostrRelays')}
                         >
                             <ListItem.Content>
                                 <ListItem.Title
                                     style={{
-                                        color: themeColor('text'),
+                                        color: themeColor('secondaryText'),
                                         fontFamily: 'PPNeueMontreal-Book'
                                     }}
                                 >
@@ -380,14 +384,16 @@ export default class LightningAddressSettings extends React.Component<
                         </ListItem>
                         <ListItem
                             containerStyle={{
-                                backgroundColor: 'transparent'
+                                backgroundColor: 'transparent',
+                                padding: 0,
+                                marginTop: 20
                             }}
                             onPress={() => navigation.navigate('ChangeAddress')}
                         >
                             <ListItem.Content>
                                 <ListItem.Title
                                     style={{
-                                        color: themeColor('text'),
+                                        color: themeColor('secondaryText'),
                                         fontFamily: 'PPNeueMontreal-Book'
                                     }}
                                 >
@@ -407,10 +413,3 @@ export default class LightningAddressSettings extends React.Component<
         );
     }
 }
-
-const styles = StyleSheet.create({
-    listItem: {
-        borderBottomWidth: 0,
-        backgroundColor: 'transparent'
-    }
-});

--- a/views/Settings/LightningAddress/index.tsx
+++ b/views/Settings/LightningAddress/index.tsx
@@ -381,41 +381,43 @@ export default class LightningAddress extends React.Component<
                             !lightningAddressHandle &&
                             hasChannels && (
                                 <>
-                                    <View style={{ flex: 1 }}>
-                                        <View style={styles.wrapper}>
-                                            <Text
-                                                style={{
-                                                    ...styles.text,
-                                                    color: themeColor('text')
+                                    <View
+                                        style={{ flex: 1, ...styles.wrapper }}
+                                    >
+                                        <Text
+                                            style={{
+                                                ...styles.text,
+                                                color: themeColor('text')
+                                            }}
+                                        >
+                                            {localeString(
+                                                'views.Settings.LightningAddress.chooseHandle'
+                                            )}
+                                        </Text>
+                                        <View
+                                            style={{
+                                                display: 'flex',
+                                                flexDirection: 'row'
+                                            }}
+                                        >
+                                            <TextInput
+                                                value={newLightningAddress}
+                                                onChangeText={(
+                                                    text: string
+                                                ) => {
+                                                    this.setState({
+                                                        newLightningAddress:
+                                                            text
+                                                    });
                                                 }}
-                                            >
-                                                {localeString(
-                                                    'views.Settings.LightningAddress.chooseHandle'
-                                                )}
-                                            </Text>
-                                            <View
+                                                autoCapitalize="none"
+                                                autoCorrect={false}
                                                 style={{
-                                                    display: 'flex',
+                                                    flex: 1,
                                                     flexDirection: 'row'
                                                 }}
-                                            >
-                                                <TextInput
-                                                    value={newLightningAddress}
-                                                    onChangeText={(
-                                                        text: string
-                                                    ) => {
-                                                        this.setState({
-                                                            newLightningAddress:
-                                                                text
-                                                        });
-                                                    }}
-                                                    autoCapitalize="none"
-                                                    autoCorrect={false}
-                                                    style={{
-                                                        flex: 1,
-                                                        flexDirection: 'row'
-                                                    }}
-                                                />
+                                            />
+                                            <Row>
                                                 <Text
                                                     style={{
                                                         ...styles.text,
@@ -428,7 +430,7 @@ export default class LightningAddress extends React.Component<
                                                 >
                                                     @zeuspay.com
                                                 </Text>
-                                            </View>
+                                            </Row>
                                         </View>
 
                                         <>
@@ -537,30 +539,26 @@ export default class LightningAddress extends React.Component<
                                             </ListItem>
                                         </>
                                     </View>
-                                    <View>
-                                        <View
-                                            style={{ bottom: 15, margin: 10 }}
-                                        >
-                                            <Button
-                                                title={localeString(
-                                                    'views.Settings.LightningAddress.create'
-                                                )}
-                                                onPress={() =>
-                                                    create(
-                                                        newLightningAddress,
-                                                        nostrPublicKey,
-                                                        nostrPrivateKey,
-                                                        nostrRelays
-                                                    ).then(() => status())
-                                                }
-                                                disabled={
-                                                    !nostrPublicKey ||
-                                                    !nostrNpub ||
-                                                    !nostrRelays ||
-                                                    nostrRelays.length === 0
-                                                }
-                                            />
-                                        </View>
+                                    <View style={{ bottom: 15, margin: 10 }}>
+                                        <Button
+                                            title={localeString(
+                                                'views.Settings.LightningAddress.create'
+                                            )}
+                                            onPress={() =>
+                                                create(
+                                                    newLightningAddress,
+                                                    nostrPublicKey,
+                                                    nostrPrivateKey,
+                                                    nostrRelays
+                                                ).then(() => status())
+                                            }
+                                            disabled={
+                                                !nostrPublicKey ||
+                                                !nostrNpub ||
+                                                !nostrRelays ||
+                                                nostrRelays.length === 0
+                                            }
+                                        />
                                     </View>
                                 </>
                             )}

--- a/views/Settings/LightningAddress/index.tsx
+++ b/views/Settings/LightningAddress/index.tsx
@@ -381,56 +381,56 @@ export default class LightningAddress extends React.Component<
                             !lightningAddressHandle &&
                             hasChannels && (
                                 <>
-                                    <View
-                                        style={{ flex: 1, ...styles.wrapper }}
-                                    >
-                                        <Text
-                                            style={{
-                                                ...styles.text,
-                                                color: themeColor('text')
-                                            }}
-                                        >
-                                            {localeString(
-                                                'views.Settings.LightningAddress.chooseHandle'
-                                            )}
-                                        </Text>
-                                        <View
-                                            style={{
-                                                display: 'flex',
-                                                flexDirection: 'row'
-                                            }}
-                                        >
-                                            <TextInput
-                                                value={newLightningAddress}
-                                                onChangeText={(
-                                                    text: string
-                                                ) => {
-                                                    this.setState({
-                                                        newLightningAddress:
-                                                            text
-                                                    });
-                                                }}
-                                                autoCapitalize="none"
-                                                autoCorrect={false}
+                                    <View style={{ flex: 1 }}>
+                                        <View style={styles.wrapper}>
+                                            <Text
                                                 style={{
-                                                    flex: 1,
+                                                    ...styles.text,
+                                                    color: themeColor('text')
+                                                }}
+                                            >
+                                                {localeString(
+                                                    'views.Settings.LightningAddress.chooseHandle'
+                                                )}
+                                            </Text>
+                                            <View
+                                                style={{
+                                                    display: 'flex',
                                                     flexDirection: 'row'
                                                 }}
-                                            />
-                                            <Row>
-                                                <Text
-                                                    style={{
-                                                        ...styles.text,
-                                                        color: themeColor(
-                                                            'text'
-                                                        ),
-                                                        fontSize: 20,
-                                                        marginLeft: 5
+                                            >
+                                                <TextInput
+                                                    value={newLightningAddress}
+                                                    onChangeText={(
+                                                        text: string
+                                                    ) => {
+                                                        this.setState({
+                                                            newLightningAddress:
+                                                                text
+                                                        });
                                                     }}
-                                                >
-                                                    @zeuspay.com
-                                                </Text>
-                                            </Row>
+                                                    autoCapitalize="none"
+                                                    autoCorrect={false}
+                                                    style={{
+                                                        flex: 1,
+                                                        flexDirection: 'row'
+                                                    }}
+                                                />
+                                                <Row>
+                                                    <Text
+                                                        style={{
+                                                            ...styles.text,
+                                                            color: themeColor(
+                                                                'text'
+                                                            ),
+                                                            fontSize: 20,
+                                                            marginLeft: 5
+                                                        }}
+                                                    >
+                                                        @zeuspay.com
+                                                    </Text>
+                                                </Row>
+                                            </View>
                                         </View>
 
                                         <>

--- a/views/Settings/PaymentsSettings.tsx
+++ b/views/Settings/PaymentsSettings.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Text, View } from 'react-native';
-import { ListItem } from 'react-native-elements';
 import { inject, observer } from 'mobx-react';
 import { StackNavigationProp } from '@react-navigation/stack';
 
@@ -105,8 +104,8 @@ export default class PaymentsSettings extends React.Component<
                 />
                 <View
                     style={{
-                        paddingLeft: 15,
-                        paddingRight: 15
+                        paddingHorizontal: 15,
+                        marginTop: 5
                     }}
                 >
                     {BackendUtils.isLNDBased() && (
@@ -114,7 +113,6 @@ export default class PaymentsSettings extends React.Component<
                             <Text
                                 style={{
                                     fontFamily: 'PPNeueMontreal-Book',
-                                    paddingTop: 5,
                                     color: themeColor('secondaryText')
                                 }}
                             >
@@ -162,7 +160,7 @@ export default class PaymentsSettings extends React.Component<
                                         paddingTop: 5,
                                         color: themeColor('text'),
                                         top: 28,
-                                        right: 30
+                                        right: 35
                                     }}
                                 >
                                     {localeString('general.sats')}
@@ -220,7 +218,6 @@ export default class PaymentsSettings extends React.Component<
                             <Text
                                 style={{
                                     fontFamily: 'PPNeueMontreal-Book',
-                                    paddingTop: 5,
                                     color: themeColor('secondaryText')
                                 }}
                             >
@@ -345,30 +342,24 @@ export default class PaymentsSettings extends React.Component<
                             />
                         </>
                     )}
-                    <ListItem
-                        containerStyle={{
-                            borderBottomWidth: 0,
-                            backgroundColor: 'transparent'
+                    <View
+                        style={{
+                            flexDirection: 'row',
+                            marginTop: 20
                         }}
                     >
-                        <ListItem.Title
+                        <Text
                             style={{
-                                color: themeColor('secondaryText'),
                                 fontFamily: 'PPNeueMontreal-Book',
-                                left: -10
+                                color: themeColor('secondaryText'),
+                                flex: 1
                             }}
                         >
                             {localeString(
                                 'views.Settings.Privacy.enableMempoolRates'
                             )}
-                        </ListItem.Title>
-                        <View
-                            style={{
-                                flex: 1,
-                                flexDirection: 'row',
-                                right: 10
-                            }}
-                        >
+                        </Text>
+                        <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={enableMempoolRates}
                                 onValueChange={async () => {
@@ -394,29 +385,31 @@ export default class PaymentsSettings extends React.Component<
                                 }}
                             />
                         </View>
-                    </ListItem>
-                    <DropdownSetting
-                        title={localeString(
-                            'views.Settings.Payments.preferredMempoolRate'
-                        )}
-                        selectedValue={preferredMempoolRate}
-                        onValueChange={async (value: string) => {
-                            this.setState({
-                                preferredMempoolRate: value
-                            });
-                            await updateSettings({
-                                payments: {
-                                    defaultFeeMethod: feeLimitMethod,
-                                    defaultFeePercentage: feePercentage,
-                                    defaultFeeFixed: feeLimit,
-                                    timeoutSeconds,
+                    </View>
+                    <View style={{ marginTop: 20 }}>
+                        <DropdownSetting
+                            title={localeString(
+                                'views.Settings.Payments.preferredMempoolRate'
+                            )}
+                            selectedValue={preferredMempoolRate}
+                            onValueChange={async (value: string) => {
+                                this.setState({
                                     preferredMempoolRate: value
-                                }
-                            });
-                        }}
-                        values={MEMPOOL_RATES_KEYS}
-                        disabled={!enableMempoolRates}
-                    />
+                                });
+                                await updateSettings({
+                                    payments: {
+                                        defaultFeeMethod: feeLimitMethod,
+                                        defaultFeePercentage: feePercentage,
+                                        defaultFeeFixed: feeLimit,
+                                        timeoutSeconds,
+                                        preferredMempoolRate: value
+                                    }
+                                });
+                            }}
+                            values={MEMPOOL_RATES_KEYS}
+                            disabled={!enableMempoolRates}
+                        />
+                    </View>
                 </View>
             </Screen>
         );

--- a/views/Settings/Privacy.tsx
+++ b/views/Settings/Privacy.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { ScrollView, View } from 'react-native';
-import { ListItem } from 'react-native-elements';
 import { inject, observer } from 'mobx-react';
 import { StackNavigationProp } from '@react-navigation/stack';
 
@@ -102,7 +101,7 @@ export default class Privacy extends React.Component<
                     navigation={navigation}
                 />
                 <ScrollView
-                    style={{ flex: 1, margin: 10 }}
+                    style={{ flex: 1, paddingHorizontal: 15, marginTop: 5 }}
                     keyboardShouldPersistTaps="handled"
                 >
                     <DropdownSetting
@@ -160,32 +159,29 @@ export default class Privacy extends React.Component<
                         </>
                     )}
 
-                    <ListItem
-                        containerStyle={{
-                            borderBottomWidth: 0,
-                            backgroundColor: 'transparent'
+                    <View
+                        style={{
+                            flexDirection: 'row',
+                            marginTop: 20
                         }}
                     >
-                        <Text
-                            style={{
-                                color: themeColor('secondaryText'),
-                                fontSize: 17,
-                                fontFamily: 'PPNeueMontreal-Book',
-                                left: -10
-                            }}
-                            infoModalText={localeString(
-                                'views.Settings.Privacy.clipboard.explainer'
-                            ).replace('Zeus', 'ZEUS')}
-                        >
-                            {localeString('views.Settings.Privacy.clipboard')}
-                        </Text>
-                        <View
-                            style={{
-                                flex: 1,
-                                flexDirection: 'row',
-                                justifyContent: 'flex-end'
-                            }}
-                        >
+                        <View style={{ flex: 1 }}>
+                            <Text
+                                style={{
+                                    color: themeColor('secondaryText'),
+                                    fontSize: 17,
+                                    fontFamily: 'PPNeueMontreal-Book'
+                                }}
+                                infoModalText={localeString(
+                                    'views.Settings.Privacy.clipboard.explainer'
+                                ).replace('Zeus', 'ZEUS')}
+                            >
+                                {localeString(
+                                    'views.Settings.Privacy.clipboard'
+                                )}
+                            </Text>
+                        </View>
+                        <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={clipboard}
                                 onValueChange={async () => {
@@ -204,38 +200,35 @@ export default class Privacy extends React.Component<
                                 }}
                             />
                         </View>
-                    </ListItem>
-                    <ListItem
-                        containerStyle={{
-                            borderBottomWidth: 0,
-                            backgroundColor: 'transparent'
+                    </View>
+                    <View
+                        style={{
+                            flexDirection: 'row',
+                            marginTop: 20
                         }}
                     >
-                        <Text
-                            style={{
-                                color: themeColor('secondaryText'),
-                                fontSize: 17,
-                                fontFamily: 'PPNeueMontreal-Book',
-                                left: -10
-                            }}
-                            infoModalText={[
-                                localeString(
-                                    'views.Settings.Privacy.lurkerMode.explainer1'
-                                ),
-                                localeString(
-                                    'views.Settings.Privacy.lurkerMode.explainer2'
-                                )
-                            ]}
-                        >
-                            {localeString('views.Settings.Privacy.lurkerMode')}
-                        </Text>
-                        <View
-                            style={{
-                                flex: 1,
-                                flexDirection: 'row',
-                                justifyContent: 'flex-end'
-                            }}
-                        >
+                        <View style={{ flex: 1 }}>
+                            <Text
+                                style={{
+                                    color: themeColor('secondaryText'),
+                                    fontSize: 17,
+                                    fontFamily: 'PPNeueMontreal-Book'
+                                }}
+                                infoModalText={[
+                                    localeString(
+                                        'views.Settings.Privacy.lurkerMode.explainer1'
+                                    ),
+                                    localeString(
+                                        'views.Settings.Privacy.lurkerMode.explainer2'
+                                    )
+                                ]}
+                            >
+                                {localeString(
+                                    'views.Settings.Privacy.lurkerMode'
+                                )}
+                            </Text>
+                        </View>
+                        <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={lurkerMode}
                                 onValueChange={async () => {
@@ -254,31 +247,27 @@ export default class Privacy extends React.Component<
                                 }}
                             />
                         </View>
-                    </ListItem>
-                    <ListItem
-                        containerStyle={{
-                            borderBottomWidth: 0,
-                            backgroundColor: 'transparent'
+                    </View>
+                    <View
+                        style={{
+                            flexDirection: 'row',
+                            marginTop: 20
                         }}
                     >
-                        <ListItem.Title
-                            style={{
-                                color: themeColor('secondaryText'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                left: -10
-                            }}
-                        >
-                            {localeString(
-                                'views.Settings.Privacy.enableMempoolRates'
-                            )}
-                        </ListItem.Title>
-                        <View
-                            style={{
-                                flex: 1,
-                                flexDirection: 'row',
-                                justifyContent: 'flex-end'
-                            }}
-                        >
+                        <View style={{ flex: 1 }}>
+                            <Text
+                                style={{
+                                    color: themeColor('secondaryText'),
+                                    fontSize: 17,
+                                    fontFamily: 'PPNeueMontreal-Book'
+                                }}
+                            >
+                                {localeString(
+                                    'views.Settings.Privacy.enableMempoolRates'
+                                )}
+                            </Text>
+                        </View>
+                        <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={enableMempoolRates}
                                 onValueChange={async () => {
@@ -298,7 +287,7 @@ export default class Privacy extends React.Component<
                                 }}
                             />
                         </View>
-                    </ListItem>
+                    </View>
                 </ScrollView>
             </Screen>
         );


### PR DESCRIPTION
# Description

There is still work to do after this PR, but this is a step towards more consistent and cleaner layouting.

General:
Same overall padding/margin for Invoice, Payment, Privacy and Lightning Address Settings
&nbsp;

Payment Settings/Invoices Settings/Privacy Settings/Lightning Address Settings/Receive:
- improved styling to avoid problems in case of smaller screens/larger font size/longer locale strings (non english)
 -> switch cannot be pushed out of display view or overlap with text anymore
 -> switch is now correctly centered vertically in case text has more than 1 line
- removed `<Row>` component in `<Text>` component to not break layout if explainer is used
&nbsp;

Additionally:
- Payment Settings: `Lightning - Default Fee Limit`: "sats" now has more space to the right
- Lightning Address Settings: changed text color to `themeColor('secondaryText')` to align with other font colors in Settings
- Invoices Settings: replaced outer View wrapper with ScrollView (in case scrolling is needed)

Before:
![grafik](https://github.com/user-attachments/assets/ea4691c0-74ce-47ea-b39a-9a4178d7d651)
![grafik](https://github.com/user-attachments/assets/d449ad25-c425-4216-9c39-d8cbd615df82)
![grafik](https://github.com/user-attachments/assets/3f0a89ac-0bc1-4108-aece-8b730b40eacf)

After:
![grafik](https://github.com/user-attachments/assets/866e079d-6469-4488-bd8e-c92ce085d892)
![grafik](https://github.com/user-attachments/assets/11b88523-5cd0-40f2-be05-d5aeecc99c0b)
![grafik](https://github.com/user-attachments/assets/b6f19153-4130-4e11-a027-bb16f2eb677c)

-> This fixes #2546.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
