### PR TITLE
refactor: Cashu robustness

### DIFF
--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -1475,16 +1475,16 @@ export default class CashuStore {
             console.log('PROOFS TO SEND:', proofsToSend);
             console.log('PROOFS TO KEEP:', proofsToKeep);
 
-            proofs = proofsToSend; // Ensure 'proofs' variable is updated for subsequent logic
+            proofs = proofsToSend;
 
             if (proofsToKeep.length)
                 await this.addMintProofs(mintUrl, proofsToKeep);
 
             let meltResponse = await wallet!!.meltProofs(
                 this.meltQuote!!,
-                proofsToSend, // Use the successfully obtained proofsToSend
+                proofsToSend,
                 {
-                    counter: newCounterValue + 1 // Use the successfully obtained newCounterValue
+                    counter: newCounterValue + 1
                 }
             );
             console.log('melt response', meltResponse);
@@ -1492,11 +1492,11 @@ export default class CashuStore {
             if (meltResponse?.change?.length) {
                 await this.setMintCounter(
                     mintUrl,
-                    newCounterValue + meltResponse.change.length + 1 // Use the successfully obtained newCounterValue
+                    newCounterValue + meltResponse.change.length + 1
                 );
                 await this.addMintProofs(mintUrl, meltResponse.change);
             } else {
-                await this.setMintCounter(mintUrl, newCounterValue + 1); // Use the successfully obtained newCounterValue
+                await this.setMintCounter(mintUrl, newCounterValue + 1);
             }
 
             const realFee = Math.max(

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -2067,6 +2067,17 @@ export default class CashuStore {
                 );
             }
 
+            // Ensure there are proofs to send before creating the token
+            if (!proofsToSend || proofsToSend.length === 0) {
+                console.error(
+                    'mintToken: No proofs to send, cannot create a valid token.'
+                );
+                throw new Error(
+                    localeString('stores.CashuStore.errorMintingToken') +
+                        ' (no proofs to create token)'
+                );
+            }
+
             if (proofsToKeep.length) {
                 await this.addMintProofs(mintUrl, proofsToKeep);
             }

--- a/views/Cashu/UnspentTokens.tsx
+++ b/views/Cashu/UnspentTokens.tsx
@@ -35,8 +35,14 @@ export default class UnspentTokens extends React.PureComponent<
         unspentTokens: []
     };
 
-    UNSAFE_componentWillMount() {
-        this.loadTokens();
+    componentDidMount() {
+        this.props.navigation.addListener('focus', this.loadTokens);
+        this.loadTokens(); // Initial load
+    }
+
+    componentWillUnmount() {
+        this.props.navigation.removeListener &&
+            this.props.navigation.removeListener('focus', this.loadTokens);
     }
 
     loadTokens = () => {


### PR DESCRIPTION
# Description

A series of modifications to make Cashu support more robust, largely centered around iterating the counter to avoid `outputs have already been signed` errors.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
