### PR TITLE
ChannelsFilter: Prevent auto correction in SearchBar

### DIFF
--- a/components/Channels/ChannelsFilter.tsx
+++ b/components/Channels/ChannelsFilter.tsx
@@ -140,6 +140,7 @@ class ChannelsFilter extends React.PureComponent<ChannelsFilterProps> {
                             backgroundColor: themeColor('secondary')
                         }}
                         autoCapitalize="none"
+                        autoCorrect={false}
                         keyboardType="visible-password"
                         platform="default"
                         showLoading={false}


### PR DESCRIPTION
# Description

To prevent auto correction, there is a prop `autoCorrect` but some keyboards seem to ignore this.
Let's see how this workaround behaves on real devices (looks good on Android emulator) and for different users, then we can implement it for all other inputs where we do not want auto correction.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
