### PR TITLE
Display keysend messages like memos in Activity and Payment

### DIFF
--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -374,12 +374,12 @@ export default class Activity extends React.PureComponent<
                                 subTitle = (
                                     <Text>
                                         {localeString('general.lightning')}
-                                        {item.memo ? ': ' : ''}
-                                        {item.memo ? (
+                                        {item.getMemo ? ': ' : ''}
+                                        {item.getMemo ? (
                                             <Text
                                                 style={{ fontStyle: 'italic' }}
                                             >
-                                                {item.memo}
+                                                {item.getMemo}
                                             </Text>
                                         ) : (
                                             ''


### PR DESCRIPTION
# Description

This fixes #1444.
-> Keysend messages are displayed just like regular memos in Activity and Payment view.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
