### PR TITLE
feat: Receive: tuck QR tabs and 'Receive via NFC' button under advanced toggle

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -162,6 +162,7 @@ interface ReceiveState {
     routeHintMode: RouteHintMode;
     selectedRouteHintChannels?: Channel[];
     hideRightHeaderComponent?: boolean;
+    showAdvanced: boolean;
 }
 
 enum RouteHintMode {
@@ -217,7 +218,8 @@ export default class Receive extends React.Component<
             lspIsActive: false,
             flowLspNotConfigured: true,
             routeHintMode: RouteHintMode.Automatic,
-            selectedRouteHintChannels: undefined
+            selectedRouteHintChannels: undefined,
+            showAdvanced: false
         };
     }
 
@@ -1227,7 +1229,8 @@ export default class Receive extends React.Component<
             hideRightHeaderComponent,
             nfcSupported,
             advancedSettingsToggle,
-            durationSettingsToggle
+            durationSettingsToggle,
+            showAdvanced
         } = this.state;
 
         const { fontScale } = Dimensions.get('window');
@@ -1594,6 +1597,18 @@ export default class Receive extends React.Component<
         const baseModalHeight = 300;
         const itemHeight = ADDRESS_TYPES.length <= 2 ? 25 : 50;
         const modalHeight = baseModalHeight + ADDRESS_TYPES.length * itemHeight;
+
+        const showButtonGroup =
+            !belowDustLimit &&
+            haveUnifiedInvoice &&
+            !lnOnly &&
+            !watchedInvoicePaid;
+
+        const showNfcButton =
+            !(
+                selectedIndex === 3 &&
+                (!lightningAddress || lightningAddressLoading)
+            ) && nfcSupported;
 
         return (
             <Screen>
@@ -2149,43 +2164,135 @@ export default class Receive extends React.Component<
                                                     }
                                                 />
                                             )}
-                                        {!(
-                                            selectedIndex === 3 &&
-                                            (!lightningAddress ||
-                                                lightningAddressLoading)
-                                        ) &&
-                                            nfcSupported && (
-                                                <View
-                                                    style={[
-                                                        styles.button,
-                                                        {
-                                                            marginTop: 15,
-                                                            paddingTop: 0
-                                                        }
-                                                    ]}
+                                        {(showButtonGroup || showNfcButton) && (
+                                            <>
+                                                <TouchableOpacity
+                                                    onPress={() => {
+                                                        this.setState({
+                                                            showAdvanced:
+                                                                !this.state
+                                                                    .showAdvanced
+                                                        });
+                                                    }}
                                                 >
-                                                    <Button
-                                                        title={
-                                                            posStatus ===
-                                                            'active'
-                                                                ? localeString(
-                                                                      'general.payNfc'
-                                                                  )
-                                                                : localeString(
-                                                                      'general.receiveNfc'
-                                                                  )
-                                                        }
-                                                        icon={{
-                                                            name: 'nfc',
-                                                            size: 25
+                                                    <View
+                                                        style={{
+                                                            marginBottom: 10,
+                                                            marginTop: 20
                                                         }}
-                                                        onPress={() =>
-                                                            this.enableNfc()
-                                                        }
-                                                        secondary
-                                                    />
-                                                </View>
-                                            )}
+                                                    >
+                                                        <Row justify="space-between">
+                                                            <View
+                                                                style={{
+                                                                    width: '95%'
+                                                                }}
+                                                            >
+                                                                <KeyValue
+                                                                    keyValue={localeString(
+                                                                        'general.advanced'
+                                                                    )}
+                                                                />
+                                                            </View>
+                                                            {showAdvanced ? (
+                                                                <CaretDown
+                                                                    fill={themeColor(
+                                                                        'text'
+                                                                    )}
+                                                                    width="20"
+                                                                    height="20"
+                                                                />
+                                                            ) : (
+                                                                <CaretRight
+                                                                    fill={themeColor(
+                                                                        'text'
+                                                                    )}
+                                                                    width="20"
+                                                                    height="20"
+                                                                />
+                                                            )}
+                                                        </Row>
+                                                    </View>
+                                                </TouchableOpacity>
+
+                                                {showAdvanced && (
+                                                    <View
+                                                        style={{
+                                                            marginTop: 10
+                                                        }}
+                                                    >
+                                                        {showButtonGroup && (
+                                                            <ButtonGroup
+                                                                onPress={
+                                                                    this
+                                                                        .updateIndex
+                                                                }
+                                                                selectedIndex={
+                                                                    selectedIndex
+                                                                }
+                                                                buttons={
+                                                                    buttons
+                                                                }
+                                                                selectedButtonStyle={{
+                                                                    backgroundColor:
+                                                                        themeColor(
+                                                                            'highlight'
+                                                                        ),
+                                                                    borderRadius: 12
+                                                                }}
+                                                                containerStyle={{
+                                                                    backgroundColor:
+                                                                        themeColor(
+                                                                            'secondary'
+                                                                        ),
+                                                                    borderRadius: 12,
+                                                                    borderWidth: 0,
+                                                                    height: 80
+                                                                }}
+                                                                innerBorderStyle={{
+                                                                    color: themeColor(
+                                                                        'secondary'
+                                                                    )
+                                                                }}
+                                                            />
+                                                        )}
+
+                                                        {showNfcButton &&
+                                                            nfcSupported && (
+                                                                <View
+                                                                    style={[
+                                                                        styles.button,
+                                                                        {
+                                                                            marginTop: 15,
+                                                                            paddingTop: 0
+                                                                        }
+                                                                    ]}
+                                                                >
+                                                                    <Button
+                                                                        title={
+                                                                            posStatus ===
+                                                                            'active'
+                                                                                ? localeString(
+                                                                                      'general.payNfc'
+                                                                                  )
+                                                                                : localeString(
+                                                                                      'general.receiveNfc'
+                                                                                  )
+                                                                        }
+                                                                        icon={{
+                                                                            name: 'nfc',
+                                                                            size: 25
+                                                                        }}
+                                                                        onPress={() =>
+                                                                            this.enableNfc()
+                                                                        }
+                                                                        secondary
+                                                                    />
+                                                                </View>
+                                                            )}
+                                                    </View>
+                                                )}
+                                            </>
+                                        )}
                                     </View>
                                 )}
                                 {!loading &&
@@ -3303,31 +3410,7 @@ export default class Receive extends React.Component<
                         </ScrollView>
                     )}
                 </View>
-                <View style={{ bottom: 0 }}>
-                    {!belowDustLimit &&
-                        haveUnifiedInvoice &&
-                        !lnOnly &&
-                        !watchedInvoicePaid && (
-                            <ButtonGroup
-                                onPress={this.updateIndex}
-                                selectedIndex={selectedIndex}
-                                buttons={buttons}
-                                selectedButtonStyle={{
-                                    backgroundColor: themeColor('highlight'),
-                                    borderRadius: 12
-                                }}
-                                containerStyle={{
-                                    backgroundColor: themeColor('secondary'),
-                                    borderRadius: 12,
-                                    borderWidth: 0,
-                                    height: 80
-                                }}
-                                innerBorderStyle={{
-                                    color: themeColor('secondary')
-                                }}
-                            />
-                        )}
-                </View>
+
                 <ModalBox
                     style={{
                         backgroundColor: themeColor('modalBackground'),

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -2166,131 +2166,110 @@ export default class Receive extends React.Component<
                                             )}
                                         {(showButtonGroup || showNfcButton) && (
                                             <>
-                                                <TouchableOpacity
-                                                    onPress={() => {
-                                                        this.setState({
-                                                            showAdvanced:
-                                                                !this.state
-                                                                    .showAdvanced
-                                                        });
+                                                <View
+                                                    style={{
+                                                        alignItems: 'center',
+                                                        marginTop: 30
                                                     }}
                                                 >
-                                                    <View
+                                                    <TouchableOpacity
+                                                        activeOpacity={0.5}
+                                                        onPress={() =>
+                                                            this.setState({
+                                                                showAdvanced:
+                                                                    !this.state
+                                                                        .showAdvanced
+                                                            })
+                                                        }
                                                         style={{
-                                                            marginBottom: 10,
-                                                            marginTop: 20
+                                                            height: 40,
+                                                            paddingHorizontal: 12,
+                                                            borderRadius: 12,
+                                                            justifyContent:
+                                                                'center'
                                                         }}
                                                     >
-                                                        <Row justify="space-between">
-                                                            <View
+                                                        <View
+                                                            style={{
+                                                                flexDirection:
+                                                                    'row',
+                                                                alignItems:
+                                                                    'center',
+                                                                justifyContent:
+                                                                    'center'
+                                                            }}
+                                                        >
+                                                            <Text
                                                                 style={{
-                                                                    width: '95%'
+                                                                    color: themeColor(
+                                                                        'secondaryText'
+                                                                    ),
+                                                                    fontFamily:
+                                                                        'PPNeueMontreal-Book',
+                                                                    fontSize: 16
                                                                 }}
                                                             >
-                                                                <KeyValue
-                                                                    keyValue={localeString(
-                                                                        'general.advanced'
-                                                                    )}
-                                                                />
-                                                            </View>
+                                                                {localeString(
+                                                                    'general.advanced'
+                                                                )}
+                                                            </Text>
                                                             {showAdvanced ? (
                                                                 <CaretDown
                                                                     fill={themeColor(
-                                                                        'text'
+                                                                        'secondaryText'
                                                                     )}
                                                                     width="20"
                                                                     height="20"
+                                                                    style={{
+                                                                        marginLeft: 8
+                                                                    }}
                                                                 />
                                                             ) : (
                                                                 <CaretRight
                                                                     fill={themeColor(
-                                                                        'text'
+                                                                        'secondaryText'
                                                                     )}
                                                                     width="20"
                                                                     height="20"
+                                                                    style={{
+                                                                        marginLeft: 8
+                                                                    }}
                                                                 />
                                                             )}
-                                                        </Row>
-                                                    </View>
-                                                </TouchableOpacity>
+                                                        </View>
+                                                    </TouchableOpacity>
+                                                </View>
 
-                                                {showAdvanced && (
-                                                    <View
-                                                        style={{
-                                                            marginTop: 10
-                                                        }}
-                                                    >
-                                                        {showButtonGroup && (
-                                                            <ButtonGroup
-                                                                onPress={
-                                                                    this
-                                                                        .updateIndex
+                                                {showAdvanced &&
+                                                    showNfcButton &&
+                                                    nfcSupported && (
+                                                        <View
+                                                            style={[
+                                                                styles.button
+                                                            ]}
+                                                        >
+                                                            <Button
+                                                                title={
+                                                                    posStatus ===
+                                                                    'active'
+                                                                        ? localeString(
+                                                                              'general.payNfc'
+                                                                          )
+                                                                        : localeString(
+                                                                              'general.receiveNfc'
+                                                                          )
                                                                 }
-                                                                selectedIndex={
-                                                                    selectedIndex
+                                                                icon={{
+                                                                    name: 'nfc',
+                                                                    size: 25
+                                                                }}
+                                                                onPress={() =>
+                                                                    this.enableNfc()
                                                                 }
-                                                                buttons={
-                                                                    buttons
-                                                                }
-                                                                selectedButtonStyle={{
-                                                                    backgroundColor:
-                                                                        themeColor(
-                                                                            'highlight'
-                                                                        ),
-                                                                    borderRadius: 12
-                                                                }}
-                                                                containerStyle={{
-                                                                    backgroundColor:
-                                                                        themeColor(
-                                                                            'secondary'
-                                                                        ),
-                                                                    borderRadius: 12,
-                                                                    borderWidth: 0,
-                                                                    height: 80
-                                                                }}
-                                                                innerBorderStyle={{
-                                                                    color: themeColor(
-                                                                        'secondary'
-                                                                    )
-                                                                }}
+                                                                secondary
                                                             />
-                                                        )}
-
-                                                        {showNfcButton &&
-                                                            nfcSupported && (
-                                                                <View
-                                                                    style={[
-                                                                        styles.button,
-                                                                        {
-                                                                            marginTop: 15,
-                                                                            paddingTop: 0
-                                                                        }
-                                                                    ]}
-                                                                >
-                                                                    <Button
-                                                                        title={
-                                                                            posStatus ===
-                                                                            'active'
-                                                                                ? localeString(
-                                                                                      'general.payNfc'
-                                                                                  )
-                                                                                : localeString(
-                                                                                      'general.receiveNfc'
-                                                                                  )
-                                                                        }
-                                                                        icon={{
-                                                                            name: 'nfc',
-                                                                            size: 25
-                                                                        }}
-                                                                        onPress={() =>
-                                                                            this.enableNfc()
-                                                                        }
-                                                                        secondary
-                                                                    />
-                                                                </View>
-                                                            )}
-                                                    </View>
-                                                )}
+                                                        </View>
+                                                    )}
                                             </>
                                         )}
                                     </View>
@@ -3410,7 +3389,35 @@ export default class Receive extends React.Component<
                         </ScrollView>
                     )}
                 </View>
-
+                {showAdvanced && showButtonGroup && (
+                    <View style={{ bottom: 0 }}>
+                        {!belowDustLimit &&
+                            haveUnifiedInvoice &&
+                            !lnOnly &&
+                            !watchedInvoicePaid && (
+                                <ButtonGroup
+                                    onPress={this.updateIndex}
+                                    selectedIndex={selectedIndex}
+                                    buttons={buttons}
+                                    selectedButtonStyle={{
+                                        backgroundColor:
+                                            themeColor('highlight'),
+                                        borderRadius: 12
+                                    }}
+                                    containerStyle={{
+                                        backgroundColor:
+                                            themeColor('secondary'),
+                                        borderRadius: 12,
+                                        borderWidth: 0,
+                                        height: 80
+                                    }}
+                                    innerBorderStyle={{
+                                        color: themeColor('secondary')
+                                    }}
+                                />
+                            )}
+                    </View>
+                )}
                 <ModalBox
                     style={{
                         backgroundColor: themeColor('modalBackground'),


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-3143**](https://github.com/ZeusLN/zeus/issues/3143)

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding




<p align="center">
<img src="https://github.com/user-attachments/assets/7f117a98-aa1c-400b-8804-7c3b44fffb38" width="32%" height="650" />
  <img src="https://github.com/user-attachments/assets/1b54b1a1-c2d3-432b-b44d-f34f0ad140f9" width="32%" height="650" />
  <img src="https://github.com/user-attachments/assets/a38dee86-fc28-406f-8715-0ddf75ab4d2e" width="32%" height="650" />
</p>

@kaloudis 
