### PR TITLE
Use store for fee updates between screens

### DIFF
--- a/components/OnchainFeeInput.tsx
+++ b/components/OnchainFeeInput.tsx
@@ -50,18 +50,24 @@ export default function OnchainFeeInput(props: OnchainFeeInputProps) {
         }
     }, []);
 
+    useEffect(() => {
+        const unsubscribe = navigation.addListener('focus', () => {
+            if (feeStore.tempFee) {
+                setErrorOccurredLoadingFees(false);
+                onChangeFee(feeStore.tempFee);
+                feeStore.setTempFee('');
+            }
+        });
+
+        return unsubscribe;
+    }, [navigation]);
+
     return (
         <>
             {enableMempoolRates ? (
                 <TouchableWithoutFeedback
                     onPress={() =>
                         navigation.navigate('EditFee', {
-                            onNavigateBack: (fee: string) => {
-                                if (fee) {
-                                    setErrorOccurredLoadingFees(false);
-                                }
-                                onChangeFee(fee);
-                            },
                             fee: newFee
                         })
                     }

--- a/stores/FeeStore.ts
+++ b/stores/FeeStore.ts
@@ -22,6 +22,7 @@ export default class FeeStore {
     @observable public setFeesError = false;
     @observable public setFeesErrorMsg: string;
     @observable public setFeesSuccess = false;
+    @observable public tempFee: string = '';
 
     @observable public dayEarned: string | number;
     @observable public weekEarned: string | number;
@@ -176,6 +177,10 @@ export default class FeeStore {
                 this.loading = false;
                 this.setFeesError = true;
             });
+    };
+
+    @action setTempFee = (fee: string) => {
+        this.tempFee = fee;
     };
 
     forwardingError = () => {

--- a/views/EditFee.tsx
+++ b/views/EditFee.tsx
@@ -388,10 +388,12 @@ export default class EditFee extends React.Component<
                                             'views.EditFee.confirmFee'
                                         )}
                                         onPress={() => {
-                                            this.props.route.params.onNavigateBack(
-                                                fee
+                                            FeeStore.setTempFee(
+                                                selectedFee === 'custom'
+                                                    ? customFee
+                                                    : fee
                                             );
-                                            this.props.navigation.goBack();
+                                            navigation.goBack();
                                         }}
                                         disabled={
                                             !fee ||

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -510,12 +510,6 @@ export default class Send extends React.Component<SendProps, SendState> {
         navigation.navigate('SendingLightning');
     };
 
-    handleOnNavigateBack = (fee: string) => {
-        this.setState({
-            fee
-        });
-    };
-
     displayAddress = (item: any) => {
         const contact = new Contact(item);
         const {


### PR DESCRIPTION
# Description

Now FeeStore is used to manage fee state between EditFee and parent screens via MobX observables. This removes the need to pass callback functions through navigation params, eliminating the "Non-serializable values found in navigation state" warning.

Additionally removed unused handleOnNavigateBack() in Send.tsx.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
