### PR TITLE
feat: Add ability to delete rescue key

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1679,6 +1679,8 @@
     "views.Swaps.rescueKey.invalid": "Invalid rescue key",
     "views.Swaps.rescueKey.noSwapsFound": "No swaps found for this rescue key",
     "views.Swaps.rescueKey.incorrectHost": "Could not connect to the specified host. Please check the host and try again",
+    "views.Swaps.rescueKey.delete": "Delete rescue key",
+    "views.Swaps.rescueKey.deleteConfirmation": "Are you sure you want to delete the rescue key? All submarine swaps will also be deleted from your swap history. Please back up your keys before proceeding, as you can use them later to recover those swaps.",
     "views.SwapDetails.title": "Swap Details",
     "views.SwapDetails.acceptZeroConf": "Accept Zero Conf",
     "views.SwapDetails.expectedAmount": "Expected amount",

--- a/views/Settings/Seed.tsx
+++ b/views/Settings/Seed.tsx
@@ -22,8 +22,14 @@ import Button from '../../components/Button';
 import CopyButton from '../../components/CopyButton';
 import Screen from '../../components/Screen';
 import Header from '../../components/Header';
+import ModalBox from '../../components/ModalBox';
 
 import SettingsStore from '../../stores/SettingsStore';
+import {
+    SWAPS_KEY,
+    SWAPS_LAST_USED_KEY,
+    SWAPS_RESCUE_KEY
+} from '../../stores/SwapStore';
 
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
@@ -48,6 +54,7 @@ interface SeedProps {
 interface SeedState {
     understood: boolean;
     showModal: boolean;
+    isDeleteModalVisible: boolean;
 }
 
 const MnemonicWord = ({ index, word }: { index: any; word: any }) => {
@@ -103,13 +110,74 @@ const MnemonicWord = ({ index, word }: { index: any; word: any }) => {
 export default class Seed extends React.PureComponent<SeedProps, SeedState> {
     state = {
         understood: false,
-        showModal: false
+        showModal: false,
+        isDeleteModalVisible: false
     };
 
     UNSAFE_componentWillMount() {
         // make sure we have latest settings and the seed phrase is accessible
         this.props.SettingsStore.getSettings();
     }
+
+    renderDeleteModal = () => {
+        const { navigation } = this.props;
+        return (
+            <ModalBox
+                isOpen={this.state.isDeleteModalVisible}
+                onClosed={() => this.setState({ isDeleteModalVisible: false })}
+                style={{
+                    backgroundColor: themeColor('background'),
+                    borderRadius: 20,
+                    width: '100%',
+                    maxWidth: 400,
+                    maxHeight: 270
+                }}
+                position="center"
+                backdropOpacity={0.5}
+            >
+                <View
+                    style={{
+                        padding: 20,
+                        alignItems: 'center'
+                    }}
+                >
+                    <Text
+                        style={{
+                            color: themeColor('text'),
+                            fontFamily: 'PPNeueMontreal-Book',
+                            fontSize: 18,
+                            textAlign: 'center',
+                            marginBottom: 20
+                        }}
+                    >
+                        {localeString(
+                            'views.Swaps.rescueKey.deleteConfirmation'
+                        )}
+                    </Text>
+
+                    <Button
+                        title={localeString('general.confirm')}
+                        onPress={async () => {
+                            await Storage.removeItem(SWAPS_RESCUE_KEY);
+                            await Storage.removeItem(SWAPS_KEY);
+                            await Storage.removeItem(SWAPS_LAST_USED_KEY);
+                            this.setState({ isDeleteModalVisible: false });
+                            navigation.popTo('Swaps');
+                        }}
+                        containerStyle={{ marginBottom: 10 }}
+                        warning
+                    />
+                    <Button
+                        title={localeString('general.cancel')}
+                        onPress={() =>
+                            this.setState({ isDeleteModalVisible: false })
+                        }
+                        secondary
+                    />
+                </View>
+            </ModalBox>
+        );
+    };
 
     render() {
         const { navigation, SettingsStore, route } = this.props;
@@ -182,6 +250,7 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
 
         return (
             <Screen>
+                {this.renderDeleteModal()}
                 <Header
                     leftComponent="Back"
                     centerComponent={{
@@ -439,7 +508,21 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                                               'views.Settings.Seed.backupComplete'
                                           )
                                 }
+                                containerStyle={{ marginBottom: 10 }}
                             />
+                            {isRefundRescueKey && (
+                                <Button
+                                    onPress={() =>
+                                        this.setState({
+                                            isDeleteModalVisible: true
+                                        })
+                                    }
+                                    title={localeString(
+                                        'views.Swaps.rescueKey.delete'
+                                    )}
+                                    warning
+                                />
+                            )}
                         </View>
                     </View>
                 )}

--- a/views/Swaps/index.tsx
+++ b/views/Swaps/index.tsx
@@ -248,6 +248,11 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
                         showRescueKeyBtn: true,
                         seedPhrase: mnemonic.split(' ')
                     });
+                } else {
+                    this.setState({
+                        isModalVisible: true,
+                        showRescueKeyBtn: false
+                    });
                 }
             }
         );


### PR DESCRIPTION
# Description

We can now delete the swaps rescue key.  

This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [X] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [X] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
