### PR TITLE
feat: CLNREST listclosedchannels

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -9,7 +9,8 @@ import {
     getBalance,
     getChainTransactions,
     getOffchainBalance,
-    listPeers
+    listPeers,
+    listClosedChannels
 } from './CoreLightningRequestHandler';
 import { localeString } from '../utils/LocaleUtils';
 import ReactNativeBlobUtil from 'react-native-blob-util';
@@ -189,6 +190,11 @@ export default class CLNRest {
 
     postRequest = (route: string, data?: any, timeout?: number) =>
         this.request(route, 'post', data, null, timeout);
+
+    getClosedChannels = async () => {
+        const channels = await this.postRequest('/v1/listclosedchannels');
+        return listClosedChannels(channels);
+    };
 
     getNode = (data: any) =>
         this.postRequest('/v1/listnodes', { id: data.id }).then((res) => {
@@ -415,6 +421,7 @@ export default class CLNRest {
     supportsKeysend = () => true;
     supportsChannelManagement = () => true;
     supportsPendingChannels = () => false;
+    supportsClosedChannels = () => true;
     supportsMPP = () => false;
     supportsAMP = () => false;
     supportsCoinControl = () => true;

--- a/backends/CoreLightningRequestHandler.ts
+++ b/backends/CoreLightningRequestHandler.ts
@@ -131,6 +131,34 @@ export const listPeers = async (data: any) => {
     return { channels: channelsWithAliases };
 };
 
+// Returns a list of closed Lightning Network channels
+export const listClosedChannels = (data: any) => {
+    const formattedClosedChannels = data.closedchannels.map((channel: any) => ({
+        peer_id: channel.peer_id,
+        capacity: Number(channel.total_msat / 1000).toString(),
+        channel_id: channel.channel_id,
+        short_channel_id: channel.short_channel_id,
+        alias: channel.alias?.local || '',
+        opener: channel.opener,
+        closer: channel.closer,
+        private: channel.private,
+        channel_type: channel.channel_type?.names || [],
+        funding_txid: channel.funding_txid,
+        total_msat: channel.total_msat.toString(),
+        to_us_msat: channel.final_to_us_msat.toString(),
+        min_to_us_satoshis: Number(channel.min_to_us_msat / 1000).toString(),
+        max_to_us_satoshis: Number(channel.max_to_us_msat / 1000).toString(),
+        total_htlcs_sent: channel.total_htlcs_sent.toString(),
+        close_cause: channel.close_cause,
+        last_commitment_fee_satoshis: Number(
+            channel.last_commitment_fee_msat / 1000
+        ).toString(),
+        last_stable_connection: channel.last_stable_connection
+    }));
+
+    return { channels: formattedClosedChannels };
+};
+
 // Get all chain transactions from your core-lightnig node
 export const getChainTransactions = async () => {
     const sqlQuery =

--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -297,6 +297,7 @@ export default class EmbeddedLND extends LND {
     supportsKeysend = () => true;
     supportsChannelManagement = () => true;
     supportsPendingChannels = () => true;
+    supportsClosedChannels = () => true;
     supportsMPP = () => this.supports('v0.10.0');
     supportsAMP = () => this.supports('v0.13.0');
     supportsCoinControl = () => this.supports('v0.12.0');

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -710,6 +710,7 @@ export default class LND {
     supportsKeysend = () => true;
     supportsChannelManagement = () => true;
     supportsPendingChannels = () => true;
+    supportsClosedChannels = () => true;
     supportsMPP = () => this.supports('v0.10.0');
     supportsAMP = () => this.supports('v0.13.0');
     supportsCoinControl = () => this.supports('v0.12.0');

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -539,6 +539,7 @@ export default class LightningNodeConnect {
     supportsKeysend = () => true;
     supportsChannelManagement = () => this.permOpenChannel;
     supportsPendingChannels = () => true;
+    supportsClosedChannels = () => true;
     supportsMPP = () => this.supports('v0.10.0');
     supportsAMP = () => this.supports('v0.13.0');
     supportsCoinControl = () => this.permNewAddress;

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -136,6 +136,7 @@ export default class LndHub extends LND {
     supportsKeysend = () => false;
     supportsChannelManagement = () => false;
     supportsPendingChannels = () => false;
+    supportsClosedChannels = () => false;
     supportsMPP = () => false;
     supportsAMP = () => false;
     supportsCoinControl = () => false;

--- a/backends/NostrWalletConnect.ts
+++ b/backends/NostrWalletConnect.ts
@@ -91,6 +91,7 @@ export default class NostrWalletConnect {
     supportsKeysend = () => false;
     supportsChannelManagement = () => false;
     supportsPendingChannels = () => false;
+    supportsClosedChannels = () => false;
     supportsMPP = () => false;
     supportsAMP = () => false;
     supportsCoinControl = () => false;

--- a/models/Channel.ts
+++ b/models/Channel.ts
@@ -54,6 +54,7 @@ export default class Channel extends BaseModel {
     // c-lightning
     @observable
     state: string;
+    close_height: number;
     // CLN v23.05 msat deprecations
     msatoshi_total: string;
     msatoshi_to_us: string;
@@ -63,6 +64,7 @@ export default class Channel extends BaseModel {
     total: string;
     to_us: string;
     short_channel_id: string; // CLN
+    close_cause: string;
 
     channel_id?: string;
     alias?: string;
@@ -71,6 +73,22 @@ export default class Channel extends BaseModel {
 
     // enrichments
     displayName?: string;
+
+    @computed
+    public get closeHeight(): number {
+        return this.close_height;
+    }
+
+    @computed
+    public get isOpen(): boolean {
+        return (
+            !this.closeHeight &&
+            !this.closing_txid &&
+            !this.pendingClose &&
+            !this.closing &&
+            !this.close_cause
+        );
+    }
 
     @computed
     public get isActive(): boolean {

--- a/models/ClosedChannel.ts
+++ b/models/ClosedChannel.ts
@@ -3,7 +3,6 @@ import Channel from './Channel';
 import { lnrpc } from '../proto/lightning';
 
 export default class ClosedChannel extends Channel {
-    close_height: number;
     time_lock_balance: string;
     close_time: number;
     resolutions: any;
@@ -11,17 +10,26 @@ export default class ClosedChannel extends Channel {
 
     @computed
     public get localBalance(): string {
+        if (this.to_us_msat) {
+            return (Number(this.to_us_msat) / 1000).toString();
+        }
         return this.settled_balance;
     }
 
     @computed
     public get remoteBalance(): string {
+        if (this.to_us_msat) {
+            return (
+                (Number(this.total_msat) - Number(this.to_us_msat)) /
+                1000
+            ).toString();
+        }
         return `${Number(this.capacity) - Number(this.settled_balance || 0)}`;
     }
 
     @computed
     public get closeHeight(): number {
-        return this.close_height;
+        return Number(this.capacity) - Number(this.settled_balance || 0);
     }
 
     @computed

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -441,6 +441,17 @@ export default class ChannelsStore {
             })
         ];
 
+        if (BackendUtils.supportsClosedChannels()) {
+            loadPromises.push(
+                BackendUtils.getClosedChannels().then((data: any) => {
+                    const closedChannels = data.channels.map(
+                        (channel: any) => new ClosedChannel(channel)
+                    );
+                    this.closedChannels = closedChannels;
+                })
+            );
+        }
+
         if (BackendUtils.supportsPendingChannels()) {
             loadPromises.push(
                 BackendUtils.getPendingChannels().then((data: any) => {
@@ -477,15 +488,6 @@ export default class ChannelsStore {
                         .concat(pendingCloseChannels)
                         .concat(forceCloseChannels)
                         .concat(waitCloseChannels);
-                })
-            );
-
-            loadPromises.push(
-                BackendUtils.getClosedChannels().then((data: any) => {
-                    const closedChannels = data.channels.map(
-                        (channel: any) => new ClosedChannel(channel)
-                    );
-                    this.closedChannels = closedChannels;
                 })
             );
         }

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -143,6 +143,7 @@ class BackendUtils {
     supportsKeysend = () => this.call('supportsKeysend');
     supportsChannelManagement = () => this.call('supportsChannelManagement');
     supportsPendingChannels = () => this.call('supportsPendingChannels');
+    supportsClosedChannels = () => this.call('supportsClosedChannels');
     supportsMPP = () => this.call('supportsMPP');
     supportsAMP = () => this.call('supportsAMP');
     supportsCoinControl = () => this.call('supportsCoinControl');

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -343,6 +343,7 @@ export default class ChannelView extends React.Component<
             remote_chan_reserve_sat,
             displayName,
             // closed
+            to_us_msat,
             closeHeight,
             closeType,
             getOpenInitiator,
@@ -484,7 +485,7 @@ export default class ChannelView extends React.Component<
                             ? localeString('views.Channel.pendingClose')
                             : forceClose
                             ? localeString('views.Channel.forceClose')
-                            : closeHeight
+                            : closeHeight || to_us_msat
                             ? localeString('views.Channel.closed')
                             : isActive
                             ? localeString('general.active')
@@ -1104,37 +1105,32 @@ export default class ChannelView extends React.Component<
                                 />
                             </View>
                         )}
-                    {!closeHeight &&
-                        !closing_txid &&
-                        !pendingClose &&
-                        !closing && (
-                            <View
-                                style={{
-                                    ...styles.button,
-                                    marginTop: 20,
-                                    marginBottom: confirmCloseChannel ? 0 : 50
-                                }}
-                            >
-                                <Button
-                                    title={
-                                        confirmCloseChannel
-                                            ? localeString(
-                                                  'views.Channel.cancelClose'
-                                              )
-                                            : localeString(
-                                                  'views.Channel.close'
-                                              )
-                                    }
-                                    onPress={() =>
-                                        this.setState({
-                                            confirmCloseChannel:
-                                                !confirmCloseChannel
-                                        })
-                                    }
-                                    warning={!confirmCloseChannel}
-                                />
-                            </View>
-                        )}
+                    {this.state.channel.isOpen && (
+                        <View
+                            style={{
+                                ...styles.button,
+                                marginTop: 20,
+                                marginBottom: confirmCloseChannel ? 0 : 50
+                            }}
+                        >
+                            <Button
+                                title={
+                                    confirmCloseChannel
+                                        ? localeString(
+                                              'views.Channel.cancelClose'
+                                          )
+                                        : localeString('views.Channel.close')
+                                }
+                                onPress={() =>
+                                    this.setState({
+                                        confirmCloseChannel:
+                                            !confirmCloseChannel
+                                    })
+                                }
+                                warning={!confirmCloseChannel}
+                            />
+                        </View>
+                    )}
                     {confirmCloseChannel && (
                         <View>
                             {closingChannel && (

--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -40,6 +40,7 @@ import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 
 import Channel from '../../models/Channel';
+import ClosedChannel from '../../models/ClosedChannel';
 
 // TODO: does this belong in the model? Or can it be computed from the model?
 export enum Status {
@@ -190,6 +191,38 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
                         sendingCapacity={item.sendingCapacity}
                         largestTotal={largestChannelSats}
                         isBelowReserve={item.isBelowReserve}
+                    />
+                </TouchableHighlight>
+            );
+        }
+
+        if (channelsType === ChannelsType.Closed) {
+            const closedItem = item as ClosedChannel;
+
+            return (
+                <TouchableHighlight
+                    onPress={() =>
+                        navigation.navigate('Channel', {
+                            channel: item
+                        })
+                    }
+                >
+                    <ChannelItem
+                        title={closedItem.displayName}
+                        localBalance={closedItem.localBalance}
+                        remoteBalance={closedItem.remoteBalance}
+                        receivingCapacity={closedItem.receivingCapacity}
+                        sendingCapacity={closedItem.sendingCapacity}
+                        status={getStatus()}
+                        pendingHTLCs={closedItem?.pending_htlcs?.length > 0}
+                        pendingTimelock={
+                            closedItem.forceClose
+                                ? forceCloseTimeLabel(
+                                      closedItem.blocks_til_maturity
+                                  )
+                                : undefined
+                        }
+                        isBelowReserve={closedItem.isBelowReserve}
                     />
                 </TouchableHighlight>
             );
@@ -406,6 +439,55 @@ export default class ChannelsPane extends React.PureComponent<ChannelsProps> {
                                             setChannelsType(
                                                 ChannelsType.Pending
                                             )
+                                    }}
+                                />
+                                <Tab.Screen
+                                    name={closedChannelsTabName}
+                                    component={ClosedChannelsScreen}
+                                    listeners={{
+                                        focus: () =>
+                                            setChannelsType(ChannelsType.Closed)
+                                    }}
+                                />
+                            </Tab.Navigator>
+                        </NavigationContainer>
+                    </NavigationIndependentTree>
+                ) : BackendUtils.supportsClosedChannels() ? (
+                    <NavigationIndependentTree>
+                        <NavigationContainer
+                            theme={Theme}
+                            ref={this.tabNavigationRef}
+                        >
+                            <Tab.Navigator
+                                initialRouteName={initialRoute}
+                                backBehavior="none"
+                                screenOptions={() => ({
+                                    headerShown: false,
+                                    tabBarActiveTintColor: themeColor('text'),
+                                    tabBarInactiveTintColor: 'gray',
+                                    tabBarShowLabel: true,
+                                    tabBarStyle: {
+                                        borderTopWidth: 0.2,
+                                        borderTopColor:
+                                            themeColor('secondaryText')
+                                    },
+                                    tabBarItemStyle: {
+                                        justifyContent: 'center'
+                                    },
+                                    tabBarIconStyle: { display: 'none' },
+                                    tabBarLabelStyle: {
+                                        fontSize: 16,
+                                        fontFamily: 'PPNeueMontreal-Medium'
+                                    },
+                                    animation: 'shift'
+                                })}
+                            >
+                                <Tab.Screen
+                                    name={openChannelsTabName}
+                                    component={OpenChannelsScreen}
+                                    listeners={{
+                                        focus: () =>
+                                            setChannelsType(ChannelsType.Open)
                                     }}
                                 />
                                 <Tab.Screen


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2894**](https://github.com/ZeusLN/zeus/issues/2894)

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding


![image](https://github.com/user-attachments/assets/2b08b511-ea53-4cf6-b636-b33bf0b347b9)

![image](https://github.com/user-attachments/assets/0f883949-27cf-44be-b4b1-c647cfddc223)

