### PR TITLE
Tests for channel backup functions (lndmobile/channel.ts)

### DIFF
--- a/lndmobile/channel.test.ts
+++ b/lndmobile/channel.test.ts
@@ -1,0 +1,57 @@
+jest.mock('./utils', () => ({
+    sendCommand: jest.fn()
+}));
+
+import { sendCommand } from './utils';
+import {
+    exportAllChannelBackups,
+    restoreChannelBackups,
+    verifyChanBackup
+} from './channel';
+import { lnrpc } from '../proto/lightning';
+
+describe('channel', () => {
+    const testBackupBase64 = 'dGVzdGJhY2t1cA==';
+
+    describe('exportAllChannelBackups', () => {
+        it('calls sendCommand with correct parameters', async () => {
+            await exportAllChannelBackups();
+            expect(sendCommand).toHaveBeenCalledWith({
+                request: lnrpc.ChanBackupExportRequest,
+                response: lnrpc.ChanBackupSnapshot,
+                method: 'ExportAllChannelBackups',
+                options: {}
+            });
+        });
+    });
+
+    describe('restoreChannelBackups', () => {
+        it('calls sendCommand with correct parameters', async () => {
+            await restoreChannelBackups(testBackupBase64);
+            expect(sendCommand).toHaveBeenCalledWith({
+                request: lnrpc.RestoreChanBackupRequest,
+                response: lnrpc.RestoreBackupResponse,
+                method: 'RestoreChannelBackups',
+                options: {
+                    multi_chan_backup: expect.any(Uint8Array)
+                }
+            });
+        });
+    });
+
+    describe('verifyChanBackup', () => {
+        it('calls sendCommand with correct parameters', async () => {
+            await verifyChanBackup(testBackupBase64);
+            expect(sendCommand).toHaveBeenCalledWith({
+                request: lnrpc.ChanBackupSnapshot,
+                response: lnrpc.VerifyChanBackupResponse,
+                method: 'VerifyChanBackup',
+                options: {
+                    multi_chan_backup: {
+                        multi_chan_backup: expect.any(Uint8Array)
+                    }
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
# Description

This adds first test coverage for channel backup functions in lndmobile/channel.ts.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [x] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
