### PR TITLE
Wallets: skip connecting procedures if wallet already active

### DIFF
--- a/views/Settings/Wallets.tsx
+++ b/views/Settings/Wallets.tsx
@@ -246,31 +246,42 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                                                 : 'transparent'
                                         }}
                                         onPress={async () => {
-                                            const currentImplementation =
-                                                implementation;
-                                            if (
-                                                currentImplementation ===
-                                                'lightning-node-connect'
-                                            ) {
-                                                BackendUtils.disconnect();
-                                            }
-                                            await updateSettings({
-                                                nodes,
-                                                selectedNode: index
-                                            }).then(() => {
+                                            if (nodeActive) {
+                                                // if already on selected node, just pop to
+                                                // the Wallet view, skip connecting procedures
+                                                navigation.popTo('Wallet');
+                                            } else {
+                                                const currentImplementation =
+                                                    implementation;
                                                 if (
-                                                    item.implementation ===
-                                                        'embedded-lnd' &&
-                                                    Platform.OS === 'android' &&
-                                                    embeddedLndStarted
+                                                    currentImplementation ===
+                                                    'lightning-node-connect'
                                                 ) {
-                                                    restartNeeded(true);
-                                                } else {
-                                                    setConnectingStatus(true);
-                                                    setInitialStart(false);
-                                                    navigation.popTo('Wallet');
+                                                    BackendUtils.disconnect();
                                                 }
-                                            });
+                                                await updateSettings({
+                                                    nodes,
+                                                    selectedNode: index
+                                                }).then(() => {
+                                                    if (
+                                                        item.implementation ===
+                                                            'embedded-lnd' &&
+                                                        Platform.OS ===
+                                                            'android' &&
+                                                        embeddedLndStarted
+                                                    ) {
+                                                        restartNeeded(true);
+                                                    } else {
+                                                        setConnectingStatus(
+                                                            true
+                                                        );
+                                                        setInitialStart(false);
+                                                        navigation.popTo(
+                                                            'Wallet'
+                                                        );
+                                                    }
+                                                });
+                                            }
                                         }}
                                     >
                                         <ListItem


### PR DESCRIPTION
# Description

This addresses a bug where the wallet will go thru a boot loop, if the user has `Settings > Display > Select wallet on startup` enabled, and is selecting an Embedded LND wallet.

Also saves us on unnecessary calls for other backends.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
