### PR TITLE
fix: LND: custom route hints channel ID

### DIFF
--- a/models/Channel.ts
+++ b/models/Channel.ts
@@ -42,7 +42,7 @@ export default class Channel extends BaseModel {
     capacity: string;
     private: boolean;
     initiator?: boolean;
-    peer_scid_alias?: number;
+    peer_scid_alias?: string;
     zero_conf_confirmed_scid?: number;
     alias_scids?: Array<number>; // array uint64
     local_chan_reserve_sat?: string;

--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -278,8 +278,10 @@ export default class InvoicesStore {
                             {
                                 node_id: routeHintChannel.remotePubkey,
                                 chan_id:
-                                    routeHintChannel.peer_scid_alias ||
-                                    routeHintChannel.channelId, // must not be converted to Number as this might lead to a loss of precision
+                                    routeHintChannel.peer_scid_alias &&
+                                    routeHintChannel.peer_scid_alias !== '0'
+                                        ? routeHintChannel.peer_scid_alias
+                                        : routeHintChannel.channelId, // must not be converted to Number as this might lead to a loss of precision
                                 fee_base_msat: Number(
                                     remotePolicy?.fee_base_msat
                                 ),


### PR DESCRIPTION
# Description

Invoices with custom route hints did not include the correct channel id because peer_scid_alias was used even if it contained '0'. Changed the type to string and now using channel id if peer_scid_alias is '0'.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
