### PR TITLE
Keypad Pane: Long press "delete" icon to reset amount

### DIFF
--- a/components/PinPad.tsx
+++ b/components/PinPad.tsx
@@ -356,6 +356,10 @@ export default function PinPad({
                                 decrementPinValueLength();
                                 deleteValue();
                             }}
+                            onLongPress={() => {
+                                clearPinValueLength();
+                                clearValue();
+                            }}
                             highlight={numberHighlight}
                             style={styles.key}
                         >

--- a/components/Touchable.tsx
+++ b/components/Touchable.tsx
@@ -3,6 +3,7 @@ import { Pressable, TouchableOpacity } from 'react-native';
 
 interface TouchableProps {
     touch: () => void;
+    onLongPress?: () => void;
     highlight: boolean;
     children: JSX.Element;
     style?: any;
@@ -10,6 +11,7 @@ interface TouchableProps {
 
 export default function Touchable({
     touch,
+    onLongPress,
     highlight,
     children,
     style
@@ -17,7 +19,11 @@ export default function Touchable({
     return (
         <>
             {highlight && (
-                <TouchableOpacity style={style} onPress={touch}>
+                <TouchableOpacity
+                    style={style}
+                    onPress={touch}
+                    onLongPress={onLongPress}
+                >
                     {children}
                 </TouchableOpacity>
             )}


### PR DESCRIPTION
# Description

With this PR you can long press the delete icon in Keypad pane to reset the amount.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
