### PR TITLE
fix: 'LND is getting ready to make payments' for remote connections

### DIFF
--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -143,7 +143,7 @@ export default class PaymentRequest extends React.Component<
         selectedIndex: null
     };
 
-    async UNSAFE_componentWillMount() {
+    async componentDidMount() {
         this.isComponentMounted = true;
         const { SettingsStore, InvoicesStore } = this.props;
         const { getSettings, implementation } = SettingsStore;


### PR DESCRIPTION
# Description

On occasion, the `LND is getting ready to make payments` error is displayed for remote node connections. We believe this was caused due to a race condition in the deprecated `UNSAFE_componentWillMount` lifecycle func.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
