### PR TITLE
Channel and peer connection error clearing in UI

### DIFF
--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -991,6 +991,7 @@ export default class ChannelsStore {
                         this.funding_txid_str = null;
                         this.errorOpenChannel = true;
                         this.openingChannel = false;
+                        this.connectingToPeer = false;
                         this.channelRequest = null;
                         this.peerSuccess = false;
                         this.channelSuccess = false;

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -833,6 +833,7 @@ export default class ChannelsStore {
         this.channelRequest = null;
         this.peerSuccess = false;
         this.channelSuccess = false;
+        this.connectingToPeer = false;
     };
 
     @action
@@ -982,6 +983,7 @@ export default class ChannelsStore {
                         this.errorMsgChannel = null;
                         this.channelRequest = null;
                         this.channelSuccess = true;
+                        this.connectingToPeer = false;
                     })
                 )
                 .catch((error: Error) =>

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -335,6 +335,8 @@ export default class OpenChannel extends React.Component<
         } = ChannelsStore;
         const { confirmedBlockchainBalance } = BalanceStore;
 
+        const loading = connectingToPeer || openingChannel;
+
         if (funded_psbt)
             navigation.navigate('PSBT', {
                 psbt: funded_psbt
@@ -368,8 +370,6 @@ export default class OpenChannel extends React.Component<
                             // Clear error messages when switching tabs to prevent them from persisting
                             ChannelsStore.errorMsgPeer = null;
                             ChannelsStore.errorMsgChannel = null;
-                            ChannelsStore.connectingToPeer = false;
-                            ChannelsStore.openingChannel = false;
 
                             this.setState({
                                 connectPeerOnly: e === 0 ? false : true
@@ -398,6 +398,7 @@ export default class OpenChannel extends React.Component<
                             containerStyle={{
                                 backgroundColor: themeColor('secondary')
                             }}
+                            disabled={loading}
                         />
                         <Tab.Item
                             title={localeString(
@@ -410,6 +411,7 @@ export default class OpenChannel extends React.Component<
                             containerStyle={{
                                 backgroundColor: themeColor('secondary')
                             }}
+                            disabled={loading}
                         />
                     </Tab>
 
@@ -444,9 +446,7 @@ export default class OpenChannel extends React.Component<
                     )}
 
                     <View style={styles.content}>
-                        {(connectingToPeer || openingChannel) && (
-                            <LightningIndicator />
-                        )}
+                        {loading && <LightningIndicator />}
                         {peerSuccess && (
                             <SuccessMessage
                                 message={localeString(

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -364,11 +364,17 @@ export default class OpenChannel extends React.Component<
                 >
                     <Tab
                         value={connectPeerOnly ? 1 : 0}
-                        onChange={(e) =>
+                        onChange={(e) => {
+                            // Clear error messages when switching tabs to prevent them from persisting
+                            ChannelsStore.errorMsgPeer = null;
+                            ChannelsStore.errorMsgChannel = null;
+                            ChannelsStore.connectingToPeer = false;
+                            ChannelsStore.openingChannel = false;
+
                             this.setState({
                                 connectPeerOnly: e === 0 ? false : true
-                            })
-                        }
+                            });
+                        }}
                         indicatorStyle={{
                             backgroundColor: themeColor('text'),
                             height: 3


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS- #2780**

This PR addresses two UI bugs in the OpenChannel view:
- Error messages persist when switching between "Open Channel" and "Connect Peer" tabs
- The lightning loading indicator remains visible after errors occur during connection attempts

**Solution**
When switching between tabs in the OpenChannel view, we now properly reset all error messages and loading indicators. This ensures that errors from one tab don't incorrectly appear in the other tab.

https://github.com/user-attachments/assets/0cb170d7-b329-434b-8925-a4259cb02df7






This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
