### PR TITLE
fix: Peers: show N/A if ping time is negative

### DIFF
--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -803,19 +803,17 @@ export default class ChannelsPane extends React.PureComponent<
                                                                 {`${localeString(
                                                                     'views.ChannelsPane.pingTime'
                                                                 )}: ${
-                                                                    BackendUtils.isLNDBased()
+                                                                    peer.ping_time >=
+                                                                    0
                                                                         ? (
                                                                               peer.ping_time /
                                                                               1000
                                                                           ).toFixed(
-                                                                              peer.ping_time /
-                                                                                  1000 <
-                                                                                  0.01
-                                                                                  ? 3
-                                                                                  : 2
-                                                                          )
-                                                                        : peer.ping_time
-                                                                } ms`}
+                                                                              2
+                                                                          ) +
+                                                                          ' ms'
+                                                                        : 'N/A'
+                                                                }`}
                                                             </Text>
                                                         )}
                                                         {peer.sats_sent && (


### PR DESCRIPTION
# Description

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
