### PR TITLE
fix: add approximate symbol for fiat currencies and fix RTL placement

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -201,83 +201,73 @@ function AmountDisplay({
             </>
         );
 
-        if (rtl) {
-            return (
-                <Row
-                    style={styles.row}
-                    accessible={accessible}
-                    accessibilityLabel={accessibilityLabel}
-                >
-                    <View style={styles.textContainer}>
-                        {feeSection}
-                        {unit === 'BTC' && roundAmount && <RoundingIndicator />}
-                        {unit === 'fiat' && <ApproximateSymbol accessible />}
-                        {unit === 'BTC' && amount !== 'N/A' && (
-                            <FiatSymbol accessible />
-                        )}
-                        {space ? <TextSpace /> : <Spacer width={1} />}
-                        <Body
-                            jumbo={jumboText}
-                            defaultSize={defaultTextSize}
-                            color={color}
-                            colorOverride={colorOverride}
-                            accessible={accessible}
-                        >
-                            {negative ? '-' : ''}
-                            {amount === 'N/A' && fiatRatesLoading ? (
-                                <LoadingIndicator size={20} />
-                            ) : unit === 'BTC' ? (
-                                formatBitcoinWithSpaces(amount)
-                            ) : (
-                                amount.toString()
-                            )}
-                        </Body>
-                        {amount !== 'N/A' && unit === 'fiat' && (
-                            <FiatSymbol accessible />
-                        )}
-                    </View>
-                    {pending && <Pending />}
-                </Row>
-            );
-        } else {
-            return (
-                <Row
-                    style={styles.row}
-                    accessible={accessible}
-                    accessibilityLabel={accessibilityLabel}
-                >
-                    {pending && <Pending />}
-                    <View style={styles.textContainer}>
-                        {unit === 'BTC' && roundAmount && <RoundingIndicator />}
-                        {unit === 'fiat' && <ApproximateSymbol accessible />}
-                        {unit === 'BTC' && amount !== 'N/A' && (
-                            <FiatSymbol accessible />
-                        )}
-                        {amount !== 'N/A' && unit === 'fiat' && (
-                            <FiatSymbol accessible />
-                        )}
-                        {space ? <TextSpace /> : <Spacer width={1} />}
-                        <Body
-                            jumbo={jumboText}
-                            defaultSize={defaultTextSize}
-                            color={color}
-                            colorOverride={colorOverride}
-                            accessible={accessible}
-                        >
-                            {negative ? '-' : ''}
-                            {amount === 'N/A' && fiatRatesLoading ? (
-                                <LoadingIndicator size={20} />
-                            ) : unit === 'BTC' ? (
-                                formatBitcoinWithSpaces(amount)
-                            ) : (
-                                amount.toString()
-                            )}
-                        </Body>
-                        {feeSection}
-                    </View>
-                </Row>
-            );
-        }
+        const amountContent = (
+            <Body
+                jumbo={jumboText}
+                defaultSize={defaultTextSize}
+                color={color}
+                colorOverride={colorOverride}
+                accessible={accessible}
+            >
+                {negative ? '-' : ''}
+                {amount === 'N/A' && fiatRatesLoading ? (
+                    <LoadingIndicator size={20} />
+                ) : unit === 'BTC' ? (
+                    formatBitcoinWithSpaces(amount)
+                ) : (
+                    amount.toString()
+                )}
+            </Body>
+        );
+
+        const indicators = (
+            <>
+                {unit === 'BTC' && roundAmount && <RoundingIndicator />}
+                {unit === 'fiat' && <ApproximateSymbol accessible />}
+            </>
+        );
+
+        const symbols = (
+            <>
+                {unit === 'BTC' && amount !== 'N/A' && (
+                    <FiatSymbol accessible />
+                )}
+                {amount !== 'N/A' && unit === 'fiat' && (
+                    <FiatSymbol accessible />
+                )}
+            </>
+        );
+
+        const spacer = space ? <TextSpace /> : <Spacer width={1} />;
+
+        return (
+            <Row
+                style={styles.row}
+                accessible={accessible}
+                accessibilityLabel={accessibilityLabel}
+            >
+                {!rtl && pending && <Pending />}
+                <View style={styles.textContainer}>
+                    {rtl && feeSection}
+                    {indicators}
+                    {rtl ? (
+                        <>
+                            {amountContent}
+                            {spacer}
+                            {symbols}
+                        </>
+                    ) : (
+                        <>
+                            {symbols}
+                            {spacer}
+                            {amountContent}
+                        </>
+                    )}
+                    {!rtl && feeSection}
+                </View>
+                {rtl && pending && <Pending />}
+            </Row>
+        );
     };
 
     switch (unit) {

--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -184,37 +184,6 @@ function AmountDisplay({
     };
 
     const renderCurrencyAmount = () => {
-        const commonContent = (
-            <>
-                {unit !== 'BTC' && roundAmount && (
-                    <ApproximateSymbol accessible={accessible} />
-                )}
-                {amount !== 'N/A' && unit === 'fiat' && (
-                    <FiatSymbol accessible />
-                )}
-                {space ? <TextSpace /> : <Spacer width={1} />}
-                <Body
-                    jumbo={jumboText}
-                    defaultSize={defaultTextSize}
-                    color={color}
-                    colorOverride={colorOverride}
-                    accessible={accessible}
-                >
-                    {negative ? '-' : ''}
-                    {amount === 'N/A' && fiatRatesLoading ? (
-                        <LoadingIndicator size={20} />
-                    ) : unit === 'BTC' ? (
-                        formatBitcoinWithSpaces(amount)
-                    ) : (
-                        amount.toString()
-                    )}
-                </Body>
-                {unit === 'BTC' && amount !== 'N/A' && (
-                    <FiatSymbol accessible />
-                )}
-            </>
-        );
-
         const feeSection = fee && (
             <>
                 <Spacer width={2} />
@@ -232,21 +201,83 @@ function AmountDisplay({
             </>
         );
 
-        return (
-            <Row
-                style={styles.row}
-                accessible={accessible}
-                accessibilityLabel={accessibilityLabel}
-            >
-                {!rtl && pending && <Pending />}
-                <View style={styles.textContainer}>
-                    {rtl && feeSection}
-                    {commonContent}
-                    {!rtl && feeSection}
-                </View>
-                {rtl && pending && <Pending />}
-            </Row>
-        );
+        if (rtl) {
+            return (
+                <Row
+                    style={styles.row}
+                    accessible={accessible}
+                    accessibilityLabel={accessibilityLabel}
+                >
+                    <View style={styles.textContainer}>
+                        {feeSection}
+                        {unit === 'BTC' && roundAmount && <RoundingIndicator />}
+                        {unit === 'fiat' && <ApproximateSymbol accessible />}
+                        {unit === 'BTC' && amount !== 'N/A' && (
+                            <FiatSymbol accessible />
+                        )}
+                        {space ? <TextSpace /> : <Spacer width={1} />}
+                        <Body
+                            jumbo={jumboText}
+                            defaultSize={defaultTextSize}
+                            color={color}
+                            colorOverride={colorOverride}
+                            accessible={accessible}
+                        >
+                            {negative ? '-' : ''}
+                            {amount === 'N/A' && fiatRatesLoading ? (
+                                <LoadingIndicator size={20} />
+                            ) : unit === 'BTC' ? (
+                                formatBitcoinWithSpaces(amount)
+                            ) : (
+                                amount.toString()
+                            )}
+                        </Body>
+                        {amount !== 'N/A' && unit === 'fiat' && (
+                            <FiatSymbol accessible />
+                        )}
+                    </View>
+                    {pending && <Pending />}
+                </Row>
+            );
+        } else {
+            return (
+                <Row
+                    style={styles.row}
+                    accessible={accessible}
+                    accessibilityLabel={accessibilityLabel}
+                >
+                    {pending && <Pending />}
+                    <View style={styles.textContainer}>
+                        {unit === 'BTC' && roundAmount && <RoundingIndicator />}
+                        {unit === 'fiat' && <ApproximateSymbol accessible />}
+                        {unit === 'BTC' && amount !== 'N/A' && (
+                            <FiatSymbol accessible />
+                        )}
+                        {amount !== 'N/A' && unit === 'fiat' && (
+                            <FiatSymbol accessible />
+                        )}
+                        {space ? <TextSpace /> : <Spacer width={1} />}
+                        <Body
+                            jumbo={jumboText}
+                            defaultSize={defaultTextSize}
+                            color={color}
+                            colorOverride={colorOverride}
+                            accessible={accessible}
+                        >
+                            {negative ? '-' : ''}
+                            {amount === 'N/A' && fiatRatesLoading ? (
+                                <LoadingIndicator size={20} />
+                            ) : unit === 'BTC' ? (
+                                formatBitcoinWithSpaces(amount)
+                            ) : (
+                                amount.toString()
+                            )}
+                        </Body>
+                        {feeSection}
+                    </View>
+                </Row>
+            );
+        }
     };
 
     switch (unit) {


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS- #3139 **

This PR fixes RTL (right-to-left) layout issues in the Amount component that were introduced after PR #3179 was merged. The rounding indicator feature inadvertently broke the RTL/LTR logic and caused symbol misplacement issues.

## Changes Made:

1. **Restored approximate symbol (≈) for all fiat currencies** - Since fiat amounts are inherently approximate due to exchange rate volatility, all fiat displays now show the ≈ symbol to indicate this uncertainty.

2. **Fixed RTL symbol placement** - Restored proper RTL/LTR conditional rendering paths that were consolidated incorrectly in #3139 , ensuring currency symbols and indicators appear on the correct side based on text direction.


<img width="577" height="266" alt="image" src="https://github.com/user-attachments/assets/4e1aa8d0-7c7e-48ad-96d7-6e7b301bb44e" />
<img width="536" height="226" alt="image" src="https://github.com/user-attachments/assets/ebad0a47-b7d9-426e-8450-bbb4cd4c4161" />

<img width="537" height="944" alt="image" src="https://github.com/user-attachments/assets/9fb4f57e-fb64-4569-b0d7-291e3d71a355" />
<img width="543" height="888" alt="image" src="https://github.com/user-attachments/assets/c8fad828-cbe9-43c4-98d8-a6e30d949b43" />
<img width="550" height="233" alt="image" src="https://github.com/user-attachments/assets/bf2e4530-479e-4ccd-8854-b7d86a783239" />
<img width="552" height="1114" alt="image" src="https://github.com/user-attachments/assets/2f7af15a-2a06-415e-8a01-1d11c46e7fe1" />


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
