### PR TITLE
POS: Use placeholders instead of "real" 0 value for Tax percentage and Product Price

### DIFF
--- a/stores/PosStore.ts
+++ b/stores/PosStore.ts
@@ -200,14 +200,19 @@ export default class PosStore {
             this.currentOrder.total_money.sats = totalSats.toNumber();
 
             // calculate taxes
-            if (this.settingsStore?.settings?.pos?.taxPercentage !== '0') {
+            const { settings } = this.settingsStore;
+            const { taxPercentage } = settings.pos;
+
+            if (
+                taxPercentage &&
+                taxPercentage !== '0' &&
+                taxPercentage !== ''
+            ) {
                 this.currentOrder.total_tax_money.amount = new BigNumber(
                     totalFiat
                 )
                     .div(100)
-                    .multipliedBy(
-                        this.settingsStore?.settings?.pos?.taxPercentage || 0
-                    )
+                    .multipliedBy(taxPercentage)
                     .toNumber();
                 if (this.fiatStore.fiatRates) {
                     const fiatEntry = this.fiatStore.fiatRates.filter(

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1129,7 +1129,7 @@ export default class SettingsStore {
             disableTips: false,
             squareDevMode: false,
             showKeypad: true,
-            taxPercentage: '0',
+            taxPercentage: '',
             enablePrinter: false,
             defaultView: 'Products'
         },

--- a/views/POS/ProductDetails.tsx
+++ b/views/POS/ProductDetails.tsx
@@ -157,13 +157,8 @@ export default class ProductDetails extends React.Component<
                     break;
 
                 case 'price':
-                    if (
-                        value === '' ||
-                        value === '0' ||
-                        value === null ||
-                        isNaN(parseFloat(value))
-                    ) {
-                        value = '0';
+                    if (value === null || isNaN(parseFloat(value))) {
+                        value = '';
                     } else {
                         value = value.replace(/^0+(?=\d)/, '');
                     }

--- a/views/Settings/PointOfSale.tsx
+++ b/views/Settings/PointOfSale.tsx
@@ -59,7 +59,7 @@ export default class PointOfSale extends React.Component<
         disableTips: false,
         squareDevMode: false,
         showKeypad: true,
-        taxPercentage: '0',
+        taxPercentage: '',
         enablePrinter: false,
         defaultView: 'Products'
     };
@@ -79,7 +79,7 @@ export default class PointOfSale extends React.Component<
             disableTips: settings?.pos?.disableTips || false,
             squareDevMode: settings?.pos?.squareDevMode || false,
             showKeypad: settings?.pos?.showKeypad || false,
-            taxPercentage: settings?.pos?.taxPercentage || '0',
+            taxPercentage: settings?.pos?.taxPercentage || '',
             enablePrinter: settings?.pos?.enablePrinter || false,
             defaultView:
                 (settings?.pos && settings?.pos?.defaultView) || 'Products'
@@ -592,6 +592,7 @@ export default class PointOfSale extends React.Component<
                                     )}
                                 </Text>
                                 <TextInput
+                                    placeholder={'0'}
                                     value={taxPercentage}
                                     keyboardType="numeric"
                                     onChangeText={async (text: string) => {


### PR DESCRIPTION
# Description

Product Price:
Before, `value` was replaced with '0' which leads to not using `AmountInput`'s default placeholder '0'.

Settings->POS->Tax percentage:
Before, `taxPercentage` was initialized with '0' and placeholder for "Text percentage" `TextInput` was missing.
-> **Note:** This will only affect fresh installs or in case user manually deletes the '0', because '0' is persisted in settings. It is not worth it to create migration for this though.

|Before|After|
|-|-|
|![grafik](https://github.com/user-attachments/assets/390c4001-b354-42b3-a263-6a939bfd03c4)|![grafik](https://github.com/user-attachments/assets/3763623c-ed36-4fa5-bfba-0e7b5261867e)|
|![grafik](https://github.com/user-attachments/assets/48ee157d-0aaa-4534-8d1d-c13df69d3095)|![grafik](https://github.com/user-attachments/assets/0b8d6ebe-a6fb-482e-990e-b4cd287aecd7)|

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
