### PR TITLE
LSPS7: clear last order when entering extension flow

### DIFF
--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -115,6 +115,11 @@ export default class LSPStore {
         this.error_msg = '';
     };
 
+    @action
+    public clearLSPS7Order = () => {
+        this.createExtensionOrderResponse = {};
+    };
+
     public isOlympus = () => {
         const olympusREST = this.nodeInfoStore!.nodeInfo.isTestNet
             ? DEFAULT_LSPS1_REST_TESTNET

--- a/views/LSPS7/index.tsx
+++ b/views/LSPS7/index.tsx
@@ -109,7 +109,8 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
     }
 
     async componentDidMount() {
-        const { SettingsStore, navigation } = this.props;
+        const { LSPStore, SettingsStore, navigation } = this.props;
+        LSPStore.clearLSPS7Order();
         navigation.addListener('focus', () => {
             this.setState({
                 token: SettingsStore.settings?.lsps1Token || ''


### PR DESCRIPTION
# Description

Clears the last loaded order when attempting to extend a channel lease.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
