### PR TITLE
fix: Incorrect totalSats calculation after adding tip %

### DIFF
--- a/utils/TipUtils.test.ts
+++ b/utils/TipUtils.test.ts
@@ -1,0 +1,27 @@
+import { calculateTotalSats } from './TipUtils';
+
+describe('calculateTotalSats', () => {
+    it('calculates with 5% tip and no tax', () => {
+        const result = calculateTotalSats('100', '5', '0');
+        expect(result.toString()).toBe('105');
+    });
+    it('calculates with 50% tip and no tax', () => {
+        const result = calculateTotalSats('100', '50', '0');
+        expect(result.toString()).toBe('150');
+    });
+
+    it('calculates with 10% tip and 15 sats tax', () => {
+        const result = calculateTotalSats('200', '10', '15');
+        expect(result.toString()).toBe('235');
+    });
+
+    it('calculates with 0% tip and 0 tax', () => {
+        const result = calculateTotalSats('500', '0', '0');
+        expect(result.toString()).toBe('500');
+    });
+
+    it('calculates with 150% tip and 0 tax', () => {
+        const result = calculateTotalSats('100', '150', '0');
+        expect(result.toString()).toBe('250');
+    });
+});

--- a/utils/TipUtils.ts
+++ b/utils/TipUtils.ts
@@ -1,0 +1,23 @@
+import BigNumber from 'bignumber.js';
+
+/**
+ * Calculates total sats including tip percentage and tax.
+ *
+ * @param subTotalSats - The base amount in sats
+ * @param tipPercentage - Tip percentage to apply
+ * @param taxSats - Tax amount in sats
+ * @returns - Total sats after applying tip and tax
+ */
+export const calculateTotalSats = (
+    subTotalSats: string,
+    tipPercentage: string,
+    taxSats: string
+): string => {
+    const subtotal = new BigNumber(subTotalSats);
+    const tip = new BigNumber(tipPercentage).div(100);
+
+    return subtotal
+        .multipliedBy(new BigNumber(1).plus(tip))
+        .plus(taxSats)
+        .toFixed(0);
+};

--- a/views/Order.tsx
+++ b/views/Order.tsx
@@ -236,7 +236,11 @@ export default class OrderView extends React.Component<OrderProps, OrderState> {
                                 ? DEFAULT_CUSTOM_TIP_PERCENTAGE
                                 : customPercentage;
                         totalSats = new BigNumber(subTotalSats)
-                            .multipliedBy(`1.${effectivePercentage}`)
+                            .multipliedBy(
+                                new BigNumber(1).plus(
+                                    new BigNumber(effectivePercentage).div(100)
+                                )
+                            )
                             .plus(taxSats)
                             .toFixed(0);
                         tipSats = new BigNumber(subTotalSats)
@@ -648,7 +652,11 @@ export default class OrderView extends React.Component<OrderProps, OrderState> {
                                 ? DEFAULT_CUSTOM_TIP_PERCENTAGE
                                 : customPercentage;
                         totalSats = new BigNumber(subTotalSats)
-                            .multipliedBy(`1.${effectivePercentage}`)
+                            .multipliedBy(
+                                new BigNumber(1).plus(
+                                    new BigNumber(effectivePercentage).div(100)
+                                )
+                            )
                             .plus(taxSats)
                             .toFixed(0);
                         tipSats = new BigNumber(subTotalSats)

--- a/views/Order.tsx
+++ b/views/Order.tsx
@@ -24,6 +24,7 @@ import TextInput from '../components/TextInput';
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
 import { SATS_PER_BTC } from '../utils/UnitsUtils';
+import { calculateTotalSats } from '../utils/TipUtils';
 
 import BackendUtils from '../utils/BackendUtils';
 import FiatStore from '../stores/FiatStore';
@@ -235,14 +236,11 @@ export default class OrderView extends React.Component<OrderProps, OrderState> {
                             customPercentage === ''
                                 ? DEFAULT_CUSTOM_TIP_PERCENTAGE
                                 : customPercentage;
-                        totalSats = new BigNumber(subTotalSats)
-                            .multipliedBy(
-                                new BigNumber(1).plus(
-                                    new BigNumber(effectivePercentage).div(100)
-                                )
-                            )
-                            .plus(taxSats)
-                            .toFixed(0);
+                        totalSats = calculateTotalSats(
+                            subTotalSats,
+                            effectivePercentage,
+                            taxSats
+                        );
                         tipSats = new BigNumber(subTotalSats)
                             .multipliedBy(
                                 new BigNumber(effectivePercentage).dividedBy(
@@ -651,14 +649,11 @@ export default class OrderView extends React.Component<OrderProps, OrderState> {
                             customPercentage === ''
                                 ? DEFAULT_CUSTOM_TIP_PERCENTAGE
                                 : customPercentage;
-                        totalSats = new BigNumber(subTotalSats)
-                            .multipliedBy(
-                                new BigNumber(1).plus(
-                                    new BigNumber(effectivePercentage).div(100)
-                                )
-                            )
-                            .plus(taxSats)
-                            .toFixed(0);
+                        totalSats = calculateTotalSats(
+                            subTotalSats,
+                            effectivePercentage,
+                            taxSats
+                        );
                         tipSats = new BigNumber(subTotalSats)
                             .multipliedBy(
                                 new BigNumber(effectivePercentage).dividedBy(


### PR DESCRIPTION
# Description

Fixed a bug in the total sats calculation where the tip percentage was applied incorrectly.

Previously, we were using `new BigNumber(subTotalSats).multipliedBy(1.${effectivePercentage})` that was causing incorrect results:

For example, with subTotalSats = 100 and tip = 5%, the calculation became:

totalSats = 100 * 1.5 = 150 (**which is equivalent to a 50% tip**)

Now, we correctly calculate:

totalSats = 100 * (1 + 5 / 100) = 105

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
