### PR TITLE
Dismiss warning: Fix styling

### DIFF
--- a/views/Settings/CustodialWalletWarning.tsx
+++ b/views/Settings/CustodialWalletWarning.tsx
@@ -256,11 +256,13 @@ export default class CustodialWalletWarning extends React.Component<
                                     }
                                     containerStyle={{
                                         backgroundColor: 'transparent',
-                                        borderWidth: 0
+                                        borderWidth: 0,
+                                        width: '100%'
                                     }}
                                     textStyle={{
                                         ...styles.text,
-                                        color: themeColor('text')
+                                        color: themeColor('text'),
+                                        flex: 1
                                     }}
                                 />
                             ))}
@@ -288,6 +290,7 @@ export default class CustodialWalletWarning extends React.Component<
                         </View>
                     </View>
                 </Modal>
+
                 <Button
                     title={localeString(
                         'views.Settings.CustodialWalletWarning.dismissWarning'


### PR DESCRIPTION
I have aligned the dismiss warning explainers

Before:
![Simulator Screenshot - iPhone 16e - 2025-03-25 at 16 01 33](https://github.com/user-attachments/assets/3a29359a-ff98-4e51-b398-a02bb8e49d4c)

After:
![Simulator Screenshot - iPhone 16e - 2025-03-25 at 16 01 54](https://github.com/user-attachments/assets/d587fe95-855f-45c3-8bc8-ca21c794265c)
