### PR TITLE
fix: notes rendering in activity view

### DIFF
--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -405,6 +405,16 @@ export default class Activity extends React.PureComponent<
         isCsvModalVisible: false
     };
 
+    async componentDidMount() {
+        const { ActivityStore, SettingsStore, navigation } = this.props;
+        const { getActivityAndFilter } = ActivityStore;
+        await getActivityAndFilter(SettingsStore.settings.locale);
+        this.subscribeEvents();
+        navigation.addListener('focus', async () => {
+            await getActivityAndFilter(SettingsStore.settings.locale);
+        });
+    }
+
     async UNSAFE_componentWillMount() {
         const {
             ActivityStore: { getActivityAndFilter, getFilters },


### PR DESCRIPTION
# Description

This PR, solves the problem of real-time updates of notes in the activity view.

https://github.com/user-attachments/assets/7e212c0b-18ee-4815-ae0f-0cfdcd5a891d

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
