### PR TITLE
Payment path: Display 'Unknown' if backend throws or needs >10s to retrieve node alias

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -128,6 +128,7 @@
     "general.experimental": "Experimental",
     "general.defaultNodeNickname": "My Lightning Node",
     "general.active": "Active",
+    "general.unknown": "Unkown",
     "restart.title": "Restart required",
     "restart.msg": "ZEUS has to be restarted before the new configuration is applied.",
     "restart.msg1": "Would you like to restart now?",

--- a/locales/en.json
+++ b/locales/en.json
@@ -128,7 +128,7 @@
     "general.experimental": "Experimental",
     "general.defaultNodeNickname": "My Lightning Node",
     "general.active": "Active",
-    "general.unknown": "Unkown",
+    "general.unknown": "Unknown",
     "restart.title": "Restart required",
     "restart.msg": "ZEUS has to be restarted before the new configuration is applied.",
     "restart.msg1": "Would you like to restart now?",

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -298,7 +298,15 @@ export default class ChannelsStore {
     @action
     getNodeInfo = (pubkey: string) => {
         this.loading = true;
-        return BackendUtils.getNodeInfo([pubkey])
+
+        const timeoutPromise = new Promise((_, reject) => {
+            setTimeout(() => reject(new Error('Timeout')), 10000);
+        });
+
+        return Promise.race([
+            timeoutPromise,
+            BackendUtils.getNodeInfo([pubkey])
+        ])
             .then((data: any) => {
                 this.loading = false;
                 if (data?.node?.alias)
@@ -307,6 +315,7 @@ export default class ChannelsStore {
             })
             .catch(() => {
                 this.loading = false;
+                this.aliasMap.set(pubkey, localeString('general.unknown'));
             });
     };
 


### PR DESCRIPTION
# Description

This fixes the loading indicator being displayed forever in case backend cannot retrieve node alias (e.g. happening when paying to phoenix wallets).

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
