### PR TITLE
PaymentPath: move getNodeInfo() call outside render()

### DIFF
--- a/components/PaymentPath.tsx
+++ b/components/PaymentPath.tsx
@@ -245,6 +245,27 @@ export default class PaymentPath extends React.Component<
         };
     }
 
+    componentDidMount() {
+        this.prefetchAliases(this.props.enhancedPath);
+    }
+
+    componentDidUpdate(prevProps: PaymentPathProps) {
+        if (prevProps.enhancedPath !== this.props.enhancedPath) {
+            this.prefetchAliases(this.props.enhancedPath);
+        }
+    }
+
+    prefetchAliases(paths: any[]) {
+        paths.forEach((path) => {
+            path.forEach((hop: any) => {
+                const aliasMap = stores.channelsStore.aliasMap;
+                if (hop?.pubKey && !hop.alias && !aliasMap.get(hop.pubKey)) {
+                    stores.channelsStore.getNodeInfo(hop.pubKey);
+                }
+            });
+        });
+    }
+
     render() {
         const { enhancedPath } = this.props;
         const { expanded } = this.state;
@@ -300,13 +321,7 @@ export default class PaymentPath extends React.Component<
                 );
             }
             path.forEach((hop: any, pathIndex: number) => {
-                let loading = false;
-                if (!hop.alias && !aliasMap.get(hop.pubKey)) {
-                    loading = true;
-                    stores.channelsStore.getNodeInfo(hop.pubKey).finally(() => {
-                        loading = false;
-                    });
-                }
+                const loading = !hop.alias && !aliasMap.get(hop.pubKey);
                 (expanded.get(index) || enhancedPath.length === 1) &&
                     hops.push(
                         <ExpandedHop

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -91,7 +91,7 @@ export default class ChannelsStore {
     };
     @observable public showSearch: boolean = false;
     // aliasMap
-    @observable public aliasMap: any = observable.map({});
+    @observable public aliasMap = observable.map({});
     // external account funding
     @observable public funded_psbt: string = '';
     @observable public pending_chan_ids: Array<string>;


### PR DESCRIPTION
# Description

This hopefully fixes #2953.

Previously, getNodeInfo() was called during render. Since getNodeInfo() is asynchronous and might be called multiple times for multiple hops, the first result that arrives could trigger unnecessary additional getNodeInfo() calls. By moving the alias prefetching to lifecycle methods, we ensure that getNodeInfo() is only called once per hop when necessary.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
