### PR TITLE
Add iconOnly mode to CopyButton

### DIFF
--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -1,14 +1,19 @@
 import * as React from 'react';
-import { Platform } from 'react-native';
+import { Platform, TouchableOpacity, ViewStyle } from 'react-native';
+import { Icon } from 'react-native-elements';
 import Clipboard from '@react-native-clipboard/clipboard';
 import Button from './../components/Button';
 import { localeString } from './../utils/LocaleUtils';
+import { themeColor } from './../utils/ThemeUtils';
 
 interface CopyButtonProps {
     title?: string;
     copyValue: string;
     icon?: any;
     noUppercase?: boolean;
+    iconOnly?: boolean;
+    iconSize?: number;
+    copyIconContainerStyle?: ViewStyle;
 }
 
 interface CopyButtonState {
@@ -52,11 +57,36 @@ export default class CopyButton extends React.Component<
 
     render() {
         const { copied } = this.state;
-        const { title, icon, noUppercase } = this.props;
+        const {
+            title,
+            icon,
+            noUppercase,
+            iconOnly,
+            iconSize,
+            copyIconContainerStyle
+        } = this.props;
 
         const buttonTitle = copied
             ? localeString('components.CopyButton.copied')
             : title || localeString('components.CopyButton.copy');
+
+        if (iconOnly) {
+            return (
+                <TouchableOpacity
+                    // "padding: 5" leads to a larger area where users can click on
+                    // "copyIconContainerStyle" allows contextual spacing (marginRight)
+                    // when used alongside ShareButton
+                    style={[{ padding: 5 }, copyIconContainerStyle]}
+                    onPress={() => this.copyToClipboard()}
+                >
+                    <Icon
+                        name={copied ? 'check' : 'content-copy'}
+                        size={iconSize ?? 27}
+                        color={themeColor('secondaryText')}
+                    />
+                </TouchableOpacity>
+            );
+        }
 
         return (
             <Button


### PR DESCRIPTION
# Description

This adds iconOnly mode to CopyButton for #2728 (share feature).

![grafik](https://github.com/user-attachments/assets/d8616ffb-81a0-4c89-b775-3e2b5e66da13)

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
