### PR TITLE
feat: Cashu: handle keyset rotation

### DIFF
--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -440,7 +440,7 @@ export default class CashuStore {
             await Storage.setItem(`${walletId}-mintInfo`, mintInfo);
 
             const keysets = (await mint.getKeySets()).keysets.filter(
-                (ks) => ks.unit === 'sat'
+                (ks) => ks.unit === 'sat' && ks.active
             );
             const keys = (await mint.getKeys()).keysets.find(
                 (ks) => ks.unit === 'sat'


### PR DESCRIPTION
# Description

From calle:

```
Cashu wallet devs: is your wallet ready for keyset rotations?

Keysets can become inactive (`{active: false}`) any time which means the mint won't allow creating new ecash from that keyset (typically in favor of a new one)!

A good strategy is to get /v1/info and /v1/keysets every time a user opens the wallet and talks to the mint. That way you can get all the updated settings and keysets of the mint (and persist it).

In case you're missing a keyset, you can get it via /v1/keys/<id>
```

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
