### PR TITLE
Performance improvement for updateSettings()

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1392,6 +1392,39 @@ export default class SettingsStore {
         return this.macaroonHex || this.accessKey ? true : false;
     }
 
+    @action
+    private updateNodeProperties(settings: Settings) {
+        const node: any =
+            settings?.nodes?.length &&
+            settings?.nodes[settings.selectedNode || 0];
+        if (node) {
+            this.host = node.host;
+            this.port = node.port;
+            this.url = node.url;
+            this.username = node.username;
+            this.password = node.password;
+            this.lndhubUrl = node.lndhubUrl;
+            this.macaroonHex = node.macaroonHex;
+            this.rune = node.rune;
+            this.accessKey = node.accessKey;
+            this.dismissCustodialWarning = node.dismissCustodialWarning;
+            this.implementation = node.implementation || 'lnd';
+            this.certVerification = node.certVerification || false;
+            this.enableTor = node.enableTor;
+            // LNC
+            this.pairingPhrase = node.pairingPhrase;
+            this.mailboxServer = node.mailboxServer;
+            this.customMailboxServer = node.customMailboxServer;
+            // Embedded lnd
+            this.seedPhrase = node.seedPhrase;
+            this.walletPassword = node.walletPassword;
+            this.adminMacaroon = node.adminMacaroon;
+            this.embeddedLndNetwork = node.embeddedLndNetwork;
+            // NWC
+            this.nostrWalletConnectUrl = node.nostrWalletConnectUrl;
+        }
+    }
+
     public async getSettings(silentUpdate: boolean = false) {
         if (!silentUpdate) this.loading = true;
         try {
@@ -1423,37 +1456,7 @@ export default class SettingsStore {
                 }
             }
 
-            runInAction(() => {
-                const node: any =
-                    this.settings?.nodes?.length &&
-                    this.settings?.nodes[this.settings.selectedNode || 0];
-                if (node) {
-                    this.host = node.host;
-                    this.port = node.port;
-                    this.url = node.url;
-                    this.username = node.username;
-                    this.password = node.password;
-                    this.lndhubUrl = node.lndhubUrl;
-                    this.macaroonHex = node.macaroonHex;
-                    this.rune = node.rune;
-                    this.accessKey = node.accessKey;
-                    this.dismissCustodialWarning = node.dismissCustodialWarning;
-                    this.implementation = node.implementation || 'lnd';
-                    this.certVerification = node.certVerification || false;
-                    this.enableTor = node.enableTor;
-                    // LNC
-                    this.pairingPhrase = node.pairingPhrase;
-                    this.mailboxServer = node.mailboxServer;
-                    this.customMailboxServer = node.customMailboxServer;
-                    // Embeded lnd
-                    this.seedPhrase = node.seedPhrase;
-                    this.walletPassword = node.walletPassword;
-                    this.adminMacaroon = node.adminMacaroon;
-                    this.embeddedLndNetwork = node.embeddedLndNetwork;
-                    // NWC
-                    this.nostrWalletConnectUrl = node.nostrWalletConnectUrl;
-                }
-            });
+            this.updateNodeProperties(this.settings);
         } catch (error) {
             console.error('Could not load settings', error);
         } finally {
@@ -1478,9 +1481,9 @@ export default class SettingsStore {
         };
 
         await this.setSettings(newSettings);
-        // ensure we get the enhanced settings set
-        const settings = await this.getSettings(true);
-        return settings;
+        // Update store's node properties from latest settings
+        this.updateNodeProperties(newSettings);
+        return newSettings;
     };
 
     // LNDHub


### PR DESCRIPTION
# Description

This optimizes the settings update process by extracting node properties updates into a dedicated method. It eliminates redundant `getSettings()` calls (storage operations, parsing JSON) which leads to significant performance improvements.

On Android emulator `updateSettings()` runs significantly faster now (average of 5 runs):
Before: 2285 ms
After: 1306 ms

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
