### PR TITLE
Activity: Visible feedback in case filters are active, fix filter storage consistency

### DIFF
--- a/stores/ActivityStore.ts
+++ b/stores/ActivityStore.ts
@@ -202,17 +202,17 @@ export default class ActivityStore {
 
     @action
     public setFilters = async (filters: Filter, locale?: string) => {
-        this.filters = filters;
+        this.filters = { ...DEFAULT_FILTERS, ...filters };
         this.filteredActivity = ActivityFilterUtils.filterActivities(
             this.activity,
-            filters
+            this.filters
         );
         this.filteredActivity.forEach((activity) => {
             if (activity instanceof Invoice) {
                 activity.determineFormattedRemainingTimeUntilExpiry(locale);
             }
         });
-        Storage.setItem(ACTIVITY_FILTERS_KEY, filters);
+        Storage.setItem(ACTIVITY_FILTERS_KEY, this.filters);
     };
 
     @action

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -14,6 +14,7 @@ import { inject, observer } from 'mobx-react';
 import BigNumber from 'bignumber.js';
 import { Route } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
+import isEqual from 'lodash/isEqual';
 
 import Amount from '../../components/Amount';
 import Header from '../../components/Header';
@@ -31,7 +32,7 @@ import {
 } from '../../utils/UnitsUtils';
 import PrivacyUtils from '../../utils/PrivacyUtils';
 
-import ActivityStore from '../../stores/ActivityStore';
+import ActivityStore, { DEFAULT_FILTERS } from '../../stores/ActivityStore';
 import FiatStore from '../../stores/FiatStore';
 import PosStore from '../../stores/PosStore';
 import SettingsStore from '../../stores/SettingsStore';
@@ -449,7 +450,8 @@ export default class Activity extends React.PureComponent<
         const { loading, selectedPaymentForOrder, isCsvModalVisible } =
             this.state;
 
-        const { filteredActivity, getActivityAndFilter } = ActivityStore;
+        const { filteredActivity, getActivityAndFilter, filters } =
+            ActivityStore;
         const { recordPayment } = PosStore;
         const { settings } = SettingsStore;
         const { fiat } = settings;
@@ -536,7 +538,14 @@ export default class Activity extends React.PureComponent<
                 }
                 accessibilityLabel={localeString('views.ActivityFilter.title')}
             >
-                <Filter fill={themeColor('text')} size={35} />
+                <Filter
+                    fill={
+                        isEqual(filters, DEFAULT_FILTERS)
+                            ? themeColor('text')
+                            : themeColor('highlight')
+                    }
+                    size={35}
+                />
             </TouchableOpacity>
         );
 


### PR DESCRIPTION
# Description

This fixes #2824.

Additionally improved `setFilters()` so it maintains complete filter structure when saving to storage, ensuring consistent comparison with default filters for filter icon color, but also now only displaying trash icon if filters are not in default mode.

|Before|After|
|-|-|
|![grafik](https://github.com/user-attachments/assets/0245217d-23a9-4eae-a9b1-39693fb6313c)|![grafik](https://github.com/user-attachments/assets/e9b66c24-e005-42a5-81c4-58e41f710f73)|

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
