### PR TITLE
locale: Taiwanese Mandarin (zh-tw)

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -403,7 +403,8 @@ export const LOCALE_KEYS = [
     { key: 'hr', value: 'Hrvatski' },
     { key: 'ko', value: '한국어' },
     { key: 'sw', value: 'Kiswahili' },
-    { key: 'hi_IN', value: 'हिन्दी' }
+    { key: 'hi_IN', value: 'हिन्दी' },
+    { key: 'zh_TW', value: '台灣華語' }
 ];
 
 // this mapping is only for migration and does not need to be updated when new languages are added

--- a/utils/LocaleUtils.ts
+++ b/utils/LocaleUtils.ts
@@ -24,6 +24,7 @@ import * as HE from '../locales/he.json';
 import * as HR from '../locales/hr.json';
 import * as SW from '../locales/sw.json';
 import * as hi_EN from '../locales/hi_IN.json';
+import * as zh_TW from '../locales/zh_TW.json';
 
 // in progress
 import * as FA from '../locales/fa.json';
@@ -67,6 +68,7 @@ const Hebrew: any = HE;
 const Croatian: any = HR;
 const Korean: any = KO;
 const Hindi: any = hi_EN;
+const TaiwaneseMandarin: any = zh_TW;
 
 // strings that are needed on the java layer
 const JAVA_LAYER_STRINGS = [
@@ -137,6 +139,8 @@ export function localeString(localeString: string): any {
             return Korean[localeString] || English[localeString];
         case 'hi_IN':
             return Hindi[localeString] || English[localeString];
+        case 'zh_TW':
+            return TaiwaneseMandarin[localeString] || English[localeString];
 
         default:
             return English[localeString];


### PR DESCRIPTION
# Description

The translation for locale zh_TW is finished on Transifex, this modification enable it in the Language menu.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [X] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [X] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [X] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [X] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
