### PR TITLE
FontUtils

### DIFF
--- a/components/Modals/InfoModal.tsx
+++ b/components/Modals/InfoModal.tsx
@@ -7,9 +7,10 @@ import ModalBox from '../ModalBox';
 
 import ModalStore from '../../stores/ModalStore';
 
+import { font } from '../../utils/FontUtils';
 import { localeString } from '../../utils/LocaleUtils';
-import UrlUtils from '../../utils/UrlUtils';
 import { themeColor } from '../../utils/ThemeUtils';
+import UrlUtils from '../../utils/UrlUtils';
 
 interface InfoModalProps {
     ModalStore: ModalStore;
@@ -63,7 +64,7 @@ export default class InfoModal extends React.Component<InfoModalProps, {}> {
                         {infoModalTitle && (
                             <Text
                                 style={{
-                                    fontFamily: 'MarlideDisplay_Bold',
+                                    fontFamily: font('marlideBold'),
                                     color: themeColor('text'),
                                     fontSize: 34,
                                     textAlign: 'center',

--- a/utils/FontUtils.ts
+++ b/utils/FontUtils.ts
@@ -1,0 +1,16 @@
+import { Platform } from 'react-native';
+
+const Fonts: { [key: string]: any } = {
+    marlide:
+        Platform.OS === 'android'
+            ? 'Marlide-Display'
+            : 'MarlideDisplay_Regular',
+    marlideBold:
+        Platform.OS === 'android'
+            ? 'Marlide-Display-Bold'
+            : 'MarlideDisplay_Bold'
+};
+
+export function font(id: string): any {
+    return Fonts[id];
+}

--- a/views/LightningAddress/ZeusPayPlus.tsx
+++ b/views/LightningAddress/ZeusPayPlus.tsx
@@ -19,6 +19,7 @@ import SettingsStore from '../../stores/SettingsStore';
 
 import handleAnything from '../../utils/handleAnything';
 import DateTimeUtils from '../../utils/DateTimeUtils';
+import { font } from '../../utils/FontUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 
@@ -110,7 +111,7 @@ export default class ZeusPayPlus extends React.Component<ZeusPayPlusProps, {}> {
                             <Text
                                 style={{
                                     ...styles.text,
-                                    fontFamily: 'MarlideDisplay_Bold',
+                                    fontFamily: font('marlideBold'),
                                     fontSize: 55,
                                     color: themeColor('text')
                                 }}

--- a/views/LightningAddress/ZeusPayPlusPerksList.tsx
+++ b/views/LightningAddress/ZeusPayPlusPerksList.tsx
@@ -5,6 +5,7 @@ import { inject, observer } from 'mobx-react';
 import Text from '../../components/Text';
 import { Row } from '../../components/layout/Row';
 
+import { font } from '../../utils/FontUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 
@@ -79,12 +80,12 @@ export default class ZeusPayPlusPerksList extends React.PureComponent {
 
 const styles = StyleSheet.create({
     perk: {
-        fontFamily: 'MarlideDisplay_Regular',
+        fontFamily: font('marlide'),
         fontSize: 30,
         marginBottom: 5
     },
     comingSoon: {
-        fontFamily: 'MarlideDisplay_Bold',
+        fontFamily: font('marlideBold'),
         fontSize: 20
     }
 });


### PR DESCRIPTION
# Description

In preparing some screenshots for the Cashu functionality, I discovered the Marlide fonts weren't wired up properly on Android. It appears Android uses the font file name, whereas iOS uses the internal name.

A couple of options moving forward:
1) Line up font file names with the internal names.
2) Keep this util and flesh it out. It can potentially be uses to change font styles through the app in one place.

Leaning towards the latter.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
