### PR TITLE
enhancement: Close channel changes

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -445,6 +445,8 @@
     "views.Channel.externalAddress": "(Optional) External address",
     "views.Channel.externalAddress.info": "If specified, your channel funds will be sent to this external address, instead of an address in the internal wallet.",
     "views.Channel.forceClose": "Force close",
+    "views.Channel.forceClose.infoText1": "Force closes should only be done when the channel partner has been offline for an extended period of time. Typically, the party initiating the force close will have to wait to spend their bitcoin, while the other side can spend their funds immediately.",
+    "views.Channel.forceClose.infoText2": "The length of the waiting period is defined when the channel is opened. It can range from just a day to a few weeks. This time period may be listed on this page, labeled as 'CSV Delay'.", 
     "views.Channel.confirmClose": "Confirm Channel Close",
     "views.Channel.aliases": "Aliases",
     "views.Channel.aliasScid": "Alias SCID",

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -1186,33 +1186,32 @@ export default class ChannelView extends React.Component<
                                                 }}
                                                 navigation={navigation}
                                             />
+
+                                            <Text
+                                                style={{
+                                                    ...styles.text,
+                                                    color: themeColor('text')
+                                                }}
+                                                infoModalText={localeString(
+                                                    'views.Channel.externalAddress.info'
+                                                )}
+                                            >
+                                                {localeString(
+                                                    'views.Channel.externalAddress'
+                                                )}
+                                            </Text>
+                                            <TextInput
+                                                placeholder={'bc1...'}
+                                                value={deliveryAddress}
+                                                onChangeText={(text: string) =>
+                                                    this.setState({
+                                                        deliveryAddress: text
+                                                    })
+                                                }
+                                                locked={closingChannel}
+                                            />
                                         </>
                                     )}
-                                    <>
-                                        <Text
-                                            style={{
-                                                ...styles.text,
-                                                color: themeColor('text')
-                                            }}
-                                            infoModalText={localeString(
-                                                'views.Channel.externalAddress.info'
-                                            )}
-                                        >
-                                            {localeString(
-                                                'views.Channel.externalAddress'
-                                            )}
-                                        </Text>
-                                        <TextInput
-                                            placeholder={'bc1...'}
-                                            value={deliveryAddress}
-                                            onChangeText={(text: string) =>
-                                                this.setState({
-                                                    deliveryAddress: text
-                                                })
-                                            }
-                                            locked={closingChannel}
-                                        />
-                                    </>
                                 </>
                             )}
                             <View style={styles.button}>

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -1145,6 +1145,14 @@ export default class ChannelView extends React.Component<
                                 <>
                                     <View style={{ marginBottom: 10 }}>
                                         <Text
+                                            infoModalText={[
+                                                localeString(
+                                                    'views.Channel.forceClose.infoText1'
+                                                ),
+                                                localeString(
+                                                    'views.Channel.forceClose.infoText2'
+                                                )
+                                            ]}
                                             style={{
                                                 ...styles.text,
                                                 color: themeColor('text'),


### PR DESCRIPTION
# Description

This PR makes two changes to the `Channel` view

- Hides the external address field when force close is toggled on
- Adds info modal text for the force close switch

![Screenshot_1745882564](https://github.com/user-attachments/assets/f2cf8b4d-0a2c-4b2c-8b01-35e74a0e58e3)
![Screenshot_1745882759](https://github.com/user-attachments/assets/37f2d825-8177-4f2a-ab6a-e4add3f2aec2)

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
