### PR TITLE
ui: Activity label on Home view

### DIFF
--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -933,8 +933,19 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                                     accessibilityLabel={localeString(
                                         'general.activity'
                                     )}
+                                    style={{ alignItems: 'center' }}
                                 >
                                     <CaretUp fill={themeColor('text')} />
+                                    <Text
+                                        style={{
+                                            marginTop: 7,
+                                            textAlign: 'center',
+                                            fontFamily: 'PPNeueMontreal-Book',
+                                            color: themeColor('text')
+                                        }}
+                                    >
+                                        {localeString('general.activity')}
+                                    </Text>
                                 </TouchableOpacity>
                             </Animated.View>
                         </>


### PR DESCRIPTION
# Description

Users often have issues finding the Activity/History view. This PR adds a label to the ^ caret on the Balance/Home view. Pressing the label will also take you to the Activity view.

This PR also properly centers the ^ caret which was floating slightly to the left.

<img width="1320" height="2868" alt="simulator_screenshot_3E51CA7F-5691-42F9-978C-8391399EE2F6" src="https://github.com/user-attachments/assets/e8fad272-ac4c-43ed-b46a-7051f8e68efd" />

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
