### PR TITLE
fix: don't auto-enable hints if blinded paths are enabled

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -273,8 +273,12 @@ export default class Receive extends React.Component<
             timePeriod: settings?.invoices?.timePeriod || 'Seconds',
             expirySeconds: newExpirySeconds,
             routeHints:
-                settings?.invoices?.routeHints ||
-                !this.props.ChannelsStore.haveAnnouncedChannels
+                (settings?.invoices?.routeHints ||
+                    !this.props.ChannelsStore.haveAnnouncedChannels) &&
+                !(
+                    settings?.invoices?.blindedPaths &&
+                    BackendUtils.supportsBolt11BlindedRoutes()
+                )
                     ? true
                     : false,
             ampInvoice:


### PR DESCRIPTION
# Description

Somewhat recently, we added a UX improvement for users that only have unannounced channels: auto-enabled routing hints if the user only has unannounced channels (otherwise invoices are unpayable).

This conflicts with the blinded paths option (when setting in Settings > Invoices) as the two cannot be set together. This fix adds an additional check, in this auto-enable condition, checking if blinded paths are turned on or not.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
