### PR TITLE
Hide modal dialogs on lock screen

### DIFF
--- a/components/ModalBox.tsx
+++ b/components/ModalBox.tsx
@@ -19,6 +19,9 @@ import {
     StyleProp,
     LayoutChangeEvent
 } from 'react-native';
+import { inject, observer } from 'mobx-react';
+
+import SettingsStore from '../stores/SettingsStore';
 
 const {
     height: SCREEN_HEIGHT,
@@ -69,6 +72,7 @@ interface ModalBoxProps {
     children?: React.ReactNode;
     useNativeDriver?: boolean;
     onLayout?: (event: LayoutChangeEvent) => void;
+    SettingsStore?: SettingsStore;
 }
 
 interface ModalBoxState {
@@ -92,6 +96,8 @@ interface ModalBoxState {
     positionDest?: number;
 }
 
+@inject('SettingsStore')
+@observer
 export default class ModalBox extends React.PureComponent<
     ModalBoxProps,
     ModalBoxState
@@ -641,9 +647,10 @@ export default class ModalBox extends React.PureComponent<
      */
     render() {
         const visible =
-            this.state.isOpen ||
-            this.state.isAnimateOpen ||
-            this.state.isAnimateClose;
+            !this.props.SettingsStore!.loginRequired() &&
+            (this.state.isOpen ||
+                this.state.isAnimateOpen ||
+                this.state.isAnimateClose);
 
         if (!visible) return <View />;
 


### PR DESCRIPTION
# Description

This fixes #2477 by hiding modal dialogs when login is required.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
