### PR TITLE
Remove scan view from navigation stack after usage

### DIFF
--- a/views/NodeQRScanner.tsx
+++ b/views/NodeQRScanner.tsx
@@ -17,7 +17,7 @@ function NodeQRScanner(props: NodeQRProps) {
     const handleNodeScanned = (data: string) => {
         if (NodeUriUtils.isValidNodeUri(data)) {
             const { pubkey, host } = NodeUriUtils.processNodeUri(data);
-            navigation.navigate('OpenChannel', {
+            navigation.popTo('OpenChannel', {
                 node_pubkey_string: pubkey,
                 host
             });


### PR DESCRIPTION
# Description

When user scanned something successfully and then uses back button (or back icon in header), user obviously doesn't want to scan something again, but decided to not do whatever was planned.

Example (how it is now):
- Channel open view
- scan a nodes pubkey
- try to open the channel, but it doesn't work (e.g. remote node refused to open because channel to small)
- giving up for now by using back button (or back icon in header)
-> scanner reopens

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
