### PR TITLE
clnrest: supportOffers is always true starting with cln 24.11

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -421,15 +421,7 @@ export default class CLNRest {
     supportsLSPS1rest = () => true;
     supportsBolt11BlindedRoutes = () => false;
     supportsAddressesWithDerivationPaths = () => false;
-    supportsOffers = async () => {
-        const { configs } = await this.postRequest('/v1/listconfigs');
-
-        const supportsOffers: boolean = configs['experimental-offers']
-            ? true
-            : false;
-
-        return supportsOffers;
-    };
+    supportsOffers = () => true;
     isLNDBased = () => false;
     supportInboundFees = () => false;
     supportsDevTools = () => true;


### PR DESCRIPTION
# Description

The problem is that previously clnrest's supportsOffers was returning a Promise<boolean> instead of a boolean like all the others. This was not awaited and therefore was always evaluated as true. Let's actually set it to always true since cln has offers enabled by default since v24.11. Unless you want to work with different return types and implement a check that works across cln versions. The current check would not work on newer cln versions since the option experimental-offers was removed.

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
