### PR TITLE
Import contact: Always create new ID

### DIFF
--- a/views/ContactDetails.tsx
+++ b/views/ContactDetails.tsx
@@ -10,6 +10,7 @@ import {
 import { inject, observer } from 'mobx-react';
 import { Route } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { v4 as uuidv4 } from 'uuid';
 
 import Screen from '../components/Screen';
 import Button from '../components/Button';
@@ -173,13 +174,18 @@ export default class ContactDetails extends React.Component<
     importToContacts = async () => {
         const { contact } = this.state;
 
+        const newContact = {
+            ...contact,
+            contactId: uuidv4()
+        };
+
         const contactsString: any = await Storage.getItem(CONTACTS_KEY);
 
         const existingContacts: Contact[] = contactsString
             ? JSON.parse(contactsString)
             : [];
 
-        const updatedContacts = [...existingContacts, contact].sort((a, b) =>
+        const updatedContacts = [...existingContacts, newContact].sort((a, b) =>
             a.name.localeCompare(b.name)
         );
 


### PR DESCRIPTION
# Description

Before, the original `contactId` of a contact was kept/used when imported via QR scan. This leads to a problem in case a contact was imported twice: Deleting one of the duplicates was not possible, because **both** contacts were then deleted.

Now a new `contactId` is created for every imported contact, so separate deletion is now possible in case needed.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
