### PR TITLE
improve minSendableSats handling

### DIFF
--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -18,6 +18,7 @@ import LoadingIndicator from '../../components/LoadingIndicator';
 
 import InvoicesStore from '../../stores/InvoicesStore';
 import LnurlPayStore from '../../stores/LnurlPayStore';
+import UnitsStore from '../../stores/UnitsStore';
 
 import LnurlPayMetadata from './Metadata';
 
@@ -29,6 +30,7 @@ interface LnurlPayProps {
     navigation: StackNavigationProp<any, any>;
     InvoicesStore: InvoicesStore;
     LnurlPayStore: LnurlPayStore;
+    UnitsStore: UnitsStore;
     route: Route<'LnurlPay', { lnurlParams: any; amount: any; satAmount: any }>;
 }
 
@@ -40,7 +42,7 @@ interface LnurlPayState {
     loading: boolean;
 }
 
-@inject('InvoicesStore', 'LnurlPayStore')
+@inject('InvoicesStore', 'LnurlPayStore', 'UnitsStore')
 @observer
 export default class LnurlPay extends React.Component<
     LnurlPayProps,
@@ -73,15 +75,17 @@ export default class LnurlPay extends React.Component<
     }
 
     stateFromProps(props: LnurlPayProps) {
-        const { route } = props;
+        const { route, UnitsStore } = props;
         const { lnurlParams: lnurl, amount, satAmount } = route.params ?? {};
 
+        const minSendableSats = Math.floor(lnurl.minSendable / 1000);
+
+        const { amount: unformattedAmount } =
+            UnitsStore.getUnformattedAmount(minSendableSats);
+
         return {
-            amount:
-                amount && amount != 0
-                    ? amount
-                    : Math.floor(lnurl.minSendable / 1000).toString(),
-            satAmount: satAmount ? satAmount : '',
+            amount: amount && amount != 0 ? amount : unformattedAmount,
+            satAmount: satAmount ? satAmount : minSendableSats,
             domain: lnurl.domain,
             comment: ''
         };


### PR DESCRIPTION
# Description

This fixes #2821.

Before, we were using `lnurl.minSendable` for `amount` only, but it's needed for `satAmount` also, since this is actually used for sending (`amount` is only used for displaying).

Additionally fixed another bug: When unit was set to `₿` or `Fiat` when scanning the lnurlp QR, `lnurl.minSendable` was used without conversion, resulting in `₿ 1` or `$1`.
**Note:** In `Fiat` case it will display `$0.00` in Amount input now, which is correct, but also `₿0.00 000 000` and `0sats`, which is wrong, because this conversion here uses the actual input `$0.00`. It still uses the correct satAmount (1) internally, so when user proceeds it works fine (see last screenshot), but of course we should think about how to handle this better, but not in this PR.

|Before|After|
|-|-|
|![grafik](https://github.com/user-attachments/assets/af7bcffd-5993-4da2-8c6d-49ce7461581c)|![grafik](https://github.com/user-attachments/assets/7389a4bb-1130-40be-9051-e15d5e2c41e8)|
|![grafik](https://github.com/user-attachments/assets/ff82d3f5-47db-4a7e-b1d6-98bbed9a07b7)|![grafik](https://github.com/user-attachments/assets/6df039e5-1de3-4fb1-9e33-2615383ca71f)|

It still uses `1sat`, although displayed Amount was converted to `0sats` in the view before:
![grafik](https://github.com/user-attachments/assets/505b23af-3a24-4b7b-b8ef-5d0d7daace55)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
