### PR TITLE
fix(ui): add scroll area to Bolt12Address and remove double error messages

### DIFF
--- a/views/Settings/Bolt12Address.tsx
+++ b/views/Settings/Bolt12Address.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+import { Text, View, StyleSheet, ScrollView } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { themeColor } from '../../utils/ThemeUtils';
 
@@ -161,99 +161,93 @@ export default class Bolt12AddressSettings extends React.Component<
                     containerStyle={{ borderBottomWidth: 0 }}
                     navigation={navigation}
                 />
-                {error && <ErrorMessage message={error} />}
-                {existingLocalPart ? (
-                    <View style={{ padding: 20 }}>
-                        <Text
-                            style={{
-                                ...styles.handle,
-                                color: themeColor('text'),
-                                paddingBottom: 10
-                            }}
-                        >
-                            {`${existingLocalPart}@${HOST}`}
-                        </Text>
-                        <View style={styles.button}>
-                            <Button
-                                title={localeString(
-                                    'views.Settings.Bolt12Address.changeButton'
-                                )}
-                                onPress={() => {
-                                    this.setState({
-                                        existingLocalPart: '',
-                                        newLocalPart: ''
-                                    });
-                                }}
-                            />
-                        </View>
-                    </View>
-                ) : (
-                    <View
-                        style={{
-                            padding: 20
-                        }}
-                    >
-                        <Text
-                            style={{
-                                ...styles.secondaryText,
-                                color: themeColor('secondaryText')
-                            }}
-                        >
-                            {localeString(
-                                'views.Settings.Bolt12Address.handle'
-                            )}
-                        </Text>
-                        <View
-                            style={{
-                                display: 'flex',
-                                flexDirection: 'row'
-                            }}
-                        >
-                            <TextInput
-                                value={newLocalPart}
-                                onChangeText={(text: string) => {
-                                    this.setState({
-                                        newLocalPart: text
-                                    });
-                                }}
-                                autoCapitalize="none"
-                                autoCorrect={false}
-                                style={{
-                                    flex: 1,
-                                    flexDirection: 'row'
-                                }}
-                            />
+                <ScrollView style={{ flex: 1 }}>
+                    {error && <ErrorMessage message={error} />}
+                    {existingLocalPart ? (
+                        <View style={{ padding: 20 }}>
                             <Text
                                 style={{
-                                    fontFamily: 'PPNeueMontreal-Book',
+                                    ...styles.handle,
                                     color: themeColor('text'),
-                                    fontSize: 20,
-                                    marginLeft: 5,
-                                    marginTop: 27
+                                    paddingBottom: 10
                                 }}
                             >
-                                @{HOST}
+                                {`${existingLocalPart}@${HOST}`}
                             </Text>
+                            <View style={styles.button}>
+                                <Button
+                                    title={localeString(
+                                        'views.Settings.Bolt12Address.changeButton'
+                                    )}
+                                    onPress={() => {
+                                        this.setState({
+                                            existingLocalPart: '',
+                                            newLocalPart: ''
+                                        });
+                                    }}
+                                />
+                            </View>
                         </View>
-                        <Text
+                    ) : (
+                        <View
                             style={{
-                                fontFamily: 'PPNeueMontreal-Book',
-                                color: themeColor('warning')
+                                padding: 20
                             }}
                         >
-                            {error}
-                        </Text>
-                        <View style={styles.button}>
-                            <Button
-                                title={localeString(
-                                    'views.Settings.Bolt12Address.requestButton'
+                            <Text
+                                style={{
+                                    ...styles.secondaryText,
+                                    color: themeColor('secondaryText')
+                                }}
+                            >
+                                {localeString(
+                                    'views.Settings.Bolt12Address.handle'
                                 )}
-                                disabled={!this.state.newLocalPart}
-                                onPress={() => this.requestPaymentAddress()}
-                            />
+                            </Text>
+                            <View
+                                style={{
+                                    display: 'flex',
+                                    flexDirection: 'row'
+                                }}
+                            >
+                                <TextInput
+                                    value={newLocalPart}
+                                    onChangeText={(text: string) => {
+                                        this.setState({
+                                            newLocalPart: text
+                                        });
+                                    }}
+                                    autoCapitalize="none"
+                                    autoCorrect={false}
+                                    style={{
+                                        flex: 1,
+                                        flexDirection: 'row'
+                                    }}
+                                />
+                                <Text
+                                    style={{
+                                        fontFamily: 'PPNeueMontreal-Book',
+                                        color: themeColor('text'),
+                                        fontSize: 20,
+                                        marginLeft: 5,
+                                        marginTop: 27
+                                    }}
+                                >
+                                    @{HOST}
+                                </Text>
+                            </View>
+                            <View style={styles.button}>
+                                <Button
+                                    title={localeString(
+                                        'views.Settings.Bolt12Address.requestButton'
+                                    )}
+                                    disabled={!this.state.newLocalPart}
+                                    onPress={() => this.requestPaymentAddress()}
+                                />
+                            </View>
                         </View>
-                    </View>
-                )}
+                    )}
+                </ScrollView>
             </Screen>
         );
     }


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This PR addresses issues in the BoltAddress UI component.

Changes: -
- Added a scroll area to properly display long error messages
- Removed duplicate error messages

Before Screen Recording, when we get a long error message, we are unable to scroll below:
https://github.com/user-attachments/assets/cd9db306-f79d-4279-81cf-7c25ffcddc09
This long error happened because I disconnected from the CLN node
And when we add scrollView, we see a double error message in ui 
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-12 at 10 29 33" src="https://github.com/user-attachments/assets/055be746-c031-43c3-a890-8d4e43a86bec" />

After Changes Screen Recording : 
https://github.com/user-attachments/assets/04fc128d-76fd-4b38-9baa-978db4fe24fe


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
