### PR TITLE
Check, request and handle notification permissions

### DIFF
--- a/components/KeyValue.tsx
+++ b/components/KeyValue.tsx
@@ -109,11 +109,11 @@ export default class KeyValue extends React.Component<KeyValueProps, {}> {
             Key = (
                 <TouchableOpacity
                     onPress={() =>
-                        toggleInfoModal(
-                            infoModalText,
-                            infoModalLink,
-                            infoModalAdditionalButtons
-                        )
+                        toggleInfoModal({
+                            text: infoModalText,
+                            link: infoModalLink,
+                            buttons: infoModalAdditionalButtons
+                        })
                     }
                 >
                     {KeyBase}

--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -271,9 +271,9 @@ export default class LightningSwipeableRow extends Component<
             return (
                 <TouchableOpacity
                     onPress={() =>
-                        stores.modalStore.toggleInfoModal(
-                            localeString('views.Wallet.waitForSync')
-                        )
+                        stores.modalStore.toggleInfoModal({
+                            text: localeString('views.Wallet.waitForSync')
+                        })
                     }
                     activeOpacity={1}
                 >

--- a/components/LayerBalances/OnchainSwipeableRow.tsx
+++ b/components/LayerBalances/OnchainSwipeableRow.tsx
@@ -185,9 +185,9 @@ export default class OnchainSwipeableRow extends Component<
             return (
                 <TouchableOpacity
                     onPress={() =>
-                        stores.modalStore.toggleInfoModal(
-                            localeString('views.Wallet.waitForSync')
-                        )
+                        stores.modalStore.toggleInfoModal({
+                            text: localeString('views.Wallet.waitForSync')
+                        })
                     }
                     activeOpacity={1}
                     style={{ width: '100%' }}

--- a/components/Modals/InfoModal.tsx
+++ b/components/Modals/InfoModal.tsx
@@ -13,6 +13,7 @@ import { themeColor } from '../../utils/ThemeUtils';
 
 interface InfoModalProps {
     ModalStore: ModalStore;
+    onDismiss?: () => void;
 }
 
 @inject('ModalStore')
@@ -130,7 +131,11 @@ export default class InfoModal extends React.Component<InfoModalProps, {}> {
                             <View style={styles.button}>
                                 <Button
                                     title={localeString('general.close')}
-                                    onPress={() => toggleInfoModal()}
+                                    onPress={() => {
+                                        toggleInfoModal({
+                                            onDismiss: ModalStore.onDismiss
+                                        });
+                                    }}
                                     secondary
                                 />
                             </View>

--- a/components/Text.tsx
+++ b/components/Text.tsx
@@ -59,11 +59,11 @@ export default class ZeusText extends React.Component<TextProps, {}> {
             return (
                 <TouchableOpacity
                     onPress={() =>
-                        toggleInfoModal(
-                            infoModalText,
-                            infoModalLink,
-                            infoModalAdditionalButtons
-                        )
+                        toggleInfoModal({
+                            text: infoModalText,
+                            link: infoModalLink,
+                            buttons: infoModalAdditionalButtons
+                        })
                     }
                 >
                     <CoreText />

--- a/locales/en.json
+++ b/locales/en.json
@@ -1379,5 +1379,7 @@
     "views.OnChainAddresses.createAddress": "Create address",
     "views.OnChainAddresses.changeAddresses": "Change addresses",
     "androidNotification.lndRunningBackground": "LND is running in the background",
-    "androidNotification.shutdown": "Shutdown"
+    "androidNotification.shutdown": "Shutdown",
+    "notifications.permissionNeeded": "Without notifications some ZEUS features will not work as intended.",
+    "notifications.permissionBlocked": "Please enable notifications in your device settings to continue."
 }

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "react-native-nfc-manager": "3.14.14",
     "react-native-notifications": "5.1.0",
     "react-native-os": "aprock/react-native-os#5/head",
+    "react-native-permissions": "5.2.5",
     "react-native-ping": "1.2.8",
     "react-native-print": "0.11.0",
     "react-native-qrcode-svg": "6.2.0",

--- a/stores/LightningAddressStore.ts
+++ b/stores/LightningAddressStore.ts
@@ -23,6 +23,7 @@ import BackendUtils from '../utils/BackendUtils';
 import Base64Utils from '../utils/Base64Utils';
 import { sleep } from '../utils/SleepUtils';
 import { localeString } from '../utils/LocaleUtils';
+import { checkAndRequestNotificationPermissions } from '../utils/NotificationUtils';
 
 import Storage from '../storage';
 
@@ -288,6 +289,9 @@ export default class LightningAddressStore {
                 this.setLightningAddress(responseHandle, domain);
             }
 
+            const permissionGranted =
+                await checkAndRequestNotificationPermissions();
+
             await this.settingsStore.updateSettings({
                 lightningAddress: {
                     enabled: true,
@@ -296,7 +300,7 @@ export default class LightningAddressStore {
                     allowComments: true,
                     nostrPrivateKey,
                     nostrRelays: relays,
-                    notifications: 1
+                    notifications: permissionGranted ? 1 : 0
                 }
             });
 

--- a/stores/ModalStore.ts
+++ b/stores/ModalStore.ts
@@ -1,5 +1,12 @@
 import { action, observable } from 'mobx';
 
+interface InfoModalParams {
+    text?: string | Array<string>;
+    link?: string;
+    buttons?: Array<{ title: string; callback?: () => void }>;
+    onDismiss?: () => void;
+}
+
 export default class ModalStore {
     @observable public showExternalLinkModal: boolean = false;
     @observable public showAndroidNfcModal: boolean = false;
@@ -17,6 +24,7 @@ export default class ModalStore {
     @observable public alertModalLink: string | undefined;
     @observable public alertModalNav: string | undefined;
     @observable public onPress: () => void;
+    @observable public onDismiss: (() => void) | undefined;
 
     /* External Link Modal */
     @action
@@ -25,15 +33,13 @@ export default class ModalStore {
     };
 
     @action
-    public toggleInfoModal = (
-        text?: string | Array<string>,
-        link?: string,
-        buttons?: Array<{ title: string; callback?: () => void }>
-    ) => {
-        this.showInfoModal = text ? true : false;
-        this.infoModalText = text;
-        this.infoModalLink = link;
-        this.infoModalAdditionalButtons = buttons;
+    public toggleInfoModal = (params?: InfoModalParams) => {
+        this.showInfoModal = !!params?.text;
+        this.infoModalText = params?.text;
+        this.infoModalLink = params?.link;
+        this.infoModalAdditionalButtons = params?.buttons;
+        this.onDismiss = params?.onDismiss;
+        if (!params?.text && params?.onDismiss) params.onDismiss();
     };
 
     @action
@@ -73,9 +79,11 @@ export default class ModalStore {
             return true;
         }
         if (this.showInfoModal) {
+            if (this.onDismiss) this.onDismiss();
             this.showInfoModal = false;
             this.infoModalText = '';
             this.infoModalLink = '';
+            this.onDismiss = undefined;
             this.infoModalAdditionalButtons = undefined;
             return true;
         }

--- a/utils/NotificationUtils.test.ts
+++ b/utils/NotificationUtils.test.ts
@@ -1,0 +1,189 @@
+import { Linking, AppState } from 'react-native';
+import {
+    checkNotifications,
+    requestNotifications
+} from 'react-native-permissions';
+
+import { Settings } from '../stores/SettingsStore';
+import {
+    handleNotificationPermissions,
+    checkAndRequestNotificationPermissions
+} from './NotificationUtils';
+
+jest.mock('react-native', () => ({
+    Platform: {
+        OS: 'android'
+    },
+    Linking: {
+        openSettings: jest.fn()
+    },
+    AppState: {
+        addEventListener: jest.fn()
+    }
+}));
+jest.mock('react-native-permissions', () => ({
+    checkNotifications: jest.fn(),
+    requestNotifications: jest.fn()
+}));
+jest.mock('@react-native-async-storage/async-storage', () => {
+    const mockGetItem = jest.fn();
+    return {
+        getItem: mockGetItem.mockImplementation((key) => {
+            if (key === 'persistentServicesEnabled') {
+                return Promise.resolve('true');
+            }
+            return Promise.resolve(null);
+        })
+    };
+});
+
+jest.mock('../stores/Stores', () => ({
+    __esModule: true,
+    default: {
+        modalStore: {
+            toggleInfoModal: jest.fn()
+        },
+        nodeInfoStore: {
+            nodeInfo: {
+                identity_pubkey: 'test-pubkey'
+            }
+        },
+        settingsStore: {
+            settings: {
+                locale: 'en'
+            }
+        }
+    }
+}));
+
+const mockSettings: Partial<Settings> = {
+    lightningAddress: {
+        enabled: true,
+        automaticallyAccept: true,
+        automaticallyAcceptAttestationLevel: 2,
+        automaticallyRequestOlympusChannels: false,
+        routeHints: false,
+        allowComments: true,
+        nostrPrivateKey: '',
+        nostrRelays: [],
+        notifications: 1
+    }
+};
+
+describe('NotificationUtils', () => {
+    let toggleInfoModal: jest.Mock;
+    let addEventListener: jest.Mock;
+
+    beforeEach(() => {
+        toggleInfoModal = jest.mocked(
+            require('../stores/Stores').default.modalStore.toggleInfoModal
+        );
+        addEventListener = AppState.addEventListener as jest.Mock;
+        jest.clearAllMocks();
+    });
+
+    describe('checkAndRequestNotificationPermissions', () => {
+        it('returns true when permissions are granted', async () => {
+            (requestNotifications as jest.Mock).mockResolvedValue({
+                status: 'granted'
+            });
+            const result = await checkAndRequestNotificationPermissions();
+            expect(result).toBe(true);
+        });
+
+        it('returns false when permissions are denied', async () => {
+            (requestNotifications as jest.Mock).mockResolvedValue({
+                status: 'denied'
+            });
+            const result = await checkAndRequestNotificationPermissions();
+            expect(result).toBe(false);
+        });
+
+        it('returns true when user grants permission through settings after initial block', async () => {
+            (requestNotifications as jest.Mock).mockResolvedValue({
+                status: 'blocked'
+            });
+            (checkNotifications as jest.Mock).mockResolvedValue({
+                status: 'granted'
+            });
+
+            const promise = checkAndRequestNotificationPermissions();
+
+            await Promise.resolve();
+            expect(toggleInfoModal).toHaveBeenCalled();
+            const modalCallback =
+                toggleInfoModal.mock.calls[0][0].buttons[0].callback;
+            await modalCallback();
+
+            const appStateCallback = addEventListener.mock.calls[0][1];
+            appStateCallback('active');
+
+            const result = await promise;
+            expect(result).toBe(true);
+            expect(Linking.openSettings).toHaveBeenCalled();
+        });
+
+        it('returns false when user dismisses infoModal', async () => {
+            (requestNotifications as jest.Mock).mockResolvedValue({
+                status: 'blocked'
+            });
+
+            const promise = checkAndRequestNotificationPermissions();
+
+            await Promise.resolve();
+            expect(toggleInfoModal).toHaveBeenCalled();
+            const onCloseCallback = toggleInfoModal.mock.calls[0][0].onDismiss;
+            onCloseCallback();
+
+            const result = await promise;
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('handleNotificationPermissions', () => {
+        it('requests notification permissions when current node has ln address and and push notifications enabled', async () => {
+            (requestNotifications as jest.Mock).mockResolvedValue({
+                status: 'granted'
+            });
+            await handleNotificationPermissions(mockSettings as Settings);
+            expect(requestNotifications).toHaveBeenCalled();
+        });
+
+        it('requests notification permissions when current node is embedded-lnd with persistent mode enabled', async () => {
+            const mockAsyncStorage = require('@react-native-async-storage/async-storage');
+            const embeddedSettings = {
+                ...mockSettings,
+                lightningAddress: {
+                    ...mockSettings.lightningAddress,
+                    enabled: false,
+                    nostrPrivateKey: ''
+                },
+                nodes: [
+                    {
+                        implementation: 'embedded-lnd',
+                        dismissCustodialWarning: false
+                    }
+                ],
+                selectedNode: 0
+            } as Settings;
+
+            await handleNotificationPermissions(embeddedSettings);
+            expect(mockAsyncStorage.getItem).toHaveBeenCalledWith(
+                'persistentServicesEnabled'
+            );
+        });
+
+        it('should not request permissions when notifications are disabled', async () => {
+            const noNotificationSettings = {
+                ...mockSettings,
+                lightningAddress: {
+                    ...mockSettings.lightningAddress,
+                    notifications: 0
+                }
+            } as Settings;
+
+            await handleNotificationPermissions(noNotificationSettings);
+            expect(requestNotifications).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/utils/NotificationUtils.ts
+++ b/utils/NotificationUtils.ts
@@ -1,0 +1,98 @@
+import { Platform, Linking, AppState } from 'react-native';
+import {
+    checkNotifications,
+    requestNotifications
+} from 'react-native-permissions';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import stores from '../stores/Stores';
+import { Settings } from '../stores/SettingsStore';
+import { localeString } from './LocaleUtils';
+
+const checkIfNotificationsNeeded = async (
+    settings: Settings
+): Promise<boolean> => {
+    if (
+        settings?.lightningAddress?.enabled &&
+        settings?.lightningAddress?.notifications === 1
+    )
+        return true;
+
+    if (
+        settings?.nodes?.[settings.selectedNode!]?.implementation ===
+        'embedded-lnd'
+    ) {
+        const persistentMode =
+            (await AsyncStorage.getItem('persistentServicesEnabled')) ===
+            'true';
+        if (persistentMode) return true;
+    }
+
+    return false;
+};
+
+const handleNotificationPermissionBlocked = (
+    permissionCheck: () => Promise<boolean>,
+    callback?: (hasPermission: boolean) => void
+) => {
+    return new Promise<boolean>((resolve) => {
+        stores.modalStore.toggleInfoModal({
+            text: `${localeString(
+                'notifications.permissionNeeded'
+            )} ${localeString('notifications.permissionBlocked')}`,
+            buttons: [
+                {
+                    title: localeString('views.Wallet.MainPane.goToSettings'),
+                    callback: async () => {
+                        Linking.openSettings();
+                        // Wait for app to return to foreground and recheck
+                        let appStateSubscription: any;
+                        const checkPermission = async () => {
+                            const hasPermission = await permissionCheck();
+                            appStateSubscription?.remove();
+                            callback?.(hasPermission);
+                            resolve(hasPermission);
+                        };
+                        appStateSubscription = AppState.addEventListener(
+                            'change',
+                            (nextAppState) => {
+                                if (nextAppState === 'active') {
+                                    checkPermission();
+                                }
+                            }
+                        );
+                    }
+                }
+            ],
+            onDismiss: () => {
+                resolve(false);
+            }
+        });
+    });
+};
+
+export const checkAndRequestNotificationPermissions =
+    async (): Promise<boolean> => {
+        const { status } = await requestNotifications(
+            Platform.OS === 'ios' ? ['alert', 'sound'] : undefined
+        );
+        if (status === 'granted') return true;
+        if (status === 'denied') return false;
+        if (status === 'blocked') {
+            return new Promise((resolve) => {
+                handleNotificationPermissionBlocked(
+                    async () => {
+                        const { status } = await checkNotifications();
+                        return status === 'granted';
+                    },
+                    (hasPermission) => resolve(hasPermission)
+                ).then((result) => resolve(result));
+            });
+        }
+        return false;
+    };
+
+export const handleNotificationPermissions = async (settings: Settings) => {
+    if (await checkIfNotificationsNeeded(settings)) {
+        await checkAndRequestNotificationPermissions();
+    }
+};

--- a/utils/handleAnything.test.ts
+++ b/utils/handleAnything.test.ts
@@ -1,6 +1,14 @@
 jest.mock('../stores/ChannelBackupStore', () => ({}));
 jest.mock('../stores/LSPStore', () => ({}));
 jest.mock('react-native-notifications', () => ({}));
+jest.mock('react-native-permissions', () => ({
+    checkNotifications: jest.fn(),
+    requestNotifications: jest.fn()
+}));
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    getItem: jest.fn(),
+    setItem: jest.fn()
+}));
 
 import stores from '../stores/Stores';
 import handleAnything from './handleAnything';

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -554,14 +554,16 @@ export default class ChannelView extends React.Component<
                                     <TouchableOpacity
                                         style={{ width: '50%' }}
                                         onPress={() => {
-                                            ModalStore.toggleInfoModal([
-                                                localeString(
-                                                    'views.Channel.lease.lspDiscretion.explainer1'
-                                                ),
-                                                localeString(
-                                                    'views.Channel.lease.lspDiscretion.explainer2'
-                                                )
-                                            ]);
+                                            ModalStore.toggleInfoModal({
+                                                text: [
+                                                    localeString(
+                                                        'views.Channel.lease.lspDiscretion.explainer1'
+                                                    ),
+                                                    localeString(
+                                                        'views.Channel.lease.lspDiscretion.explainer2'
+                                                    )
+                                                ]
+                                            });
                                         }}
                                     >
                                         <Text

--- a/views/Settings/EmbeddedNode/Advanced.tsx
+++ b/views/Settings/EmbeddedNode/Advanced.tsx
@@ -21,7 +21,7 @@ import { localeString } from '../../../utils/LocaleUtils';
 import { restartNeeded } from '../../../utils/RestartUtils';
 import { sleep } from '../../../utils/SleepUtils';
 import { themeColor } from '../../../utils/ThemeUtils';
-
+import { checkAndRequestNotificationPermissions } from '../../../utils/NotificationUtils';
 import { stopLnd } from '../../../utils/LndMobileUtils';
 
 interface EmbeddedNodeAdvancedSettingsProps {
@@ -274,6 +274,15 @@ export default class EmbeddedNodeAdvancedSettings extends React.Component<
                                         <Switch
                                             value={persistentMode}
                                             onValueChange={async () => {
+                                                if (!persistentMode) {
+                                                    const permissionGranted =
+                                                        await checkAndRequestNotificationPermissions();
+
+                                                    // Enabling persistent mode only works if notification permission is granted
+                                                    if (!permissionGranted)
+                                                        return;
+                                                }
+
                                                 this.setState({
                                                     persistentMode:
                                                         !persistentMode

--- a/views/Settings/LightningAddress/LightningAddressSettings.tsx
+++ b/views/Settings/LightningAddress/LightningAddressSettings.tsx
@@ -21,6 +21,7 @@ import LightningAddressStore from '../../../stores/LightningAddressStore';
 
 import { localeString } from '../../../utils/LocaleUtils';
 import { themeColor } from '../../../utils/ThemeUtils';
+import { checkAndRequestNotificationPermissions } from '../../../utils/NotificationUtils';
 
 interface LightningAddressSettingsProps {
     navigation: StackNavigationProp<any, any>;
@@ -318,6 +319,12 @@ export default class LightningAddressSettings extends React.Component<
                                 )}
                                 selectedValue={notifications}
                                 onValueChange={async (value: number) => {
+                                    if (value === 1) {
+                                        const permissionGranted =
+                                            await checkAndRequestNotificationPermissions();
+                                        if (!permissionGranted) return;
+                                    }
+
                                     try {
                                         await update({
                                             notifications: value

--- a/views/Settings/LightningAddress/index.tsx
+++ b/views/Settings/LightningAddress/index.tsx
@@ -41,6 +41,7 @@ import BackendUtils from '../../../utils/BackendUtils';
 import { localeString } from '../../../utils/LocaleUtils';
 import { themeColor } from '../../../utils/ThemeUtils';
 import UrlUtils from '../../../utils/UrlUtils';
+import { checkAndRequestNotificationPermissions } from '../../../utils/NotificationUtils';
 
 import QR from '../../../assets/images/SVG/QR.svg';
 import Gear from '../../../assets/images/SVG/Gear.svg';
@@ -564,14 +565,38 @@ export default class LightningAddress extends React.Component<
                                             title={localeString(
                                                 'views.Settings.LightningAddress.create'
                                             )}
-                                            onPress={() =>
+                                            onPress={async () => {
+                                                const {
+                                                    updateSettings,
+                                                    settings
+                                                } = SettingsStore;
+                                                const pushNotificationsEnabled =
+                                                    settings.lightningAddress
+                                                        ?.notifications === 1;
+                                                if (pushNotificationsEnabled) {
+                                                    const permissionGranted =
+                                                        await checkAndRequestNotificationPermissions();
+                                                    if (!permissionGranted) {
+                                                        await updateSettings({
+                                                            lightningAddress: {
+                                                                ...settings.lightningAddress,
+                                                                notifications: 0
+                                                            }
+                                                        });
+                                                    }
+                                                }
                                                 create(
                                                     newLightningAddress,
                                                     nostrPublicKey,
                                                     nostrPrivateKey,
                                                     nostrRelays
-                                                ).then(() => status())
-                                            }
+                                                )
+                                                    .then(() => status())
+                                                    .catch(() => {
+                                                        // Empty catch to prevent unhandled rejection warning
+                                                        // Error state is handled by MobX store
+                                                    });
+                                            }}
                                             disabled={
                                                 !nostrPublicKey ||
                                                 !nostrNpub ||

--- a/views/Settings/Security.tsx
+++ b/views/Settings/Security.tsx
@@ -159,12 +159,11 @@ export default class Security extends React.Component<
         const { pin, passphrase } = SettingsStore.settings;
 
         if (value && !pin && !passphrase) {
-            ModalStore.toggleInfoModal(
-                localeString(
+            ModalStore.toggleInfoModal({
+                text: localeString(
                     'views.Settings.Security.BiometryRequiresPinOrPassword'
                 ),
-                undefined,
-                [
+                buttons: [
                     {
                         title: localeString(
                             'views.Settings.createYourPassword'
@@ -182,7 +181,7 @@ export default class Security extends React.Component<
                             })
                     }
                 ]
-            );
+            });
             return;
         }
 
@@ -215,15 +214,14 @@ export default class Security extends React.Component<
         if (!(settings.passphrase || settings.pin)) {
             navigation.navigate(item.screen);
         } else if (item.action === 'DeletePin' && isBiometryEnabled) {
-            ModalStore.toggleInfoModal(
-                [
+            ModalStore.toggleInfoModal({
+                text: [
                     localeString(
                         'views.Settings.Security.biometricsWillBeDisabled'
                     ),
                     localeString('general.continueQuestion')
                 ],
-                undefined,
-                [
+                buttons: [
                     {
                         title: localeString('general.ok'),
                         callback: () =>
@@ -232,7 +230,7 @@ export default class Security extends React.Component<
                             })
                     }
                 ]
-            );
+            });
         } else if (item.action === 'DeletePin') {
             navigation.navigate('Lockscreen', {
                 deletePin: true

--- a/views/Settings/SetPassword.tsx
+++ b/views/Settings/SetPassword.tsx
@@ -270,12 +270,11 @@ export default class SetPassphrase extends React.Component<
                                             confirmDelete: true
                                         });
                                     } else if (this.state.isBiometryEnabled) {
-                                        this.props.ModalStore.toggleInfoModal(
-                                            localeString(
+                                        this.props.ModalStore.toggleInfoModal({
+                                            text: localeString(
                                                 'views.Settings.Security.biometricsWillBeDisabled'
                                             ),
-                                            undefined,
-                                            [
+                                            buttons: [
                                                 {
                                                     title: localeString(
                                                         'general.ok'
@@ -284,7 +283,7 @@ export default class SetPassphrase extends React.Component<
                                                         this.deletePassword()
                                                 }
                                             ]
-                                        );
+                                        });
                                     } else {
                                         this.deletePassword();
                                     }

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -50,6 +50,7 @@ import { localeString, bridgeJavaStrings } from '../../utils/LocaleUtils';
 import { IS_BACKED_UP_KEY } from '../../utils/MigrationUtils';
 import { protectedNavigation } from '../../utils/NavigationUtils';
 import { isLightTheme, themeColor } from '../../utils/ThemeUtils';
+import { handleNotificationPermissions } from '../../utils/NotificationUtils';
 
 import Storage from '../../storage';
 
@@ -522,6 +523,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 setConnectingStatus(false);
                 return;
             }
+        }
+
+        if (connecting) {
+            await handleNotificationPermissions(settings);
         }
 
         if (

--- a/yarn.lock
+++ b/yarn.lock
@@ -9035,6 +9035,11 @@ react-native-os@aprock/react-native-os#5/head:
   version "1.2.2"
   resolved "https://codeload.github.com/aprock/react-native-os/tar.gz/4490cdae7c5575ab4ecce4b87558637ee52523fc"
 
+react-native-permissions@5.2.5:
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-5.2.5.tgz#c431b7dc15213dd87cebad0ba5658eaf7c30efd3"
+  integrity sha512-pECev4EuA+XAq9kduJu9V5OtqKlOokf+5lawPmkTHvr6LoOl6VLZlI2Ue4tnOu1PLc6tQaG19kQ5gbKG4gyNAw==
+
 react-native-ping@1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/react-native-ping/-/react-native-ping-1.2.8.tgz#c84a944cad50e7874f35b3f8bf884cd08333575e"


### PR DESCRIPTION
# Description

This lets Zeus properly check, request and handle notification permissions.

Tested with Android 12 and Android 14 (notification permission logic changed as of Android 13). **Untested for iOS.**

Zeus now handles notification permissions across different Android versions (and iOS hopefully also works :alien:). When notifications are needed, it will either request permission directly (not possible on Android 12 and lower) or guide users to system settings with an infoModal. This happens when:
  - user enables persistent mode
  - user creates a lightning address (because `notifications=push` is default)
  - Wallet.tsx loads while persistent mode is enabled OR ln address is enabled + `notifications=push`

Also:
- enabling persistent mode is only possible if user grants notification permission
- changing lightning address settings to `notifications=push` is only possible if user grants notification permission
- creating a lightning address will still be possible if user denies notification permission, but it will then set `notifications=disabled`

Additionally fixed a "Possible unhandled promise rejection" warning by adding an empty catch in `LightningAddress\index.tsx`.

**Note:**
Added AsyncStorage and react-native-permissions mocks to handleAnything.test.ts because these modules are required through the dependency chain.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [x] Contributors will need to run `yarn` after this PR is merged in
- [x] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
