### PR TITLE
Add approximate symbol to fiat amounts

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -47,7 +47,7 @@ interface AmountDisplayProps {
     accessibilityLabel?: string;
 }
 
-interface FiatSymbolProps {
+interface SymbolProps {
     accessible?: boolean;
 }
 
@@ -90,7 +90,7 @@ function AmountDisplay({
         </View>
     );
 
-    const FiatSymbol: React.FC<FiatSymbolProps> = ({ accessible }) => (
+    const FiatSymbol: React.FC<SymbolProps> = ({ accessible }) => (
         <Body
             secondary
             jumbo={jumboText}
@@ -100,6 +100,19 @@ function AmountDisplay({
             accessibilityLabel={unit}
         >
             {actualSymbol}
+        </Body>
+    );
+
+    const ApproximateSymbol: React.FC<SymbolProps> = ({ accessible }) => (
+        <Body
+            secondary
+            jumbo={jumboText}
+            color={color}
+            colorOverride={colorOverride}
+            accessible={accessible}
+            accessibilityLabel={localeString('general.approximately')}
+        >
+            ≈
         </Body>
     );
 
@@ -194,6 +207,11 @@ function AmountDisplay({
                                 accessible={accessible}
                             >
                                 {negative ? '-' : ''}
+                                {unit !== 'BTC' && (
+                                    <ApproximateSymbol
+                                        accessible={accessible}
+                                    />
+                                )}
                                 {amount === 'N/A' && fiatRatesLoading ? (
                                     <LoadingIndicator size={20} />
                                 ) : unit === 'BTC' ? (
@@ -217,6 +235,9 @@ function AmountDisplay({
                     >
                         {pending && <Pending />}
                         <View style={styles.textContainer}>
+                            {unit !== 'BTC' && (
+                                <ApproximateSymbol accessible={accessible} />
+                            )}
                             {amount !== 'N/A' && <FiatSymbol accessible />}
                             {space ? <TextSpace /> : <Spacer width={1} />}
                             <Body

--- a/locales/en.json
+++ b/locales/en.json
@@ -133,6 +133,7 @@
     "general.unknown": "Unknown",
     "general.retry": "Retry",
     "general.response": "Response",
+    "general.approximately": "Approximately",
     "channel.status.good": "Good",
     "channel.status.stable": "Stable",
     "channel.status.unstable": "Unstable",


### PR DESCRIPTION
# Description

Since fiat denominations in the app are always approximations, leveraging exchange rates, let's prefix them all with the approximation symbol: ≈

|-|-|-|
|-|-|-|
|![Simulator Screenshot - iPhone 16 Plus - 2025-04-03 at 22 25 23](https://github.com/user-attachments/assets/17476b5f-f176-4449-af96-3e42d7eba679)|![Simulator Screenshot - iPhone 16 Plus - 2025-04-03 at 22 25 30](https://github.com/user-attachments/assets/ad50609c-1fcb-4b6e-bf6d-1309e15eee0a)|![Simulator Screenshot - iPhone 16 Plus - 2025-04-03 at 22 26 17](https://github.com/user-attachments/assets/0a073746-4e60-424d-aa30-5769452565fe)|

|-|-|
|-|-|
|![Simulator Screenshot - iPhone 16 Plus - 2025-04-03 at 22 27 05](https://github.com/user-attachments/assets/d264a4b9-bd33-4fc2-b461-d9cf3e768221)|![Simulator Screenshot - iPhone 16 Plus - 2025-04-03 at 22 27 36](https://github.com/user-attachments/assets/b8ef8619-b38a-470b-b6dc-3c118bc96e0a)|


This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
