### PR TITLE
Remove redundant getSettings() calls

### DIFF
--- a/views/Menu.tsx
+++ b/views/Menu.tsx
@@ -69,9 +69,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
     };
 
     UNSAFE_componentWillMount() {
-        const { SettingsStore, navigation } = this.props;
-
-        SettingsStore.getSettings();
+        const { navigation } = this.props;
 
         // triggers when loaded from navigation or back action
         navigation.addListener('focus', this.handleFocus);

--- a/views/Settings/Currency.tsx
+++ b/views/Settings/Currency.tsx
@@ -61,9 +61,7 @@ export default class Currency extends React.Component<
         prevState: Readonly<CurrencyState>,
         _snapshot?: any
     ): Promise<void> {
-        const { SettingsStore } = this.props;
-        const { getSettings } = SettingsStore;
-        const settings = await getSettings();
+        const { settings } = this.props.SettingsStore;
         if (prevState.selectedCurrency !== settings.fiat) {
             this.setState({
                 selectedCurrency: settings.fiat

--- a/views/Settings/Security.tsx
+++ b/views/Settings/Security.tsx
@@ -81,7 +81,6 @@ export default class Security extends React.Component<
     };
 
     componentDidMount() {
-        this.checkSettings();
         this.props.navigation.addListener('focus', this.checkSettings);
     }
 

--- a/views/Settings/Settings.tsx
+++ b/views/Settings/Settings.tsx
@@ -40,9 +40,7 @@ interface SettingsProps {
 @observer
 export default class Settings extends React.Component<SettingsProps, {}> {
     UNSAFE_componentWillMount() {
-        const { SettingsStore, navigation } = this.props;
-
-        SettingsStore.getSettings();
+        const { navigation } = this.props;
 
         // triggers when loaded from navigation or back action
         navigation.addListener('focus', this.handleFocus);

--- a/views/Tools.tsx
+++ b/views/Tools.tsx
@@ -33,9 +33,7 @@ interface ToolsProps {
 @observer
 export default class Tools extends React.Component<ToolsProps, {}> {
     UNSAFE_componentWillMount() {
-        const { SettingsStore, navigation } = this.props;
-
-        SettingsStore.getSettings();
+        const { navigation } = this.props;
 
         // triggers when loaded from navigation or back action
         navigation.addListener('focus', this.handleFocus);


### PR DESCRIPTION
# Description

This improves performance by reducing redundant getSettings() calls in various screens.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
