### PR TITLE
ZEUS-3162: lock invoice expiry time when LSP is enabled

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -88,6 +88,7 @@ import {
 
 import CaretDown from '../assets/images/SVG/Caret Down.svg';
 import CaretRight from '../assets/images/SVG/Caret Right.svg';
+import LockIcon from '../assets/images/SVG/Lock.svg';
 import UnifiedSvg from '../assets/images/SVG/DynamicSVG/UnifiedSvg';
 import LightningSvg from '../assets/images/SVG/DynamicSVG/LightningSvg';
 import OnChainSvg from '../assets/images/SVG/DynamicSVG/OnChainSvg';
@@ -262,14 +263,22 @@ export default class Receive extends React.Component<
             expirationIndex = 4;
         }
 
+        const lspIsActive =
+            settings?.enableLSP &&
+            BackendUtils.supportsFlowLSP() &&
+            !flowLspNotConfigured;
+
         this.setState({
             addressType: settings?.invoices?.addressType || '0',
             expirationIndex,
             memo: settings?.invoices?.memo || '',
             receiverName: settings?.invoices?.receiverName || '',
-            expiry: settings?.invoices?.expiry || '3600',
-            timePeriod: settings?.invoices?.timePeriod || 'Seconds',
-            expirySeconds: newExpirySeconds,
+            // if LSP is active, default to 3600 seconds
+            expiry: lspIsActive ? '3600' : settings?.invoices?.expiry || '3600',
+            timePeriod: lspIsActive
+                ? 'Seconds'
+                : settings?.invoices?.timePeriod || 'Seconds',
+            expirySeconds: lspIsActive ? '3600' : newExpirySeconds,
             routeHints:
                 settings?.invoices?.routeHints ||
                 !this.props.ChannelsStore.haveAnnouncedChannels
@@ -284,10 +293,7 @@ export default class Receive extends React.Component<
                     BackendUtils.supportsBolt11BlindedRoutes()) ||
                 false,
             enableLSP: settings?.enableLSP,
-            lspIsActive:
-                settings?.enableLSP &&
-                BackendUtils.supportsFlowLSP() &&
-                !flowLspNotConfigured,
+            lspIsActive,
             flowLspNotConfigured
         });
 
@@ -2261,7 +2267,23 @@ export default class Receive extends React.Component<
                                                                             lspIsActive:
                                                                                 !enableLSP &&
                                                                                 BackendUtils.supportsFlowLSP() &&
-                                                                                !flowLspNotConfigured
+                                                                                !flowLspNotConfigured,
+                                                                            // lock toggle and reset if LSP enabled
+                                                                            durationSettingsToggle:
+                                                                                durationSettingsToggle &&
+                                                                                enableLSP ===
+                                                                                    true,
+                                                                            expiry: !enableLSP
+                                                                                ? '3600'
+                                                                                : expiry,
+                                                                            timePeriod:
+                                                                                !enableLSP
+                                                                                    ? 'Seconds'
+                                                                                    : timePeriod,
+                                                                            expirySeconds:
+                                                                                !enableLSP
+                                                                                    ? '3600'
+                                                                                    : expirySeconds
                                                                         }
                                                                     );
                                                                     await updateSettings(
@@ -2431,6 +2453,8 @@ export default class Receive extends React.Component<
                                                     <>
                                                         <TouchableOpacity
                                                             onPress={() => {
+                                                                if (enableLSP)
+                                                                    return;
                                                                 this.setState({
                                                                     durationSettingsToggle:
                                                                         !durationSettingsToggle
@@ -2490,7 +2514,16 @@ export default class Receive extends React.Component<
                                                                             )}
                                                                         </Row>
                                                                     </View>
-                                                                    {durationSettingsToggle ? (
+
+                                                                    {enableLSP ? (
+                                                                        <LockIcon
+                                                                            fill={themeColor(
+                                                                                'secondaryText'
+                                                                            )}
+                                                                            width="20"
+                                                                            height="20"
+                                                                        />
+                                                                    ) : durationSettingsToggle ? (
                                                                         <CaretDown
                                                                             fill={themeColor(
                                                                                 'text'


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-3162**](https://github.com/ZeusLN/zeus/issues/3162)

This PR locks the expiry settings to 3600 settings when the wrapped LSP service is enabled.

- Expiry is locked
- Expiry is changed to 3600 seconds
- Expiry dropdown toggle is closed

<img width="1206" height="2622" alt="simulator_screenshot_F5A1F75F-BF58-4E55-93B5-F4DF5DDA18D9" src="https://github.com/user-attachments/assets/bd3aeb35-8307-432b-80a2-f6b824e87ec8" />

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
