### PR TITLE
Loading Columns: make surrounding wordmarks visible on light themes

### DIFF
--- a/components/LoadingColumns.tsx
+++ b/components/LoadingColumns.tsx
@@ -11,9 +11,63 @@ function LoadingColumns() {
             source={loader}
             autoPlay
             colorFilters={[
+                // highlighted wordmark
                 {
                     keypath: 'Layer 14 Outlines',
                     color: themeColor('highlight')
+                },
+                // surrounding wordmarks
+                {
+                    keypath: 'Layer 1 Outlines',
+                    color: themeColor('text')
+                },
+                {
+                    keypath: 'Layer 2 Outlines',
+                    color: themeColor('text')
+                },
+                {
+                    keypath: 'Layer 3 Outlines',
+                    color: themeColor('text')
+                },
+                {
+                    keypath: 'Layer 4 Outlines',
+                    color: themeColor('text')
+                },
+                {
+                    keypath: 'Layer 5 Outlines',
+                    color: themeColor('text')
+                },
+                {
+                    keypath: 'Layer 6 Outlines',
+                    color: themeColor('text')
+                },
+                {
+                    keypath: 'Layer 7 Outlines',
+                    color: themeColor('text')
+                },
+                {
+                    keypath: 'Layer 8 Outlines',
+                    color: themeColor('text')
+                },
+                {
+                    keypath: 'Layer 9 Outlines',
+                    color: themeColor('text')
+                },
+                {
+                    keypath: 'Layer 10 Outlines',
+                    color: themeColor('text')
+                },
+                {
+                    keypath: 'Layer 11 Outlines',
+                    color: themeColor('text')
+                },
+                {
+                    keypath: 'Layer 12 Outlines',
+                    color: themeColor('text')
+                },
+                {
+                    keypath: 'Layer 13 Outlines',
+                    color: themeColor('text')
                 }
             ]}
             resizeMode="contain"


### PR DESCRIPTION
# Description

Before:
![Screenshot_1734568865](https://github.com/user-attachments/assets/6a14d1cd-d786-4672-9cd3-e93dc377a70b)

After:
![Screenshot_1734568824](https://github.com/user-attachments/assets/8709b1a5-789c-4b74-8e0a-0eef32425904)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
