### PR TITLE
Channel: display 0-conf Confirmed SCID and ensure renewal

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -437,6 +437,7 @@
     "views.Channel.aliasScid": "Alias SCID",
     "views.Channel.aliasScids": "Alias SCIDs",
     "views.Channel.peerAliasScid": "Peer Alias SCID",
+    "views.Channel.zeroConfConfirmedScid": "0-conf Confirmed SCID",
     "views.Channel.closeHeight": "Close height",
     "views.Channel.closeType": "Close type",
     "views.Channel.openInitiator": "Open initiator",

--- a/models/Channel.ts
+++ b/models/Channel.ts
@@ -43,6 +43,7 @@ export default class Channel extends BaseModel {
     private: boolean;
     initiator?: boolean;
     peer_scid_alias?: number;
+    zero_conf_confirmed_scid?: number;
     alias_scids?: Array<number>; // array uint64
     local_chan_reserve_sat?: string;
     remote_chan_reserve_sat?: string;
@@ -193,6 +194,33 @@ export default class Channel extends BaseModel {
             : this.channelId
             ? chanFormat({ number: this.channelId }).channel
             : undefined;
+    }
+
+    @computed
+    public get aliasScids(): Array<string> {
+        const scids: Array<string> = [];
+        this.alias_scids?.forEach((scid) => {
+            try {
+                const formatted = chanFormat({ number: scid }).channel;
+                if (formatted !== '0x0x0') scids.push(formatted);
+            } catch (e) {}
+        });
+        return scids;
+    }
+
+    @computed
+    public get peerScidAlias(): string | undefined {
+        const scid = this.peer_scid_alias
+            ? chanFormat({ number: this.peer_scid_alias }).channel
+            : undefined;
+        return scid !== '0x0x0' ? scid : undefined;
+    }
+
+    @computed get zeroConfConfirmedScid(): string | undefined {
+        const scid = this.zero_conf_confirmed_scid
+            ? chanFormat({ number: this.zero_conf_confirmed_scid }).channel
+            : undefined;
+        return scid !== '0x0x0' ? scid : undefined;
     }
 
     @computed

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -112,7 +112,11 @@ export default class ChannelView extends React.Component<
             (extendableChannel: any) => {
                 return (
                     extendableChannel.short_channel_id ===
-                    channel.shortChannelId
+                        channel.shortChannelId ||
+                    extendableChannel.short_channel_id ===
+                        channel.peerScidAlias ||
+                    extendableChannel.short_channel_id ===
+                        channel.zeroConfConfirmedScid
                 );
             }
         )[0];
@@ -325,8 +329,9 @@ export default class ChannelView extends React.Component<
             channelId,
             shortChannelId,
             initiator,
-            alias_scids,
-            peer_scid_alias,
+            aliasScids,
+            peerScidAlias,
+            zeroConfConfirmedScid,
             local_chan_reserve_sat,
             remote_chan_reserve_sat,
             displayName,
@@ -363,13 +368,11 @@ export default class ChannelView extends React.Component<
         const peerDisplay = PrivacyUtils.sensitiveValue(displayName, 8);
 
         const showAliasScids =
-            !!alias_scids &&
-            alias_scids.length > 0 &&
-            !(
-                alias_scids.length === 1 &&
-                alias_scids[0].toString() === channelId
-            );
-        const showPeerAliasScid = !!peer_scid_alias && peer_scid_alias != 0;
+            !!aliasScids &&
+            aliasScids.length > 0 &&
+            !(aliasScids.length === 1 && aliasScids[0] === shortChannelId);
+        const showPeerAliasScid = !!peerScidAlias;
+        const showZeroConfConfirmedScid = !!zeroConfConfirmedScid;
 
         const EditFees = () => (
             <TouchableOpacity
@@ -643,7 +646,9 @@ export default class ChannelView extends React.Component<
                         />
                     )}
 
-                    {(showPeerAliasScid || showAliasScids) && (
+                    {(showPeerAliasScid ||
+                        showAliasScids ||
+                        showZeroConfConfirmedScid) && (
                         <TouchableOpacity
                             onPress={() => {
                                 this.setState({
@@ -683,7 +688,7 @@ export default class ChannelView extends React.Component<
                             {showAliasScids && (
                                 <KeyValue
                                     keyValue={
-                                        alias_scids.length > 1
+                                        aliasScids.length > 1
                                             ? localeString(
                                                   'views.Channel.aliasScids'
                                               )
@@ -692,7 +697,7 @@ export default class ChannelView extends React.Component<
                                               )
                                     }
                                     value={PrivacyUtils.sensitiveValue(
-                                        alias_scids.join(', ')
+                                        aliasScids.join(', ')
                                     )}
                                 />
                             )}
@@ -702,7 +707,17 @@ export default class ChannelView extends React.Component<
                                         'views.Channel.peerAliasScid'
                                     )}
                                     value={PrivacyUtils.sensitiveValue(
-                                        peer_scid_alias
+                                        peerScidAlias
+                                    )}
+                                />
+                            )}
+                            {showZeroConfConfirmedScid && (
+                                <KeyValue
+                                    keyValue={localeString(
+                                        'views.Channel.zeroConfConfirmedScid'
+                                    )}
+                                    value={PrivacyUtils.sensitiveValue(
+                                        zeroConfConfirmedScid
                                     )}
                                 />
                             )}

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -134,7 +134,11 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
                 (extendableChannel: any) => {
                     return (
                         extendableChannel.short_channel_id ===
-                        item.shortChannelId
+                            item.shortChannelId ||
+                        extendableChannel.short_channel_id ===
+                            item.peerScidAlias ||
+                        extendableChannel.short_channel_id ===
+                            item.zeroConfConfirmedScid
                     );
                 }
             )[0];


### PR DESCRIPTION
# Description

- Adds a display of 0-conf Confirmed SCID to the single `Channel` view
- Display all aliases on the single `Channel` view are displayed in short channel format
- Ensure 0-conf purchased chans can be renewed by linking the renewal info and the 0-conf Confirmed SCID

|Display of 0-conf Confirmed SCID on the Channel view|
|-|
|![simulator_screenshot_40E855F5-43F2-4D07-B219-1C326750A712](https://github.com/user-attachments/assets/f42543fc-f750-4161-a0b7-d567ae5f20a6)|

This pull request is categorized as a:

- [x] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
