### PR TITLE
ZEUS-2967: toggle edit icon on Currency Converter

### DIFF
--- a/views/Tools/CurrencyConverter.tsx
+++ b/views/Tools/CurrencyConverter.tsx
@@ -34,6 +34,7 @@ import FiatStore from '../../stores/FiatStore';
 import { CURRENCY_KEYS, CURRENCY_CODES_KEY } from '../../stores/SettingsStore';
 
 import Add from '../../assets/images/SVG/Add.svg';
+import Checkmark from '../../assets/images/SVG/Checkmark.svg';
 import Edit from '../../assets/images/SVG/Pen.svg';
 import DragDots from '../../assets/images/SVG/DragDots.svg';
 import BitcoinIcon from '../../assets/images/SVG/bitcoin-icon.svg';
@@ -394,14 +395,26 @@ export default class CurrencyConverter extends React.Component<
 
         const EditButton = () => (
             <TouchableOpacity onPress={this.toggleEditMode}>
-                <Edit
-                    fill={themeColor('text')}
-                    style={{
-                        alignSelf: 'center',
-                        marginTop: -4,
-                        marginRight: 4
-                    }}
-                />
+                {editMode ? (
+                    <Checkmark
+                        width={30}
+                        height={30}
+                        style={{
+                            alignSelf: 'center',
+                            marginTop: -4,
+                            marginRight: 4
+                        }}
+                    />
+                ) : (
+                    <Edit
+                        fill={themeColor('text')}
+                        style={{
+                            alignSelf: 'center',
+                            marginTop: -4,
+                            marginRight: 4
+                        }}
+                    />
+                )}
             </TouchableOpacity>
         );
 


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2967**](https://github.com/ZeusLN/zeus/issues/2967)

Swaps the edit icon with a checkmark icon when in edit mode.

|default|edit mode|
|-|-|
|![simulator_screenshot_D668325B-FCCE-41F5-8ED3-5F722C4AADD3](https://github.com/user-attachments/assets/cdf8c917-a1bc-4d54-9279-cf80b3530fa9)|![simulator_screenshot_C11EE36A-6148-41A6-8ED1-BFE6A8A86E47](https://github.com/user-attachments/assets/d1fa4680-62f6-492d-b849-6061f4e89535)|


This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
