### PR TITLE
Fix LNC mailbox server switching

### DIFF
--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -48,7 +48,9 @@ export default class LightningNodeConnect {
             settingsStore;
 
         this.lnc = new LNC({
-            credentialStore: new CredentialStore()
+            credentialStore: await new CredentialStore(
+                pairingPhrase
+            ).initialize()
         });
 
         this.lnc.credentials.pairingPhrase = pairingPhrase;


### PR DESCRIPTION
# Description

This fixes an issue where Zeus was reconnecting to old host, even though mailbox server was modified.
Steps to reproduce:
- connect to LNC node
- modify host to something unreachable
- click "save"
-> Zeus will reconnect to old host...

The root cause was that serverHost was being stored in two places: within the main credentials object and as part of the persisted data. When loading credentials, the old serverHost value from persisted data was overriding the new host setting.
-> Fixed this by separating serverHost storage into its own dedicated storage location and implementing proper migration to handle existing data.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
