### PR TITLE
Add LoadingIndicator to LnurlPay

### DIFF
--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -14,6 +14,7 @@ import Header from '../../components/Header';
 import Screen from '../../components/Screen';
 import TextInput from '../../components/TextInput';
 import { Row } from '../..//components/layout/Row';
+import LoadingIndicator from '../../components/LoadingIndicator';
 
 import InvoicesStore from '../../stores/InvoicesStore';
 import LnurlPayStore from '../../stores/LnurlPayStore';
@@ -36,6 +37,7 @@ interface LnurlPayState {
     satAmount: string | number;
     domain: string;
     comment: string;
+    loading: boolean;
 }
 
 @inject('InvoicesStore', 'LnurlPayStore')
@@ -48,13 +50,17 @@ export default class LnurlPay extends React.Component<
         super(props);
 
         try {
-            this.state = this.stateFromProps(props);
+            this.state = {
+                ...this.stateFromProps(props),
+                loading: false
+            };
         } catch (err: any) {
             this.state = {
                 amount: '',
                 satAmount: '',
                 domain: '',
-                comment: ''
+                comment: '',
+                loading: false
             };
 
             Alert.alert(
@@ -82,6 +88,8 @@ export default class LnurlPay extends React.Component<
     }
 
     sendValues(satAmount: string | number) {
+        this.setState({ loading: true });
+
         const { navigation, InvoicesStore, LnurlPayStore, route } = this.props;
         const { domain, comment } = this.state;
         const lnurl = route.params?.lnurlParams;
@@ -109,6 +117,8 @@ export default class LnurlPay extends React.Component<
             }))
             .then((data: any) => {
                 if (data.status === 'ERROR') {
+                    this.setState({ loading: false });
+
                     Alert.alert(
                         `[error] ${domain} says:`,
                         data.reason,
@@ -135,6 +145,8 @@ export default class LnurlPay extends React.Component<
                 const relays_sig = data.relays_sig;
 
                 InvoicesStore.getPayReq(pr).then(() => {
+                    this.setState({ loading: false });
+
                     if (InvoicesStore.getPayReqError) {
                         Alert.alert(
                             localeString(
@@ -341,7 +353,13 @@ export default class LnurlPay extends React.Component<
                                 buttonStyle={{
                                     backgroundColor: themeColor('secondary')
                                 }}
+                                disabled={this.state.loading}
                             />
+                            {this.state.loading && (
+                                <View style={{ marginTop: 20 }}>
+                                    <LoadingIndicator size={30} />
+                                </View>
+                            )}
                         </View>
                     </View>
                     <View style={styles.metadata}>

--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -216,11 +216,7 @@ export default class LnurlPay extends React.Component<
                                 alignItems: 'center'
                             }}
                         >
-                            {loading && (
-                                <View style={{ paddingRight: 15 }}>
-                                    <LoadingIndicator size={35} />
-                                </View>
-                            )}
+                            {loading && <LoadingIndicator size={35} />}
                         </View>
                     }
                     navigation={navigation}

--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -194,7 +194,7 @@ export default class LnurlPay extends React.Component<
 
     render() {
         const { navigation, route } = this.props;
-        const { amount, satAmount, domain, comment } = this.state;
+        const { amount, satAmount, domain, comment, loading } = this.state;
 
         const lnurl = route.params?.lnurlParams;
 
@@ -296,10 +296,11 @@ export default class LnurlPay extends React.Component<
                             <AmountInput
                                 amount={amount}
                                 locked={
-                                    lnurl &&
+                                    loading ||
+                                    (lnurl &&
                                     lnurl.minSendable === lnurl.maxSendable
                                         ? true
-                                        : false
+                                        : false)
                                 }
                                 onAmountChange={(
                                     amount: string,
@@ -331,6 +332,7 @@ export default class LnurlPay extends React.Component<
                                     onChangeText={(text: string) => {
                                         this.setState({ comment: text });
                                     }}
+                                    locked={loading}
                                 />
                             </>
                         ) : null}
@@ -353,9 +355,9 @@ export default class LnurlPay extends React.Component<
                                 buttonStyle={{
                                     backgroundColor: themeColor('secondary')
                                 }}
-                                disabled={this.state.loading}
+                                disabled={loading}
                             />
-                            {this.state.loading && (
+                            {loading && (
                                 <View style={{ marginTop: 20 }}>
                                     <LoadingIndicator size={30} />
                                 </View>

--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -209,6 +209,20 @@ export default class LnurlPay extends React.Component<
                             fontFamily: 'PPNeueMontreal-Book'
                         }
                     }}
+                    rightComponent={
+                        <View
+                            style={{
+                                flexDirection: 'row',
+                                alignItems: 'center'
+                            }}
+                        >
+                            {loading && (
+                                <View style={{ paddingRight: 15 }}>
+                                    <LoadingIndicator size={35} />
+                                </View>
+                            )}
+                        </View>
+                    }
                     navigation={navigation}
                 />
                 <ScrollView keyboardShouldPersistTaps="handled">
@@ -357,11 +371,6 @@ export default class LnurlPay extends React.Component<
                                 }}
                                 disabled={loading}
                             />
-                            {loading && (
-                                <View style={{ marginTop: 20 }}>
-                                    <LoadingIndicator size={30} />
-                                </View>
-                            )}
                         </View>
                     </View>
                     <View style={styles.metadata}>


### PR DESCRIPTION
# Description

While doing backend calls, display LoadingIndicator and disable CONFIRM button in LnurlPay.tsx.

![grafik](https://github.com/user-attachments/assets/e800ab84-2b78-4142-ba01-a06c8161e3ed)

![grafik](https://github.com/user-attachments/assets/1eb3e37c-36b6-48c7-8ac0-06c589215874)


This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
