### PR TITLE
fix: properly set locked invoice expiry when LSP is enabled

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -286,7 +286,7 @@ export default class CLNRest {
             description: data.memo,
             label: 'zeus.' + Math.random() * 1000000,
             amount_msat: data.value != 0 ? Number(data.value) * 1000 : 'any',
-            expiry: Number(data.expiry),
+            expiry: Number(data.expiry_seconds),
             exposeprivatechannels: true
         });
 

--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -110,7 +110,7 @@ export default class EmbeddedLND extends LND {
             amount: data.value ? Number(data.value) : undefined,
             amount_msat: data.value_msat ? Number(data.value_msat) : undefined,
             memo: data.memo,
-            expiry: data.expiry,
+            expiry: data.expiry_seconds,
             is_amp: data.is_amp,
             is_blinded: data.is_blinded,
             is_private: data.private,

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -338,7 +338,7 @@ export default class LND {
         this.postRequest('/v1/invoices', {
             memo: data.memo,
             value_msat: data.value_msat || Number(data.value) * 1000,
-            expiry: data.expiry,
+            expiry: data.expiry_seconds,
             is_amp: data.is_amp,
             is_blinded: data.is_blinded,
             private: data.private,

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -175,7 +175,7 @@ export default class LightningNodeConnect {
             .addInvoice({
                 memo: data.memo,
                 value_msat: data.value_msat || Number(data.value) * 1000,
-                expiry: data.expiry,
+                expiry: data.expiry_seconds,
                 is_amp: data.is_amp,
                 is_blinded: data.is_blinded,
                 private: data.private,

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -1731,7 +1731,7 @@ export default class CashuStore {
                 )}${decoded.memo ? `: ${decoded.memo}` : ''}`;
 
                 const invoiceParams = {
-                    expiry: '3600',
+                    expirySeconds: '3600',
                     routeHints: true,
                     noLsp: true
                 };
@@ -1980,7 +1980,7 @@ export default class CashuStore {
                 'stores.CashuStore.autoSweep'
             )} ${mintUrl}`;
             const invoiceParams = {
-                expiry: '3600',
+                expirySeconds: '3600',
                 routeHints: true,
                 noLsp: true
             };

--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -241,7 +241,7 @@ export default class InvoicesStore {
     public createUnifiedInvoice = ({
         memo,
         value,
-        expiry = '3600',
+        expirySeconds = '3600',
         lnurl,
         ampInvoice,
         blindedPaths,
@@ -253,7 +253,7 @@ export default class InvoicesStore {
     }: {
         memo: string;
         value: string;
-        expiry: string;
+        expirySeconds: string;
         lnurl?: LNURLWithdrawParams;
         ampInvoice?: boolean;
         blindedPaths?: boolean;
@@ -267,7 +267,7 @@ export default class InvoicesStore {
         return this.createInvoice({
             memo,
             value,
-            expiry,
+            expirySeconds,
             lnurl,
             ampInvoice,
             blindedPaths,
@@ -320,7 +320,7 @@ export default class InvoicesStore {
     public createInvoice = async ({
         memo,
         value,
-        expiry = '3600',
+        expirySeconds = '3600',
         lnurl,
         ampInvoice,
         blindedPaths,
@@ -332,7 +332,7 @@ export default class InvoicesStore {
     }: {
         memo: string;
         value: string;
-        expiry: string;
+        expirySeconds: string;
         lnurl?: LNURLWithdrawParams;
         ampInvoice?: boolean;
         blindedPaths?: boolean;
@@ -352,7 +352,7 @@ export default class InvoicesStore {
         const req: any = {
             memo,
             value,
-            expiry
+            expiry_seconds: expirySeconds
         };
 
         if (ampInvoice) req.is_amp = true;

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -546,7 +546,7 @@ export default class Receive extends React.Component<
                     ? `${receiverName}:  ${memo}`
                     : memo || '',
                 value: amount || '0',
-                expiry: lspIsActive
+                expirySeconds: lspIsActive
                     ? LOCKED_EXPIRY_SECONDS
                     : expirySeconds || '3600',
                 ampInvoice: lspIsActive ? false : ampInvoice || false,
@@ -697,7 +697,7 @@ export default class Receive extends React.Component<
                                 ? `${receiverName}:  ${memo}`
                                 : memo,
                             value: satAmount.toString(),
-                            expiry: '3600',
+                            expirySeconds: '3600',
                             lnurl: lnurlParams,
                             noLsp: !lspIsActive
                         })
@@ -3390,7 +3390,7 @@ export default class Receive extends React.Component<
                                                             value:
                                                                 satAmount.toString() ||
                                                                 '0',
-                                                            expiry:
+                                                            expirySeconds:
                                                                 lspIsActive
                                                                     ? LOCKED_EXPIRY_SECONDS
                                                                     : expirySeconds ||

--- a/views/Swaps/Refund.tsx
+++ b/views/Swaps/Refund.tsx
@@ -225,7 +225,7 @@ export default class RefundSwap extends React.Component<
                                                 {
                                                     memo: '',
                                                     value: '0',
-                                                    expiry: '3600'
+                                                    expirySeconds: '3600'
                                                 }
                                             );
                                             if (InvoicesStore.onChainAddress) {

--- a/views/Swaps/index.tsx
+++ b/views/Swaps/index.tsx
@@ -1502,7 +1502,8 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
                                                             value:
                                                                 outputSats.toString() ||
                                                                 '0',
-                                                            expiry: '3600'
+                                                            expirySeconds:
+                                                                '3600'
                                                         }
                                                     );
 


### PR DESCRIPTION
# Description

This PR fixes a bug where the user defined is used, when creating an invoice directly on the `Receive` view, instead of the locked LSP default. Work has also been done to refactor the `expiry` parameter to `expirySeconds` on `createInvoice` and `createUnifiedInvoice`, for clarity.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
