### PR TITLE
App startup wallet selection 

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -802,7 +802,7 @@
     "views.Settings.Display.showAllDecimalPlaces": "Show all decimal places",
     "views.Settings.Display.removeDecimalSpaces": "Remove decimal spaces from Bitcoin denominated amounts",
     "views.Settings.Display.showMillisatoshiAmounts": "Show millisatoshi amounts",
-    "views.Settings.Display.selectNodeOnStartup": "Select node on startup",
+    "views.Settings.Display.selectNodeOnStartup": "Select wallet on startup",
     "views.Settings.privacy": "Privacy",
     "views.Settings.payments": "Payments",
     "views.Settings.Privacy.title": "Privacy settings",

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -311,9 +311,19 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 settings.nodes &&
                 settings.nodes.length > 0
             ) {
+                // If select wallet on startup is enabled and this is initial start,
+                // navigate to wallet selection screen without activating any wallet
                 if (settings.selectNodeOnStartup && initialStart) {
-                    navigation.navigate('Wallets');
+                    // Update UI state but don't connect to any wallet yet
+                    if (!this.state.unlocked) {
+                        this.startListeners();
+                        this.setState({ unlocked: true });
+                    }
+                    // Skip wallet activation by navigating directly to Wallets screen
+                    navigation.navigate('Wallets', { fromStartup: true });
+                    return;
                 }
+
                 if (!this.state.unlocked) {
                     this.startListeners();
                     this.setState({ unlocked: true });

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -316,11 +316,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 if (settings.selectNodeOnStartup && initialStart) {
                     // Update UI state but don't connect to any wallet yet
                     if (!this.state.unlocked) {
-                        this.startListeners();
                         this.setState({ unlocked: true });
                     }
                     // Skip wallet activation by navigating directly to Wallets screen
-                    navigation.navigate('Wallets', { fromStartup: true });
+                    navigation.replace('Wallets', { fromStartup: true });
                     return;
                 }
 


### PR DESCRIPTION
# Description

When the "Select wallet on startup" option is enabled, the app incorrectly initiates a connection to the previously selected wallet in the background. The user is shown a wallet selection screen, but a wallet is already being activated
And also the wording needs to be changed from `Select node on startup` to `Select wallet on startup`. 

**Solution :** 
- Modified the app startup flow to completely bypass wallet activation when "Select wallet on startup" is enabled.
- Added proper state handling in the Wallets screen to track when it's being displayed in "startup mode".
- Prevented Android hardware back button from exiting the wallet selection screen when in startup mode.
- Removed the back button from the header when in startup mode.
- Ensured the restart prompt is never shown when selecting a wallet from the startup screen.
- Updated the wallet selection handling to properly activate the first selected wallet without requiring restart if the app is not killed and running in the background.

**Technical Implementation :**
- Added a state flag to track when wallet selection screen is shown due to the startup setting.
- Added early return in `getSettingsAndNavigate` to skip connecting to any wallet when in startup mode.
- Implemented Android back button handler to prevent navigation when on startup screen.
- Modified wallet activation logic to skip restart prompt when coming from startup screen.
- Improved terminology consistency by using "wallet" instead of "node" throughout the UI.

Here is the link for the demo showing the implementation :
https://drive.google.com/file/d/1FNYABXA35aNU8U0pI0XVi0q4sDcNznIW/view?usp=sharing

Relates to issue: **ZEUS-2618** ( #2618 )



This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
