### PR TITLE
Trigger balance update after sending/receiving funds

### DIFF
--- a/stores/Stores.ts
+++ b/stores/Stores.ts
@@ -48,12 +48,13 @@ export const invoicesStore = new InvoicesStore(
     channelsStore,
     nodeInfoStore
 );
+export const balanceStore = new BalanceStore(settingsStore);
 export const transactionsStore = new TransactionsStore(
     settingsStore,
     nodeInfoStore,
-    channelsStore
+    channelsStore,
+    balanceStore
 );
-export const balanceStore = new BalanceStore(settingsStore);
 export const unitsStore = new UnitsStore(settingsStore, fiatStore);
 export const paymentsStore = new PaymentsStore(settingsStore, channelsStore);
 export const lnurlPayStore = new LnurlPayStore(settingsStore, nodeInfoStore);

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -20,6 +20,7 @@ import { localeString } from '../utils/LocaleUtils';
 import { lnrpc } from '../proto/lightning';
 import NodeInfoStore from './NodeInfoStore';
 import ChannelsStore from './ChannelsStore';
+import BalanceStore from './BalanceStore';
 
 const keySendPreimageType = '5482373484';
 const keySendMessageType = '34349334';
@@ -67,15 +68,18 @@ export default class TransactionsStore {
     settingsStore: SettingsStore;
     nodeInfoStore: NodeInfoStore;
     channelsStore: ChannelsStore;
+    balanceStore: BalanceStore;
 
     constructor(
         settingsStore: SettingsStore,
         nodeInfoStore: NodeInfoStore,
-        channelsStore: ChannelsStore
+        channelsStore: ChannelsStore,
+        balanceStore: BalanceStore
     ) {
         this.settingsStore = settingsStore;
         this.nodeInfoStore = nodeInfoStore;
         this.channelsStore = channelsStore;
+        this.balanceStore = balanceStore;
     }
 
     @action
@@ -432,6 +436,7 @@ export default class TransactionsStore {
                     this.txid = data.txid;
                     this.publishSuccess = true;
                     this.loading = false;
+                    this.balanceStore.getCombinedBalance();
                 });
             })
             .catch((error: Error) => {

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -71,6 +71,7 @@ import SettingsStore, { TIME_PERIOD_KEYS } from '../stores/SettingsStore';
 import LightningAddressStore from '../stores/LightningAddressStore';
 import LSPStore from '../stores/LSPStore';
 import UnitsStore from '../stores/UnitsStore';
+import BalanceStore from '../stores/BalanceStore';
 
 import { localeString } from '../utils/LocaleUtils';
 import BackendUtils from '../utils/BackendUtils';
@@ -107,6 +108,7 @@ interface ReceiveProps {
     UnitsStore: UnitsStore;
     LSPStore: LSPStore;
     LightningAddressStore: LightningAddressStore;
+    BalanceStore: BalanceStore;
     route: Route<
         'Receive',
         {
@@ -183,7 +185,8 @@ const LOCKED_EXPIRY_SECONDS = '3600';
     'PosStore',
     'NodeInfoStore',
     'LightningAddressStore',
-    'LSPStore'
+    'LSPStore',
+    'BalanceStore'
 )
 @observer
 export default class Receive extends React.Component<
@@ -727,8 +730,13 @@ export default class Receive extends React.Component<
     };
 
     subscribeInvoice = async (rHash?: string, onChainAddress?: string) => {
-        const { InvoicesStore, PosStore, SettingsStore, NodeInfoStore } =
-            this.props;
+        const {
+            InvoicesStore,
+            PosStore,
+            SettingsStore,
+            NodeInfoStore,
+            BalanceStore
+        } = this.props;
         const { orderId, orderTotal, orderTip, exchangeRate, rate, value } =
             this.state;
         const { implementation, settings } = SettingsStore;
@@ -773,6 +781,7 @@ export default class Receive extends React.Component<
                                 setWatchedInvoicePaid(
                                     Number(invoice.amt_paid_sat)
                                 );
+                                BalanceStore.getCombinedBalance();
 
                                 if (orderId) {
                                     PosStore.recordPayment({
@@ -836,6 +845,8 @@ export default class Receive extends React.Component<
                                 setWatchedInvoicePaid(
                                     Number(transaction.amount)
                                 );
+                                BalanceStore.getCombinedBalance();
+
                                 if (orderId) {
                                     PosStore.recordPayment({
                                         orderId,
@@ -889,6 +900,8 @@ export default class Receive extends React.Component<
                                 }
                                 if (result.settled) {
                                     setWatchedInvoicePaid(result.amt_paid_sat);
+                                    BalanceStore.getCombinedBalance();
+
                                     if (orderId) {
                                         PosStore.recordPayment({
                                             orderId,
@@ -945,6 +958,8 @@ export default class Receive extends React.Component<
                                     Number(result.amount) >= Number(value)
                                 ) {
                                     setWatchedInvoicePaid(result.amount);
+                                    BalanceStore.getCombinedBalance();
+
                                     if (orderId) {
                                         PosStore.recordPayment({
                                             orderId,
@@ -988,6 +1003,8 @@ export default class Receive extends React.Component<
                                     Number(result.amt_paid_sat) !== 0
                                 ) {
                                     setWatchedInvoicePaid(result.amt_paid_sat);
+                                    BalanceStore.getCombinedBalance();
+
                                     if (orderId) {
                                         PosStore.recordPayment({
                                             orderId,
@@ -1044,6 +1061,8 @@ export default class Receive extends React.Component<
                                         output.address === onChainAddress
                                     ) {
                                         setWatchedInvoicePaid(output.amount);
+                                        BalanceStore.getCombinedBalance();
+
                                         if (orderId) {
                                             PosStore.recordPayment({
                                                 orderId,

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -20,6 +20,7 @@ import Screen from '../components/Screen';
 import SuccessAnimation from '../components/SuccessAnimation';
 import { Row } from '../components/layout/Row';
 
+import BalanceStore from '../stores/BalanceStore';
 import LnurlPayStore from '../stores/LnurlPayStore';
 import PaymentsStore from '../stores/PaymentsStore';
 import SettingsStore from '../stores/SettingsStore';
@@ -37,6 +38,7 @@ import CopyBox from '../components/CopyBox';
 
 interface SendingLightningProps {
     navigation: StackNavigationProp<any, any>;
+    BalanceStore: BalanceStore;
     LnurlPayStore: LnurlPayStore;
     PaymentsStore: PaymentsStore;
     SettingsStore: SettingsStore;
@@ -49,7 +51,13 @@ interface SendingLightningState {
     currentPayment: any;
 }
 
-@inject('LnurlPayStore', 'PaymentsStore', 'SettingsStore', 'TransactionsStore')
+@inject(
+    'BalanceStore',
+    'LnurlPayStore',
+    'PaymentsStore',
+    'SettingsStore',
+    'TransactionsStore'
+)
 @observer
 export default class SendingLightning extends React.Component<
     SendingLightningProps,
@@ -90,12 +98,13 @@ export default class SendingLightning extends React.Component<
     }
 
     componentDidUpdate(_prevProps: SendingLightningProps) {
-        const { TransactionsStore } = this.props;
+        const { TransactionsStore, BalanceStore } = this.props;
         const wasSuccessful = this.successfullySent(TransactionsStore);
 
         if (wasSuccessful && !this.state.wasSuccessful) {
             this.fetchPayments();
             this.setState({ wasSuccessful: true }); // Update success state
+            BalanceStore.getCombinedBalance();
         } else if (!wasSuccessful && this.state.wasSuccessful) {
             this.setState({ wasSuccessful: false }); // Reset success state if needed
         }


### PR DESCRIPTION
# Description

Since we call `getSettingsAndNavigate()` less often (https://github.com/ZeusLN/zeus/pull/2660), Zeus is not updating the balance everytime when Wallet.tsx gets focus. That is fine, especially because `getSettingsAndNavigate()` does a lot more and adds quite some loading time. But Zeus **should** update the balance after the user sent or received funds.

This is now done, including updating fiat rates, by using a new flag `triggerBalanceUpdate` in SettingsStore.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
