### PR TITLE
Split lightning address settings into global and pubkey specific

### DIFF
--- a/PushNotificationManager.tsx
+++ b/PushNotificationManager.tsx
@@ -31,10 +31,14 @@ export default class PushNotificationManager extends React.Component<any, any> {
         Notifications.events().registerNotificationReceivedForeground(
             (notification, completion) => {
                 console.log('Notification Received - Foreground', notification);
+                const pubkeySpecificLNAddressSettings =
+                    stores.settingsStore.settings?.lightningAddressByPubkey?.[
+                        stores.nodeInfoStore.nodeInfo.identity_pubkey
+                    ];
+
                 // Don't display redeem notification if auto-redeem is on
                 if (
-                    stores.settingsStore.settings?.lightningAddressGlobal
-                        ?.automaticallyAccept &&
+                    pubkeySpecificLNAddressSettings?.automaticallyAccept &&
                     JSON.stringify(notification.payload).includes(
                         'Redeem within the next 24 hours'
                     )

--- a/PushNotificationManager.tsx
+++ b/PushNotificationManager.tsx
@@ -33,7 +33,7 @@ export default class PushNotificationManager extends React.Component<any, any> {
                 console.log('Notification Received - Foreground', notification);
                 // Don't display redeem notification if auto-redeem is on
                 if (
-                    stores.settingsStore.settings?.lightningAddress
+                    stores.settingsStore.settings?.lightningAddressGlobal
                         ?.automaticallyAccept &&
                     JSON.stringify(notification.payload).includes(
                         'Redeem within the next 24 hours'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "<rootDir>/node_modules"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!(react-native|@react-native|react-native-blob-util|react-native-randombytes|dateformat)/)"
+      "node_modules/(?!(react-native|@react-native|react-native-blob-util|react-native-randombytes|dateformat|uuid)/)"
     ],
     "testPathIgnorePatterns": [
       "check-styles.test.ts"
@@ -142,6 +142,7 @@
     "tty-browserify": "0.0.0",
     "url": "0.10.3",
     "util": "0.10.4",
+    "uuid": "9.0.1",
     "vm-browserify": "0.0.4"
   },
   "devDependencies": {

--- a/stores/LightningAddressStore.ts
+++ b/stores/LightningAddressStore.ts
@@ -282,9 +282,11 @@ export default class LightningAddressStore {
                 throw createData.error;
             }
 
-            const { handle: responseHandle, created_at } = createData;
+            const { handle: responseHandle, domain, created_at } = createData;
 
             if (responseHandle) {
+                this.setLightningAddress(responseHandle, domain);
+            
                 await this.settingsStore.updateSettings({
                     lightningAddressGlobal: {
                         automaticallyAccept: true,

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1441,6 +1441,7 @@ export default class SettingsStore {
                         this.initMigrationPromise();
 
                         console.log('calling runIncrementalMigrations');
+                        SettingsStore.migrationsCheckedThisSession = true;
                         this.settings =
                             await MigrationsUtils.runIncrementalSettingsMigrations(
                                 this.settings
@@ -1449,7 +1450,6 @@ export default class SettingsStore {
                         if (this.migrationResolve) this.migrationResolve();
                         SettingsStore.migrationLock = false;
                     }
-                    SettingsStore.migrationsCheckedThisSession = true;
                 }
             } else if (!SettingsStore.migrationLock) {
                 SettingsStore.migrationLock = true;

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -123,18 +123,15 @@ interface LegacyLightningAddressSettings {
     notifications: number;
 }
 
-interface GlobalLightningAddressSettings {
+interface NodeSpecificLightningAddressSettings {
+    enabled: boolean;
     automaticallyAccept: boolean;
     automaticallyAcceptAttestationLevel: number;
     routeHints: boolean;
     allowComments: boolean;
+    nostrPrivateKey: string;
     nostrRelays: Array<string>;
     notifications: number;
-}
-
-interface NodeSpecificLightningAddressSettings {
-    enabled: boolean;
-    nostrPrivateKey: string;
 }
 
 interface PubkeyLightningAddressMap {
@@ -204,7 +201,6 @@ export interface Settings {
     lsps1ShowPurchaseButton: boolean;
     // Lightning Address
     lightningAddress?: LegacyLightningAddressSettings;
-    lightningAddressGlobal: GlobalLightningAddressSettings;
     lightningAddressByPubkey: PubkeyLightningAddressMap;
     bolt12Address: Bolt12AddressSettings;
     selectNodeOnStartup: boolean;
@@ -1229,15 +1225,7 @@ export default class SettingsStore {
         lsps1Token: '',
         lsps1ShowPurchaseButton: true,
         // Lightning Address
-        lightningAddressGlobal: {
-            automaticallyAccept: true,
-            automaticallyAcceptAttestationLevel: 2,
-            routeHints: false,
-            allowComments: true,
-            nostrRelays: DEFAULT_NOSTR_RELAYS,
-            notifications: 0
-        },
-        // lightningAddressByPubkey settings will be added
+        // all lightningAddressByPubkey settings will be added
         // for each node's pubkey when connecting to that node.
         lightningAddressByPubkey: {},
         bolt12Address: {

--- a/stores/storeInstances.ts
+++ b/stores/storeInstances.ts
@@ -3,3 +3,4 @@ export const fiatStore = stores.fiatStore;
 export const notesStore = stores.notesStore;
 export const settingsStore = stores.settingsStore;
 export const nodeInfoStore = stores.nodeInfoStore;
+export const lightningAddressStore = stores.lightningAddressStore;

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -3,66 +3,157 @@ jest.mock('react-native-encrypted-storage', () => ({
     getItem: jest.fn(),
     setItem: jest.fn()
 }));
-jest.mock('../stores/Stores', () => ({
+jest.mock('react-native-randombytes', () => ({
+    randomBytes: jest.fn()
+}));
+jest.mock('react-native-notifications', () => ({
+    Notifications: {
+        registerRemoteNotifications: jest.fn(),
+        events: jest.fn(() => ({
+            registerRemoteNotificationsRegistered: jest.fn(),
+            registerRemoteNotificationsRegistrationFailed: jest.fn(),
+            registerNotificationReceived: jest.fn(),
+            registerNotificationOpened: jest.fn()
+        }))
+    }
+}));
+jest.mock('react-native-ping', () => ({
+    default: {
+        start: jest.fn(),
+        stop: jest.fn(),
+        getPingStats: jest.fn()
+    }
+}));
+jest.mock('react-native-device-info', () => ({
+    default: {
+        getVersion: jest.fn(),
+        getBuildNumber: jest.fn(),
+        getModel: jest.fn(),
+        getSystemVersion: jest.fn(),
+        getUniqueId: jest.fn()
+    }
+}));
+jest.mock('react-native-securerandom', () => ({
+    generateSecureRandom: jest.fn()
+}));
+jest.mock('react-native', () => ({
+    NativeModules: {
+        LndMobile: {
+            addListener: jest.fn(),
+            removeListeners: jest.fn()
+        }
+    },
+    Platform: {
+        OS: 'android'
+    },
+    NativeEventEmitter: jest.fn(),
+    DeviceEventEmitter: {
+        addListener: jest.fn()
+    }
+}));
+jest.mock('../storage', () => ({
+    getItem: jest.fn(),
+    setItem: jest.fn()
+}));
+
+jest.mock('../stores/storeInstances', () => ({
     settingsStore: {
-        setSettings: jest.fn()
+        setSettings: jest.fn(),
+        settings: {},
+        migrationPromise: Promise.resolve(),
+        currentNodeUuid: 'uuid1'
+    },
+    lightningAddressStore: {
+        checkLightningAddressExists: jest.fn()
+    },
+    nodeInfoStore: {
+        nodeInfo: {
+            identity_pubkey: 'pubkey123'
+        }
     }
 }));
 jest.mock('../stores/ChannelBackupStore', () => ({}));
-jest.mock('../stores/LightningAddressStore', () => ({}));
 jest.mock('../stores/LSPStore', () => ({}));
-jest.mock('../utils/BackendUtils', () => ({}));
+jest.mock('../stores/SettingsStore', () => {
+    class MockSettingsStore {
+        setSettings = jest.fn();
+        settings = {};
+        migrationPromise = Promise.resolve();
+    }
 
-jest.mock('../stores/SettingsStore', () => ({
-    DEFAULT_FIAT_RATES_SOURCE: 'Zeus',
-    DEFAULT_FIAT: 'USD',
-    DEFAULT_LSP_MAINNET: 'https://0conf.lnolymp.us',
-    DEFAULT_LSP_TESTNET: 'https://testnet-0conf.lnolymp.us',
-    DEFAULT_NOSTR_RELAYS: [
-        'wss://relay.damus.io',
-        'wss://nostr.land',
-        'wss://nostr.wine',
-        'wss://nos.lol',
-        'wss://relay.snort.social'
-    ],
-    DEFAULT_NEUTRINO_PEERS_MAINNET: [
-        'btcd1.lnolymp.us',
-        'btcd2.lnolymp.us',
-        'btcd-mainnet.lightning.computer',
-        'node.eldamar.icu',
-        'noad.sathoarder.com'
-    ],
-    DEFAULT_NEUTRINO_PEERS_TESTNET: [
-        'testnet.lnolymp.us',
-        'btcd-testnet.lightning.computer',
-        'testnet.blixtwallet.com'
-    ],
-    DEFAULT_LSPS1_HOST_MAINNET: '45.79.192.236:9735',
-    DEFAULT_LSPS1_HOST_TESTNET: '139.144.22.237:9735',
-    DEFAULT_LSPS1_PUBKEY_MAINNET:
-        '031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581',
-    DEFAULT_LSPS1_PUBKEY_TESTNET:
-        '03e84a109cd70e57864274932fc87c5e6434c59ebb8e6e7d28532219ba38f7f6df',
-    DEFAULT_LSPS1_REST_MAINNET: 'https://lsps1.lnolymp.us',
-    DEFAULT_LSPS1_REST_TESTNET: 'https://testnet-lsps1.lnolymp.us',
-    DEFAULT_SPEEDLOADER: 'https://egs.lnze.us/',
-    DEFAULT_NOSTR_RELAYS_2023: [
-        'wss://nostr.mutinywallet.com',
-        'wss://relay.damus.io',
-        'wss://nostr.lnproxy.org'
-    ],
-    DEFAULT_SLIDE_TO_PAY_THRESHOLD: 10000,
-    STORAGE_KEY: 'zeus-settings-v2',
-    LEGACY_CURRENCY_CODES_KEY: 'currency-codes',
-    CURRENCY_CODES_KEY: 'zeus-currency-codes',
-    PosEnabled: {
-        Disabled: 'disabled',
-        Square: 'square',
-        Standalone: 'standalone'
+    return {
+        DEFAULT_FIAT_RATES_SOURCE: 'Zeus',
+        DEFAULT_FIAT: 'USD',
+        DEFAULT_LSP_MAINNET: 'https://0conf.lnolymp.us',
+        DEFAULT_LSP_TESTNET: 'https://testnet-0conf.lnolymp.us',
+        DEFAULT_NOSTR_RELAYS: [
+            'wss://relay.damus.io',
+            'wss://nostr.land',
+            'wss://nostr.wine',
+            'wss://nos.lol',
+            'wss://relay.snort.social'
+        ],
+        DEFAULT_NEUTRINO_PEERS_MAINNET: [
+            'btcd1.lnolymp.us',
+            'btcd2.lnolymp.us',
+            'btcd-mainnet.lightning.computer',
+            'node.eldamar.icu',
+            'noad.sathoarder.com'
+        ],
+        DEFAULT_NEUTRINO_PEERS_TESTNET: [
+            'testnet.lnolymp.us',
+            'btcd-testnet.lightning.computer',
+            'testnet.blixtwallet.com'
+        ],
+        DEFAULT_LSPS1_HOST_MAINNET: '45.79.192.236:9735',
+        DEFAULT_LSPS1_HOST_TESTNET: '139.144.22.237:9735',
+        DEFAULT_LSPS1_PUBKEY_MAINNET:
+            '031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581',
+        DEFAULT_LSPS1_PUBKEY_TESTNET:
+            '03e84a109cd70e57864274932fc87c5e6434c59ebb8e6e7d28532219ba38f7f6df',
+        DEFAULT_LSPS1_REST_MAINNET: 'https://lsps1.lnolymp.us',
+        DEFAULT_LSPS1_REST_TESTNET: 'https://testnet-lsps1.lnolymp.us',
+        DEFAULT_SPEEDLOADER: 'https://egs.lnze.us/',
+        DEFAULT_NOSTR_RELAYS_2023: [
+            'wss://nostr.mutinywallet.com',
+            'wss://relay.damus.io',
+            'wss://nostr.lnproxy.org'
+        ],
+        DEFAULT_SLIDE_TO_PAY_THRESHOLD: 10000,
+        STORAGE_KEY: 'zeus-settings-v2',
+        LEGACY_CURRENCY_CODES_KEY: 'currency-codes',
+        CURRENCY_CODES_KEY: 'zeus-currency-codes',
+        PosEnabled: {
+            Disabled: 'disabled',
+            Square: 'square',
+            Standalone: 'standalone'
+        },
+        default: MockSettingsStore
+    };
+});
+jest.mock('../stores/Stores', () => ({
+    default: {
+        settingsStore: new (jest.fn(() => ({
+            setSettings: jest.fn(),
+            settings: {},
+            migrationPromise: Promise.resolve()
+        })))(),
+        modalStore: {},
+        offersStore: {},
+        fiatStore: {}
     }
 }));
 
-import MigrationUtils from './MigrationUtils';
+jest.mock('../utils/BackendUtils', () => ({}));
+
+import migrationUtils from './MigrationUtils';
+import Storage from '../storage';
+import { Settings } from '../stores/SettingsStore';
+import {
+    settingsStore,
+    lightningAddressStore,
+    nodeInfoStore
+} from '../stores/storeInstances';
 
 describe('MigrationUtils', () => {
     const defaultSettings = {
@@ -122,17 +213,17 @@ describe('MigrationUtils', () => {
         speedloader: 'https://egs.lnze.us/'
     };
 
-    describe('MigrationUtils', () => {
+    describe('MigrationUtils Legacy Settings', () => {
         it('handles empty settings', async () => {
             await expect(
-                MigrationUtils.legacySettingsMigrations('{}')
+                migrationUtils.legacySettingsMigrations('{}')
             ).resolves.toEqual({
                 ...defaultSettings
             });
         });
         it('handles mod1', async () => {
             await expect(
-                MigrationUtils.legacySettingsMigrations(
+                migrationUtils.legacySettingsMigrations(
                     JSON.stringify({
                         requestSimpleTaproot: false,
                         fiatRatesSource: 'Yadio'
@@ -145,7 +236,7 @@ describe('MigrationUtils', () => {
         });
         it('handles mod2', async () => {
             await expect(
-                MigrationUtils.legacySettingsMigrations(
+                migrationUtils.legacySettingsMigrations(
                     JSON.stringify({
                         lspMainnet: 'https://lsp-preview.lnolymp.us',
                         lspTestnet: 'https://testnet-lsp.lnolymp.us'
@@ -157,7 +248,7 @@ describe('MigrationUtils', () => {
         });
         it('handles mod3', async () => {
             await expect(
-                MigrationUtils.legacySettingsMigrations(
+                migrationUtils.legacySettingsMigrations(
                     JSON.stringify({
                         neutrinoPeersMainnet: [
                             'btcd1.lnolymp.us',
@@ -174,7 +265,7 @@ describe('MigrationUtils', () => {
         });
         it('handles mod7', async () => {
             await expect(
-                MigrationUtils.legacySettingsMigrations(
+                migrationUtils.legacySettingsMigrations(
                     JSON.stringify({
                         bimodalPathfinding: true
                     })
@@ -186,7 +277,7 @@ describe('MigrationUtils', () => {
         });
         it('handles mod8', async () => {
             await expect(
-                MigrationUtils.legacySettingsMigrations(
+                migrationUtils.legacySettingsMigrations(
                     JSON.stringify({
                         lightningAddress: {
                             nostrRelays: [
@@ -211,7 +302,7 @@ describe('MigrationUtils', () => {
         });
         it('migrates old POS squareEnabled setting to posEnabled', async () => {
             await expect(
-                MigrationUtils.legacySettingsMigrations(
+                migrationUtils.legacySettingsMigrations(
                     JSON.stringify({
                         pos: {
                             squareEnabled: true
@@ -225,6 +316,170 @@ describe('MigrationUtils', () => {
                     squareEnabled: false
                 }
             });
+        });
+    });
+
+    describe('migrateLightningAddressSettings', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+            Storage.getItem = jest.fn();
+            Storage.setItem = jest.fn();
+            settingsStore.setSettings = jest.fn();
+            lightningAddressStore.checkLightningAddressExists = jest.fn();
+        });
+
+        it('creates global settings at first run and puts only those node UUIDs on todo list that need migration', async () => {
+            settingsStore.settings = {
+                nodes: [
+                    { implementation: 'embedded-lnd', uuid: 'uuid1' },
+                    { implementation: 'lnd', uuid: 'uuid2' },
+                    { implementation: 'lndhub', uuid: 'uuid3' }
+                ],
+                lightningAddress: {
+                    automaticallyAccept: true,
+                    automaticallyAcceptAttestationLevel: 2,
+                    routeHints: false,
+                    allowComments: true,
+                    nostrRelays: ['relay1', 'relay2'],
+                    notifications: 0,
+                    nostrPrivateKey: 'test-key'
+                }
+            } as Settings;
+
+            // simulate first run
+            (Storage.getItem as jest.Mock).mockResolvedValue(null);
+
+            const result =
+                await migrationUtils.migrateLightningAddressSettings();
+
+            expect(result).toBe(true);
+            expect(Storage.setItem).toHaveBeenCalledWith(
+                'lightning-address-settings-split-2025',
+                ['uuid1', 'uuid2']
+            );
+            expect(settingsStore.setSettings).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    lightningAddressGlobal: {
+                        automaticallyAccept: true,
+                        automaticallyAcceptAttestationLevel: 2,
+                        routeHints: false,
+                        allowComments: true,
+                        nostrRelays: ['relay1', 'relay2'],
+                        notifications: 0
+                    }
+                })
+            );
+        });
+
+        it('creates global settings at first run and deletes legacy settings when there are only nodes that do not need migration', async () => {
+            settingsStore.settings = {
+                nodes: [
+                    { implementation: 'lndhub', uuid: 'uuid1' },
+                    { implementation: 'cln-rest', uuid: 'uuid2' }
+                ],
+                lightningAddress: {
+                    automaticallyAccept: true
+                }
+            } as Settings;
+
+            // simulate first run
+            (Storage.getItem as jest.Mock).mockResolvedValue(null);
+
+            const result =
+                await migrationUtils.migrateLightningAddressSettings();
+
+            expect(result).toBe(true);
+            expect(settingsStore.setSettings).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    lightningAddressGlobal: {
+                        automaticallyAccept: true,
+                        automaticallyAcceptAttestationLevel: undefined,
+                        routeHints: undefined,
+                        allowComments: undefined,
+                        nostrRelays: undefined,
+                        notifications: undefined
+                    }
+                })
+            );
+            expect(settingsStore.setSettings).toHaveBeenCalledWith(
+                expect.not.objectContaining({
+                    lightningAddress: expect.anything()
+                })
+            );
+        });
+
+        it('creates global settings at first run and returns true when checkLightningAddressExists()', async () => {
+            settingsStore.currentNodeUuid = 'uuid1';
+
+            // simulate first run
+            (Storage.getItem as jest.Mock).mockResolvedValue(null);
+            (
+                lightningAddressStore.checkLightningAddressExists as jest.Mock
+            ).mockRejectedValue(new Error('error'));
+
+            const result =
+                await migrationUtils.migrateLightningAddressSettings();
+
+            expect(settingsStore.setSettings).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    lightningAddressGlobal: expect.any(Object)
+                })
+            );
+            expect(result).toBe(true);
+        });
+
+        it('creates lightningAddressByPubkey settings for current node, removes node from migration todo list and deletes legacy settings when it was the last node to migrate', async () => {
+            settingsStore.settings = {
+                lightningAddress: {
+                    nostrPrivateKey: 'privateKey123'
+                }
+            } as Settings;
+            settingsStore.currentNodeUuid = 'uuid1';
+            nodeInfoStore.nodeInfo = { identity_pubkey: 'pubkey123' };
+
+            (Storage.getItem as jest.Mock).mockResolvedValue(
+                JSON.stringify(['uuid1'])
+            );
+
+            (
+                lightningAddressStore.checkLightningAddressExists as jest.Mock
+            ).mockResolvedValue(true);
+
+            const result =
+                await migrationUtils.migrateLightningAddressSettings();
+
+            expect(result).toBe(true);
+            expect(settingsStore.setSettings).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    lightningAddressByPubkey: {
+                        pubkey123: {
+                            enabled: true,
+                            nostrPrivateKey: 'privateKey123'
+                        }
+                    }
+                })
+            );
+            expect(Storage.setItem).toHaveBeenCalledWith(
+                'lightning-address-settings-split-2025',
+                []
+            );
+            expect(settingsStore.setSettings).toHaveBeenCalledWith(
+                expect.not.objectContaining({
+                    lightningAddress: expect.anything()
+                })
+            );
+        });
+
+        it('skips migration when all nodes are migrated', async () => {
+            (Storage.getItem as jest.Mock).mockResolvedValue(
+                JSON.stringify([])
+            );
+
+            const result =
+                await migrationUtils.migrateLightningAddressSettings();
+
+            expect(result).toBe(false);
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
         });
     });
 });

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -1,4 +1,8 @@
-import stores from '../stores/Stores';
+import {
+    settingsStore,
+    nodeInfoStore,
+    lightningAddressStore
+} from '../stores/storeInstances';
 import {
     Settings,
     DEFAULT_FIAT_RATES_SOURCE,
@@ -33,9 +37,7 @@ import {
     LAST_CHANNEL_BACKUP_TIME
 } from '../stores/ChannelBackupStore';
 import {
-    LEGACY_ADDRESS_ACTIVATED_STRING,
     LEGACY_HASHES_STORAGE_STRING,
-    ADDRESS_ACTIVATED_STRING,
     HASHES_STORAGE_STRING
 } from '../stores/LightningAddressStore';
 import {
@@ -70,6 +72,7 @@ export const IS_BACKED_UP_KEY = 'backup-complete-v2';
 
 import EncryptedStorage from 'react-native-encrypted-storage';
 import Storage from '../storage';
+import { v4 as uuidv4 } from 'uuid';
 
 class MigrationsUtils {
     public async legacySettingsMigrations(settings: string) {
@@ -124,7 +127,7 @@ class MigrationsUtils {
         const mod = await EncryptedStorage.getItem(MOD_KEY);
         if (!mod) {
             newSettings.requestSimpleTaproot = true;
-            stores.settingsStore.setSettings(JSON.stringify(newSettings));
+            settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY, 'true');
         }
 
@@ -137,7 +140,7 @@ class MigrationsUtils {
             if (newSettings?.lspTestnet === 'https://testnet-lsp.lnolymp.us') {
                 newSettings.lspTestnet = DEFAULT_LSP_TESTNET;
             }
-            stores.settingsStore.setSettings(JSON.stringify(newSettings));
+            settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY2, 'true');
         }
 
@@ -158,7 +161,7 @@ class MigrationsUtils {
                 newSettings.neutrinoPeersMainnet =
                     DEFAULT_NEUTRINO_PEERS_MAINNET;
             }
-            stores.settingsStore.setSettings(JSON.stringify(newSettings));
+            settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY3, 'true');
         }
 
@@ -192,7 +195,7 @@ class MigrationsUtils {
                 newSettings.lsps1ShowPurchaseButton = true;
             }
 
-            stores.settingsStore.setSettings(JSON.stringify(newSettings));
+            settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY4, 'true');
         }
 
@@ -209,7 +212,7 @@ class MigrationsUtils {
                 }
             }
 
-            stores.settingsStore.setSettings(JSON.stringify(newSettings));
+            settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY5, 'true');
         }
 
@@ -221,7 +224,7 @@ class MigrationsUtils {
                 newSettings.customSpeedloader = '';
             }
 
-            stores.settingsStore.setSettings(JSON.stringify(newSettings));
+            settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY6, 'true');
         }
 
@@ -234,7 +237,7 @@ class MigrationsUtils {
                 newSettings.bimodalPathfinding = false;
             }
 
-            stores.settingsStore.setSettings(JSON.stringify(newSettings));
+            settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY7, 'true');
         }
 
@@ -248,8 +251,27 @@ class MigrationsUtils {
                 newSettings.lightningAddress.nostrRelays = DEFAULT_NOSTR_RELAYS;
             }
 
-            stores.settingsStore.setSettings(JSON.stringify(newSettings));
+            settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY8, 'true');
+        }
+
+        const MOD_KEY9 = 'add-node-uuids';
+        const mod9 = await EncryptedStorage.getItem(MOD_KEY9);
+        if (!mod9 && newSettings.nodes) {
+            console.log('Starting UUID addition for nodes');
+            newSettings.nodes = newSettings.nodes.map((node: any) => {
+                if (!node.uuid) {
+                    return {
+                        ...node,
+                        uuid: uuidv4()
+                    };
+                }
+                return node;
+            });
+
+            settingsStore.setSettings(JSON.stringify(newSettings));
+            await EncryptedStorage.setItem(MOD_KEY9, 'true');
+            console.log('UUID addition completed');
         }
 
         // migrate old POS squareEnabled setting to posEnabled
@@ -365,42 +387,21 @@ class MigrationsUtils {
         // Lightning address migration
         const lightningAddressMigration = (async () => {
             try {
-                let activatedSuccess: any = true;
-                let hashesSuccess: any = true;
-
-                const activated = await EncryptedStorage.getItem(
-                    LEGACY_ADDRESS_ACTIVATED_STRING
-                );
-                if (activated) {
-                    console.log(
-                        'Attemping lightning address activated migration'
-                    );
-                    activatedSuccess = await Storage.setItem(
-                        ADDRESS_ACTIVATED_STRING,
-                        activated
-                    );
-                    console.log(
-                        'Lightning address activated migration status',
-                        activatedSuccess
-                    );
-                }
-
                 const hashes = await EncryptedStorage.getItem(
                     LEGACY_HASHES_STORAGE_STRING
                 );
                 if (hashes) {
                     console.log('Attemping lightning address hashes migration');
-                    hashesSuccess = await Storage.setItem(
+                    const writeSuccess = await Storage.setItem(
                         HASHES_STORAGE_STRING,
                         hashes
                     );
                     console.log(
                         'Lightning address hashes migration status',
-                        hashesSuccess
+                        writeSuccess
                     );
+                    return writeSuccess;
                 }
-
-                return activatedSuccess && hashesSuccess;
             } catch (error) {
                 console.error(
                     'Error loading lightning address data from encrypted storage',
@@ -763,6 +764,141 @@ class MigrationsUtils {
         console.log('storageMigrationV2 completed!', results);
         return results.every((result) => result === true);
     }
+
+    public migrateLightningAddressSettings = async (): Promise<boolean> => {
+        console.log('migrateLightningAddressSettings() started');
+        // We need to wait until other migrations are done
+        await settingsStore.migrationPromise;
+
+        const newSettings = JSON.parse(
+            JSON.stringify(settingsStore.settings)
+        ) as Settings;
+
+        let globalSettingsChanged = false;
+
+        const MOD_KEY10 = 'lightning-address-settings-split-2025';
+        const mod10String = await Storage.getItem(MOD_KEY10);
+        let mod10Array = mod10String ? JSON.parse(mod10String) : [];
+
+        if (!mod10String) {
+            // At first run we need to
+            // - add UUIDs from all nodes but lndhub and cln-rest to MOD_KEY10
+            //  - set up global settings from legacy settings
+            const nodesToMigrate = newSettings.nodes
+                ?.filter(
+                    (node: any) =>
+                        node.implementation === 'embedded-lnd' ||
+                        node.implementation === 'lnd' ||
+                        node.implementation === 'lightning-node-connect'
+                )
+                .map((node: any) => node.uuid);
+
+            await Storage.setItem(MOD_KEY10, nodesToMigrate);
+            mod10Array = nodesToMigrate;
+
+            // --- Set up global settings from legacy settings
+            if (newSettings.lightningAddress) {
+                newSettings.lightningAddressGlobal = {
+                    automaticallyAccept:
+                        newSettings.lightningAddress.automaticallyAccept,
+                    automaticallyAcceptAttestationLevel:
+                        newSettings.lightningAddress
+                            .automaticallyAcceptAttestationLevel,
+                    routeHints: newSettings.lightningAddress.routeHints,
+                    allowComments: newSettings.lightningAddress.allowComments,
+                    nostrRelays: newSettings.lightningAddress.nostrRelays,
+                    notifications: newSettings.lightningAddress.notifications
+                };
+                globalSettingsChanged = true;
+                console.log(
+                    'Global settings created:',
+                    newSettings.lightningAddressGlobal
+                );
+
+                if (!nodesToMigrate?.length) {
+                    delete newSettings.lightningAddress;
+                    await settingsStore.setSettings(newSettings);
+                    console.log(
+                        'No nodes to migrate, legacy settings deleted. Migration completed.'
+                    );
+                    return true;
+                }
+            }
+        } else if ((mod10Array as string[]).length === 0) {
+            console.log(
+                'Lightning Address migration skipped - all nodes migrated'
+            );
+            return false;
+        }
+
+        const currentNodeUuid = settingsStore.currentNodeUuid;
+        console.log('Current node uuid:', currentNodeUuid);
+
+        // Run migration if this node's UUID is still in mod10Array
+        if (
+            newSettings.lightningAddress &&
+            mod10Array.includes(currentNodeUuid)
+        ) {
+            // --- Set up node-specific settings ---
+            // First we check if Lightning Address exists for this node, so we can
+            // - set correct flag "enabled" per pubkey
+            // - use existing nostr priv key
+            const currentPubkey = nodeInfoStore.nodeInfo.identity_pubkey;
+            console.log(
+                'Starting Lightning Address migration for pubkey:',
+                currentPubkey
+            );
+
+            try {
+                const hasLightningAddress =
+                    await lightningAddressStore.checkLightningAddressExists();
+                newSettings.lightningAddressByPubkey = {
+                    ...newSettings.lightningAddressByPubkey,
+                    [currentPubkey]: {
+                        enabled: hasLightningAddress === true,
+                        nostrPrivateKey:
+                            hasLightningAddress === true
+                                ? newSettings.lightningAddress.nostrPrivateKey
+                                : ''
+                    }
+                };
+                console.log(
+                    'Node-specific settings created:',
+                    newSettings.lightningAddressByPubkey[currentPubkey]
+                );
+
+                const remainingUuids = mod10Array.filter(
+                    (uuid: string) => uuid !== currentNodeUuid
+                );
+                if (remainingUuids.length === 0) {
+                    delete newSettings.lightningAddress;
+                    console.log('All nodes migrated, legacy settings deleted');
+                }
+                await Storage.setItem(MOD_KEY10, remainingUuids);
+
+                await settingsStore.setSettings(newSettings);
+                console.log(
+                    'Migration completed and marked as done for pubkey:',
+                    currentPubkey
+                );
+                return true;
+            } catch (error) {
+                // If checkLightningAddressExists() throws error, but ln address global settings
+                // were changed, we still need to call getSettings() in Wallet.tsx
+                console.log('Migration error details:', {
+                    error,
+                    errorMessage: (error as Error).message,
+                    errorStack: (error as Error).stack
+                });
+                return globalSettingsChanged;
+            }
+        } else {
+            console.log(
+                'Migration skipped because because UUID is not in mod10Array or no legacy settings exist'
+            );
+        }
+        return false;
+    };
 }
 
 const migrationsUtils = new MigrationsUtils();

--- a/views/Activity/ActivityFilter.tsx
+++ b/views/Activity/ActivityFilter.tsx
@@ -12,6 +12,7 @@ import { themeColor } from '../../utils/ThemeUtils';
 
 import ActivityStore, { DEFAULT_FILTERS } from '../../stores/ActivityStore';
 import SettingsStore from '../../stores/SettingsStore';
+import NodeInfoStore from '../../stores/NodeInfoStore';
 
 import Header from '../../components/Header';
 import Screen from '../../components/Screen';
@@ -22,6 +23,7 @@ interface ActivityFilterProps {
     navigation: StackNavigationProp<any, any>;
     ActivityStore: ActivityStore;
     SettingsStore: SettingsStore;
+    NodeInfoStore: NodeInfoStore;
 }
 
 interface ActivityFilterState {
@@ -31,7 +33,7 @@ interface ActivityFilterState {
     workingEndDate: any;
 }
 
-@inject('ActivityStore', 'SettingsStore')
+@inject('ActivityStore', 'SettingsStore', 'NodeInfoStore')
 @observer
 export default class ActivityFilter extends React.Component<
     ActivityFilterProps,
@@ -229,7 +231,10 @@ export default class ActivityFilter extends React.Component<
                 value: zeusPay,
                 var: 'zeusPay',
                 type: 'Toggle',
-                condition: SettingsStore.settings.lightningAddress.enabled
+                condition:
+                    SettingsStore.settings.lightningAddressByPubkey[
+                        this.props.NodeInfoStore.nodeInfo.identity_pubkey
+                    ]?.enabled
             },
             {
                 label: localeString('general.unconfirmed'),

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -230,7 +230,12 @@ export default class Receive extends React.Component<
 
         const settings = await getSettings();
 
-        if (settings?.lightningAddress?.enabled && !lightningAddressHandle) {
+        if (
+            settings?.lightningAddressByPubkey[
+                NodeInfoStore.nodeInfo.identity_pubkey
+            ]?.enabled &&
+            !lightningAddressHandle
+        ) {
             status();
         }
 

--- a/views/Settings/LightningAddress/LightningAddressSettings.tsx
+++ b/views/Settings/LightningAddress/LightningAddressSettings.tsx
@@ -17,6 +17,7 @@ import SettingsStore, {
     AUTOMATIC_ATTESTATION_KEYS
 } from '../../../stores/SettingsStore';
 import LightningAddressStore from '../../../stores/LightningAddressStore';
+import NodeInfoStore from '../../../stores/NodeInfoStore';
 
 import { localeString } from '../../../utils/LocaleUtils';
 import { themeColor } from '../../../utils/ThemeUtils';
@@ -25,6 +26,7 @@ interface LightningAddressSettingsProps {
     navigation: StackNavigationProp<any, any>;
     SettingsStore: SettingsStore;
     LightningAddressStore: LightningAddressStore;
+    NodeInfoStore: NodeInfoStore;
 }
 
 interface LightningAddressSettingsState {
@@ -37,7 +39,7 @@ interface LightningAddressSettingsState {
     notifications: number;
 }
 
-@inject('SettingsStore', 'LightningAddressStore')
+@inject('SettingsStore', 'LightningAddressStore', 'NodeInfoStore')
 @observer
 export default class LightningAddressSettings extends React.Component<
     LightningAddressSettingsProps,
@@ -54,27 +56,24 @@ export default class LightningAddressSettings extends React.Component<
     };
 
     async UNSAFE_componentWillMount() {
-        const { SettingsStore } = this.props;
-        const { settings } = SettingsStore;
+        const { SettingsStore, NodeInfoStore } = this.props;
+        const lightningAddressGlobal =
+            SettingsStore.settings.lightningAddressGlobal;
 
         this.setState({
-            automaticallyAccept: settings.lightningAddress?.automaticallyAccept
-                ? true
-                : false,
-            automaticallyAcceptAttestationLevel: settings.lightningAddress
-                ?.automaticallyAcceptAttestationLevel
-                ? settings.lightningAddress.automaticallyAcceptAttestationLevel
-                : 2,
-            routeHints: settings.lightningAddress?.routeHints ? true : false,
-            allowComments: settings.lightningAddress?.allowComments
-                ? true
-                : false,
-            nostrPrivateKey: settings.lightningAddress?.nostrPrivateKey || '',
-            nostrRelays: settings.lightningAddress?.nostrRelays || [],
-            notifications:
-                settings.lightningAddress?.notifications !== undefined
-                    ? settings.lightningAddress.notifications
-                    : 1
+            // Global settings
+            automaticallyAccept: lightningAddressGlobal.automaticallyAccept,
+            automaticallyAcceptAttestationLevel:
+                lightningAddressGlobal.automaticallyAcceptAttestationLevel,
+            routeHints: lightningAddressGlobal.routeHints,
+            allowComments: lightningAddressGlobal.allowComments,
+            nostrRelays: lightningAddressGlobal.nostrRelays,
+            notifications: lightningAddressGlobal.notifications,
+            // Node-specific settings
+            nostrPrivateKey:
+                SettingsStore.settings.lightningAddressByPubkey?.[
+                    NodeInfoStore.nodeInfo.identity_pubkey
+                ].nostrPrivateKey ?? ''
         });
     }
 
@@ -148,8 +147,8 @@ export default class LightningAddressSettings extends React.Component<
                                                 !automaticallyAccept
                                         });
                                         await updateSettings({
-                                            lightningAddress: {
-                                                ...settings.lightningAddress,
+                                            lightningAddressGlobal: {
+                                                ...settings.lightningAddressGlobal,
                                                 automaticallyAccept:
                                                     !automaticallyAccept
                                             }
@@ -172,8 +171,8 @@ export default class LightningAddressSettings extends React.Component<
                                             value
                                     });
                                     await updateSettings({
-                                        lightningAddress: {
-                                            ...settings.lightningAddress,
+                                        lightningAddressGlobal: {
+                                            ...settings.lightningAddressGlobal,
                                             automaticallyAcceptAttestationLevel:
                                                 value
                                         }
@@ -218,8 +217,8 @@ export default class LightningAddressSettings extends React.Component<
                                             routeHints: !routeHints
                                         });
                                         await updateSettings({
-                                            lightningAddress: {
-                                                ...settings.lightningAddress,
+                                            lightningAddressGlobal: {
+                                                ...settings.lightningAddressGlobal,
                                                 routeHints: !routeHints
                                             }
                                         });
@@ -261,8 +260,8 @@ export default class LightningAddressSettings extends React.Component<
                                                         !allowComments
                                                 });
                                                 await updateSettings({
-                                                    lightningAddress: {
-                                                        ...settings.lightningAddress,
+                                                    lightningAddressGlobal: {
+                                                        ...settings.lightningAddressGlobal,
                                                         allowComments:
                                                             !allowComments
                                                     }
@@ -288,8 +287,8 @@ export default class LightningAddressSettings extends React.Component<
                                                 notifications: value
                                             });
                                             await updateSettings({
-                                                lightningAddress: {
-                                                    ...settings.lightningAddress,
+                                                lightningAddressGlobal: {
+                                                    ...settings.lightningAddressGlobal,
                                                     notifications: value
                                                 }
                                             });

--- a/views/Settings/LightningAddress/NostrKeys.tsx
+++ b/views/Settings/LightningAddress/NostrKeys.tsx
@@ -357,10 +357,14 @@ export default class NostrKey extends React.Component<
                                                     { nostrPrivateKey }
                                                 );
                                             } else {
-                                                const relays =
+                                                const pubkeySpecificLNAddressSettings =
                                                     settings
-                                                        .lightningAddressGlobal
-                                                        .nostrRelays;
+                                                        .lightningAddressByPubkey[
+                                                        NodeInfoStore.nodeInfo
+                                                            .identity_pubkey
+                                                    ];
+                                                const relays =
+                                                    pubkeySpecificLNAddressSettings.nostrRelays;
                                                 const relays_sig = bytesToHex(
                                                     schnorr.sign(
                                                         hashjs

--- a/views/Settings/LightningAddress/NostrKeys.tsx
+++ b/views/Settings/LightningAddress/NostrKeys.tsx
@@ -23,6 +23,7 @@ import {
 import { Row } from '../../../components/layout/Row';
 
 import SettingsStore from '../../../stores/SettingsStore';
+import NodeInfoStore from '../../../stores/NodeInfoStore';
 import LightningAddressStore from '../../../stores/LightningAddressStore';
 
 import { localeString } from '../../../utils/LocaleUtils';
@@ -36,6 +37,7 @@ import Edit from '../../../assets/images/SVG/Pen.svg';
 interface NostrKeyProps {
     navigation: StackNavigationProp<any, any>;
     SettingsStore: SettingsStore;
+    NodeInfoStore: NodeInfoStore;
     LightningAddressStore: LightningAddressStore;
     route: Route<'NostrKey', { setup: boolean; nostrPrivateKey: string }>;
 }
@@ -51,7 +53,7 @@ interface NostrKeyState {
     revealSensitive: boolean;
 }
 
-@inject('SettingsStore', 'LightningAddressStore')
+@inject('SettingsStore', 'NodeInfoStore', 'LightningAddressStore')
 @observer
 export default class NostrKey extends React.Component<
     NostrKeyProps,
@@ -89,7 +91,10 @@ export default class NostrKey extends React.Component<
         const setup = route.params?.setup;
         const nostrPrivateKey =
             route.params?.nostrPrivateKey ??
-            (settings?.lightningAddress?.nostrPrivateKey || '');
+            (settings?.lightningAddressByPubkey[
+                this.props.NodeInfoStore.nodeInfo.identity_pubkey
+            ]?.nostrPrivateKey ||
+                '');
 
         let nostrPublicKey, nostrNsec, nostrNpub;
         if (nostrPrivateKey) {
@@ -111,7 +116,12 @@ export default class NostrKey extends React.Component<
     }
 
     render() {
-        const { navigation, LightningAddressStore, SettingsStore } = this.props;
+        const {
+            navigation,
+            LightningAddressStore,
+            SettingsStore,
+            NodeInfoStore
+        } = this.props;
         const {
             existingNostrPrivateKey,
             nostrPrivateKey,
@@ -348,7 +358,8 @@ export default class NostrKey extends React.Component<
                                                 );
                                             } else {
                                                 const relays =
-                                                    settings.lightningAddress
+                                                    settings
+                                                        .lightningAddressGlobal
                                                         .nostrRelays;
                                                 const relays_sig = bytesToHex(
                                                     schnorr.sign(
@@ -376,10 +387,15 @@ export default class NostrKey extends React.Component<
                                                             editMode: false
                                                         });
                                                         await updateSettings({
-                                                            lightningAddress: {
-                                                                ...settings.lightningAddress,
-                                                                nostrPrivateKey
-                                                            }
+                                                            lightningAddressByPubkey:
+                                                                {
+                                                                    [NodeInfoStore
+                                                                        .nodeInfo
+                                                                        .identity_pubkey]:
+                                                                        {
+                                                                            nostrPrivateKey
+                                                                        }
+                                                                }
                                                         });
                                                     });
                                                 } catch (e) {}

--- a/views/Settings/LightningAddress/NostrRelays.tsx
+++ b/views/Settings/LightningAddress/NostrRelays.tsx
@@ -68,7 +68,7 @@ export default class NostrRelays extends React.Component<
             setup,
             relays: relays
                 ? relays
-                : settings.lightningAddress.nostrRelays || []
+                : settings.lightningAddressGlobal.nostrRelays || []
         });
     }
 
@@ -201,11 +201,11 @@ export default class NostrRelays extends React.Component<
                                                             addRelay: ''
                                                         });
                                                         await updateSettings({
-                                                            lightningAddress: {
-                                                                ...settings.lightningAddress,
-                                                                nostrRelays:
-                                                                    newNostrRelays
-                                                            }
+                                                            lightningAddressGlobal:
+                                                                {
+                                                                    nostrRelays:
+                                                                        newNostrRelays
+                                                                }
                                                         });
                                                     });
                                                 } catch (e) {}
@@ -286,10 +286,10 @@ export default class NostrRelays extends React.Component<
                                                                         );
                                                                         await updateSettings(
                                                                             {
-                                                                                lightningAddress:
+                                                                                lightningAddressGlobal:
                                                                                     {
-                                                                                        ...settings.lightningAddress,
-                                                                                        relays: newNostrRelays
+                                                                                        nostrRelays:
+                                                                                            newNostrRelays
                                                                                     }
                                                                             }
                                                                         );

--- a/views/Settings/LightningAddress/NostrRelays.tsx
+++ b/views/Settings/LightningAddress/NostrRelays.tsx
@@ -19,6 +19,7 @@ import TextInput from '../../../components/TextInput';
 
 import SettingsStore from '../../../stores/SettingsStore';
 import LightningAddressStore from '../../../stores/LightningAddressStore';
+import NodeInfoStore from '../../../stores/NodeInfoStore';
 
 import { localeString } from '../../../utils/LocaleUtils';
 import { themeColor } from '../../../utils/ThemeUtils';
@@ -29,6 +30,7 @@ interface NostrRelaysProps {
     navigation: StackNavigationProp<any, any>;
     SettingsStore: SettingsStore;
     LightningAddressStore: LightningAddressStore;
+    NodeInfoStore: NodeInfoStore;
     route: Route<'NostrRelays', { setup: boolean; relays: string[] }>;
 }
 
@@ -38,7 +40,7 @@ interface NostrRelaysState {
     addRelay: string;
 }
 
-@inject('SettingsStore', 'LightningAddressStore')
+@inject('SettingsStore', 'LightningAddressStore', 'NodeInfoStore')
 @observer
 export default class NostrRelays extends React.Component<
     NostrRelaysProps,
@@ -57,28 +59,41 @@ export default class NostrRelays extends React.Component<
     };
 
     async UNSAFE_componentWillMount() {
-        const { SettingsStore, route } = this.props;
+        const { SettingsStore, NodeInfoStore, route } = this.props;
         const { settings, getSettings } = SettingsStore;
 
         const { setup, relays } = route.params ?? {};
 
         await getSettings();
 
+        const pubkeySpecificLNAddressSettings =
+            settings.lightningAddressByPubkey[
+                NodeInfoStore.nodeInfo.identity_pubkey
+            ];
+
         this.setState({
             setup,
             relays: relays
                 ? relays
-                : settings.lightningAddressGlobal.nostrRelays || []
+                : pubkeySpecificLNAddressSettings.nostrRelays || []
         });
     }
 
     render() {
-        const { navigation, SettingsStore, LightningAddressStore } = this.props;
+        const {
+            navigation,
+            SettingsStore,
+            LightningAddressStore,
+            NodeInfoStore
+        } = this.props;
         const { relays, addRelay, setup } = this.state;
         const { updateSettings, settings }: any = SettingsStore;
         const { lightningAddress } = settings;
         const { nostrPrivateKey } = lightningAddress;
         const { update, loading, error_msg } = LightningAddressStore;
+        const pubkey = NodeInfoStore.nodeInfo.identity_pubkey;
+        const pubkeySpecificLNAddressSettings =
+            settings.lightningAddressByPubkey[pubkey];
 
         return (
             <Screen>
@@ -201,11 +216,14 @@ export default class NostrRelays extends React.Component<
                                                             addRelay: ''
                                                         });
                                                         await updateSettings({
-                                                            lightningAddressGlobal:
+                                                            lightningAddressByPubkey:
                                                                 {
-                                                                    ...settings.lightningAddressGlobal,
-                                                                    nostrRelays:
-                                                                        newNostrRelays
+                                                                    ...settings.lightningAddressByPubkey,
+                                                                    [pubkey]: {
+                                                                        ...pubkeySpecificLNAddressSettings,
+                                                                        nostrRelays:
+                                                                            newNostrRelays
+                                                                    }
                                                                 }
                                                         });
                                                     });
@@ -287,10 +305,15 @@ export default class NostrRelays extends React.Component<
                                                                         );
                                                                         await updateSettings(
                                                                             {
-                                                                                lightningAddressGlobal:
+                                                                                lightningAddressByPubkey:
                                                                                     {
-                                                                                        nostrRelays:
-                                                                                            newNostrRelays
+                                                                                        ...settings.lightningAddressByPubkey,
+                                                                                        [pubkey]:
+                                                                                            {
+                                                                                                ...pubkeySpecificLNAddressSettings,
+                                                                                                nostrRelays:
+                                                                                                    newNostrRelays
+                                                                                            }
                                                                                     }
                                                                             }
                                                                         );

--- a/views/Settings/LightningAddress/NostrRelays.tsx
+++ b/views/Settings/LightningAddress/NostrRelays.tsx
@@ -203,6 +203,7 @@ export default class NostrRelays extends React.Component<
                                                         await updateSettings({
                                                             lightningAddressGlobal:
                                                                 {
+                                                                    ...settings.lightningAddressGlobal,
                                                                     nostrRelays:
                                                                         newNostrRelays
                                                                 }

--- a/views/Settings/LightningAddress/index.tsx
+++ b/views/Settings/LightningAddress/index.tsx
@@ -184,8 +184,12 @@ export default class LightningAddress extends React.Component<
 
         const { fontScale } = Dimensions.get('window');
 
+        const pubkeySpecificLNAddressSettings =
+            SettingsStore.settings?.lightningAddressByPubkey?.[
+                NodeInfoStore.nodeInfo.identity_pubkey
+            ];
         const automaticallyAccept =
-            SettingsStore.settings?.lightningAddressGlobal?.automaticallyAccept;
+            pubkeySpecificLNAddressSettings?.automaticallyAccept;
         const isReady =
             SettingsStore.implementation !== 'embedded-lnd' ||
             !prepareToAutomaticallyAcceptStart ||

--- a/views/Settings/LightningAddress/index.tsx
+++ b/views/Settings/LightningAddress/index.tsx
@@ -185,7 +185,7 @@ export default class LightningAddress extends React.Component<
         const { fontScale } = Dimensions.get('window');
 
         const automaticallyAccept =
-            SettingsStore.settings?.lightningAddress?.automaticallyAccept;
+            SettingsStore.settings?.lightningAddressGlobal?.automaticallyAccept;
         const isReady =
             SettingsStore.implementation !== 'embedded-lnd' ||
             !prepareToAutomaticallyAcceptStart ||

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -14,6 +14,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import differenceBy from 'lodash/differenceBy';
 import { Route } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { v4 as uuidv4 } from 'uuid';
 
 import { hash, LNC_STORAGE_KEY } from '../../backends/LNC/credentialStore';
 
@@ -506,7 +507,8 @@ export default class WalletConfiguration extends React.Component<
             adminMacaroon,
             embeddedLndNetwork,
             photo,
-            nostrWalletConnectUrl
+            nostrWalletConnectUrl,
+            uuid: uuidv4()
         };
 
         let nodes: Node[];
@@ -626,6 +628,7 @@ export default class WalletConfiguration extends React.Component<
         const { index } = this.state;
         const { nodes } = settings;
 
+        const deletedNode = nodes![index!];
         const newNodes: any = [];
         for (let i = 0; nodes && i < nodes.length; i++) {
             if (index !== i) {
@@ -636,7 +639,17 @@ export default class WalletConfiguration extends React.Component<
         updateSettings({
             nodes: newNodes,
             selectedNode: this.getNewSelectedNodeIndex(index, settings)
-        }).then(() => {
+        }).then(async () => {
+            // Remove UUID from migration todo list if it's on there
+            const MOD_KEY9 = 'lightning-address-pubkey-2025';
+            const uuidArray = (await Storage.getItem(MOD_KEY9)) || [];
+            if (uuidArray.includes(deletedNode.uuid)) {
+                const remainingUuids = uuidArray.filter(
+                    (uuid: string) => uuid !== deletedNode.uuid
+                );
+                await Storage.setItem(MOD_KEY9, remainingUuids);
+            }
+
             if (newNodes.length === 0) {
                 navigation.navigate('IntroSplash');
             } else {

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -526,7 +526,11 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             }
         }
 
-        if (BackendUtils.supportsCustomPreimages() && !NodeInfoStore.testnet) {
+        if (
+            connecting &&
+            BackendUtils.supportsCustomPreimages() &&
+            !NodeInfoStore.testnet
+        ) {
             this.handlePubkeySpecificLightningAddressSettings();
         }
 

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -47,10 +47,9 @@ import {
     expressGraphSync
 } from '../../utils/LndMobileUtils';
 import { localeString, bridgeJavaStrings } from '../../utils/LocaleUtils';
-import { IS_BACKED_UP_KEY } from '../../utils/MigrationUtils';
 import { protectedNavigation } from '../../utils/NavigationUtils';
 import { isLightTheme, themeColor } from '../../utils/ThemeUtils';
-import MigrationUtils from '../../utils/MigrationUtils';
+import MigrationUtils, { IS_BACKED_UP_KEY } from '../../utils/MigrationUtils';
 
 import Storage from '../../storage';
 

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -533,26 +533,24 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             this.handlePubkeySpecificLightningAddressSettings();
         }
 
-        if (
+        const pubkeySpecificLNAddressSettings =
             SettingsStore.settings.lightningAddressByPubkey?.[
                 NodeInfoStore.nodeInfo.identity_pubkey
-            ]?.enabled &&
+            ];
+        if (
+            pubkeySpecificLNAddressSettings?.enabled &&
             BackendUtils.supportsCustomPreimages() &&
             !NodeInfoStore.testnet
         ) {
             if (connecting) {
                 try {
                     await LightningAddressStore.status();
-                    if (
-                        SettingsStore.settings.lightningAddressGlobal
-                            .automaticallyAccept
-                    ) {
+                    if (pubkeySpecificLNAddressSettings.automaticallyAccept) {
                         LightningAddressStore.prepareToAutomaticallyAccept();
                     }
                     if (
                         // TODO add enum
-                        SettingsStore.settings.lightningAddressGlobal
-                            .notifications === 1
+                        pubkeySpecificLNAddressSettings.notifications === 1
                     ) {
                         LightningAddressStore.updatePushCredentials();
                     }
@@ -609,21 +607,19 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
     private handlePubkeySpecificLightningAddressSettings = async () => {
         const { LightningAddressStore, NodeInfoStore, SettingsStore } =
             this.props;
+        const { settings, updateSettings, getSettings } = SettingsStore;
         const currentPubkey = NodeInfoStore.nodeInfo.identity_pubkey;
 
-        if (!SettingsStore.settings.lightningAddressByPubkey?.[currentPubkey]) {
+        if (!settings.lightningAddressByPubkey?.[currentPubkey]) {
             const hasLightningAddress =
                 await LightningAddressStore.checkLightningAddressExists();
-            await SettingsStore.updateSettings({
+            await updateSettings({
                 lightningAddressByPubkey: {
-                    ...SettingsStore.settings.lightningAddressByPubkey,
-                    [currentPubkey]: {
-                        enabled: hasLightningAddress === true,
-                        nostrPrivateKey: ''
-                    }
+                    ...settings.lightningAddressByPubkey,
+                    [currentPubkey]: { enabled: hasLightningAddress === true }
                 }
             });
-            SettingsStore.getSettings();
+            getSettings();
         }
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10558,6 +10558,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"


### PR DESCRIPTION
# Description

(https://github.com/ZeusLN/zeus/pull/2687 needs to be merged first.)

Right now we have all lightning address settings as global settings, but `enabled` and `nostrPrivateKey` need to be pubkey-specific (not node specific, that is the tricky part). Since we can only obtain the pubkey after we are connected to the node, the migration for this (`migrateLightningAddressSettings()`) is called after `getNodeInfo()` in Wallet.tsx (not like other migrations which are called in `getSettings()`).

Before, `LightningAddressStore:status();` was often times not called at all in Wallet.tsx:fetchData(), because the flag  `enabled` (for LightningAddress) was `false` globally (and never corrected). Now it will be correct (or corrected automatically) for all nodes (pubkeys).

To make sure there won't be any conflicts/mixed data, it is ensured the migration only runs after other migration methods are finished.

Additionally:
- removed require cycle warning in MigrationUtils by using storeInstances
- added logic to ensure we skip calling migration methods (`legacySettingsMigrations` and `storageMigrationV2`) again if already running (`getSettings()` is called 2x in quick sequence)
- removed unused `LEGACY_ADDRESS_ACTIVATED_STRING` and `ADDRESS_ACTIVATED_STRING` and unused method `getLightningAddressActivated()` in LightningAddressStore.ts.
- added uuid to package.json to ensure it is explicitly declared (even though it is currently available through other deps)

This also fixes #2730.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [x] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [x] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
