### PR TITLE
Convert getSettings() and updateNodeProperties() to arrow functions

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1396,7 +1396,7 @@ export default class SettingsStore {
     }
 
     @action
-    private updateNodeProperties(settings: Settings) {
+    private updateNodeProperties = (settings: Settings) => {
         const node: any =
             settings?.nodes?.length &&
             settings?.nodes[settings.selectedNode || 0];
@@ -1426,9 +1426,9 @@ export default class SettingsStore {
             // NWC
             this.nostrWalletConnectUrl = node.nostrWalletConnectUrl;
         }
-    }
+    };
 
-    public async getSettings(silentUpdate: boolean = false) {
+    public getSettings = async (silentUpdate: boolean = false) => {
         if (!silentUpdate) this.loading = true;
         try {
             const modernSettings: any = await Storage.getItem(STORAGE_KEY);
@@ -1467,7 +1467,7 @@ export default class SettingsStore {
         }
 
         return this.settings;
-    }
+    };
 
     public async setSettings(settings: any) {
         this.loading = true;


### PR DESCRIPTION
# Description

This fixes a regression introduced by https://github.com/ZeusLN/zeus/pull/2843:
When you open `Send` view this error occured:
` ERROR  Could not load settings [TypeError: this.updateNodeProperties is not a function (it is undefined)]`

Converting the methods to arrow functions ensures they maintain the correct `this` binding to the SettingsStore instance. This is needed since `getSettings()` calls `updateNodeProperties()` when loading settings e.g. in the Send view.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub
- [ ] [DEPRECATED] Core Lightning (c-lightning-REST)
- [ ] [DEPRECATED] Core Lightning (Spark)
- [ ] [DEPRECATED] Eclair

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
