### PR TITLE
Android: Graceful shutdown button in notification for persistent mode

### DIFF
--- a/android/app/src/main/java/com/zeus/LndMobile.java
+++ b/android/app/src/main/java/com/zeus/LndMobile.java
@@ -54,6 +54,7 @@ import java.util.EnumSet;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -69,6 +70,7 @@ import com.reactnativecommunity.asyncstorage.AsyncLocalStorageUtil;
 // TODO break this class up
 class LndMobile extends ReactContextBaseJavaModule {
   private final String TAG = "LndMobile";
+  public static Map<String, String> translationCache = new HashMap<>();
   Messenger messenger;
   private boolean lndMobileServiceBound = false;
   private Messenger lndMobileServiceMessenger; // The service
@@ -243,6 +245,21 @@ class LndMobile extends ReactContextBaseJavaModule {
   @Override
   public String getName() {
     return "LndMobile";
+  }
+
+  @ReactMethod
+  public void updateTranslationCache(String locale, ReadableMap translations) {
+    translationCache.clear();
+    ReadableMapKeySetIterator iterator = translations.keySetIterator();
+    while (iterator.hasNextKey()) {
+      String key = iterator.nextKey();
+      translationCache.put(key, translations.getString(key));
+    }
+
+    // Get service instance and rebuild notification
+    Intent intent = new Intent(getReactApplicationContext(), LndMobileService.class);
+    intent.setAction("app.zeusln.zeus.android.intent.action.UPDATE_NOTIFICATION");
+    getReactApplicationContext().startService(intent);
   }
 
   @ReactMethod

--- a/lndmobile/LndMobile.d.ts
+++ b/lndmobile/LndMobile.d.ts
@@ -47,6 +47,10 @@ export interface ILndMobile {
     unbindLndMobileService(): Promise<void>; // TODO(hsjoberg): function looks broken
     sendPongToLndMobileservice(): Promise<{ data: string }>;
     checkLndMobileServiceConnected(): Promise<boolean>;
+    updateTranslationCache(
+        locale: string,
+        translations: { [key: string]: string }
+    ): void;
 }
 
 export interface ILndMobileTools {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1311,5 +1311,7 @@
     "views.OnChainAddresses.sortBy.balanceAscending": "Balance (ascending)",
     "views.OnChainAddresses.sortBy.balanceDescending": "Balance (descending)",
     "views.OnChainAddresses.createAddress": "Create address",
-    "views.OnChainAddresses.changeAddresses": "Change addresses"
+    "views.OnChainAddresses.changeAddresses": "Change addresses",
+    "androidNotification.lndRunningBackground": "LND is running in the background",
+    "androidNotification.shutdown": "Shutdown"
 }

--- a/utils/LocaleUtils.ts
+++ b/utils/LocaleUtils.ts
@@ -1,3 +1,5 @@
+import { NativeModules } from 'react-native';
+
 import stores from '../stores/Stores';
 import * as EN from '../locales/en.json';
 import * as CS from '../locales/cs.json';
@@ -63,6 +65,12 @@ const Japanese: any = JA;
 const Hebrew: any = HE;
 const Croatian: any = HR;
 const Korean: any = KO;
+
+// strings that are needed on the java layer
+const JAVA_LAYER_STRINGS = [
+    'androidNotification.lndRunningBackground',
+    'androidNotification.shutdown'
+];
 
 export function localeString(localeString: string): any {
     const { settings } = stores.settingsStore;
@@ -141,4 +149,12 @@ export const formatInlineNoun = (text: string): string => {
         return text.toLowerCase();
     }
     return text;
+};
+
+export const bridgeJavaStrings = async (locale: string) => {
+    const neededTranslations: { [key: string]: string } = {};
+    JAVA_LAYER_STRINGS.forEach((key) => {
+        neededTranslations[key] = localeString(key);
+    });
+    NativeModules.LndMobile.updateTranslationCache(locale, neededTranslations);
 };

--- a/views/Settings/Language.tsx
+++ b/views/Settings/Language.tsx
@@ -9,7 +9,7 @@ import Screen from '../../components/Screen';
 
 import SettingsStore, { LOCALE_KEYS } from '../../stores/SettingsStore';
 
-import { localeString } from '../../utils/LocaleUtils';
+import { localeString, bridgeJavaStrings } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 
 interface LanguageProps {
@@ -116,6 +116,7 @@ export default class Language extends React.Component<
                                     await updateSettings({
                                         locale: item.key
                                     }).then(() => {
+                                        bridgeJavaStrings(item.key);
                                         navigation.goBack();
                                     });
                                 }}

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -46,7 +46,7 @@ import {
     startLnd,
     expressGraphSync
 } from '../../utils/LndMobileUtils';
-import { localeString } from '../../utils/LocaleUtils';
+import { localeString, bridgeJavaStrings } from '../../utils/LocaleUtils';
 import { IS_BACKED_UP_KEY } from '../../utils/MigrationUtils';
 import { protectedNavigation } from '../../utils/NavigationUtils';
 import { isLightTheme, themeColor } from '../../utils/ThemeUtils';
@@ -250,6 +250,9 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
 
         // This awaits on settings, so should await on Tor being bootstrapped before making requests
         await SettingsStore.getSettings().then(async (settings: Settings) => {
+            const locale = settings.locale || 'en';
+            bridgeJavaStrings(locale);
+
             SystemNavigationBar.setNavigationColor(
                 themeColor('background'),
                 isLightTheme() ? 'dark' : 'light'


### PR DESCRIPTION
# Description

This fixes #2501.

https://github.com/ZeusLN/zeus/pull/2735 has to be merged first.

**Note:**
As of Android 13, the OS gives users a way to stop Apps that are running in the background (see https://developer.android.com/develop/background-work/services/fgs/handle-user-stopping). Unfortunately that "Stop" button it not trying any graceful shutdown, but does a hard kill (tested with logging in `LndMobileService.java`). So we should provide a button on our own notification that will do a graceful shutdown. (Chances are low, but I guess it is not impossible to corrupt the db when doing a hard kill.)

**Changes:**
- Added button "Shutdown" to Android notification for persistent mode to stop LND gracefully
- Added bridge to use some locale strings on Java layer
  -> translation cache will be updated at app start and when language is changed
- Now using locale strings "LND is running in the background" and "Shutdown" in notification
  -> bridged locale strings are defined in LocaleUtils.ts
- Additionally: removed redundant label "ZEUS" from notification

|Android 12 on Pixel 4a|Android 14 on Pixel 7|
|-|-|
|![grafik](https://github.com/user-attachments/assets/f205b311-b8b4-4907-bab6-896810dc528d)|![grafik](https://github.com/user-attachments/assets/251f44fd-d45c-4f6b-a512-d2ab71b323b0)|
|![grafik](https://github.com/user-attachments/assets/894cc0af-03f9-4a6e-b2d2-83b5ad906d2c)|![grafik](https://github.com/user-attachments/assets/e6afc16b-0684-4744-9379-26f1c17f917d)|

Before:
![grafik](https://github.com/user-attachments/assets/c31785b9-b8c6-4d60-9c87-bffae96b67d1)



This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [x] No, I’m a fool :)
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
