### PR TITLE
Reset POS status when disabling POS

### DIFF
--- a/views/Settings/PointOfSale.tsx
+++ b/views/Settings/PointOfSale.tsx
@@ -174,9 +174,15 @@ export default class PointOfSale extends React.Component<
                             title={localeString('views.Settings.POS.enablePos')}
                             selectedValue={posEnabled}
                             onValueChange={async (value: PosEnabled) => {
+                                const { SettingsStore } = this.props;
+                                const { setPosStatus } = SettingsStore;
+
                                 this.setState({
                                     posEnabled: value
                                 });
+                                if (value === PosEnabled.Disabled) {
+                                    setPosStatus('unselected');
+                                }
                                 await updateSettings({
                                     pos: {
                                         posEnabled: value,


### PR DESCRIPTION
# Description

This fixes a bug, where Wallet.tsx still displayed POS tabs, after POS was disabled.
(Probably regression from https://github.com/ZeusLN/zeus/pull/2395)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
