### PR TITLE
Unify memo handling for sent and received payments (invoice and payment)

### DIFF
--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -130,17 +130,24 @@ export default class Invoice extends BaseModel {
         );
     }
 
-    @computed public get getMemo(): string | undefined {
+    @computed public get getKeysendMessage(): string | undefined {
         if (this.htlcs?.[0]?.custom_records?.[keySendMessageType]) {
             return Base64Utils.base64ToUtf8(
                 this.htlcs[0].custom_records[keySendMessageType]
             );
         }
+        return undefined;
+    }
 
+    @computed public get getMemo(): string | undefined {
         const memo = this.memo || this.description;
         if (typeof memo === 'string') return memo;
         if (Array.isArray(memo)) return memo[0];
         return undefined;
+    }
+
+    @computed public get getKeysendMessageOrMemo(): string | undefined {
+        return this.getKeysendMessage || this.getMemo;
     }
 
     @computed public get isPaid(): boolean {

--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -130,11 +130,17 @@ export default class Invoice extends BaseModel {
         );
     }
 
-    @computed public get getMemo(): string {
+    @computed public get getMemo(): string | undefined {
+        if (this.htlcs?.[0]?.custom_records?.[keySendMessageType]) {
+            return Base64Utils.base64ToUtf8(
+                this.htlcs[0].custom_records[keySendMessageType]
+            );
+        }
+
         const memo = this.memo || this.description;
         if (typeof memo === 'string') return memo;
         if (Array.isArray(memo)) return memo[0];
-        return '';
+        return undefined;
     }
 
     @computed public get isPaid(): boolean {
@@ -260,24 +266,6 @@ export default class Invoice extends BaseModel {
         }
 
         return getExpiryTimestamp * 1000 <= Date.now();
-    }
-
-    @computed public get getKeysendMessage(): string {
-        if (
-            this.htlcs?.length > 0 &&
-            this.htlcs[0].custom_records &&
-            this.htlcs[0].custom_records[keySendMessageType]
-        ) {
-            const encodedMessage =
-                this.htlcs[0].custom_records[keySendMessageType];
-            try {
-                return Base64Utils.base64ToUtf8(encodedMessage);
-            } catch (e) {
-                return '';
-            }
-        }
-
-        return '';
     }
 
     @computed public get isZeusPay(): boolean {

--- a/models/Payment.ts
+++ b/models/Payment.ts
@@ -80,15 +80,21 @@ export default class Payment extends BaseModel {
         }
     }
 
-    @computed public get getMemo(): string | undefined {
+    @computed public get getKeysendMessage(): string | undefined {
         if (
             this.htlcs?.[0]?.route?.hops?.[0]?.custom_records?.[
                 keySendMessageType
             ]
         ) {
-            const customRecords = this.htlcs[0].route.hops[0].custom_records;
-            return Base64Utils.base64ToUtf8(customRecords[keySendMessageType]);
-        } else if (this.getPaymentRequest) {
+            return Base64Utils.base64ToUtf8(
+                this.htlcs[0].route.hops[0].custom_records[keySendMessageType]
+            );
+        }
+        return undefined;
+    }
+
+    @computed public get getMemo(): string | undefined {
+        if (this.getPaymentRequest) {
             try {
                 const decoded: any = bolt11.decode(this.getPaymentRequest);
                 for (let i = 0; i < decoded.tags.length; i++) {
@@ -100,6 +106,10 @@ export default class Payment extends BaseModel {
             }
         }
         return undefined;
+    }
+
+    @computed public get getKeysendMessageOrMemo(): string | undefined {
+        return this.getKeysendMessage || this.getMemo;
     }
 
     @computed public get model(): string {

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -346,12 +346,12 @@ export default class Activity extends React.PureComponent<
                                             : localeString(
                                                   'views.PaymentRequest.title'
                                               )}
-                                        {item.memo ? ': ' : ''}
-                                        {item.memo ? (
+                                        {item.getMemo ? ': ' : ''}
+                                        {item.getMemo ? (
                                             <Text
                                                 style={{ fontStyle: 'italic' }}
                                             >
-                                                {item.memo}
+                                                {item.getMemo}
                                             </Text>
                                         ) : (
                                             ''

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -346,12 +346,14 @@ export default class Activity extends React.PureComponent<
                                             : localeString(
                                                   'views.PaymentRequest.title'
                                               )}
-                                        {item.getMemo ? ': ' : ''}
-                                        {item.getMemo ? (
+                                        {item.getKeysendMessageOrMemo
+                                            ? ': '
+                                            : ''}
+                                        {item.getKeysendMessageOrMemo ? (
                                             <Text
                                                 style={{ fontStyle: 'italic' }}
                                             >
-                                                {item.getMemo}
+                                                {item.getKeysendMessageOrMemo}
                                             </Text>
                                         ) : (
                                             ''
@@ -374,12 +376,14 @@ export default class Activity extends React.PureComponent<
                                 subTitle = (
                                     <Text>
                                         {localeString('general.lightning')}
-                                        {item.getMemo ? ': ' : ''}
-                                        {item.getMemo ? (
+                                        {item.getKeysendMessageOrMemo
+                                            ? ': '
+                                            : ''}
+                                        {item.getKeysendMessageOrMemo ? (
                                             <Text
                                                 style={{ fontStyle: 'italic' }}
                                             >
-                                                {item.getMemo}
+                                                {item.getKeysendMessageOrMemo}
                                             </Text>
                                         ) : (
                                             ''

--- a/views/Invoice.tsx
+++ b/views/Invoice.tsx
@@ -61,7 +61,7 @@ export default class InvoiceView extends React.Component<
             fallback_addr,
             getRHash,
             isPaid,
-            getMemo,
+            getKeysendMessageOrMemo,
             receipt,
             creation_date,
             getDescriptionHash,
@@ -162,10 +162,10 @@ export default class InvoiceView extends React.Component<
                             />
                         )}
 
-                        {getMemo && (
+                        {getKeysendMessageOrMemo && (
                             <KeyValue
                                 keyValue={localeString('views.Invoice.memo')}
-                                value={getMemo}
+                                value={getKeysendMessageOrMemo}
                                 sensitive
                             />
                         )}

--- a/views/Invoice.tsx
+++ b/views/Invoice.tsx
@@ -71,7 +71,6 @@ export default class InvoiceView extends React.Component<
             formattedOriginalTimeUntilExpiry,
             formattedTimeUntilExpiry,
             getPaymentRequest,
-            getKeysendMessage,
             is_amp,
             value,
             getNoteKey,
@@ -151,16 +150,6 @@ export default class InvoiceView extends React.Component<
                     </View>
 
                     <View style={styles.content}>
-                        {getKeysendMessage && (
-                            <KeyValue
-                                keyValue={localeString(
-                                    'views.Invoices.keysendMessage'
-                                )}
-                                value={getKeysendMessage}
-                                sensitive
-                            />
-                        )}
-
                         {is_amp && isPaid && (
                             <KeyValue
                                 keyValue={localeString(
@@ -173,13 +162,13 @@ export default class InvoiceView extends React.Component<
                             />
                         )}
 
-                        <KeyValue
-                            keyValue={localeString('views.Invoice.memo')}
-                            value={
-                                getMemo || localeString('models.Invoice.noMemo')
-                            }
-                            sensitive
-                        />
+                        {getMemo && (
+                            <KeyValue
+                                keyValue={localeString('views.Invoice.memo')}
+                                value={getMemo}
+                                sensitive
+                            />
+                        )}
 
                         {!!receipt && (
                             <KeyValue

--- a/views/Invoice.tsx
+++ b/views/Invoice.tsx
@@ -61,7 +61,8 @@ export default class InvoiceView extends React.Component<
             fallback_addr,
             getRHash,
             isPaid,
-            getKeysendMessageOrMemo,
+            getKeysendMessage,
+            getMemo,
             receipt,
             creation_date,
             getDescriptionHash,
@@ -162,10 +163,20 @@ export default class InvoiceView extends React.Component<
                             />
                         )}
 
-                        {getKeysendMessageOrMemo && (
+                        {getKeysendMessage && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.Invoices.keysendMessage'
+                                )}
+                                value={getKeysendMessage}
+                                sensitive
+                            />
+                        )}
+
+                        {getMemo && (
                             <KeyValue
                                 keyValue={localeString('views.Invoice.memo')}
-                                value={getKeysendMessageOrMemo}
+                                value={getMemo}
                                 sensitive
                             />
                         )}

--- a/views/Payment.tsx
+++ b/views/Payment.tsx
@@ -97,7 +97,7 @@ export default class PaymentView extends React.Component<
             getPreimage,
             getDestination,
             enhancedPath,
-            getMemo,
+            getKeysendMessageOrMemo,
             isIncomplete,
             isInTransit,
             isFailed,
@@ -207,10 +207,10 @@ export default class PaymentView extends React.Component<
                             />
                         )}
 
-                        {getMemo && (
+                        {getKeysendMessageOrMemo && (
                             <KeyValue
                                 keyValue={localeString('views.Receive.memo')}
-                                value={getMemo}
+                                value={getKeysendMessageOrMemo}
                                 sensitive
                             />
                         )}

--- a/views/Payment.tsx
+++ b/views/Payment.tsx
@@ -97,7 +97,8 @@ export default class PaymentView extends React.Component<
             getPreimage,
             getDestination,
             enhancedPath,
-            getKeysendMessageOrMemo,
+            getKeysendMessage,
+            getMemo,
             isIncomplete,
             isInTransit,
             isFailed,
@@ -207,10 +208,20 @@ export default class PaymentView extends React.Component<
                             />
                         )}
 
-                        {getKeysendMessageOrMemo && (
+                        {getKeysendMessage && (
                             <KeyValue
-                                keyValue={localeString('views.Receive.memo')}
-                                value={getKeysendMessageOrMemo}
+                                keyValue={localeString(
+                                    'views.Invoices.keysendMessage'
+                                )}
+                                value={getKeysendMessage}
+                                sensitive
+                            />
+                        )}
+
+                        {getMemo && (
+                            <KeyValue
+                                keyValue={localeString('views.Invoice.memo')}
+                                value={getMemo}
                                 sensitive
                             />
                         )}


### PR DESCRIPTION
# Description

In #2634 I forgot to look at the receiving side, so now
- `Invoice.ts` handles keysend messages and regular memos in a single getter `getMemo()` instead of using a separate getter `getKeysendMessage()` (like we have it in `Payment.ts`).
- `Activity.tsx` uses `item.getMemo` instead of `item.memo` for invoice case as well (like payment case).
- `Invoice.tsx` does not show duplicate memos, and no memo row at all if memo doesn't exist (like we have it in `Payment.tsx`).
-> Memo handling and displaying is now consistent between sent and received payments.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
