### PR TITLE
Rephrase "In advance channel purchase" to "Channel lease purchase"

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1047,7 +1047,7 @@
     "views.Sync.currentBlockHeight": "Current block height",
     "views.Sync.tip": "Tip",
     "views.Sync.numBlocksUntilSynced": "Number of blocks until synced",
-    "views.LSPS1.type": "In advance channel purchase",
+    "views.LSPS1.type": "Channel lease purchase",
     "views.LSPS1.pubkeyAndHostNotFound": "Node pubkey and host are not set",
     "views.SyncRecovery.title": "Recovering wallet",
     "views.LSPS1.timeoutError": "Did not receive response from server",


### PR DESCRIPTION
# Description

As discussed with @kaloudis:

We have `"views.LSPS7.type": "Channel lease extension"`, so `"views.LSPS1.type": "Channel lease purchase"` just makes sense.
Before: `"views.LSPS1.type": "In advance channel purchase"`


This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
