### PR TITLE
More comprehensive error message for FAILURE_REASON_INCORRECT_PAYMENT_DETAILS

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1092,7 +1092,7 @@
     "error.failureReasonTimeout": "There are more routes to try, but the payment timeout was exceeded.",
     "error.failureReasonNoRoute": "No route found",
     "error.failureReasonError": "A non-recoverable error has occured",
-    "error.failureReasonIncorrectPaymentDetails": "Payment details incorrect (unknown hash, invalid amt or invalid final cltv delta)",
+    "error.failureReasonIncorrectPaymentDetails": "Payment failed: Payment details incorrect (unknown payment hash, invalid amount or invalid final CLTV delta). If this was a keysend payment, the receiving node might not accept keysend.",
     "error.failureReasonInsufficientBalance": "Insufficient local balance",
     "pos.views.Wallet.PosPane.noOrders": "No orders open at the moment. To send to ZEUS, mark order as 'Other Payment Type' with a note that includes 'Zeus', 'BTC', or 'Bitcoin'",
     "pos.views.Wallet.PosPane.noOrdersStandalone": "No orders open at the moment",


### PR DESCRIPTION
# Description

LND throws FAILURE_REASON_INCORRECT_PAYMENT_DETAILS if a keysend payment fails due to the receiving node not accepting keysend. That cost me some time, so I want to spare others from this.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
