### PR TITLE
feat: LSPS: allow payments with Cashu

### DIFF
--- a/views/LSPS1/OrderResponse.tsx
+++ b/views/LSPS1/OrderResponse.tsx
@@ -13,33 +13,27 @@ import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import { numberWithCommas } from '../../utils/UnitsUtils';
 import UrlUtils from '../../utils/UrlUtils';
+import handleAnything from '../../utils/handleAnything';
 
-import InvoicesStore from '../../stores/InvoicesStore';
 import NodeInfoStore from '../../stores/NodeInfoStore';
 import { ChannelItem } from '../../components/Channels/ChannelItem';
 
 interface LSPS1OrderResponseProps {
     navigation: any;
     orderResponse: any;
-    InvoicesStore?: InvoicesStore;
     NodeInfoStore?: NodeInfoStore;
     orderView: boolean;
 }
 
-@inject('InvoicesStore', 'NodeInfoStore')
+@inject('NodeInfoStore')
 @observer
 export default class LSPS1OrderResponse extends React.Component<
     LSPS1OrderResponseProps,
     {}
 > {
     render() {
-        const {
-            orderResponse,
-            InvoicesStore,
-            NodeInfoStore,
-            orderView,
-            navigation
-        } = this.props;
+        const { orderResponse, NodeInfoStore, orderView, navigation } =
+            this.props;
         const { testnet } = NodeInfoStore!;
         const payment = orderResponse?.payment;
         const channel = orderResponse?.channel;
@@ -458,25 +452,16 @@ export default class LSPS1OrderResponse extends React.Component<
                                                 paddingVertical: 20
                                             }}
                                             onPress={() => {
-                                                InvoicesStore!
-                                                    .getPayReq(
-                                                        payment.bolt11
-                                                            ?.invoice ||
-                                                            payment.lightning_invoice ||
-                                                            payment.bolt11_invoice
-                                                    )
-                                                    .then(() => {
-                                                        navigation.navigate(
-                                                            'PaymentRequest',
-                                                            {}
-                                                        );
-                                                    })
-                                                    .catch((error: any) =>
-                                                        console.error(
-                                                            'Error fetching payment request:',
-                                                            error
-                                                        )
+                                                handleAnything(
+                                                    payment.bolt11?.invoice ||
+                                                        payment.lightning_invoice ||
+                                                        payment.bolt11_invoice
+                                                ).then(([route, props]) => {
+                                                    navigation.navigate(
+                                                        route,
+                                                        props
                                                     );
+                                                });
                                             }}
                                         />
                                     </>

--- a/views/LSPS1/index.tsx
+++ b/views/LSPS1/index.tsx
@@ -34,11 +34,11 @@ import BackendUtils from '../../utils/BackendUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { numberWithCommas } from '../../utils/UnitsUtils';
+import handleAnything from '../../utils/handleAnything';
 
 import Storage from '../../storage';
 
 import LSPStore, { LSPS_ORDERS_KEY } from '../../stores/LSPStore';
-import InvoicesStore from '../../stores/InvoicesStore';
 import ChannelsStore from '../../stores/ChannelsStore';
 import SettingsStore from '../../stores/SettingsStore';
 import NodeInfoStore from '../../stores/NodeInfoStore';
@@ -47,7 +47,6 @@ import { LSPOrderResponse as Order } from './OrdersPane';
 
 interface LSPS1Props {
     LSPStore: LSPStore;
-    InvoicesStore: InvoicesStore;
     ChannelsStore: ChannelsStore;
     SettingsStore: SettingsStore;
     NodeInfoStore: NodeInfoStore;
@@ -68,13 +67,7 @@ interface LSPS1State {
     advancedSettings: boolean;
 }
 
-@inject(
-    'LSPStore',
-    'ChannelsStore',
-    'InvoicesStore',
-    'SettingsStore',
-    'NodeInfoStore'
-)
+@inject('LSPStore', 'ChannelsStore', 'SettingsStore', 'NodeInfoStore')
 @observer
 export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
     listener: any;
@@ -269,13 +262,8 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
     };
 
     render() {
-        const {
-            navigation,
-            LSPStore,
-            InvoicesStore,
-            NodeInfoStore,
-            SettingsStore
-        } = this.props;
+        const { navigation, LSPStore, NodeInfoStore, SettingsStore } =
+            this.props;
         const {
             showInfo,
             advancedSettings,
@@ -1326,24 +1314,17 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                                     );
                                                 }
 
-                                                // Navigate to the PaymentRequest screen
-                                                InvoicesStore.getPayReq(
+                                                // Navigate to payment
+                                                handleAnything(
                                                     payment.bolt11?.invoice ||
                                                         payment.lightning_invoice ||
                                                         payment.bolt11_invoice
-                                                )
-                                                    .then(() => {
-                                                        navigation.navigate(
-                                                            'PaymentRequest',
-                                                            {}
-                                                        );
-                                                    })
-                                                    .catch((error: any) =>
-                                                        console.error(
-                                                            'Error fetching payment request:',
-                                                            error
-                                                        )
+                                                ).then(([route, props]) => {
+                                                    navigation.navigate(
+                                                        route,
+                                                        props
                                                     );
+                                                });
                                             })
                                             .catch((error) =>
                                                 console.error(

--- a/views/LSPS7/OrderResponse.tsx
+++ b/views/LSPS7/OrderResponse.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { inject, observer } from 'mobx-react';
 import { ScrollView, View } from 'react-native';
 import moment from 'moment';
 
@@ -10,29 +9,22 @@ import Button from '../../components/Button';
 
 import { localeString } from '../../utils/LocaleUtils';
 import { numberWithCommas } from '../../utils/UnitsUtils';
-
-import InvoicesStore from '../../stores/InvoicesStore';
+import handleAnything from '../../utils/handleAnything';
 
 interface LSPS7OrderResponseProps {
     navigation: any;
     orderResponse: any;
-    InvoicesStore?: InvoicesStore;
     orderView: boolean;
 }
 
-@inject('InvoicesStore')
-@observer
 export default class LSPS7OrderResponse extends React.Component<
     LSPS7OrderResponseProps,
     {}
 > {
     render() {
-        const { orderResponse, InvoicesStore, orderView, navigation } =
-            this.props;
+        const { orderResponse, orderView, navigation } = this.props;
         const payment = orderResponse?.payment;
         const channel = orderResponse?.channel;
-
-        console.log('orderResponse', orderResponse);
 
         return (
             <Screen>
@@ -330,25 +322,16 @@ export default class LSPS7OrderResponse extends React.Component<
                                                 paddingVertical: 20
                                             }}
                                             onPress={() => {
-                                                InvoicesStore!
-                                                    .getPayReq(
-                                                        payment.bolt11
-                                                            ?.invoice ||
-                                                            payment.lightning_invoice ||
-                                                            payment.bolt11_invoice
-                                                    )
-                                                    .then(() => {
-                                                        navigation.navigate(
-                                                            'PaymentRequest',
-                                                            {}
-                                                        );
-                                                    })
-                                                    .catch((error: any) =>
-                                                        console.error(
-                                                            'Error fetching payment request:',
-                                                            error
-                                                        )
+                                                handleAnything(
+                                                    payment.bolt11?.invoice ||
+                                                        payment.lightning_invoice ||
+                                                        payment.bolt11_invoice
+                                                ).then(([route, props]) => {
+                                                    navigation.navigate(
+                                                        route,
+                                                        props
                                                     );
+                                                });
                                             }}
                                         />
                                     </>

--- a/views/LSPS7/index.tsx
+++ b/views/LSPS7/index.tsx
@@ -27,9 +27,9 @@ import BackendUtils from '../../utils/BackendUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { numberWithCommas } from '../../utils/UnitsUtils';
+import handleAnything from '../../utils/handleAnything';
 
 import LSPStore, { LSPS_ORDERS_KEY } from '../../stores/LSPStore';
-import InvoicesStore from '../../stores/InvoicesStore';
 import ChannelsStore from '../../stores/ChannelsStore';
 import SettingsStore from '../../stores/SettingsStore';
 import NodeInfoStore from '../../stores/NodeInfoStore';
@@ -40,7 +40,6 @@ import Storage from '../../storage';
 
 interface LSPS7Props {
     LSPStore: LSPStore;
-    InvoicesStore: InvoicesStore;
     ChannelsStore: ChannelsStore;
     SettingsStore: SettingsStore;
     NodeInfoStore: NodeInfoStore;
@@ -67,13 +66,7 @@ interface LSPS7State {
     expirationBlock: number;
 }
 
-@inject(
-    'LSPStore',
-    'ChannelsStore',
-    'InvoicesStore',
-    'SettingsStore',
-    'NodeInfoStore'
-)
+@inject('LSPStore', 'ChannelsStore', 'SettingsStore', 'NodeInfoStore')
 @observer
 export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
     listener: any;
@@ -148,8 +141,7 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
     };
 
     render() {
-        const { navigation, LSPStore, NodeInfoStore, InvoicesStore } =
-            this.props;
+        const { navigation, LSPStore, NodeInfoStore } = this.props;
         const {
             showInfo,
             advancedSettings,
@@ -793,24 +785,17 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
                                                     );
                                                 }
 
-                                                // Navigate to the PaymentRequest screen
-                                                InvoicesStore.getPayReq(
+                                                // Navigate to the payment
+                                                handleAnything(
                                                     payment.bolt11?.invoice ||
                                                         payment.lightning_invoice ||
                                                         payment.bolt11_invoice
-                                                )
-                                                    .then(() => {
-                                                        navigation.navigate(
-                                                            'PaymentRequest',
-                                                            {}
-                                                        );
-                                                    })
-                                                    .catch((error: any) =>
-                                                        console.error(
-                                                            'Error fetching payment request:',
-                                                            error
-                                                        )
+                                                ).then(([route, props]) => {
+                                                    navigation.navigate(
+                                                        route,
+                                                        props
                                                     );
+                                                });
                                             })
                                             .catch((error) =>
                                                 console.error(


### PR DESCRIPTION
# Description

Previously, we would route users directly to the payment request view when receiving an invoice for an LSPS1 or LSPS7 order. No we direct them though `handleAnything` so that they will be prompted to choose between self-custody LN or Cashu if applicable.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
