### PR TITLE
ZEUS-2626: Lightning Address Settings: Notifications setting does not persist

### DIFF
--- a/views/Settings/LightningAddress/LightningAddressSettings.tsx
+++ b/views/Settings/LightningAddress/LightningAddressSettings.tsx
@@ -109,7 +109,7 @@ export default class LightningAddressSettings extends React.Component<
                             }
                         }}
                         rightComponent={
-                            loading ? <LoadingIndicator size={32} /> : <></>
+                            loading ? <LoadingIndicator size={30} /> : <></>
                         }
                         navigation={navigation}
                     />

--- a/views/Settings/LightningAddress/LightningAddressSettings.tsx
+++ b/views/Settings/LightningAddress/LightningAddressSettings.tsx
@@ -109,7 +109,11 @@ export default class LightningAddressSettings extends React.Component<
                             }
                         }}
                         rightComponent={
-                            loading ? <LoadingIndicator size={30} /> : <></>
+                            loading ? (
+                                <View>
+                                    <LoadingIndicator size={30} />
+                                </View>
+                            ) : undefined
                         }
                         navigation={navigation}
                     />

--- a/views/Settings/LightningAddress/LightningAddressSettings.tsx
+++ b/views/Settings/LightningAddress/LightningAddressSettings.tsx
@@ -72,7 +72,10 @@ export default class LightningAddressSettings extends React.Component<
                 : false,
             nostrPrivateKey: settings.lightningAddress?.nostrPrivateKey || '',
             nostrRelays: settings.lightningAddress?.nostrRelays || [],
-            notifications: settings.lightningAddress?.notifications || 1
+            notifications:
+                settings.lightningAddress?.notifications !== undefined
+                    ? settings.lightningAddress.notifications
+                    : 1
         });
     }
 


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2626**](https://github.com/ZeusLN/zeus/issues/2626)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
