### PR TITLE
fix: menu BackendUtils.supportOffers() is async

### DIFF
--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -18,7 +18,11 @@ import BackendUtils from './../../utils/BackendUtils';
 import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
 
-import { modalStore, invoicesStore } from './../../stores/Stores';
+import {
+    modalStore,
+    invoicesStore,
+    nodeInfoStore
+} from './../../stores/Stores';
 import SyncStore from '../../stores/SyncStore';
 
 import Receive from './../../assets/images/SVG/Receive.svg';
@@ -142,7 +146,7 @@ export default class LightningSwipeableRow extends Component<
         const width =
             BackendUtils.supportsRouting() &&
             BackendUtils.supportsLightningSends() &&
-            BackendUtils.supportsOffers()
+            nodeInfoStore.supportsOffers
                 ? 280
                 : BackendUtils.supportsRouting() &&
                   BackendUtils.supportsLightningSends()
@@ -164,7 +168,7 @@ export default class LightningSwipeableRow extends Component<
                     width,
                     progress
                 )}
-                {BackendUtils.supportsOffers() &&
+                {nodeInfoStore.supportsOffers &&
                     this.renderAction(
                         localeString('general.paycodes'),
                         width,

--- a/components/LayerBalances/PaymentMethodList.tsx
+++ b/components/LayerBalances/PaymentMethodList.tsx
@@ -17,7 +17,7 @@ import OnChainSvg from '../../assets/images/SVG/DynamicSVG/OnChainSvg';
 import LightningSvg from '../../assets/images/SVG/DynamicSVG/LightningSvg';
 import EcashSvg from '../../assets/images/SVG/DynamicSVG/EcashSvg';
 
-import { settingsStore } from '../../stores/Stores';
+import { nodeInfoStore, settingsStore } from '../../stores/Stores';
 
 interface PaymentMethodListProps {
     navigation: StackNavigationProp<any, any>;
@@ -213,7 +213,7 @@ export default class PaymentMethodList extends Component<
             DATA.push({
                 layer: 'Offer',
                 subtitle: `${offer?.slice(0, 12)}...${offer?.slice(-12)}`,
-                disabled: !BackendUtils.supportsOffers()
+                disabled: !nodeInfoStore.supportsOffers
             });
         }
 

--- a/stores/NodeInfoStore.ts
+++ b/stores/NodeInfoStore.ts
@@ -16,6 +16,7 @@ export default class NodeInfoStore {
     @observable public networkInfo: NetworkInfo | any = {};
     @observable public testnet: boolean;
     @observable public regtest: boolean;
+    @observable public supportsOffers: boolean;
     channelsStore: ChannelsStore;
     settingsStore: SettingsStore;
 
@@ -41,6 +42,7 @@ export default class NodeInfoStore {
         this.regtest = false;
         this.testnet = false;
         this.errorMsg = '';
+        this.supportsOffers = false;
     };
 
     @action
@@ -77,6 +79,7 @@ export default class NodeInfoStore {
                         this.regtest = nodeInfo.isRegTest;
                         this.loading = false;
                         this.error = false;
+                        this.supportsOffers = BackendUtils.supportsOffers();
                     });
                     resolve(nodeInfo);
                 })

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -429,7 +429,7 @@ const handleAnything = async (
                 ];
             }
 
-            if (offer && BackendUtils.supportsOffers()) {
+            if (offer && nodeInfoStore.supportsOffers) {
                 return [
                     'Send',
                     {

--- a/views/Menu.tsx
+++ b/views/Menu.tsx
@@ -514,7 +514,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
                         </View>
                     )}
 
-                    {selectedNode && BackendUtils.supportsOffers() && (
+                    {selectedNode && NodeInfoStore.supportsOffers && (
                         <View
                             style={{
                                 backgroundColor: themeColor('secondary'),
@@ -556,7 +556,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
                         </View>
                     )}
 
-                    {selectedNode && BackendUtils.supportsOffers() && (
+                    {selectedNode && NodeInfoStore.supportsOffers && (
                         <View
                             style={{
                                 backgroundColor: themeColor('secondary'),

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -641,6 +641,7 @@ export default class Send extends React.Component<SendProps, SendState> {
             BalanceStore,
             UTXOsStore,
             ContactStore,
+            NodeInfoStore,
             navigation
         } = this.props;
         const {
@@ -673,7 +674,7 @@ export default class Send extends React.Component<SendProps, SendState> {
 
         const paymentOptions = [localeString('views.Send.lnPayment')];
 
-        if (BackendUtils.supportsOffers()) {
+        if (NodeInfoStore.supportsOffers) {
             paymentOptions.push(
                 localeString('views.Settings.Bolt12Address'),
                 localeString('views.Settings.Bolt12Offer')
@@ -1208,7 +1209,7 @@ export default class Send extends React.Component<SendProps, SendState> {
                             </React.Fragment>
                         )}
                     {transactionType === 'BOLT 12' &&
-                        BackendUtils.supportsOffers() && (
+                        NodeInfoStore.supportsOffers && (
                             <React.Fragment>
                                 <AmountInput
                                     amount={amount}
@@ -1226,7 +1227,7 @@ export default class Send extends React.Component<SendProps, SendState> {
                             </React.Fragment>
                         )}
                     {transactionType === 'BOLT 12' &&
-                        !BackendUtils.supportsOffers() && (
+                        !NodeInfoStore.supportsOffers && (
                             <Text
                                 style={{
                                     ...styles.text,
@@ -1468,7 +1469,7 @@ export default class Send extends React.Component<SendProps, SendState> {
                             <Button
                                 title={localeString('general.proceed')}
                                 onPress={async () => await this.payBolt12()}
-                                disabled={!BackendUtils.supportsOffers()}
+                                disabled={!NodeInfoStore.supportsOffers}
                             />
                         </View>
                     )}


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000** #2895 

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_
Updates:
Saving the result while connecting, so we don't need to do a backend call when opening the menu again.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
