### PR TITLE
fix: avoid unnecessary processing when mint balance is insufficient

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1574,6 +1574,7 @@
     "stores.CashuStore.claimError.lockedToWallet": "This token is locked to a different wallet, can not redeem it",
     "stores.CashuStore.claimError.inconsistentLocking": "Token is locked to multiple different wallets",
     "stores.CashuStore.errorMintingToken": "Error minting token",
+    "stores.CashuStore.insufficientBalance": "Insufficient balance",
     "stores.CashuStore.notEnoughFunds": "Not enough funds to cover payment",
     "stores.CashuStore.feeExceedsAmt": "Melt fees match or exceed token amount",
     "stores.CashuStore.autoSweep": "Cashu auto-sweep",

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -2196,8 +2196,19 @@ export default class CashuStore {
             await this.initializeWallet(mintUrl, true);
         }
 
-        const { wallet, proofs, counter } = this.cashuWallets[mintUrl];
+        const { wallet, proofs, counter, balanceSats } =
+            this.cashuWallets[mintUrl];
 
+        if (balanceSats < Number(value)) {
+            runInAction(() => {
+                this.mintingTokenError = true;
+                this.mintingToken = false;
+                this.error_msg = localeString(
+                    'stores.CashuStore.insufficientBalance'
+                );
+            });
+            return;
+        }
         const { proofsToUse } = this.getProofsToUse(proofs, Number(value));
 
         try {


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

- Add early return when balanceSats < Number(value) in mintoken (cashuStore)
- Avoid calling getProofsToUse() and other expensive operations
- Improve performance by stopping execution at the balance check

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
