### PR TITLE
Receive: Fixed margin 

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -2597,7 +2597,12 @@ export default class Receive extends React.Component<
                                                                     ),
                                                                 borderRadius: 12,
                                                                 borderWidth: 0,
-                                                                height: 30
+                                                                height: 30,
+                                                                marginBottom:
+                                                                    Platform.OS ===
+                                                                    'ios'
+                                                                        ? 16
+                                                                        : 0
                                                             }}
                                                             innerBorderStyle={{
                                                                 color: themeColor(
@@ -2645,7 +2650,12 @@ export default class Receive extends React.Component<
                                                         style={{
                                                             flexDirection:
                                                                 'row',
-                                                            marginTop: 20
+                                                            marginTop: 16,
+                                                            marginBottom:
+                                                                Platform.OS ===
+                                                                'ios'
+                                                                    ? 10
+                                                                    : 6
                                                         }}
                                                     >
                                                         <View


### PR DESCRIPTION
Fixed the margin below expiry buttongroups and route hints switch

Before:
![Simulator Screenshot - iPhone 16 Pro - 2025-02-11 at 13 31 35](https://github.com/user-attachments/assets/71713ab3-d84c-4c7e-a259-48780ac4cf07)

After:
![Simulator Screenshot - iPhone 16 Pro - 2025-02-11 at 14 28 29](https://github.com/user-attachments/assets/e9b7c3b5-f891-4cc2-ac1b-bf999bb585d0)