### PR TITLE
Fix security issues and security-related navigation issues

### DIFF
--- a/utils/NavigationUtils.ts
+++ b/utils/NavigationUtils.ts
@@ -14,7 +14,7 @@ const protectedNavigation = async (
 
     if (posEnabled && loginRequired) {
         navigation.navigate('Lockscreen', {
-            attemptAdminLogin: true
+            pendingNavigation: { screen: route, params: routeParams }
         });
     } else {
         if (disactivatePOS) setPosStatus('inactive');

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -36,7 +36,7 @@ interface LockscreenProps {
             modifySecurityScreen: string;
             deletePin: boolean;
             deleteDuressPin: boolean;
-            attemptAdminLogin: boolean;
+            pendingNavigation?: { screen: string; params?: any };
         }
     >;
 }
@@ -84,15 +84,15 @@ export default class Lockscreen extends React.Component<
         };
     }
 
-    proceed = (navigationTarget?: string) => {
+    proceed = (targetScreen?: string, navigationParams?: any) => {
         const { SettingsStore, navigation } = this.props;
-        if (navigationTarget) {
-            navigation.navigate(navigationTarget);
+        if (targetScreen) {
+            navigation.popTo(targetScreen, navigationParams);
         } else if (
             SettingsStore.settings.selectNodeOnStartup &&
             SettingsStore.initialStart
         ) {
-            navigation.navigate('Wallets');
+            navigation.popTo('Wallets');
         } else {
             navigation.pop();
         }
@@ -105,18 +105,29 @@ export default class Lockscreen extends React.Component<
             modifySecurityScreen,
             deletePin,
             deleteDuressPin,
-            attemptAdminLogin
+            pendingNavigation
         } = route.params ?? {};
 
         const posEnabled: PosEnabled =
             (settings && settings.pos && settings.pos.posEnabled) ||
             PosEnabled.Disabled;
 
+        if (
+            posEnabled !== PosEnabled.Disabled &&
+            SettingsStore.posStatus === 'active' &&
+            !pendingNavigation &&
+            !deletePin &&
+            !deleteDuressPin
+        ) {
+            SettingsStore.setLoginStatus(true);
+            this.proceed('Wallet');
+            return;
+        }
+
         const isBiometryConfigured = SettingsStore.isBiometryConfigured();
 
         if (
             isBiometryConfigured &&
-            !attemptAdminLogin &&
             !deletePin &&
             !deleteDuressPin &&
             !modifySecurityScreen
@@ -129,22 +140,15 @@ export default class Lockscreen extends React.Component<
             );
 
             if (isVerified) {
+                SettingsStore.setPosStatus('inactive');
                 this.resetAuthenticationAttempts();
                 SettingsStore.setLoginStatus(true);
-                this.proceed();
+                this.proceed(
+                    pendingNavigation?.screen,
+                    pendingNavigation?.params
+                );
                 return;
             }
-        }
-
-        if (
-            posEnabled !== PosEnabled.Disabled &&
-            SettingsStore.posStatus === 'active' &&
-            !attemptAdminLogin &&
-            !deletePin &&
-            !deleteDuressPin
-        ) {
-            SettingsStore.setLoginStatus(true);
-            this.proceed('Wallet');
         }
 
         if (settings.authenticationAttempts) {
@@ -182,9 +186,9 @@ export default class Lockscreen extends React.Component<
                 });
             }
         } else if (settings && settings.nodes && settings?.nodes?.length > 0) {
-            this.proceed();
+            this.proceed(pendingNavigation?.screen, pendingNavigation?.params);
         } else {
-            navigation.navigate('IntroSplash');
+            navigation.popTo('IntroSplash');
         }
     }
 
@@ -210,7 +214,7 @@ export default class Lockscreen extends React.Component<
     };
 
     onAttemptLogIn = async () => {
-        const { SettingsStore, navigation } = this.props;
+        const { SettingsStore, navigation, route } = this.props;
         const {
             passphrase,
             duressPassphrase,
@@ -243,7 +247,7 @@ export default class Lockscreen extends React.Component<
             }
             if (modifySecurityScreen) {
                 this.resetAuthenticationAttempts();
-                navigation.navigate(modifySecurityScreen);
+                navigation.popTo(modifySecurityScreen);
             } else if (deletePin) {
                 this.deletePin();
             } else if (deleteDuressPin) {
@@ -251,7 +255,11 @@ export default class Lockscreen extends React.Component<
             } else {
                 setPosStatus('inactive');
                 this.resetAuthenticationAttempts();
-                this.proceed();
+                const pendingNavigation = route.params?.pendingNavigation;
+                this.proceed(
+                    pendingNavigation?.screen,
+                    pendingNavigation?.params
+                );
             }
         } else if (
             (duressPassphrase && passphraseAttempt === duressPassphrase) ||
@@ -393,7 +401,8 @@ export default class Lockscreen extends React.Component<
     };
 
     render() {
-        const { navigation, SettingsStore, route } = this.props;
+        const { navigation, SettingsStore } = this.props;
+        const pendingNavigation = this.props.route.params?.pendingNavigation;
         const { settings } = SettingsStore;
         const {
             passphrase,
@@ -406,14 +415,12 @@ export default class Lockscreen extends React.Component<
             deleteDuressPin
         } = this.state;
 
-        const { attemptAdminLogin } = route.params ?? {};
-
         return (
             <Screen>
                 {(!!modifySecurityScreen ||
                     deletePin ||
                     deleteDuressPin ||
-                    attemptAdminLogin) && (
+                    pendingNavigation) && (
                     <Header leftComponent="Back" navigation={navigation} />
                 )}
                 {!!passphrase && (


### PR DESCRIPTION
# Description

This fixes #1946, #2655 and #2659.

- replaced `attemptAdminLogin` with `pendingNavigation` to allow for navigation from POS to Menu
- allow using biometry when leaving POS
- use `popTo()` instead of `navigate()` in Lockscreen to remove Lockscreen from stack and prevent duplicate screens on stack
- added `return` after proceeding to wallet if POS is active

FYI: Not a regression but an existing bug: If Keypad is configured as default view, leaving POS navigates to Balance, not Keypad. I'm going to create an issue for this.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
