### PR TITLE
Wallet Configuration: Use showHideToogle for LNDHub and Eclair password inputs

### DIFF
--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -40,6 +40,7 @@ import {
 import Switch from '../../components/Switch';
 import TextInput from '../../components/TextInput';
 import { Row } from '../../components/layout/Row';
+import ShowHideToggle from '../../components/ShowHideToggle';
 
 import SettingsStore, {
     INTERFACE_KEYS,
@@ -88,6 +89,7 @@ interface WalletConfigurationState {
     lndhubUrl: string; // lndhub
     username: string | undefined; // lndhub
     password: string | undefined; // lndhub, eclair
+    hidden: boolean;
     existingAccount: boolean; // lndhub
     dismissCustodialWarning: boolean;
     implementation: Implementations;
@@ -155,6 +157,7 @@ export default class WalletConfiguration extends React.Component<
         showCertModal: false,
         username: '',
         password: '',
+        hidden: true,
         accessKey: '',
         photo: undefined,
         // lnc
@@ -1271,17 +1274,42 @@ export default class WalletConfiguration extends React.Component<
                                                 'views.Settings.AddEditNode.password'
                                             )}
                                         </Text>
-                                        <TextInput
-                                            placeholder={'...'}
-                                            value={password}
-                                            onChangeText={(text: string) => {
-                                                this.setState({
-                                                    password: text.trim(),
-                                                    saved: false
-                                                });
+                                        <View
+                                            style={{
+                                                flexDirection: 'row',
+                                                alignItems: 'center'
                                             }}
-                                            locked={loading}
-                                        />
+                                        >
+                                            <TextInput
+                                                placeholder={'...'}
+                                                value={password}
+                                                onChangeText={(
+                                                    text: string
+                                                ) => {
+                                                    this.setState({
+                                                        password: text.trim(),
+                                                        saved: false
+                                                    });
+                                                }}
+                                                locked={loading}
+                                                secureTextEntry={
+                                                    this.state.hidden
+                                                }
+                                                autoCapitalize="none"
+                                                style={{
+                                                    flex: 1,
+                                                    marginRight: 15
+                                                }}
+                                            />
+                                            <ShowHideToggle
+                                                onPress={() =>
+                                                    this.setState({
+                                                        hidden: !this.state
+                                                            .hidden
+                                                    })
+                                                }
+                                            />
+                                        </View>
                                     </>
                                 )}
                             </>
@@ -1370,19 +1398,40 @@ export default class WalletConfiguration extends React.Component<
                                                 'views.Settings.AddEditNode.password'
                                             )}
                                         </Text>
-                                        <TextInput
-                                            placeholder={'...'}
-                                            value={password}
-                                            onChangeText={(text: string) =>
-                                                this.setState({
-                                                    password: text.trim(),
-                                                    saved: false
-                                                })
-                                            }
-                                            locked={loading}
-                                            secureTextEntry={saved}
-                                            autoCapitalize="none"
-                                        />
+                                        <View
+                                            style={{
+                                                flexDirection: 'row',
+                                                alignItems: 'center'
+                                            }}
+                                        >
+                                            <TextInput
+                                                placeholder={'...'}
+                                                value={password}
+                                                onChangeText={(text: string) =>
+                                                    this.setState({
+                                                        password: text.trim(),
+                                                        saved: false
+                                                    })
+                                                }
+                                                locked={loading}
+                                                secureTextEntry={
+                                                    this.state.hidden
+                                                }
+                                                autoCapitalize="none"
+                                                style={{
+                                                    flex: 1,
+                                                    marginRight: 15
+                                                }}
+                                            />
+                                            <ShowHideToggle
+                                                onPress={() =>
+                                                    this.setState({
+                                                        hidden: !this.state
+                                                            .hidden
+                                                    })
+                                                }
+                                            />
+                                        </View>
 
                                         {saved && (
                                             <CollapsedQR


### PR DESCRIPTION
# Description

This fixes #2589 for LNDHub and Eclair.

![grafik](https://github.com/user-attachments/assets/0f4dcae6-6de4-45ef-a57a-8cee1db0868b)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [x] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [x] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
