### PR TITLE
Lockscreen: Display "Enter Passphrase" just like "Enter PIN"

### DIFF
--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -414,23 +414,7 @@ export default class Lockscreen extends React.Component<
                     deletePin ||
                     deleteDuressPin ||
                     attemptAdminLogin) && (
-                    <Header
-                        leftComponent="Back"
-                        centerComponent={
-                            passphrase
-                                ? {
-                                      text: localeString(
-                                          'views.Lockscreen.enterPassphrase'
-                                      ),
-                                      style: {
-                                          color: themeColor('text'),
-                                          fontFamily: 'PPNeueMontreal-Book'
-                                      }
-                                  }
-                                : undefined
-                        }
-                        navigation={navigation}
-                    />
+                    <Header leftComponent="Back" navigation={navigation} />
                 )}
                 {!!passphrase && (
                     <View
@@ -450,6 +434,18 @@ export default class Lockscreen extends React.Component<
                                 message={this.generateErrorMessage()}
                             />
                         )}
+                        <View style={{ marginBottom: 40 }}>
+                            <Text
+                                style={{
+                                    ...styles.mainText,
+                                    color: themeColor('text')
+                                }}
+                            >
+                                {localeString(
+                                    'views.Lockscreen.enterPassphrase'
+                                )}
+                            </Text>
+                        </View>
                         <View style={styles.inputContainer}>
                             <TextInput
                                 placeholder={'****************'}


### PR DESCRIPTION
# Description

When opening the App, there was no label "Enter passphrase".
When changing  the password/leaving POS, it is now consistent to when PIN is used.
This fixes #2657.

## Before:
App opening:
![grafik](https://github.com/user-attachments/assets/5bdfeec7-75f9-4dcf-b5f5-39c15ced5387)

Change password/leave POS:
![grafik](https://github.com/user-attachments/assets/b62c77ba-e0b3-491e-af03-7d188252a0a4)

## After:
App opening:
![grafik](https://github.com/user-attachments/assets/2749b16a-05c7-4a06-a8ba-1f4b48bc7503)

Change password/leave POS:
![grafik](https://github.com/user-attachments/assets/c8c3bdc7-eb21-4d44-b781-86ee8863982b)


## Comparison to PIN:
App opening:
![grafik](https://github.com/user-attachments/assets/d6aca5e3-1225-4f35-9411-fc1c91cd2ccc)

Change password/leave POS:
![grafik](https://github.com/user-attachments/assets/04070ace-c985-4131-8dbc-9a5a92625597)


This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
