### PR TITLE
Fix state mismatch lightningAddress.enabled

### DIFF
--- a/stores/LightningAddressStore.ts
+++ b/stores/LightningAddressStore.ts
@@ -605,6 +605,26 @@ export default class LightningAddressStore {
                                                 domain;
                                             if (handle && domain) {
                                                 this.lightningAddress = `${handle}@${domain}`;
+
+                                                // If we have a Lightning Address but 'enabled' flag is false,
+                                                // we fix this state mismatch now (issue #2730)
+                                                if (
+                                                    !this.settingsStore.settings
+                                                        .lightningAddress
+                                                        ?.enabled
+                                                ) {
+                                                    await this.settingsStore.updateSettings(
+                                                        {
+                                                            lightningAddress: {
+                                                                ...this
+                                                                    .settingsStore
+                                                                    .settings
+                                                                    .lightningAddress,
+                                                                enabled: true
+                                                            }
+                                                        }
+                                                    );
+                                                }
                                             }
 
                                             if (


### PR DESCRIPTION
# Description
This fixes #2730.

I don't know how exactly the bug was introduced, but I saw it in dev environment and also see it in productive environment on my phone (Zeus v0.9.4).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
