### PR TITLE
enhancement: Swaps: Amount conversion when toggling units

### DIFF
--- a/views/Swaps/index.tsx
+++ b/views/Swaps/index.tsx
@@ -1206,14 +1206,133 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
                                         >
                                             <TouchableOpacity
                                                 onPress={() => {
+                                                    const {
+                                                        FiatStore,
+                                                        SettingsStore
+                                                    } = this.props;
+                                                    const { fiatRates } =
+                                                        FiatStore;
+                                                    const { settings } =
+                                                        SettingsStore;
+                                                    const { fiat } = settings;
+
+                                                    const fiatEntry =
+                                                        fiat && fiatRates
+                                                            ? fiatRates.filter(
+                                                                  (entry) =>
+                                                                      entry.code ===
+                                                                      fiat
+                                                              )[0]
+                                                            : null;
+                                                    const rate =
+                                                        fiat &&
+                                                        fiatRates &&
+                                                        fiatEntry
+                                                            ? fiatEntry.rate
+                                                            : 0;
+
                                                     UnitsStore.changeUnits();
-                                                    this.setState({
-                                                        inputSats: 0,
-                                                        outputSats: 0,
-                                                        serviceFeeSats: 0,
-                                                        inputFiat: '',
-                                                        outputFiat: ''
-                                                    });
+                                                    const newUnit =
+                                                        UnitsStore.units;
+
+                                                    this.setState(
+                                                        (prevState) => {
+                                                            const currentInputSats =
+                                                                new BigNumber(
+                                                                    prevState.inputSats ||
+                                                                        0
+                                                                );
+                                                            const currentOutputSats =
+                                                                new BigNumber(
+                                                                    prevState.outputSats ||
+                                                                        0
+                                                                );
+                                                            let newInputDisplayAmount =
+                                                                '';
+                                                            let newOutputDisplayAmount =
+                                                                '';
+
+                                                            if (
+                                                                newUnit ===
+                                                                    'fiat' &&
+                                                                rate > 0
+                                                            ) {
+                                                                if (
+                                                                    currentInputSats.isGreaterThan(
+                                                                        0
+                                                                    )
+                                                                ) {
+                                                                    newInputDisplayAmount =
+                                                                        currentInputSats
+                                                                            .div(
+                                                                                SATS_PER_BTC
+                                                                            )
+                                                                            .times(
+                                                                                rate
+                                                                            )
+                                                                            .toFixed(
+                                                                                2
+                                                                            );
+                                                                }
+                                                                if (
+                                                                    currentOutputSats.isGreaterThan(
+                                                                        0
+                                                                    )
+                                                                ) {
+                                                                    newOutputDisplayAmount =
+                                                                        currentOutputSats
+                                                                            .div(
+                                                                                SATS_PER_BTC
+                                                                            )
+                                                                            .times(
+                                                                                rate
+                                                                            )
+                                                                            .toFixed(
+                                                                                2
+                                                                            );
+                                                                }
+                                                            } else if (
+                                                                newUnit ===
+                                                                'BTC'
+                                                            ) {
+                                                                if (
+                                                                    currentInputSats.isGreaterThan(
+                                                                        0
+                                                                    )
+                                                                ) {
+                                                                    newInputDisplayAmount =
+                                                                        currentInputSats
+                                                                            .div(
+                                                                                SATS_PER_BTC
+                                                                            )
+                                                                            .toFixed(
+                                                                                8
+                                                                            );
+                                                                }
+                                                                if (
+                                                                    currentOutputSats.isGreaterThan(
+                                                                        0
+                                                                    )
+                                                                ) {
+                                                                    newOutputDisplayAmount =
+                                                                        currentOutputSats
+                                                                            .div(
+                                                                                SATS_PER_BTC
+                                                                            )
+                                                                            .toFixed(
+                                                                                8
+                                                                            );
+                                                                }
+                                                            }
+
+                                                            return {
+                                                                inputFiat:
+                                                                    newInputDisplayAmount,
+                                                                outputFiat:
+                                                                    newOutputDisplayAmount
+                                                            };
+                                                        }
+                                                    );
                                                 }}
                                                 style={{
                                                     marginLeft: 10,


### PR DESCRIPTION
# Description

This PR is to improve the user experience on the Swaps view by preventing the input amounts from resetting when the display unit is changed. Previously, toggling between sats, BTC, and fiat would clear the fields. Now,  the amount is recalculated and displayed in the newly selected unit. 

This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- []X N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
