### PR TITLE
Call getSettingsAndNavigate less often

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1237,6 +1237,7 @@ export default class SettingsStore {
     @observable implementation: Implementations;
     @observable certVerification: boolean | undefined;
     @observable public loggedIn = false;
+    @observable public triggerSettingsRefresh: boolean = false;
     @observable public connecting = true;
     @observable public lurkerExposed = false;
     private lurkerTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1237,7 +1237,6 @@ export default class SettingsStore {
     @observable implementation: Implementations;
     @observable certVerification: boolean | undefined;
     @observable public loggedIn = false;
-    @observable public comingFromLockscreen: boolean = false;
     @observable public connecting = true;
     @observable public lurkerExposed = false;
     private lurkerTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1490,6 +1490,8 @@ export default class SettingsStore {
         }
 
         await this.setSettings(newSettings);
+        this.triggerSettingsRefresh = true;
+
         // Update store's node properties from latest settings
         this.updateNodeProperties(newSettings);
         return newSettings;

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1221,6 +1221,7 @@ export default class SettingsStore {
         selectNodeOnStartup: false
     };
     @observable public posStatus: string = 'unselected';
+    @observable public posWasEnabled: boolean = false;
     @observable public loading = false;
     @observable btcPayError: string | null;
     @observable sponsorsError: string | null;
@@ -1236,6 +1237,7 @@ export default class SettingsStore {
     @observable implementation: Implementations;
     @observable certVerification: boolean | undefined;
     @observable public loggedIn = false;
+    @observable public comingFromLockscreen: boolean = false;
     @observable public connecting = true;
     @observable public lurkerExposed = false;
     private lurkerTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -1479,6 +1481,13 @@ export default class SettingsStore {
             ...existingSettings,
             ...newSetting
         };
+
+        if (
+            newSetting.pos?.posEnabled &&
+            newSetting.pos.posEnabled !== PosEnabled.Disabled
+        ) {
+            this.posWasEnabled = true;
+        }
 
         await this.setSettings(newSettings);
         // Update store's node properties from latest settings

--- a/views/Intro.tsx
+++ b/views/Intro.tsx
@@ -240,8 +240,6 @@ const Intro: React.FC<IntroProps> = (props) => {
 
                                         updateSettings({ nodes }).then(() => {
                                             setConnectingStatus(true);
-                                            stores.settingsStore.triggerSettingsRefresh =
-                                                true;
                                             navigation.navigate('Wallet');
                                         });
                                     } else {

--- a/views/Intro.tsx
+++ b/views/Intro.tsx
@@ -240,9 +240,9 @@ const Intro: React.FC<IntroProps> = (props) => {
 
                                         updateSettings({ nodes }).then(() => {
                                             setConnectingStatus(true);
-                                            navigation.navigate('Wallet', {
-                                                refresh: true
-                                            });
+                                            stores.settingsStore.triggerSettingsRefresh =
+                                                true;
+                                            navigation.navigate('Wallet');
                                         });
                                     } else {
                                         setCreatingWallet(false);

--- a/views/IntroSplash.tsx
+++ b/views/IntroSplash.tsx
@@ -311,8 +311,6 @@ export default class IntroSplash extends React.Component<
                                             updateSettings({ nodes }).then(
                                                 () => {
                                                     setConnectingStatus(true);
-                                                    SettingsStore.triggerSettingsRefresh =
-                                                        true;
                                                     navigation.navigate(
                                                         'Wallet'
                                                     );

--- a/views/IntroSplash.tsx
+++ b/views/IntroSplash.tsx
@@ -311,11 +311,10 @@ export default class IntroSplash extends React.Component<
                                             updateSettings({ nodes }).then(
                                                 () => {
                                                     setConnectingStatus(true);
+                                                    SettingsStore.triggerSettingsRefresh =
+                                                        true;
                                                     navigation.navigate(
-                                                        'Wallet',
-                                                        {
-                                                            refresh: true
-                                                        }
+                                                        'Wallet'
                                                     );
                                                 }
                                             );

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -253,7 +253,12 @@ export default class Lockscreen extends React.Component<
             } else if (deleteDuressPin) {
                 this.deleteDuressPin();
             } else {
-                setPosStatus('inactive');
+                if (
+                    (SettingsStore.settings?.pos?.posEnabled ||
+                        PosEnabled.Disabled) !== PosEnabled.Disabled
+                ) {
+                    setPosStatus('inactive');
+                }
                 this.resetAuthenticationAttempts();
                 const pendingNavigation = route.params?.pendingNavigation;
                 this.proceed(

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -125,7 +125,7 @@ export default class Lockscreen extends React.Component<
         ) {
             // If POS is enabled and active, proceed without authentication
             SettingsStore.setLoginStatus(true);
-            this.proceed('Wallet', undefined);
+            this.proceed('Wallet');
             return;
         }
 

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -506,8 +506,6 @@ export default class SendingLightning extends React.Component<
                                         color: themeColor('background')
                                     }}
                                     onPress={() => {
-                                        this.props.SettingsStore.triggerSettingsRefresh =
-                                            true;
                                         navigation.popTo('Wallet');
                                     }}
                                     buttonStyle={{ height: 40 }}

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -22,6 +22,7 @@ import { Row } from '../components/layout/Row';
 import TransactionsStore from '../stores/TransactionsStore';
 import LnurlPayStore from '../stores/LnurlPayStore';
 import PaymentsStore from '../stores/PaymentsStore';
+import SettingsStore from '../stores/SettingsStore';
 
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
@@ -38,6 +39,7 @@ interface SendingLightningProps {
     TransactionsStore: TransactionsStore;
     LnurlPayStore: LnurlPayStore;
     PaymentsStore: PaymentsStore;
+    SettingsStore: SettingsStore;
 }
 
 interface SendingLightningState {
@@ -503,11 +505,11 @@ export default class SendingLightning extends React.Component<
                                         size: 25,
                                         color: themeColor('background')
                                     }}
-                                    onPress={() =>
-                                        navigation.popTo('Wallet', {
-                                            refresh: true
-                                        })
-                                    }
+                                    onPress={() => {
+                                        this.props.SettingsStore.triggerSettingsRefresh =
+                                            true;
+                                        navigation.popTo('Wallet');
+                                    }}
                                     buttonStyle={{ height: 40 }}
                                     titleStyle={{
                                         color: themeColor('background')

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -151,7 +151,6 @@ export default class SeedRecovery extends React.PureComponent<
 
             if (nodes.length === 1) {
                 setConnectingStatus(true);
-                SettingsStore.triggerSettingsRefresh = true;
                 navigation.popTo('Wallet');
             } else {
                 navigation.popTo('Wallets');

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -151,9 +151,10 @@ export default class SeedRecovery extends React.PureComponent<
 
             if (nodes.length === 1) {
                 setConnectingStatus(true);
-                navigation.popTo('Wallet', { refresh: true });
+                SettingsStore.triggerSettingsRefresh = true;
+                navigation.popTo('Wallet');
             } else {
-                navigation.popTo('Wallets', { refresh: true });
+                navigation.popTo('Wallets');
             }
         });
     };

--- a/views/Settings/SelectCurrency.tsx
+++ b/views/Settings/SelectCurrency.tsx
@@ -147,9 +147,7 @@ export default class SelectCurrency extends React.Component<
                                             fiat: item.value
                                         }).then(() => {
                                             getSettings();
-                                            navigation.popTo('Currency', {
-                                                refresh: true
-                                            });
+                                            navigation.popTo('Currency');
                                         });
                                     }
                                 }}

--- a/views/Settings/SetDuressPassword.tsx
+++ b/views/Settings/SetDuressPassword.tsx
@@ -98,9 +98,7 @@ export default class SetDuressPassphrase extends React.Component<
 
         await updateSettings({ duressPassphrase }).then(() => {
             getSettings();
-            navigation.popTo('Settings', {
-                refresh: true
-            });
+            navigation.popTo('Settings');
         });
     };
 
@@ -109,9 +107,7 @@ export default class SetDuressPassphrase extends React.Component<
         const { updateSettings } = SettingsStore;
 
         await updateSettings({ duressPassphrase: '' }).then(() => {
-            navigation.popTo('Settings', {
-                refresh: true
-            });
+            navigation.popTo('Settings');
         });
     };
 

--- a/views/Settings/SetDuressPin.tsx
+++ b/views/Settings/SetDuressPin.tsx
@@ -96,9 +96,7 @@ export default class SetDuressPin extends React.Component<
 
         await updateSettings({ duressPin }).then(() => {
             getSettings();
-            navigation.popTo('Settings', {
-                refresh: true
-            });
+            navigation.popTo('Settings');
         });
     };
 

--- a/views/Settings/SetPassword.tsx
+++ b/views/Settings/SetPassword.tsx
@@ -125,7 +125,7 @@ export default class SetPassphrase extends React.Component<
             passphrase: '',
             isBiometryEnabled: false
         });
-        navigation.popTo('Security', { refresh: true });
+        navigation.popTo('Security');
     };
 
     render() {

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -556,7 +556,8 @@ export default class WalletConfiguration extends React.Component<
                     BackendUtils.disconnect();
                 }
                 setConnectingStatus(true);
-                navigation.popTo('Wallet', { refresh: true });
+                SettingsStore.triggerSettingsRefresh = true;
+                navigation.popTo('Wallet');
             } else {
                 navigation.goBack();
             }
@@ -640,7 +641,7 @@ export default class WalletConfiguration extends React.Component<
             if (newNodes.length === 0) {
                 navigation.navigate('IntroSplash');
             } else {
-                navigation.popTo('Wallets', { refresh: true });
+                navigation.popTo('Wallets');
             }
         });
     };
@@ -681,7 +682,7 @@ export default class WalletConfiguration extends React.Component<
         setConnectingStatus(true);
         setInitialStart(false);
 
-        navigation.popTo('Wallet', { refresh: true });
+        navigation.popTo('Wallet', { triggerSettingsRefresh: true });
     };
 
     createNewWallet = async (network: string = 'Mainnet') => {

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -556,7 +556,6 @@ export default class WalletConfiguration extends React.Component<
                     BackendUtils.disconnect();
                 }
                 setConnectingStatus(true);
-                SettingsStore.triggerSettingsRefresh = true;
                 navigation.popTo('Wallet');
             } else {
                 navigation.goBack();
@@ -682,7 +681,7 @@ export default class WalletConfiguration extends React.Component<
         setConnectingStatus(true);
         setInitialStart(false);
 
-        navigation.popTo('Wallet', { triggerSettingsRefresh: true });
+        navigation.popTo('Wallet');
     };
 
     createNewWallet = async (network: string = 'Mainnet') => {

--- a/views/Settings/Wallets.tsx
+++ b/views/Settings/Wallets.tsx
@@ -257,9 +257,9 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                                             }).then(() => {
                                                 setConnectingStatus(true);
                                                 setInitialStart(false);
-                                                navigation.popTo('Wallet', {
-                                                    refresh: true
-                                                });
+                                                SettingsStore.triggerSettingsRefresh =
+                                                    true;
+                                                navigation.popTo('Wallet');
                                             });
                                         }}
                                     >

--- a/views/Settings/Wallets.tsx
+++ b/views/Settings/Wallets.tsx
@@ -257,8 +257,6 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                                             }).then(() => {
                                                 setConnectingStatus(true);
                                                 setInitialStart(false);
-                                                SettingsStore.triggerSettingsRefresh =
-                                                    true;
                                                 navigation.popTo('Wallet');
                                             });
                                         }}

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -197,21 +197,16 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             this.handleBackButton.bind(this)
         );
 
-        const { SettingsStore, navigation } = this.props;
-        const { triggerSettingsRefresh } =
-            navigation.getState().routes[navigation.getState().index].params ||
-            {};
+        const { SettingsStore } = this.props;
 
         if (
             this.state.initialLoad ||
             SettingsStore.posWasEnabled ||
-            triggerSettingsRefresh
+            SettingsStore.triggerSettingsRefresh
         ) {
             this.getSettingsAndNavigate();
             SettingsStore.posWasEnabled = false;
-            if (triggerSettingsRefresh) {
-                navigation.setParams({ triggerSettingsRefresh: false });
-            }
+            SettingsStore.triggerSettingsRefresh = false;
         }
     };
 

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -196,7 +196,18 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             'hardwareBackPress',
             this.handleBackButton.bind(this)
         );
-        this.getSettingsAndNavigate();
+
+        const { SettingsStore } = this.props;
+
+        if (
+            this.state.initialLoad ||
+            SettingsStore.posWasEnabled ||
+            SettingsStore.comingFromLockscreen
+        ) {
+            this.getSettingsAndNavigate();
+            SettingsStore.posWasEnabled = false;
+            SettingsStore.comingFromLockscreen = false;
+        }
     };
 
     private handleBlur = () => this.backPressSubscription?.remove();
@@ -238,8 +249,12 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             loginBackground
         ) {
             SettingsStore.setLoginStatus(false);
-        } else if (nextAppState === 'active' && SettingsStore.loginRequired()) {
-            this.props.navigation.navigate('Lockscreen');
+        } else if (nextAppState === 'active') {
+            if (SettingsStore.loginRequired()) {
+                this.props.navigation.navigate('Lockscreen');
+            } else {
+                this.getSettingsAndNavigate();
+            }
         }
     };
 

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -204,6 +204,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             SettingsStore.posWasEnabled ||
             SettingsStore.triggerSettingsRefresh
         ) {
+            // Trigger getSettingsAndNavigate() in three scenarios:
+            // 1. On initial wallet load to ensure proper initialization
+            // 2. When exiting POS to handle potential lockscreen navigation
+            // 3. When any settings are updated to refresh the UI state
             this.getSettingsAndNavigate();
             SettingsStore.posWasEnabled = false;
             SettingsStore.triggerSettingsRefresh = false;

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -197,16 +197,21 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             this.handleBackButton.bind(this)
         );
 
-        const { SettingsStore } = this.props;
+        const { SettingsStore, navigation } = this.props;
+        const { triggerSettingsRefresh } =
+            navigation.getState().routes[navigation.getState().index].params ||
+            {};
 
         if (
             this.state.initialLoad ||
             SettingsStore.posWasEnabled ||
-            SettingsStore.comingFromLockscreen
+            triggerSettingsRefresh
         ) {
             this.getSettingsAndNavigate();
             SettingsStore.posWasEnabled = false;
-            SettingsStore.comingFromLockscreen = false;
+            if (triggerSettingsRefresh) {
+                navigation.setParams({ triggerSettingsRefresh: false });
+            }
         }
     };
 


### PR DESCRIPTION
# Description

Before, getSettingsAndNavigate() was called everytime Wallet.tsx gained focus. Since processing getSettingsAndNavigate() takes some time, this resulted in the app not being responsive for a short time. Example: When you closed the menu and then immediately clicked on a balance slider, it was not responding.

With this PR the flow is optimized, so getSettingsAndNavigate() is only called:
- via handleFocus():
  - On initial load (using existing initialLoad state)
  - When coming from Lockscreen after logging in (using new triggerSettingsRefresh flag)
  - When POS was enabled (using new posWasEnabled flag)
- via handleAppStateChange():
  - when app comes from background (no PIN/password configured)

Additionally fixed a bug, where autonavigation into POS didn't work in this edge case:
- Configure a PIN/password, enable `Require login after app returns from background`
- Enable POS and leave menu (autonavigate works)
- Disable POS and leave menu
- Put the app in background and reopen it, log in
- Enable POS and leave menu
=> **no autonavigate is happening**

Root cause was in Lockscreen.tsx, now it is only setting posStatus to 'inactive' when POS is actually enabled.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
