### PR TITLE
fix: Embedded LND: don't mark as started on wallet creation

### DIFF
--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -300,7 +300,8 @@ export async function startLnd({
         lndMobile.index;
     const { unlockWallet } = lndMobile.wallet;
 
-    stores.settingsStore.embeddedLndStarted = true;
+    // don't mark as started on wallet creation, only on proper start-up
+    if (walletPassword) stores.settingsStore.embeddedLndStarted = true;
 
     const status = await checkStatus();
     if (

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -425,7 +425,10 @@ export default class WalletConfiguration extends React.Component<
         }
     }
 
-    saveWalletConfiguration = (recoveryCipherSeed?: string) => {
+    saveWalletConfiguration = (
+        recoveryCipherSeed?: string,
+        newEmbeddedLndWallet?: boolean
+    ) => {
         const { SettingsStore, navigation } = this.props;
         const {
             nickname,
@@ -502,7 +505,19 @@ export default class WalletConfiguration extends React.Component<
             nodes = [node];
         }
 
-        updateSettings({ nodes }).then(async () => {
+        let update;
+        if (newEmbeddedLndWallet) {
+            update = {
+                nodes,
+                selectedNode: nodes.length - 1
+            };
+        } else {
+            update = {
+                nodes
+            };
+        }
+
+        updateSettings(update).then(async () => {
             if (recoveryCipherSeed) {
                 await updateSettings({
                     recovery: true
@@ -537,7 +552,11 @@ export default class WalletConfiguration extends React.Component<
                 setConnectingStatus(true);
                 navigation.popTo('Wallet');
             } else {
-                navigation.goBack();
+                if (newEmbeddedLndWallet) {
+                    navigation.popTo('Wallet');
+                } else {
+                    navigation.goBack();
+                }
             }
         });
     };
@@ -715,7 +734,7 @@ export default class WalletConfiguration extends React.Component<
                 creatingWallet: false
             });
 
-            this.saveWalletConfiguration(recoveryCipherSeed);
+            this.saveWalletConfiguration(recoveryCipherSeed, true);
         } else {
             this.setState({
                 creatingWallet: false,


### PR DESCRIPTION
# Description

Bug initially reported by @myxmaster: upon wallet creation and selection (after already having a remote wallet), prompt to restart is thrown. This is because LND is technically started up to generate the seed and initialize the wallet.

This change, only marks our `embeddedLndStarted` flag, used by the prompt, on subsequent starts, once the `walletPassword` has been defined.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
