### PR TITLE
Improve biometrics setup flow: Use nav param instead of "pendingBiometricsEnable" state

### DIFF
--- a/views/Settings/Security.tsx
+++ b/views/Settings/Security.tsx
@@ -20,7 +20,7 @@ interface SecurityProps {
     navigation: StackNavigationProp<any, any>;
     SettingsStore: SettingsStore;
     ModalStore: ModalStore;
-    route: any;
+    route: { params?: { enableBiometrics?: boolean } };
 }
 
 interface SecurityState {

--- a/views/Settings/SetPassword.tsx
+++ b/views/Settings/SetPassword.tsx
@@ -18,6 +18,7 @@ interface SetPassphraseProps {
     navigation: StackNavigationProp<any, any>;
     SettingsStore: SettingsStore;
     ModalStore: ModalStore;
+    route: any;
 }
 
 interface SetPassphraseState {
@@ -74,7 +75,7 @@ export default class SetPassphrase extends React.Component<
     );
 
     saveSettings = async () => {
-        const { SettingsStore, navigation } = this.props;
+        const { SettingsStore, navigation, route } = this.props;
         const { passphrase, passphraseConfirm } = this.state;
         const { getSettings, updateSettings, setLoginStatus } = SettingsStore;
 
@@ -106,7 +107,9 @@ export default class SetPassphrase extends React.Component<
         await updateSettings({ passphrase }).then(() => {
             setLoginStatus(true);
             getSettings();
-            navigation.popTo('Security', { refresh: true });
+            navigation.popTo('Security', {
+                enableBiometrics: route.params?.forBiometrics
+            });
         });
     };
 

--- a/views/Settings/SetPassword.tsx
+++ b/views/Settings/SetPassword.tsx
@@ -18,7 +18,7 @@ interface SetPassphraseProps {
     navigation: StackNavigationProp<any, any>;
     SettingsStore: SettingsStore;
     ModalStore: ModalStore;
-    route: any;
+    route: { params?: { forBiometrics?: boolean } };
 }
 
 interface SetPassphraseState {

--- a/views/Settings/SetPin.tsx
+++ b/views/Settings/SetPin.tsx
@@ -16,7 +16,7 @@ import { themeColor } from '../../utils/ThemeUtils';
 interface SetPinProps {
     navigation: StackNavigationProp<any, any>;
     SettingsStore: SettingsStore;
-    route: any;
+    route: { params?: { forBiometrics?: boolean } };
 }
 
 interface SetPinState {

--- a/views/Settings/SetPin.tsx
+++ b/views/Settings/SetPin.tsx
@@ -16,6 +16,7 @@ import { themeColor } from '../../utils/ThemeUtils';
 interface SetPinProps {
     navigation: StackNavigationProp<any, any>;
     SettingsStore: SettingsStore;
+    route: any;
 }
 
 interface SetPinState {
@@ -66,7 +67,7 @@ export default class SetPin extends React.Component<SetPinProps, SetPinState> {
     };
 
     saveSettings = async () => {
-        const { SettingsStore, navigation } = this.props;
+        const { SettingsStore, navigation, route } = this.props;
         const { pin, pinConfirm } = this.state;
         const { getSettings, updateSettings, setLoginStatus } = SettingsStore;
 
@@ -95,7 +96,9 @@ export default class SetPin extends React.Component<SetPinProps, SetPinState> {
         await updateSettings({ pin }).then(() => {
             setLoginStatus(true);
             getSettings();
-            navigation.popTo('Security');
+            navigation.popTo('Security', {
+                enableBiometrics: route.params?.forBiometrics
+            });
         });
     };
 


### PR DESCRIPTION
# Description

This fixes #2709 by using `forBiometrics` navigation parameter when navigating to `SetPin` or `SetPassword` instead of state `pendingBiometricsEnable`.
-> Now whenever user cancels setting up pin or password, the biometric switch will not be enabled, when coming back to Security screen.

Additionally:
- SetPassword:saveSettings(): removed obsolete nav param `refresh`
 -> Security.tsx is refreshing settings via `checkSettings()` in `componentDidMount()` anyway
- refactored Security.tsx:handleBiometricsSwitchChange()
 -> removed redundant code in `if (isVerified)` case

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
