### PR TITLE
Embedded LND: Open Channel: fund max fix

### DIFF
--- a/lndmobile/channel.ts
+++ b/lndmobile/channel.ts
@@ -35,7 +35,9 @@ export const openChannelSync = async (
         options: simpleTaprootChannel
             ? {
                   node_pubkey_string: pubkey,
-                  local_funding_amount: amount
+                  local_funding_amount: fund_max
+                      ? undefined
+                      : amount
                       ? Long.fromValue(amount)
                       : undefined,
                   target_conf: fee_rate_sat ? undefined : 2,
@@ -60,7 +62,9 @@ export const openChannelSync = async (
               }
             : {
                   node_pubkey_string: pubkey,
-                  local_funding_amount: amount
+                  local_funding_amount: fund_max
+                      ? undefined
+                      : amount
                       ? Long.fromValue(amount)
                       : undefined,
                   target_conf: fee_rate_sat ? undefined : 2,


### PR DESCRIPTION
# Description

It appears we've hit a regression in v0.10.0, potentially from: https://github.com/ZeusLN/zeus/pull/2769

From a user:

```
Ok, next step:
With the remaining OnChain amount I am trying to oben a new channel to your LSP. I set „use all funds“ (in german: Gesamtes Guthaben verwendet). 
But then I receive an error:

„cannot use local funding amount and fundmax parameters“
```

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
