### PR TITLE
Lock settings elements while updateSettings() is running

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1222,6 +1222,7 @@ export default class SettingsStore {
     };
     @observable public posStatus: string = 'unselected';
     @observable public loading = false;
+    @observable public settingsUpdateInProgress: boolean = false;
     @observable btcPayError: string | null;
     @observable sponsorsError: string | null;
     @observable olympians: Array<any>;
@@ -1474,6 +1475,7 @@ export default class SettingsStore {
     }
 
     public updateSettings = async (newSetting: any) => {
+        this.settingsUpdateInProgress = true;
         const existingSettings = await this.getSettings();
         const newSettings = {
             ...existingSettings,
@@ -1483,6 +1485,7 @@ export default class SettingsStore {
         await this.setSettings(newSettings);
         // Update store's node properties from latest settings
         this.updateNodeProperties(newSettings);
+        this.settingsUpdateInProgress = false;
         return newSettings;
     };
 

--- a/views/Settings/ChannelsSettings.tsx
+++ b/views/Settings/ChannelsSettings.tsx
@@ -160,7 +160,10 @@ export default class ChannelsSettings extends React.Component<
                                         }
                                     });
                                 }}
-                                disabled={simpleTaprootChannel}
+                                disabled={
+                                    simpleTaprootChannel ||
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                             />
                         </View>
                     </View>
@@ -184,6 +187,9 @@ export default class ChannelsSettings extends React.Component<
                             >
                                 <Switch
                                     value={scidAlias}
+                                    disabled={
+                                        SettingsStore.settingsUpdateInProgress
+                                    }
                                     onValueChange={async () => {
                                         this.setState({
                                             scidAlias: !scidAlias
@@ -219,6 +225,9 @@ export default class ChannelsSettings extends React.Component<
                             >
                                 <Switch
                                     value={simpleTaprootChannel}
+                                    disabled={
+                                        SettingsStore.settingsUpdateInProgress
+                                    }
                                     onValueChange={async () => {
                                         this.setState({
                                             simpleTaprootChannel:
@@ -268,6 +277,9 @@ export default class ChannelsSettings extends React.Component<
                             >
                                 <Switch
                                     value={lsps1ShowPurchaseButton}
+                                    disabled={
+                                        SettingsStore.settingsUpdateInProgress
+                                    }
                                     onValueChange={async () => {
                                         this.setState({
                                             lsps1ShowPurchaseButton:

--- a/views/Settings/Display.tsx
+++ b/views/Settings/Display.tsx
@@ -121,6 +121,7 @@ export default class Display extends React.Component<
                     <DropdownSetting
                         title={localeString('views.Settings.Theme.title')}
                         selectedValue={theme}
+                        disabled={SettingsStore.settingsUpdateInProgress}
                         onValueChange={async (value: string) => {
                             this.setState({
                                 theme: value
@@ -147,6 +148,7 @@ export default class Display extends React.Component<
                             'views.Settings.Display.defaultView'
                         )}
                         selectedValue={defaultView}
+                        disabled={SettingsStore.settingsUpdateInProgress}
                         onValueChange={async (value: string) => {
                             this.setState({
                                 defaultView: value
@@ -178,6 +180,9 @@ export default class Display extends React.Component<
                         <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={displayNickname}
+                                disabled={
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                                 onValueChange={async () => {
                                     this.setState({
                                         displayNickname: !displayNickname
@@ -210,6 +215,9 @@ export default class Display extends React.Component<
                         <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={bigKeypadButtons}
+                                disabled={
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                                 onValueChange={async () => {
                                     this.setState({
                                         bigKeypadButtons: !bigKeypadButtons
@@ -242,6 +250,9 @@ export default class Display extends React.Component<
                         <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={showAllDecimalPlaces}
+                                disabled={
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                                 onValueChange={async () => {
                                     this.setState({
                                         showAllDecimalPlaces:
@@ -276,6 +287,9 @@ export default class Display extends React.Component<
                         <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={removeDecimalSpaces}
+                                disabled={
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                                 onValueChange={async () => {
                                     this.setState({
                                         removeDecimalSpaces:
@@ -310,6 +324,9 @@ export default class Display extends React.Component<
                         <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={showMillisatoshiAmounts}
+                                disabled={
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                                 onValueChange={async () => {
                                     this.setState({
                                         showMillisatoshiAmounts:
@@ -344,6 +361,9 @@ export default class Display extends React.Component<
                         <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={selectNodeOnStartup}
+                                disabled={
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                                 onValueChange={async () => {
                                     this.setState({
                                         selectNodeOnStartup:

--- a/views/Settings/InvoicesSettings.tsx
+++ b/views/Settings/InvoicesSettings.tsx
@@ -265,6 +265,9 @@ export default class InvoicesSettings extends React.Component<
                                     <DropdownSetting
                                         selectedValue={timePeriod}
                                         values={TIME_PERIOD_KEYS}
+                                        disabled={
+                                            SettingsStore.settingsUpdateInProgress
+                                        }
                                         onValueChange={async (
                                             value: string
                                         ) => {
@@ -361,7 +364,10 @@ export default class InvoicesSettings extends React.Component<
                                             }
                                         });
                                     }}
-                                    disabled={blindedPaths}
+                                    disabled={
+                                        blindedPaths ||
+                                        SettingsStore.settingsUpdateInProgress
+                                    }
                                 />
                             </View>
                         </View>
@@ -409,7 +415,10 @@ export default class InvoicesSettings extends React.Component<
                                             }
                                         });
                                     }}
-                                    disabled={blindedPaths}
+                                    disabled={
+                                        blindedPaths ||
+                                        SettingsStore.settingsUpdateInProgress
+                                    }
                                 />
                             </View>
                         </View>
@@ -445,6 +454,9 @@ export default class InvoicesSettings extends React.Component<
                             >
                                 <Switch
                                     value={blindedPaths}
+                                    disabled={
+                                        SettingsStore.settingsUpdateInProgress
+                                    }
                                     onValueChange={async () => {
                                         this.setState({
                                             blindedPaths: !blindedPaths,
@@ -491,6 +503,9 @@ export default class InvoicesSettings extends React.Component<
                             >
                                 <Switch
                                     value={showCustomPreimageField}
+                                    disabled={
+                                        SettingsStore.settingsUpdateInProgress
+                                    }
                                     onValueChange={async () => {
                                         this.setState({
                                             showCustomPreimageField:
@@ -531,6 +546,9 @@ export default class InvoicesSettings extends React.Component<
                         <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={displayAmountOnInvoice}
+                                disabled={
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                                 onValueChange={async () => {
                                     this.setState({
                                         displayAmountOnInvoice:

--- a/views/Settings/LightningAddress/LightningAddressSettings.tsx
+++ b/views/Settings/LightningAddress/LightningAddressSettings.tsx
@@ -168,6 +168,9 @@ export default class LightningAddressSettings extends React.Component<
                             >
                                 <Switch
                                     value={automaticallyAccept}
+                                    disabled={
+                                        SettingsStore.settingsUpdateInProgress
+                                    }
                                     onValueChange={async () => {
                                         this.setState({
                                             automaticallyAccept:
@@ -206,7 +209,10 @@ export default class LightningAddressSettings extends React.Component<
                                     });
                                 }}
                                 values={AUTOMATIC_ATTESTATION_KEYS}
-                                disabled={!automaticallyAccept}
+                                disabled={
+                                    !automaticallyAccept ||
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                             />
                         </View>
                         <View
@@ -239,6 +245,9 @@ export default class LightningAddressSettings extends React.Component<
                             >
                                 <Switch
                                     value={routeHints}
+                                    disabled={
+                                        SettingsStore.settingsUpdateInProgress
+                                    }
                                     onValueChange={async () => {
                                         this.setState({
                                             routeHints: !routeHints
@@ -277,6 +286,9 @@ export default class LightningAddressSettings extends React.Component<
                             >
                                 <Switch
                                     value={allowComments}
+                                    disabled={
+                                        SettingsStore.settingsUpdateInProgress
+                                    }
                                     onValueChange={async () => {
                                         try {
                                             await update({
@@ -323,6 +335,9 @@ export default class LightningAddressSettings extends React.Component<
                                     } catch (e) {}
                                 }}
                                 values={NOTIFICATIONS_PREF_KEYS}
+                                disabled={
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                             />
                         </View>
                         <ListItem

--- a/views/Settings/LightningAddress/NostrKeys.tsx
+++ b/views/Settings/LightningAddress/NostrKeys.tsx
@@ -387,7 +387,9 @@ export default class NostrKey extends React.Component<
                                         }}
                                         disabled={
                                             existingNostrPrivateKey ===
-                                                nostrPrivateKey || !nostrNpub
+                                                nostrPrivateKey ||
+                                            !nostrNpub ||
+                                            SettingsStore.settingsUpdateInProgress
                                         }
                                     />
                                 </View>

--- a/views/Settings/LightningAddress/NostrRelays.tsx
+++ b/views/Settings/LightningAddress/NostrRelays.tsx
@@ -162,6 +162,9 @@ export default class NostrRelays extends React.Component<
                                             color: themeColor('text')
                                         }}
                                         iconOnly
+                                        disabled={
+                                            SettingsStore.settingsUpdateInProgress
+                                        }
                                         onPress={async () => {
                                             if (
                                                 !addRelay ||
@@ -245,6 +248,9 @@ export default class NostrRelays extends React.Component<
                                                         )
                                                     }}
                                                     iconOnly
+                                                    disabled={
+                                                        SettingsStore.settingsUpdateInProgress
+                                                    }
                                                     onPress={async () => {
                                                         const newNostrRelays =
                                                             this.remove(

--- a/views/Settings/PointOfSale.tsx
+++ b/views/Settings/PointOfSale.tsx
@@ -191,6 +191,7 @@ export default class PointOfSale extends React.Component<
                                 });
                             }}
                             values={POS_ENABLED_KEYS}
+                            disabled={SettingsStore.settingsUpdateInProgress}
                         />
 
                         {posEnabled === PosEnabled.Square && (
@@ -273,6 +274,9 @@ export default class PointOfSale extends React.Component<
                                     >
                                         <Switch
                                             value={squareDevMode}
+                                            disabled={
+                                                SettingsStore.settingsUpdateInProgress
+                                            }
                                             onValueChange={async () => {
                                                 this.setState({
                                                     squareDevMode:
@@ -336,6 +340,9 @@ export default class PointOfSale extends React.Component<
                                         });
                                     }}
                                     values={POS_CONF_PREF_KEYS}
+                                    disabled={
+                                        SettingsStore.settingsUpdateInProgress
+                                    }
                                 />
                                 {posEnabled === PosEnabled.Standalone && (
                                     <DropdownSetting
@@ -357,6 +364,9 @@ export default class PointOfSale extends React.Component<
                                             });
                                         }}
                                         values={DEFAULT_VIEW_KEYS_POS}
+                                        disabled={
+                                            SettingsStore.settingsUpdateInProgress
+                                        }
                                     />
                                 )}
 
@@ -386,6 +396,9 @@ export default class PointOfSale extends React.Component<
                                     >
                                         <Switch
                                             value={disableTips}
+                                            disabled={
+                                                SettingsStore.settingsUpdateInProgress
+                                            }
                                             onValueChange={async () => {
                                                 this.setState({
                                                     disableTips: !disableTips
@@ -432,6 +445,9 @@ export default class PointOfSale extends React.Component<
                                         >
                                             <Switch
                                                 value={enablePrinter}
+                                                disabled={
+                                                    SettingsStore.settingsUpdateInProgress
+                                                }
                                                 onValueChange={async () => {
                                                     this.setState({
                                                         enablePrinter:
@@ -480,6 +496,9 @@ export default class PointOfSale extends React.Component<
                                     >
                                         <Switch
                                             value={showKeypad}
+                                            disabled={
+                                                SettingsStore.settingsUpdateInProgress
+                                            }
                                             onValueChange={async () => {
                                                 this.setState({
                                                     showKeypad: !showKeypad

--- a/views/Settings/Privacy.tsx
+++ b/views/Settings/Privacy.tsx
@@ -121,6 +121,7 @@ export default class Privacy extends React.Component<
                             });
                         }}
                         values={BLOCK_EXPLORER_KEYS}
+                        disabled={SettingsStore.settingsUpdateInProgress}
                     />
 
                     {defaultBlockExplorer === 'Custom' && (
@@ -178,6 +179,9 @@ export default class Privacy extends React.Component<
                         <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={clipboard}
+                                disabled={
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                                 onValueChange={async () => {
                                     this.setState({
                                         clipboard: !clipboard
@@ -225,6 +229,9 @@ export default class Privacy extends React.Component<
                         <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={lurkerMode}
+                                disabled={
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                                 onValueChange={async () => {
                                     this.setState({
                                         lurkerMode: !lurkerMode
@@ -261,6 +268,9 @@ export default class Privacy extends React.Component<
                         <View style={{ alignSelf: 'center', marginLeft: 5 }}>
                             <Switch
                                 value={enableMempoolRates}
+                                disabled={
+                                    SettingsStore.settingsUpdateInProgress
+                                }
                                 onValueChange={async () => {
                                     this.setState({
                                         enableMempoolRates: !enableMempoolRates


### PR DESCRIPTION
# Description

This fixes a regression from https://github.com/ZeusLN/zeus/pull/2808, where making multiple rapid settings changes led to some settings changes not being saved because `updateSettings()` was still running. To recreate, try switching on multiple switches e.g. in display settings rapidly on simulator (physical devices are much faster and it might be difficult to recreate, but not sure), then leave the settings view and come back -> some settings were maybe not saved.

As discussed with @kaloudis a queue mechanism in updateSettings() would add too much complexity, so we decided to take this simpler approach.

**Note:** Text inputs are not locked, because it would lead to a flickering effect while typing (it is visible when Dropdowns are disabled), and it should also be pretty much impossible to finish typing in one input, click an onther one, type and be done with typing even before the `updateSettings()` call of the first input ran through.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
