### PR TITLE
fix: Notifications: check Android for Google Mobile Services

### DIFF
--- a/PushNotificationManager.tsx
+++ b/PushNotificationManager.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import { Alert, Platform, View } from 'react-native';
 import { Notifications } from 'react-native-notifications';
+import DeviceInfo from 'react-native-device-info';
+
 import { lightningAddressStore, settingsStore } from './stores/Stores';
 
 export default class PushNotificationManager extends React.Component<any, any> {
-    componentDidMount() {
+    async componentDidMount() {
         if (Platform.OS === 'ios') Notifications.ios.setBadgeCount(0);
+        if (Platform.OS === 'android') {
+            const isPlayServicesAvailable = await DeviceInfo.hasGms();
+            if (!isPlayServicesAvailable) return;
+        }
         this.registerDevice();
         this.registerNotificationEvents();
     }


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2998**](https://github.com/ZeusLN/zeus/issues/2998)

Explicitly checks Android devices for Google Mobile Services (Google Play Services) before running notification services.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
