### PR TITLE
Switching from LNC to non-LNC node: Call BackendUtils.disconnect() with correct implementation

### DIFF
--- a/views/Settings/Wallets.tsx
+++ b/views/Settings/Wallets.tsx
@@ -233,17 +233,16 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                                         onPress={async () => {
                                             const currentImplementation =
                                                 implementation;
+                                            if (
+                                                currentImplementation ===
+                                                'lightning-node-connect'
+                                            ) {
+                                                BackendUtils.disconnect();
+                                            }
                                             await updateSettings({
                                                 nodes,
                                                 selectedNode: index
                                             }).then(() => {
-                                                if (
-                                                    currentImplementation &&
-                                                    currentImplementation ===
-                                                        'lightning-node-connect'
-                                                ) {
-                                                    BackendUtils.disconnect();
-                                                }
                                                 BalanceStore.reset();
                                                 NodeInfoStore.reset();
                                                 ChannelsStore.reset();


### PR DESCRIPTION
# Description

This fixes #1783.

The root cause was that we called `BackendUtils.disconnect()` after `updateSettings()` which led to calling `disconnect` with the new implementation (depending on the node you were switching to, coming from an LNC-connection), so the LNC-connection could not be disconnected properly.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
