### PR TITLE
[bug fix] Currency converter: Same currency can't be added after deletion

### DIFF
--- a/views/Tools/CurrencyConverter.tsx
+++ b/views/Tools/CurrencyConverter.tsx
@@ -98,8 +98,9 @@ export default class CurrencyConverter extends React.Component<
         const prevSelectedCurrency = prevProps.route.params?.selectedCurrency;
 
         // Check if the selected currency prop has changed
-        if (selectedCurrency !== prevSelectedCurrency) {
+        if (selectedCurrency && selectedCurrency !== prevSelectedCurrency) {
             this.handleCurrencySelect(selectedCurrency);
+            this.props.navigation.setParams({ selectedCurrency: null });
         }
     }
 


### PR DESCRIPTION
Issue #2968 
We are now resetting selectedCurrency param after handling to allow re-adding the same currency.