### PR TITLE
Activity: fix removing LNC listeners

### DIFF
--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -6,7 +6,8 @@ import {
     Text,
     TouchableOpacity,
     View,
-    StyleSheet
+    StyleSheet,
+    EmitterSubscription
 } from 'react-native';
 import { Button, Icon, ListItem } from 'react-native-elements';
 import { inject, observer } from 'mobx-react';
@@ -318,8 +319,8 @@ export default class Activity extends React.PureComponent<
     ActivityProps,
     ActivityState
 > {
-    transactionListener: any;
-    invoicesListener: any;
+    private transactionListener: EmitterSubscription;
+    private invoicesListener: EmitterSubscription;
 
     state = {
         loading: false,
@@ -348,10 +349,8 @@ export default class Activity extends React.PureComponent<
     };
 
     componentWillUnmount() {
-        if (this.transactionListener && this.transactionListener.stop)
-            this.transactionListener.stop();
-        if (this.invoicesListener && this.invoicesListener.stop)
-            this.invoicesListener.stop();
+        if (this.transactionListener) this.transactionListener.remove();
+        if (this.invoicesListener) this.invoicesListener.remove();
     }
 
     subscribeEvents = () => {


### PR DESCRIPTION
# Description

This fixes a problem where switching node after opening Activity for an LNC node crashed the app by correctly unsubscribing listeners.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
