### PR TITLE
ZEUS Pay: don't fire local notifications on manual redemption

### DIFF
--- a/stores/LightningAddressStore.ts
+++ b/stores/LightningAddressStore.ts
@@ -724,7 +724,8 @@ export default class LightningAddressStore {
         hash: string,
         amount_msat: number,
         comment?: string,
-        skipStatus?: boolean
+        skipStatus?: boolean,
+        localNotification?: boolean
     ) => {
         return await this.getPreimageMap().then(async (map) => {
             const preimage = map[hash];
@@ -773,7 +774,7 @@ export default class LightningAddressStore {
                             result.payment_request,
                             preimageNotFound
                         ).then((success) => {
-                            if (success?.success === true)
+                            if (success?.success === true && localNotification)
                                 fireLocalNotification();
                             if (!skipStatus) this.status(true);
                             return;
@@ -792,7 +793,10 @@ export default class LightningAddressStore {
                                     result.payment_request,
                                     preimageNotFound
                                 ).then((success) => {
-                                    if (success?.success === true)
+                                    if (
+                                        success?.success === true &&
+                                        localNotification
+                                    )
                                         fireLocalNotification();
                                     if (!skipStatus) this.status(true);
                                     return;
@@ -806,7 +810,7 @@ export default class LightningAddressStore {
                             undefined,
                             preimageNotFound
                         ).then((success) => {
-                            if (success?.success === true)
+                            if (success?.success === true && localNotification)
                                 fireLocalNotification();
                             if (!skipStatus) this.status(true);
                             return;
@@ -904,7 +908,9 @@ export default class LightningAddressStore {
                             this.lookupPreimageAndRedeem(
                                 hash,
                                 amount_msat,
-                                comment
+                                comment,
+                                false,
+                                true
                             );
                         } else {
                             this.lookupAttestations(hash, amount_msat)
@@ -919,7 +925,9 @@ export default class LightningAddressStore {
                                     this.lookupPreimageAndRedeem(
                                         hash,
                                         amount_msat,
-                                        comment
+                                        comment,
+                                        false,
+                                        true
                                     );
                                 })
                                 .catch((e) =>


### PR DESCRIPTION
# Description

In v0.10.0-alpha we made some refactors that now have local notifications fire correctly. However, we never restricted them to only be fired when autoredeem was happening in the background. This PR fixes that and stops local notifications from firing when payments are manually redeemed.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
