### PR TITLE
ZEUS-2621: Channels list: persist selection on reload

### DIFF
--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -187,7 +187,8 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
             filteredPendingChannels,
             filteredClosedChannels,
             showSearch,
-            setChannelsType
+            setChannelsType,
+            channelsType
         } = ChannelsStore!;
 
         const { settings } = SettingsStore!;
@@ -265,6 +266,15 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
             'views.Wallet.Wallet.closed'
         )} (${filteredClosedChannels?.length || 0})`;
 
+        let initialRoute;
+        if (channelsType === ChannelsType.Open) {
+            initialRoute = openChannelsTabName;
+        } else if (channelsType === ChannelsType.Pending) {
+            initialRoute = pendingChannelsTabName;
+        } else if (channelsType === ChannelsType.Closed) {
+            initialRoute = closedChannelsTabName;
+        }
+
         return (
             <View style={{ flex: 1 }}>
                 <WalletHeader
@@ -304,7 +314,7 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
                             ref={this.tabNavigationRef}
                         >
                             <Tab.Navigator
-                                initialRouteName={openChannelsTabName}
+                                initialRouteName={initialRoute}
                                 backBehavior="none"
                                 screenOptions={() => ({
                                     headerShown: false,


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2621**](https://github.com/ZeusLN/zeus/issues/2621)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
