### PR TITLE
Open Channel/Send on-chain: use AmountInput to display fundMax

### DIFF
--- a/components/AmountInput.tsx
+++ b/components/AmountInput.tsx
@@ -144,10 +144,11 @@ export default class AmountInput extends React.Component<
             hideUnitChangeButton,
             FiatStore,
             UnitsStore,
-            SettingsStore
+            SettingsStore,
+            forceUnit
         } = this.props;
         const { units }: any = UnitsStore;
-        const effectiveUnits = this.props.forceUnit || units;
+        const effectiveUnits = forceUnit || units;
         const { getRate, getSymbol }: any = FiatStore;
         const { settings }: any = SettingsStore;
         const { fiatEnabled } = settings;
@@ -174,7 +175,7 @@ export default class AmountInput extends React.Component<
                             const formatted = text.replace(/[^\d.,-]/g, '');
                             const satAmount = getSatAmount(
                                 formatted,
-                                this.props.forceUnit
+                                forceUnit
                             );
                             onAmountChange(formatted, satAmount);
                             this.setState({ satAmount });

--- a/components/AmountInput.tsx
+++ b/components/AmountInput.tsx
@@ -24,6 +24,7 @@ interface AmountInputProps {
     title?: string;
     hideConversion?: boolean;
     hideUnitChangeButton?: boolean;
+    forceUnit?: 'sats' | 'BTC' | 'fiat';
     FiatStore?: FiatStore;
     SettingsStore?: SettingsStore;
     UnitsStore?: UnitsStore;
@@ -33,12 +34,13 @@ interface AmountInputState {
     satAmount: string | number;
 }
 
-const getSatAmount = (amount: string | number) => {
+const getSatAmount = (amount: string | number, forceUnit?: string) => {
     const { fiatStore, settingsStore, unitsStore } = Stores;
     const { fiatRates } = fiatStore;
     const { settings } = settingsStore;
     const { fiat } = settings;
     const { units } = unitsStore;
+    const effectiveUnits = forceUnit || units;
 
     // replace , with . for unit separator
     const value = amount ? amount.toString().replace(/,/g, ',') : '';
@@ -51,7 +53,7 @@ const getSatAmount = (amount: string | number) => {
     const rate = fiat && fiatRates && fiatEntry ? fiatEntry.rate : 0;
 
     let satAmount: string | number = 0;
-    switch (units) {
+    switch (effectiveUnits) {
         case 'sats':
             satAmount = value;
             break;
@@ -89,7 +91,8 @@ export default class AmountInput extends React.Component<
 
         const { amount } = props;
         let satAmount = '0';
-        if (amount) satAmount = getSatAmount(amount).toString();
+        if (amount)
+            satAmount = getSatAmount(amount, props.forceUnit).toString();
 
         this.state = {
             satAmount
@@ -98,16 +101,26 @@ export default class AmountInput extends React.Component<
 
     componentDidMount() {
         const { amount }: any = this.props;
-        const satAmount = getSatAmount(amount);
+        const satAmount = getSatAmount(amount, this.props.forceUnit);
         this.setState({ satAmount });
     }
 
     UNSAFE_componentWillReceiveProps(
         nextProps: Readonly<AmountInputProps>
     ): void {
-        const { amount } = nextProps;
-        if (amount) {
-            const satAmount = getSatAmount(amount);
+        const { amount, forceUnit } = nextProps;
+        if (forceUnit === 'sats' && forceUnit !== this.props.forceUnit) {
+            const currentSatAmount = getSatAmount(
+                amount || '',
+                this.props.forceUnit
+            );
+            this.setState({ satAmount: currentSatAmount });
+            this.props.onAmountChange(
+                currentSatAmount.toString(),
+                currentSatAmount
+            );
+        } else {
+            const satAmount = getSatAmount(amount || '', forceUnit);
             this.setState({ satAmount });
         }
     }
@@ -115,7 +128,7 @@ export default class AmountInput extends React.Component<
     onChangeUnits = () => {
         const { amount, onAmountChange, UnitsStore }: any = this.props;
         UnitsStore.changeUnits();
-        const satAmount = getSatAmount(amount);
+        const satAmount = getSatAmount(amount, this.props.forceUnit);
         onAmountChange(amount, satAmount);
         this.setState({ satAmount });
     };
@@ -134,6 +147,7 @@ export default class AmountInput extends React.Component<
             SettingsStore
         } = this.props;
         const { units }: any = UnitsStore;
+        const effectiveUnits = this.props.forceUnit || units;
         const { getRate, getSymbol }: any = FiatStore;
         const { settings }: any = SettingsStore;
         const { fiatEnabled } = settings;
@@ -158,24 +172,27 @@ export default class AmountInput extends React.Component<
                         onChangeText={(text: string) => {
                             // remove spaces and non-numeric chars
                             const formatted = text.replace(/[^\d.,-]/g, '');
-                            const satAmount = getSatAmount(formatted);
+                            const satAmount = getSatAmount(
+                                formatted,
+                                this.props.forceUnit
+                            );
                             onAmountChange(formatted, satAmount);
                             this.setState({ satAmount });
                         }}
                         locked={locked}
                         prefix={
-                            units !== 'sats' &&
-                            (units === 'BTC'
+                            effectiveUnits !== 'sats' &&
+                            (effectiveUnits === 'BTC'
                                 ? '₿'
                                 : !getSymbol().rtl
                                 ? getSymbol().symbol
                                 : null)
                         }
                         suffix={
-                            units === 'sats'
-                                ? units
+                            effectiveUnits === 'sats'
+                                ? effectiveUnits
                                 : getSymbol().rtl &&
-                                  units === 'fiat' &&
+                                  effectiveUnits === 'fiat' &&
                                   getSymbol().symbol
                         }
                         style={{
@@ -213,16 +230,16 @@ export default class AmountInput extends React.Component<
                                     color: themeColor('text')
                                 }}
                             >
-                                {getRate(units === 'sats')}
+                                {getRate(effectiveUnits === 'sats')}
                             </Text>
                         )}
-                        {fiatEnabled && units !== 'fiat' && (
+                        {fiatEnabled && effectiveUnits !== 'fiat' && (
                             <Amount sats={satAmount} fixedUnits="fiat" />
                         )}
-                        {units !== 'BTC' && (
+                        {effectiveUnits !== 'BTC' && (
                             <Amount sats={satAmount} fixedUnits="BTC" />
                         )}
-                        {units !== 'sats' && (
+                        {effectiveUnits !== 'sats' && (
                             <Amount sats={satAmount} fixedUnits="sats" />
                         )}
                     </View>

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -14,7 +14,6 @@ import { Route } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Tab } from 'react-native-elements';
 
-import Amount from '../components/Amount';
 import AmountInput from '../components/AmountInput';
 import Button from '../components/Button';
 import DropdownSetting from '../components/DropdownSetting';
@@ -569,40 +568,32 @@ export default class OpenChannel extends React.Component<
 
                         {!connectPeerOnly && (
                             <>
-                                {!fundMax && (
-                                    <AmountInput
-                                        amount={local_funding_amount}
-                                        title={localeString(
-                                            'views.OpenChannel.localAmt'
-                                        )}
-                                        onAmountChange={(
-                                            amount: string,
-                                            satAmount: string | number
-                                        ) => {
-                                            this.setState({
-                                                local_funding_amount: amount,
-                                                satAmount
-                                            });
-                                        }}
-                                        hideConversion={
-                                            local_funding_amount === 'all'
-                                        }
-                                    />
-                                )}
-
-                                {(local_funding_amount === 'all' ||
-                                    fundMax) && (
-                                    <View style={{ marginBottom: 20 }}>
-                                        <Amount
-                                            sats={
-                                                utxoBalance > 0
-                                                    ? utxoBalance
-                                                    : confirmedBlockchainBalance
-                                            }
-                                            toggleable
-                                        />
-                                    </View>
-                                )}
+                                <AmountInput
+                                    amount={
+                                        fundMax
+                                            ? utxoBalance > 0
+                                                ? utxoBalance.toString()
+                                                : confirmedBlockchainBalance.toString()
+                                            : local_funding_amount
+                                    }
+                                    title={localeString(
+                                        'views.OpenChannel.localAmt'
+                                    )}
+                                    onAmountChange={(
+                                        amount: string,
+                                        satAmount: string | number
+                                    ) => {
+                                        this.setState({
+                                            local_funding_amount: amount,
+                                            satAmount
+                                        });
+                                    }}
+                                    hideConversion={
+                                        local_funding_amount === 'all'
+                                    }
+                                    locked={fundMax}
+                                    forceUnit={fundMax ? 'sats' : undefined}
+                                />
 
                                 {BackendUtils.supportsChannelFundMax() &&
                                     additionalChannels.length === 0 && (

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -35,7 +35,6 @@ import TransactionsStore from '../stores/TransactionsStore';
 import UTXOsStore from '../stores/UTXOsStore';
 import ContactStore from '../stores/ContactStore';
 
-import Amount from '../components/Amount';
 import AmountInput from '../components/AmountInput';
 import Button from '../components/Button';
 import FeeLimit from '../components/FeeLimit';
@@ -987,47 +986,28 @@ export default class Send extends React.Component<SendProps, SendState> {
                     {transactionType === 'On-chain' &&
                         BackendUtils.supportsOnchainSends() && (
                             <React.Fragment>
-                                {!fundMax && (
-                                    <AmountInput
-                                        amount={amount}
-                                        title={localeString(
-                                            'views.Send.amount'
-                                        )}
-                                        onAmountChange={(
-                                            amount: string,
-                                            satAmount: string | number
-                                        ) => {
-                                            this.setState({
-                                                amount,
-                                                satAmount
-                                            });
-                                        }}
-                                        hideConversion={amount === 'all'}
-                                    />
-                                )}
-
-                                <View style={{ paddingBottom: 15 }}>
-                                    {fundMax && (
-                                        <>
-                                            <Amount
-                                                sats={
-                                                    utxoBalance > 0
-                                                        ? utxoBalance
-                                                        : confirmedBlockchainBalance
-                                                }
-                                                fixedUnits="BTC"
-                                            />
-                                            <Amount
-                                                sats={
-                                                    utxoBalance > 0
-                                                        ? utxoBalance
-                                                        : confirmedBlockchainBalance
-                                                }
-                                                fixedUnits="sats"
-                                            />
-                                        </>
-                                    )}
-                                </View>
+                                <AmountInput
+                                    amount={
+                                        fundMax
+                                            ? utxoBalance > 0
+                                                ? utxoBalance.toString()
+                                                : confirmedBlockchainBalance.toString()
+                                            : amount
+                                    }
+                                    title={localeString('views.Send.amount')}
+                                    onAmountChange={(
+                                        amount: string,
+                                        satAmount: string | number
+                                    ) => {
+                                        this.setState({
+                                            amount,
+                                            satAmount
+                                        });
+                                    }}
+                                    hideConversion={amount === 'all'}
+                                    locked={fundMax}
+                                    forceUnit={fundMax ? 'sats' : undefined}
+                                />
 
                                 {BackendUtils.supportsOnchainSendMax() &&
                                     additionalOutputs.length === 0 &&


### PR DESCRIPTION
# Description

This displays the local amount in AmountInput if `Use all possible funds` is enabled, making it consistent/less flickering to normal view.

I added `forceUnit` prop to AmountInput to force it to sats mode, which is obviously needed when `Use all possible funds` is used.

When you disable it again, values get reset properly.

|Before|Before|After|
|-|-|-|
|![grafik](https://github.com/user-attachments/assets/138a6bd9-4de5-4617-911d-f6fe9a203c02)|![grafik](https://github.com/user-attachments/assets/4b25de7a-5403-498b-9fad-e14984e8493b)|![grafik](https://github.com/user-attachments/assets/bbb2a02d-9613-43cc-ba52-2f683872219e)|


This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
