### PR TITLE
ZEUS-2954: LNURL-pay fixes

### DIFF
--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -76,15 +76,27 @@ export default class LnurlPay extends React.Component<
 
     stateFromProps(props: LnurlPayProps) {
         const { route, UnitsStore } = props;
+        const { resetUnits, getUnformattedAmount, units } = UnitsStore;
         const { lnurlParams: lnurl, amount, satAmount } = route.params ?? {};
+
+        // if requested amount is fixed,
+        // convert units to sats so conversion rate doesn't make things unpayable
+        if (lnurl.minSendable === lnurl.maxSendable) {
+            resetUnits();
+        }
 
         const minSendableSats = Math.floor(lnurl.minSendable / 1000);
 
         const { amount: unformattedAmount } =
-            UnitsStore.getUnformattedAmount(minSendableSats);
+            getUnformattedAmount(minSendableSats);
+
+        // if amount to pay hasn't been previously specified by the user,
+        // fall back to the min sat amount
+        const unspecifiedDefault =
+            units === 'sats' ? minSendableSats.toString() : unformattedAmount;
 
         return {
-            amount: amount && amount != 0 ? amount : unformattedAmount,
+            amount: amount && amount != 0 ? amount : unspecifiedDefault,
             satAmount: satAmount ? satAmount : minSendableSats,
             domain: lnurl.domain,
             comment: ''


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2954**](https://github.com/ZeusLN/zeus/issues/2954)

Addresses issue of fixes satoshi amounts from LNURLp's being passed into the amount input form with commas and breaking the request call.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
