### PR TITLE
App startup wallet selection through pattern/password/lock

### DIFF
--- a/views/Settings/Wallets.tsx
+++ b/views/Settings/Wallets.tsx
@@ -82,6 +82,7 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
         if (this.props.route?.params?.fromStartup) {
             this.setState({
                 fromStartup: true,
+                isSelecting: true, // Hide back button when coming from startup
                 selectedNode: null // Set selectedNode to null when in startup mode
             });
         }


### PR DESCRIPTION
# Description

Relates to PR : #3003 

In #3003, there is an edge case where if the select wallet on app startup toggle is switched on and the app is opened fresh (by killing the app or opening it when not already present in recents), and if the app is secured with a password/PIN, then the app behaves incorrectly.

- In the list of wallets, the previously used/selected wallet is highlighted
- Back arrow button is present
- User is not prevented from using the back arrow button and the mobile's back button

These are the 3 issues discussed in the #2618 issue regarding the toggle. This PR contains the fix for this edge case when opening the app through password/PIN authentication.


Before the fix :

https://github.com/user-attachments/assets/47715bf7-7378-4848-a3e4-1801126251b4

After the fix :

https://github.com/user-attachments/assets/9340d46d-3aea-46e8-88ad-c5fad462af16



This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
