### PR TITLE
Fix payments settings getting reset to default

### DIFF
--- a/components/AmountInput.tsx
+++ b/components/AmountInput.tsx
@@ -87,20 +87,18 @@ export default class AmountInput extends React.Component<
     constructor(props: any) {
         super(props);
 
-        const { amount, onAmountChange } = props;
+        const { amount } = props;
         let satAmount = '0';
         if (amount) satAmount = getSatAmount(amount).toString();
 
-        onAmountChange(amount, satAmount);
         this.state = {
             satAmount
         };
     }
 
     componentDidMount() {
-        const { amount, onAmountChange }: any = this.props;
+        const { amount }: any = this.props;
         const satAmount = getSatAmount(amount);
-        onAmountChange(amount, satAmount);
         this.setState({ satAmount });
     }
 

--- a/views/Settings/PaymentsSettings.tsx
+++ b/views/Settings/PaymentsSettings.tsx
@@ -79,7 +79,6 @@ export default class PaymentsSettings extends React.Component<
         const { navigation } = this.props;
         const {
             feeLimit,
-            feeLimitMethod,
             feePercentage,
             enableMempoolRates,
             timeoutSeconds,
@@ -139,12 +138,9 @@ export default class PaymentsSettings extends React.Component<
                                         });
                                         await updateSettings({
                                             payments: {
+                                                ...settings.payments,
                                                 defaultFeeMethod: 'fixed',
-                                                defaultFeePercentage:
-                                                    feePercentage,
-                                                defaultFeeFixed: text,
-                                                timeoutSeconds,
-                                                preferredMempoolRate
+                                                defaultFeeFixed: text
                                             }
                                         });
                                     }}
@@ -178,11 +174,9 @@ export default class PaymentsSettings extends React.Component<
                                         });
                                         await updateSettings({
                                             payments: {
+                                                ...settings.payments,
                                                 defaultFeeMethod: 'percent',
-                                                defaultFeePercentage: text,
-                                                defaultFeeFixed: feeLimit,
-                                                timeoutSeconds,
-                                                preferredMempoolRate
+                                                defaultFeePercentage: text
                                             }
                                         });
                                     }}
@@ -248,11 +242,9 @@ export default class PaymentsSettings extends React.Component<
                                         });
                                         await updateSettings({
                                             payments: {
+                                                ...settings.payments,
                                                 defaultFeeMethod: 'percent',
-                                                defaultFeePercentage: text,
-                                                defaultFeeFixed: feeLimit,
-                                                timeoutSeconds,
-                                                preferredMempoolRate
+                                                defaultFeePercentage: text
                                             }
                                         });
                                     }}
@@ -294,11 +286,7 @@ export default class PaymentsSettings extends React.Component<
                             if (!Number.isNaN(amountNumber)) {
                                 await updateSettings({
                                     payments: {
-                                        defaultFeeMethod: feeLimitMethod,
-                                        defaultFeePercentage: feePercentage,
-                                        defaultFeeFixed: feeLimit,
-                                        timeoutSeconds,
-                                        preferredMempoolRate,
+                                        ...settings.payments,
                                         slideToPayThreshold: Number(amount)
                                     }
                                 });
@@ -331,11 +319,8 @@ export default class PaymentsSettings extends React.Component<
                                     });
                                     await updateSettings({
                                         payments: {
-                                            defaultFeeMethod: feeLimitMethod,
-                                            defaultFeePercentage: feePercentage,
-                                            defaultFeeFixed: feeLimit,
-                                            timeoutSeconds: text,
-                                            preferredMempoolRate
+                                            ...settings.payments,
+                                            timeoutSeconds: text
                                         }
                                     });
                                 }}
@@ -368,16 +353,7 @@ export default class PaymentsSettings extends React.Component<
                                     });
                                     await updateSettings({
                                         privacy: {
-                                            defaultBlockExplorer:
-                                                settings?.privacy
-                                                    ?.defaultBlockExplorer,
-                                            customBlockExplorer:
-                                                settings?.privacy
-                                                    ?.customBlockExplorer,
-                                            clipboard:
-                                                settings?.privacy?.clipboard,
-                                            lurkerMode:
-                                                settings?.privacy?.lurkerMode,
+                                            ...settings.privacy,
                                             enableMempoolRates:
                                                 !enableMempoolRates
                                         }
@@ -398,10 +374,7 @@ export default class PaymentsSettings extends React.Component<
                                 });
                                 await updateSettings({
                                     payments: {
-                                        defaultFeeMethod: feeLimitMethod,
-                                        defaultFeePercentage: feePercentage,
-                                        defaultFeeFixed: feeLimit,
-                                        timeoutSeconds,
+                                        ...settings.payments,
                                         preferredMempoolRate: value
                                     }
                                 });


### PR DESCRIPTION
# Description

This fixes #2802.

1. Removed unnecessary onAmountChange calls in AmountInput to avoid triggering updateSettings with default prop values.
2. Added spread operator usage in PaymentsSettings to preserve existing settings.
-> This is way easier to maintain, as you can see from the fact that I forgot to update all these calls when I added `slideToPayThreshold`.
--> This makes sense for all updateSettings() calls throughout the app, but not in this PR.


@shubhamkmr04 @kaloudis 
Please also do some testing to make sure I didn't miss any regression introduced by the changes in AmountInput component.


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
