### PR TITLE
add language-specific noun casing for in line usage

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -11,7 +11,7 @@ import { Row } from './layout/Row';
 import { Body } from './text/Body';
 import LoadingIndicator from './LoadingIndicator';
 
-import { localeString } from '../utils/LocaleUtils';
+import { localeString, formatInlineNoun } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
 import { formatBitcoinWithSpaces } from '../utils/UnitsUtils';
 import PrivacyUtils from '../utils/PrivacyUtils';
@@ -151,9 +151,9 @@ function AmountDisplay({
                                 {plural ? 'sats' : 'sat'}
                                 {fee
                                     ? ' ' +
-                                      localeString(
-                                          'views.Payment.fee'
-                                      ).toLowerCase()
+                                      formatInlineNoun(
+                                          localeString('views.Payment.fee')
+                                      )
                                     : ''}
                             </Body>
                         </View>
@@ -179,9 +179,9 @@ function AmountDisplay({
                                         color={color}
                                         colorOverride={colorOverride}
                                     >
-                                        {localeString(
-                                            'views.Payment.fee'
-                                        ).toLowerCase()}
+                                        {formatInlineNoun(
+                                            localeString('views.Payment.fee')
+                                        )}
                                     </Body>
                                     <Spacer width={2} />
                                 </>
@@ -246,9 +246,11 @@ function AmountDisplay({
                                             color={color}
                                             colorOverride={colorOverride}
                                         >
-                                            {localeString(
-                                                'views.Payment.fee'
-                                            ).toLowerCase()}
+                                            {formatInlineNoun(
+                                                localeString(
+                                                    'views.Payment.fee'
+                                                )
+                                            )}
                                         </Body>
                                     </View>
                                 </>

--- a/utils/LocaleUtils.ts
+++ b/utils/LocaleUtils.ts
@@ -129,3 +129,16 @@ export function localeString(localeString: string): any {
             return English[localeString];
     }
 }
+
+export const languagesWithNounCapitalization = ['de', 'pl', 'cs', 'sk'];
+
+export const formatInlineNoun = (text: string): string => {
+    if (
+        !languagesWithNounCapitalization.includes(
+            stores.settingsStore?.settings?.locale || ''
+        )
+    ) {
+        return text.toLowerCase();
+    }
+    return text;
+};


### PR DESCRIPTION
# Description

This fixes #1812.

Some languages like German capitalize all nouns, while others use lowercase for inline nouns. This adds proper language-specific casing for label texts based on locale (so far only fee label).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [x] No, I’m a fool :)
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
