### PR TITLE
ZEUS-2629: Failed payment to invoices with route hints

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -423,6 +423,7 @@
     "views.Channel.confirmClose": "Confirm Channel Close",
     "views.Channel.aliasScid": "Alias SCID",
     "views.Channel.aliasScids": "Alias SCIDs",
+    "views.Channel.peerAliasScid": "Peer Alias SCID",
     "views.Channel.closeHeight": "Close height",
     "views.Channel.closeType": "Close type",
     "views.Channel.openInitiator": "Open initiator",

--- a/models/Channel.ts
+++ b/models/Channel.ts
@@ -42,6 +42,7 @@ export default class Channel extends BaseModel {
     capacity: string;
     private: boolean;
     initiator?: boolean;
+    peer_scid_alias?: number;
     alias_scids?: Array<number>; // array uint64
     local_chan_reserve_sat?: string;
     remote_chan_reserve_sat?: string;

--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -268,7 +268,9 @@ export default class InvoicesStore {
                         hop_hints: [
                             {
                                 node_id: routeHintChannel.remotePubkey,
-                                chan_id: routeHintChannel.channelId, // must not be converted to Number as this might lead to a loss of precision
+                                chan_id:
+                                    routeHintChannel.peer_scid_alias ||
+                                    routeHintChannel.channelId, // must not be converted to Number as this might lead to a loss of precision
                                 fee_base_msat: Number(
                                     remotePolicy?.fee_base_msat
                                 ),

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -248,6 +248,7 @@ export default class ChannelView extends React.Component<
             shortChannelId,
             initiator,
             alias_scids,
+            peer_scid_alias,
             local_chan_reserve_sat,
             remote_chan_reserve_sat,
             displayName,
@@ -414,6 +415,14 @@ export default class ChannelView extends React.Component<
                             value={PrivacyUtils.sensitiveValue(
                                 alias_scids.join(', ')
                             )}
+                        />
+                    )}
+                    {!!peer_scid_alias && (
+                        <KeyValue
+                            keyValue={localeString(
+                                'views.Channel.peerAliasScid'
+                            )}
+                            value={PrivacyUtils.sensitiveValue(peer_scid_alias)}
                         />
                     )}
                     {zero_conf && (

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -405,18 +405,28 @@ export default class ChannelView extends React.Component<
                             value={shortChannelId}
                         />
                     )}
-                    {!!alias_scids && alias_scids.length > 0 && (
-                        <KeyValue
-                            keyValue={
-                                alias_scids.length > 1
-                                    ? localeString('views.Channel.aliasScids')
-                                    : localeString('views.Channel.aliasScid')
-                            }
-                            value={PrivacyUtils.sensitiveValue(
-                                alias_scids.join(', ')
-                            )}
-                        />
-                    )}
+                    {!!alias_scids &&
+                        alias_scids.length > 0 &&
+                        // hide if single SCID that matches channel ID
+                        !(
+                            alias_scids.length === 1 &&
+                            alias_scids[0].toString() === channelId
+                        ) && (
+                            <KeyValue
+                                keyValue={
+                                    alias_scids.length > 1
+                                        ? localeString(
+                                              'views.Channel.aliasScids'
+                                          )
+                                        : localeString(
+                                              'views.Channel.aliasScid'
+                                          )
+                                }
+                                value={PrivacyUtils.sensitiveValue(
+                                    alias_scids.join(', ')
+                                )}
+                            />
+                        )}
                     {!!peer_scid_alias && (
                         <KeyValue
                             keyValue={localeString(


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2629**](https://github.com/ZeusLN/zeus/issues/2629)

When manually adding route hints to an invoice, peer SCID alias should be used in place of the channel ID when available.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [x] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
