### PR TITLE
Embedded LND: delete + create multiple wallets

### DIFF
--- a/android/app/src/main/java/com/zeus/LndMobile.java
+++ b/android/app/src/main/java/com/zeus/LndMobile.java
@@ -353,7 +353,7 @@ class LndMobile extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void startLnd(String args, Boolean isTorEnabled, Boolean isTestnet, Promise promise) {
+  public void startLnd(String args, String lndDir, Boolean isTorEnabled, Boolean isTestnet, Promise promise) {
     // TODO args is only used on iOS right now
     int req = new Random().nextInt();
     requests.put(req, promise);
@@ -363,7 +363,7 @@ class LndMobile extends ReactContextBaseJavaModule {
 
     Bundle bundle = new Bundle();
 
-    String params = "--lnddir=" + getReactApplicationContext().getFilesDir().getPath();
+    String params = "--lnddir=" + getReactApplicationContext().getFilesDir().getPath() + "/" + lndDir;
     if (isTorEnabled) {
       // int listenPort = ZeusTorUtils.getListenPort(isTestnet);
       // String controlSocket = "unix://" + getReactApplicationContext().getDir(TorService.class.getSimpleName(), Context.MODE_PRIVATE).getAbsolutePath() + "/data/ControlSocket";

--- a/android/app/src/main/java/com/zeus/LndMobileTools.java
+++ b/android/app/src/main/java/com/zeus/LndMobileTools.java
@@ -94,8 +94,8 @@ class LndMobileTools extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  void writeConfig(String config, Promise promise) {
-    String filename = getReactApplicationContext().getFilesDir().toString() + "/lnd.conf";
+  void writeConfig(String config, String lndDir, Promise promise) {
+    String filename = getReactApplicationContext().getFilesDir().toString() + "/" + lndDir + "/lnd.conf";
 
     try {
       new File(filename).getParentFile().mkdirs();
@@ -425,6 +425,14 @@ class LndMobileTools extends ReactContextBaseJavaModule {
   @ReactMethod
   public void DEBUG_deleteSpeedloaderDgraphDirectory(Promise promise) {
     String filename = getReactApplicationContext().getCacheDir().toString() + "/dgraph";
+    File file = new File(filename);
+    deleteRecursive(file);
+    promise.resolve(null);
+  }
+
+  @ReactMethod
+  public void deleteLndDirectory(String lndDir, Promise promise) {
+    String filename = getReactApplicationContext().getCacheDir().toString() + "/" + lndDir;
     File file = new File(filename);
     deleteRecursive(file);
     promise.resolve(null);

--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -141,10 +141,10 @@ export default class CLNRest {
                 .join('&')}`;
         }
 
-        const headers: any = this.getHeaders(rune);
+        const headers: any = this.getHeaders(rune || '');
         headers['Content-Type'] = 'application/json';
 
-        const url = this.getURL(host, port, route);
+        const url = this.getURL(host || '', port || '', route);
 
         return this.restReq(
             headers,

--- a/backends/Eclair.ts
+++ b/backends/Eclair.ts
@@ -22,7 +22,7 @@ export default class Eclair {
             return calls.get(id);
         }
 
-        url = url.slice(-1) === '/' ? url : url + '/';
+        url = url?.slice(-1) === '/' ? url : url + '/';
         const headers = {
             Authorization: 'Basic ' + Base64Utils.utf8ToBase64(':' + password),
             'Content-Type': 'application/x-www-form-urlencoded'

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -125,7 +125,12 @@ export default class LND {
         const auth = macaroonHex || accessToken;
         const headers: any = this.getHeaders(auth, true);
         const methodRoute = `${route}?method=${method}`;
-        const url = this.getURL(host || lndhubUrl, port, methodRoute, true);
+        const url = this.getURL(
+            host || lndhubUrl || '',
+            port || '',
+            methodRoute,
+            true
+        );
 
         return new Promise(function (resolve, reject) {
             const ws: any = new WebSocket(url, null, {
@@ -216,7 +221,7 @@ export default class LND {
         const auth = macaroonHex || accessToken;
         const headers: any = this.getHeaders(auth);
         headers['Content-Type'] = 'application/json';
-        const url = this.getURL(host || lndhubUrl, port, route);
+        const url = this.getURL(host || lndhubUrl || '', port || '', route);
         return this.restReq(
             headers,
             url,
@@ -274,7 +279,12 @@ export default class LND {
         const auth = macaroonHex || accessToken;
         const headers: any = this.getHeaders(auth, true);
         const methodRoute = `${route}?method=${method}`;
-        const url = this.getURL(host || lndhubUrl, port, methodRoute, true);
+        const url = this.getURL(
+            host || lndhubUrl || '',
+            port || '',
+            methodRoute,
+            true
+        );
 
         const ws: any = new WebSocket(url, null, {
             headers
@@ -432,7 +442,12 @@ export default class LND {
         const auth = macaroonHex || accessToken;
         const headers: any = this.getHeaders(auth, true);
         const methodRoute = '/v1/channels/stream?method=POST';
-        const url = this.getURL(host || lndhubUrl, port, methodRoute, true);
+        const url = this.getURL(
+            host || lndhubUrl || '',
+            port || '',
+            methodRoute,
+            true
+        );
 
         return new Promise(function (resolve, reject) {
             const ws: any = new WebSocket(url, null, {
@@ -631,8 +646,8 @@ export default class LND {
         const auth = macaroonHex || accessToken;
         const headers: any = this.getHeaders(auth, true);
         const url = this.getURL(
-            host || lndhubUrl,
-            port,
+            host || lndhubUrl || '',
+            port || '',
             '/v1/channels/acceptor?method=POST',
             true
         );

--- a/backends/Spark.ts
+++ b/backends/Spark.ts
@@ -19,7 +19,7 @@ export default class Spark {
             return calls.get(id);
         }
 
-        url = url.slice(-4) === '/rpc' ? url : url + '/rpc';
+        url = url?.slice(-4) === '/rpc' ? url : url + '/rpc';
 
         const headers: any = { 'X-Access': accessKey };
         if (range) {

--- a/ios/LndMobile/Lnd.swift
+++ b/ios/LndMobile/Lnd.swift
@@ -180,9 +180,9 @@ open class Lnd {
     return flags
   }
 
-  func startLnd(_ args: String, isTorEnabled: Bool, isTestnet: Bool, lndStartedCallback: @escaping Callback) -> Void {
+  func startLnd(_ args: String, lndDir: String, isTorEnabled: Bool, isTestnet: Bool, lndStartedCallback: @escaping Callback) -> Void {
     let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-    let lndPath = applicationSupport.appendingPathComponent("lnd", isDirectory: true)
+    let lndPath = applicationSupport.appendingPathComponent(lndDir, isDirectory: true)
 
     var lndArgs = "--nolisten --lnddir=\"\(lndPath.path)\" " + args
     if (isTorEnabled) {

--- a/ios/LndMobile/LndMobile.m
+++ b/ios/LndMobile/LndMobile.m
@@ -15,6 +15,7 @@ RCT_EXTERN_METHOD(
 
 RCT_EXTERN_METHOD(
   startLnd: (NSString *)args
+  lndDir: (NSString *)lndDir
   isTorEnabled: (BOOL)isTorEnabled
   isTestnet: (BOOL)isTestnet
   resolver: (RCTPromiseResolveBlock)resolve

--- a/ios/LndMobile/LndMobile.swift
+++ b/ios/LndMobile/LndMobile.swift
@@ -120,9 +120,9 @@ class LndMobile: RCTEventEmitter {
     resolve(Lnd.shared.checkStatus())
   }
 
-  @objc(startLnd:isTorEnabled:isTestnet:resolver:rejecter:)
-  func startLnd(_ args: String, isTorEnabled: Bool, isTestnet: Bool, resolve: @escaping RCTPromiseResolveBlock, rejecter reject:@escaping RCTPromiseRejectBlock) {
-    Lnd.shared.startLnd(args, isTorEnabled: isTorEnabled, isTestnet: isTestnet) { (data, error) in
+  @objc(startLnd:lndDir:isTorEnabled:isTestnet:resolver:rejecter:)
+  func startLnd(_ args: String, lndDir: String, isTorEnabled: Bool, isTestnet: Bool, resolve: @escaping RCTPromiseResolveBlock, rejecter reject:@escaping RCTPromiseRejectBlock) {
+    Lnd.shared.startLnd(args, lndDir: lndDir, isTorEnabled: isTorEnabled, isTestnet: isTestnet) { (data, error) in
       if let e = error {
         reject("error", e.localizedDescription, e)
         return

--- a/ios/LndMobile/LndMobileTools.m
+++ b/ios/LndMobile/LndMobileTools.m
@@ -5,6 +5,7 @@
 
 RCT_EXTERN_METHOD(
   writeConfig: (NSString *)config
+  lndDir: (NSString *)lndDir
   resolver: (RCTPromiseResolveBlock)resolve
   rejecter: (RCTPromiseRejectBlock)reject
 )
@@ -59,6 +60,12 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
+  deleteLndDirectory: (NSString)lndDir
+  resolver: (RCTPromiseResolveBlock)resolve
+  rejecter: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
   DEBUG_deleteNeutrinoFiles: (NSString)network
   resolver: (RCTPromiseResolveBlock)resolve
   rejecter: (RCTPromiseRejectBlock)reject
@@ -75,12 +82,14 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-  createIOSApplicationSupportAndLndDirectories: (RCTPromiseResolveBlock)resolve
+  createIOSApplicationSupportAndLndDirectories: (NSString)lndDir
+  resolver: (RCTPromiseResolveBlock)resolve
   rejecter: (RCTPromiseRejectBlock)reject
 )
 
 RCT_EXTERN_METHOD(
-  excludeLndICloudBackup: (RCTPromiseResolveBlock)resolve
+  excludeLndICloudBackup: (NSString)lndDir
+  resolver: (RCTPromiseResolveBlock)resolve
   rejecter: (RCTPromiseRejectBlock)reject
 )
 

--- a/ios/LndMobile/LndMobileTools.swift
+++ b/ios/LndMobile/LndMobileTools.swift
@@ -26,11 +26,11 @@ class LndMobileTools: RCTEventEmitter {
     return false
   }
 
-  @objc(writeConfig:resolver:rejecter:)
-  func writeConfig(config: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+  @objc(writeConfig:lndDir:resolver:rejecter:)
+  func writeConfig(config: String, lndDir: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
     do {
       let paths = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-      let url = paths[0].appendingPathComponent("lnd", isDirectory: true).appendingPathComponent("lnd.conf", isDirectory: false)
+      let url = paths[0].appendingPathComponent(lndDir, isDirectory: true).appendingPathComponent("lnd.conf", isDirectory: false)
       NSLog(url.relativeString)
 
       try config.write(to: url, atomically: true, encoding: .utf8)
@@ -227,6 +227,22 @@ class LndMobileTools: RCTEventEmitter {
     resolve(nil)
   }
 
+  @objc(deleteLndDirectory:resolver:rejecter:)
+  func deleteLndDirectory(lndDir: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+    let fileManager = FileManager.default
+    let applicationSupportUrl = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    let lndUrl = applicationSupportUrl.appendingPathComponent(lndDir)
+  
+    do {
+      try FileManager.default.removeItem(at: lndUrl)
+    } catch {
+      reject("error deleting lnd dir", error.localizedDescription, error)
+      return
+    }
+
+    resolve(true)
+  }
+
   @objc(DEBUG_deleteNeutrinoFiles:resolver:rejecter:)
   func DEBUG_deleteNeutrinoFiles(network: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
     let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
@@ -265,11 +281,11 @@ class LndMobileTools: RCTEventEmitter {
     resolve(FileManager.default.fileExists(atPath: lndFolder.path))
   }
 
-  @objc(createIOSApplicationSupportAndLndDirectories:rejecter:)
-  func createIOSApplicationSupportAndLndDirectories(resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+  @objc(createIOSApplicationSupportAndLndDirectories:resolver:rejecter:)
+  func createIOSApplicationSupportAndLndDirectories(lndDir: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
     do {
       let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-      let lndFolder = applicationSupport.appendingPathComponent("lnd", isDirectory: true)
+      let lndFolder = applicationSupport.appendingPathComponent(lndDir, isDirectory: true)
       // This will create the lnd folder as well as "Application Support"
       try FileManager.default.createDirectory(at: lndFolder, withIntermediateDirectories: true)
 
@@ -279,10 +295,10 @@ class LndMobileTools: RCTEventEmitter {
     }
   }
 
-  @objc(excludeLndICloudBackup:rejecter:)
-  func excludeLndICloudBackup(resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+  @objc(excludeLndICloudBackup:resolver:rejecter:)
+  func excludeLndICloudBackup(lndDir: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
     let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-    var lndFolder = applicationSupport.appendingPathComponent("lnd", isDirectory: true)
+    var lndFolder = applicationSupport.appendingPathComponent(lndDir, isDirectory: true)
 
     do {
       if FileManager.default.fileExists(atPath: lndFolder.path) {

--- a/lndmobile/LndMobile.d.ts
+++ b/lndmobile/LndMobile.d.ts
@@ -9,6 +9,7 @@ export interface ILndMobile {
     initialize(): Promise<{ data: string }>;
     startLnd(
         args: string,
+        lndDir: string,
         isTorEnabled?: boolean,
         isTestnet?: boolean
     ): Promise<{ data: string }>;
@@ -54,7 +55,7 @@ export interface ILndMobile {
 }
 
 export interface ILndMobileTools {
-    writeConfig(data: string): Promise<string>;
+    writeConfig(lndDir: string, config: string): Promise<string>;
     killLnd(): Promise<boolean>;
     copyLndLog(network: string): Promise<boolean>;
     tailLog(numberOfLines: number, network: string): Promise<string>;
@@ -64,6 +65,7 @@ export interface ILndMobileTools {
     DEBUG_getWalletPasswordFromKeychain(): Promise<string>;
     DEBUG_deleteSpeedloaderLastrunFile(): Promise<boolean>;
     DEBUG_deleteSpeedloaderDgraphDirectory(): Promise<null>;
+    deleteLndDirectory(lndDir: string): Promise<null>;
     DEBUG_deleteNeutrinoFiles(network: string): Promise<boolean>;
 
     // Android-specific
@@ -80,8 +82,10 @@ export interface ILndMobileTools {
     checkICloudEnabled(): Promise<boolean>;
     checkApplicationSupportExists(): Promise<boolean>;
     checkLndFolderExists(): Promise<boolean>;
-    createIOSApplicationSupportAndLndDirectories(): Promise<boolean>;
-    excludeLndICloudBackup(): Promise<boolean>;
+    createIOSApplicationSupportAndLndDirectories(
+        lndDir: string
+    ): Promise<boolean>;
+    excludeLndICloudBackup(lndDir: string): Promise<boolean>;
     TEMP_moveLndToApplicationSupport(): Promise<boolean>;
 
     // macOS-specific

--- a/lndmobile/LndMobileInjection.ts
+++ b/lndmobile/LndMobileInjection.ts
@@ -112,24 +112,38 @@ import { OutPoint } from '../models/TransactionRequest';
 export interface ILndMobileInjections {
     index: {
         initialize: () => Promise<{ data: string } | number>;
-        writeConfig: (config: string) => Promise<string>;
+        writeConfig: ({
+            lndDir,
+            config
+        }: {
+            lndDir: string;
+            config: string;
+        }) => Promise<string>;
         subscribeState: () => Promise<string>;
         decodeState: (data: string) => lnrpc.SubscribeStateResponse;
         checkStatus: () => Promise<number>;
-        startLnd: (
-            args: string,
-            isTorEnabled?: boolean,
-            isTestnet?: boolean
-        ) => Promise<string>;
+        startLnd: ({
+            args,
+            lndDir,
+            isTorEnabled,
+            isTestnet
+        }: {
+            args: string;
+            lndDir: string;
+            isTorEnabled?: boolean;
+            isTestnet?: boolean;
+        }) => Promise<string>;
         stopLnd: () => Promise<string>;
         gossipSync: (serviceUrl: string) => Promise<{ data: string }>;
         cancelGossipSync: () => void;
         checkICloudEnabled: () => Promise<boolean>;
         checkApplicationSupportExists: () => Promise<boolean>;
         checkLndFolderExists: () => Promise<boolean>;
-        createIOSApplicationSupportAndLndDirectories: () => Promise<boolean>;
+        createIOSApplicationSupportAndLndDirectories: (
+            lndDir: string
+        ) => Promise<boolean>;
         TEMP_moveLndToApplicationSupport: () => Promise<boolean>;
-        excludeLndICloudBackup: () => Promise<boolean>;
+        excludeLndICloudBackup: (lndDir: string) => Promise<boolean>;
 
         addInvoice: ({
             amount,

--- a/lndmobile/index.ts
+++ b/lndmobile/index.ts
@@ -40,8 +40,14 @@ export const checkStatus = async (): Promise<ELndMobileStatusCodes> => {
  * @throws
  * @return string
  */
-export const writeConfig = async (data: string) => {
-    return await LndMobileTools.writeConfig(data);
+export const writeConfig = async ({
+    config,
+    lndDir
+}: {
+    config: string;
+    lndDir: string;
+}) => {
+    return await LndMobileTools.writeConfig(config, lndDir);
 };
 
 export const subscribeState = async () => {
@@ -75,12 +81,23 @@ export const stopLnd = async (): Promise<{ data: string }> => {
 /**
  * @throws
  */
-export const startLnd = async (
-    args?: string,
-    isTorEnabled: boolean = false,
-    isTestnet: boolean = false
-): Promise<{ data: string }> => {
-    return await LndMobile.startLnd(args || '', isTorEnabled, isTestnet);
+export const startLnd = async ({
+    args,
+    lndDir,
+    isTorEnabled = false,
+    isTestnet = false
+}: {
+    args?: string;
+    lndDir: string;
+    isTorEnabled: boolean;
+    isTestnet: boolean;
+}): Promise<{ data: string }> => {
+    return await LndMobile.startLnd(
+        args || '',
+        lndDir,
+        isTorEnabled,
+        isTestnet
+    );
 };
 
 /**
@@ -120,8 +137,12 @@ export const checkLndFolderExists = async () => {
 /**
  * @throws
  */
-export const createIOSApplicationSupportAndLndDirectories = async () => {
-    return await LndMobileTools.createIOSApplicationSupportAndLndDirectories();
+export const createIOSApplicationSupportAndLndDirectories = async (
+    lndDir: string
+) => {
+    return await LndMobileTools.createIOSApplicationSupportAndLndDirectories(
+        lndDir
+    );
 };
 
 /**
@@ -134,8 +155,8 @@ export const TEMP_moveLndToApplicationSupport = async () => {
 /**
  * @throws
  */
-export const excludeLndICloudBackup = async () => {
-    return await LndMobileTools.excludeLndICloudBackup();
+export const excludeLndICloudBackup = async (lndDir: string) => {
+    return await LndMobileTools.excludeLndICloudBackup(lndDir);
 };
 
 /**

--- a/stores/ChannelBackupStore.ts
+++ b/stores/ChannelBackupStore.ts
@@ -65,7 +65,7 @@ export default class ChannelBackupStore {
 
         const encryptedBackup = CryptoJS.AES.encrypt(
             multiString,
-            this.settingsStore.seedPhrase.toString()
+            this.settingsStore?.seedPhrase?.toString() || ''
         ).toString();
 
         try {
@@ -163,7 +163,7 @@ export default class ChannelBackupStore {
         try {
             const decryptedBytes = CryptoJS.AES.decrypt(
                 backup,
-                this.settingsStore.seedPhrase.toString()
+                this.settingsStore?.seedPhrase?.toString() || ''
             );
             const decryptedString = decryptedBytes.toString(CryptoJS.enc.Utf8);
 

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -28,18 +28,29 @@ export interface Node {
     macaroonHex?: string;
     rune?: string;
     accessKey?: string;
-    implementation?: string;
+    implementation?: Implementations;
     certVerification?: boolean;
     enableTor?: boolean;
     nickname?: string;
     dismissCustodialWarning: boolean;
     photo?: string;
+    // LNDHub
+    lndhubUrl?: string;
+    existingAccount?: boolean;
+    username?: string;
+    password?: string;
     // LNC
     pairingPhrase?: string;
     mailboxServer?: string;
     customMailboxServer?: string;
     // NWC
     nostrWalletConnectUrl?: string;
+    // Embedded LND
+    seedPhrase?: string[];
+    walletPassword?: string;
+    adminMacaroon?: string;
+    embeddedLndNetwork?: string;
+    lndDir?: string;
 }
 
 interface PrivacySettings {
@@ -127,7 +138,7 @@ interface Bolt12AddressSettings {
 }
 
 export interface Settings {
-    nodes?: Array<Node>;
+    nodes: Array<Node>;
     selectedNode?: number;
     passphrase?: string;
     duressPassphrase?: string;
@@ -1107,6 +1118,7 @@ export const DEFAULT_SLIDE_TO_PAY_THRESHOLD = 10000;
 
 export default class SettingsStore {
     @observable settings: Settings = {
+        nodes: [],
         privacy: {
             defaultBlockExplorer: 'mempool.space',
             customBlockExplorer: '',
@@ -1227,22 +1239,22 @@ export default class SettingsStore {
     @observable olympians: Array<any>;
     @observable gods: Array<any>;
     @observable mortals: Array<any>;
-    @observable host: string;
-    @observable port: string;
-    @observable url: string;
-    @observable macaroonHex: string;
-    @observable rune: string;
-    @observable accessKey: string;
+    @observable host?: string;
+    @observable port?: string;
+    @observable url?: string;
+    @observable macaroonHex?: string;
+    @observable rune?: string;
+    @observable accessKey?: string;
     @observable implementation: Implementations;
-    @observable certVerification: boolean | undefined;
+    @observable certVerification?: boolean | undefined;
     @observable public loggedIn = false;
     @observable public connecting = true;
     @observable public lurkerExposed = false;
     private lurkerTimeout: ReturnType<typeof setTimeout> | null = null;
     // LNDHub
-    @observable username: string;
-    @observable password: string;
-    @observable lndhubUrl: string;
+    @observable username?: string;
+    @observable password?: string;
+    @observable lndhubUrl?: string;
     @observable dismissCustodialWarning: boolean = false;
     @observable public createAccountError: string;
     @observable public createAccountSuccess: string;
@@ -1251,16 +1263,17 @@ export default class SettingsStore {
     // Tor
     @observable public enableTor: boolean;
     // LNC
-    @observable public pairingPhrase: string;
-    @observable public mailboxServer: string;
-    @observable public customMailboxServer: string;
+    @observable public pairingPhrase?: string;
+    @observable public mailboxServer?: string;
+    @observable public customMailboxServer?: string;
     @observable public error = false;
     @observable public errorMsg: string;
     // Embedded lnd
-    @observable public seedPhrase: Array<string>;
-    @observable public walletPassword: string;
-    @observable public adminMacaroon: string;
-    @observable public embeddedLndNetwork: string;
+    @observable public seedPhrase?: string[];
+    @observable public walletPassword?: string;
+    @observable public adminMacaroon?: string;
+    @observable public embeddedLndNetwork?: string;
+    @observable public lndDir?: string;
     @observable public initialStart: boolean = true;
     // NWC
     @observable public nostrWalletConnectUrl: string;
@@ -1440,16 +1453,17 @@ export default class SettingsStore {
                     this.dismissCustodialWarning = node.dismissCustodialWarning;
                     this.implementation = node.implementation || 'lnd';
                     this.certVerification = node.certVerification || false;
-                    this.enableTor = node.enableTor;
+                    this.enableTor = node.enableTor || false;
                     // LNC
                     this.pairingPhrase = node.pairingPhrase;
                     this.mailboxServer = node.mailboxServer;
                     this.customMailboxServer = node.customMailboxServer;
-                    // Embeded lnd
+                    // Embedded lnd
                     this.seedPhrase = node.seedPhrase;
                     this.walletPassword = node.walletPassword;
                     this.adminMacaroon = node.adminMacaroon;
                     this.embeddedLndNetwork = node.embeddedLndNetwork;
+                    this.lndDir = node.lndDir || 'lnd';
                     // NWC
                     this.nostrWalletConnectUrl = node.nostrWalletConnectUrl;
                 }

--- a/views/Intro.tsx
+++ b/views/Intro.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { Dimensions, Image, Text, View, SafeAreaView } from 'react-native';
-
 import Animated, {
     Extrapolate,
     SharedValue,
@@ -10,6 +9,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import Carousel from 'react-native-reanimated-carousel';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { v4 as uuidv4 } from 'uuid';
 
 import stores from '../stores/Stores';
 
@@ -217,9 +217,11 @@ const Intro: React.FC<IntroProps> = (props) => {
                                     setCreatingWallet(true);
                                     setChoosingPeers(false);
 
-                                    const response = await createLndWallet(
-                                        undefined
-                                    );
+                                    const lndDir = uuidv4();
+
+                                    const response = await createLndWallet({
+                                        lndDir
+                                    });
                                     const { wallet, seed, randomBase64 }: any =
                                         response;
                                     if (wallet && wallet.admin_macaroon) {
@@ -234,7 +236,8 @@ const Intro: React.FC<IntroProps> = (props) => {
                                                 implementation: 'embedded-lnd',
                                                 nickname: localeString(
                                                     'general.defaultNodeNickname'
-                                                )
+                                                ),
+                                                lndDir
                                             }
                                         ];
 

--- a/views/IntroSplash.tsx
+++ b/views/IntroSplash.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { v4 as uuidv4 } from 'uuid';
 
 import Globe from '../assets/images/SVG/Globe.svg';
 import Wordmark from '../assets/images/SVG/wordmark-black.svg';
@@ -271,11 +272,15 @@ export default class IntroSplash extends React.Component<
                                             creatingWallet: true
                                         });
 
+                                        const lndDir = uuidv4();
+
+                                        console.log('lndDir', lndDir);
+
                                         let response;
                                         try {
-                                            response = await createLndWallet(
-                                                undefined
-                                            );
+                                            response = await createLndWallet({
+                                                lndDir
+                                            });
                                         } catch (e) {
                                             this.setState({
                                                 error: true,
@@ -304,7 +309,8 @@ export default class IntroSplash extends React.Component<
                                                         'embedded-lnd',
                                                     nickname: localeString(
                                                         'general.defaultNodeNickname'
-                                                    )
+                                                    ),
+                                                    lndDir
                                                 }
                                             ];
 

--- a/views/Settings/EmbeddedNode/Chantools/Sweepremoteclosed.tsx
+++ b/views/Settings/EmbeddedNode/Chantools/Sweepremoteclosed.tsx
@@ -393,9 +393,9 @@ export default class Sweepremoteclosed extends React.Component<
                                                 seedType ===
                                                 'externalWalletSeed'
                                                     ? externalSeed
-                                                    : SettingsStore?.seedPhrase.join(
+                                                    : SettingsStore?.seedPhrase?.join(
                                                           ' '
-                                                      ),
+                                                      ) || '',
                                             apiUrl,
                                             customApiUrl,
                                             recoveryWindow,
@@ -408,9 +408,9 @@ export default class Sweepremoteclosed extends React.Component<
                                                     seedType ===
                                                         'externalWalletSeed'
                                                         ? externalSeed
-                                                        : SettingsStore?.seedPhrase.join(
+                                                        : SettingsStore?.seedPhrase?.join(
                                                               ' '
-                                                          ),
+                                                          ) || '',
                                                     apiUrl === 'custom'
                                                         ? customApiUrl
                                                         : apiUrl,

--- a/views/Settings/Wallets.tsx
+++ b/views/Settings/Wallets.tsx
@@ -25,10 +25,11 @@ import SettingsStore, {
     Node
 } from '../../stores/SettingsStore';
 
-import { getPhoto } from '../../utils/PhotoUtils';
-import { localeString } from '../../utils/LocaleUtils';
-import { themeColor } from '../../utils/ThemeUtils';
 import BackendUtils from '../../utils/BackendUtils';
+import { stopLnd } from '../../utils/LndMobileUtils';
+import { localeString } from '../../utils/LocaleUtils';
+import { getPhoto } from '../../utils/PhotoUtils';
+import { themeColor } from '../../utils/ThemeUtils';
 
 import Add from '../../assets/images/SVG/Add.svg';
 import DragDots from '../../assets/images/SVG/DragDots.svg';
@@ -254,7 +255,8 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                                             await updateSettings({
                                                 nodes,
                                                 selectedNode: index
-                                            }).then(() => {
+                                            }).then(async () => {
+                                                if (currentImplementation === 'embedded-lnd') await stopLnd;
                                                 setConnectingStatus(true);
                                                 setInitialStart(false);
                                                 navigation.popTo('Wallet', {

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -383,13 +383,16 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
 
         if (implementation === 'embedded-lnd') {
             if (connecting) {
+                console.log('A');
                 AlertStore.checkNeutrinoPeers();
+
+                console.log('B');
 
                 await stopLnd();
 
                 console.log('lndDir', lndDir);
                 await initializeLnd({
-                    lndDir: lndDir || '',
+                    lndDir: lndDir || 'lnd',
                     isTestnet: embeddedLndNetwork === 'Testnet',
                     rescan,
                     compactDb
@@ -411,8 +414,15 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                     }
                 }
 
-                await startLnd({
+                console.log('!!!', {
                     lndDir: lndDir || '',
+                    walletPassword: walletPassword || '',
+                    isTorEnabled: embeddedTor,
+                    isTestnet: embeddedLndNetwork === 'Testnet'
+                });
+
+                await startLnd({
+                    lndDir: lndDir || 'lnd',
                     walletPassword: walletPassword || '',
                     isTorEnabled: embeddedTor,
                     isTestnet: embeddedLndNetwork === 'Testnet'


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-1649**](https://github.com/ZeusLN/zeus/issues/1649)

Allows user to spin up multiple Embedded LND wallets and switch between them.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
