### PR TITLE
enhancement: condense memos in Activity view

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -426,11 +426,11 @@ export default class Amount extends React.Component<AmountProps, {}> {
 
             // This should be a string because sensitiveValue can only return a date if you pass it a date
             // TODO: can we do better than hardcoding these?
-            unformattedAmount.amount = PrivacyUtils.sensitiveValue(
-                amount,
-                sensitiveLength,
-                true
-            ) as string;
+            unformattedAmount.amount = PrivacyUtils.sensitiveValue({
+                input: amount,
+                fixedLength: sensitiveLength,
+                numberSet: true
+            }) as string;
         }
 
         if (toggleable) {

--- a/components/Channels/ChannelItem.tsx
+++ b/components/Channels/ChannelItem.tsx
@@ -93,7 +93,7 @@ export function ChannelItem({
                         >
                             {`${
                                 typeof title === 'string' &&
-                                PrivacyUtils.sensitiveValue(title)
+                                PrivacyUtils.sensitiveValue({ input: title })
                             }`}
                         </Body>
                     </View>

--- a/components/KeyValue.tsx
+++ b/components/KeyValue.tsx
@@ -144,7 +144,9 @@ export default class KeyValue extends React.Component<KeyValueProps, {}> {
                         fontFamily: 'PPNeueMontreal-Book'
                     }}
                 >
-                    {sensitive ? PrivacyUtils.sensitiveValue(value) : value}
+                    {sensitive
+                        ? PrivacyUtils.sensitiveValue({ input: value })
+                        : value}
                 </Text>
             </View>
         );

--- a/components/NodeIdenticon.tsx
+++ b/components/NodeIdenticon.tsx
@@ -28,7 +28,7 @@ export const NodeTitle = (
 
     const title = overrideSensitivity
         ? displayName
-        : PrivacyUtils.sensitiveValue(displayName, 8);
+        : PrivacyUtils.sensitiveValue({ input: displayName, fixedLength: 8 });
     return title.length > maxLength
         ? title.substring(0, maxLength - 3) + '...'
         : title;

--- a/components/PaymentPath.tsx
+++ b/components/PaymentPath.tsx
@@ -99,6 +99,12 @@ const ExpandedHop = (props: any) => {
     const { pathIndex, hop, path, aliasMap, loading } = props;
     const isOrigin = hop.sent != null;
     const isDestination = pathIndex === path.length;
+
+    const nodeValue = PrivacyUtils.sensitiveValue({ input: hop.node });
+    const pubkeyValue = PrivacyUtils.sensitiveValue({
+        input: aliasMap.get(hop.pubKey)
+    });
+
     return (
         <View
             key={pathIndex}
@@ -158,36 +164,23 @@ const ExpandedHop = (props: any) => {
                                 isOrigin
                                     ? localeString('views.Channel.yourNode')
                                     : aliasMap.get(hop.pubKey)
-                                    ? PrivacyUtils.sensitiveValue(
-                                          aliasMap.get(hop.pubKey)
-                                      )
+                                    ? pubkeyValue
                                     : typeof hop.node === 'string' &&
                                       hop.node.length >= 66
                                     ? `${
-                                          typeof PrivacyUtils.sensitiveValue(
-                                              hop.node
-                                          ) === 'string'
-                                              ? (
-                                                    PrivacyUtils.sensitiveValue(
-                                                        hop.node
-                                                    ) as string
-                                                ).slice(0, 14)
+                                          typeof nodeValue === 'string'
+                                              ? (nodeValue as string).slice(
+                                                    0,
+                                                    14
+                                                )
                                               : ''
                                       }...${
-                                          typeof PrivacyUtils.sensitiveValue(
-                                              hop.node
-                                          ) === 'string'
-                                              ? (
-                                                    PrivacyUtils.sensitiveValue(
-                                                        hop.node
-                                                    ) as string
-                                                ).slice(-14)
+                                          typeof nodeValue === 'string'
+                                              ? (nodeValue as string).slice(-14)
                                               : ''
                                       }`
-                                    : typeof PrivacyUtils.sensitiveValue(
-                                          hop.node
-                                      ) === 'string'
-                                    ? PrivacyUtils.sensitiveValue(hop.node)
+                                    : typeof nodeValue === 'string'
+                                    ? nodeValue
                                     : ''
                             }`}
                         </Text>
@@ -285,8 +278,9 @@ export default class PaymentPath extends React.Component<
             path.forEach((hop) => {
                 const displayName = aliasMap.get(hop.pubKey) || hop.node;
                 title += ', ';
-                const sensitiveDisplayName =
-                    PrivacyUtils.sensitiveValue(displayName);
+                const sensitiveDisplayName = PrivacyUtils.sensitiveValue({
+                    input: displayName
+                });
                 title +=
                     typeof sensitiveDisplayName === 'string' &&
                     sensitiveDisplayName.length >= 66

--- a/components/WalletHeader.tsx
+++ b/components/WalletHeader.tsx
@@ -588,9 +588,9 @@ export default class WalletHeader extends React.Component<
                                             navigation.navigate('Wallets');
                                         }}
                                     >
-                                        {PrivacyUtils.sensitiveValue(
-                                            displayName
-                                        )?.toString()}
+                                        {PrivacyUtils.sensitiveValue({
+                                            input: displayName
+                                        })?.toString()}
                                     </Text>
                                     <StatusBadges />
                                 </Row>

--- a/utils/PrivacyUtils.test.ts
+++ b/utils/PrivacyUtils.test.ts
@@ -1,0 +1,292 @@
+import privacyUtils from './PrivacyUtils';
+import { settingsStore } from '../stores/Stores';
+
+jest.mock('../stores/Stores', () => ({
+    settingsStore: {
+        settings: {
+            privacy: {
+                lurkerMode: false
+            }
+        }
+    }
+}));
+
+describe('PrivacyUtils', () => {
+    beforeEach(() => {
+        // Reset to default state before each test
+        (settingsStore as any).settings = {
+            privacy: {
+                lurkerMode: false
+            }
+        };
+        // Clear memoized values by creating a new instance
+        // Since privacyUtils is a singleton, we need to clear its internal state
+        (privacyUtils as any).memoizedValues.clear();
+    });
+
+    describe('sensitiveValue', () => {
+        describe('when lurkerMode is false', () => {
+            beforeEach(() => {
+                (settingsStore as any).settings.privacy.lurkerMode = false;
+            });
+
+            it('should return the original string value', () => {
+                const result = privacyUtils.sensitiveValue({
+                    input: 'test123'
+                });
+                expect(result).toBe('test123');
+            });
+
+            it('should return the original number value', () => {
+                const result = privacyUtils.sensitiveValue({ input: 12345 });
+                expect(result).toBe(12345);
+            });
+
+            it('should return the original Date value', () => {
+                const date = new Date('2024-01-01');
+                const result = privacyUtils.sensitiveValue({ input: date });
+                expect(result).toBe(date);
+            });
+
+            it('should return undefined for undefined input', () => {
+                const result = privacyUtils.sensitiveValue({
+                    input: undefined
+                });
+                expect(result).toBeUndefined();
+            });
+
+            it('should condense long strings when condenseAtLength is provided', () => {
+                const longString = 'a'.repeat(20);
+                const result = privacyUtils.sensitiveValue({
+                    input: longString,
+                    condenseAtLength: 10
+                });
+                expect(result).toBe('aaaaaaa...');
+            });
+
+            it('should not condense strings shorter than condenseAtLength', () => {
+                const shortString = 'test';
+                const result = privacyUtils.sensitiveValue({
+                    input: shortString,
+                    condenseAtLength: 10
+                });
+                expect(result).toBe('test');
+            });
+        });
+
+        describe('when lurkerMode is true', () => {
+            beforeEach(() => {
+                (settingsStore as any).settings.privacy.lurkerMode = true;
+            });
+
+            it('should return a masked value for string input', () => {
+                const result = privacyUtils.sensitiveValue({
+                    input: 'test123'
+                });
+                expect(result).toBeDefined();
+                expect(result).not.toBe('test123');
+                expect(typeof result).toBe('string');
+                expect((result as string).length).toBe(7); // Length of 'test123'
+            });
+
+            it('should return a masked value using alphabet by default', () => {
+                const result = privacyUtils.sensitiveValue({ input: 'test' });
+                const alphabet = 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ';
+                expect(result).toBeDefined();
+                // Check that all characters are from the alphabet
+                for (const char of result as string) {
+                    expect(alphabet).toContain(char);
+                }
+            });
+
+            it('should return a masked value using numbers when numberSet is true', () => {
+                const result = privacyUtils.sensitiveValue({
+                    input: 'test',
+                    numberSet: true
+                });
+                const numbers = 'ΑΒΓΔΕϚΣΤΖΗΘϝϟϡ–◦¤☼ΙΠΧΜ';
+                expect(result).toBeDefined();
+                // Check that all characters are from the numbers set
+                for (const char of result as string) {
+                    expect(numbers).toContain(char);
+                }
+            });
+
+            it('should use fixedLength when provided', () => {
+                const result = privacyUtils.sensitiveValue({
+                    input: 'test',
+                    fixedLength: 10
+                });
+                expect(result).toBeDefined();
+                expect((result as string).length).toBe(10);
+            });
+
+            it('should memoize values - same input returns same masked value', () => {
+                const input = 'test123';
+                const result1 = privacyUtils.sensitiveValue({ input });
+                const result2 = privacyUtils.sensitiveValue({ input });
+                expect(result1).toBe(result2);
+            });
+
+            it('should generate different masked values for different inputs', () => {
+                const result1 = privacyUtils.sensitiveValue({ input: 'test1' });
+                const result2 = privacyUtils.sensitiveValue({ input: 'test2' });
+                expect(result1).not.toBe(result2);
+            });
+
+            it('should memoize based on all parameters', () => {
+                const input = 'test';
+                const result1 = privacyUtils.sensitiveValue({
+                    input,
+                    fixedLength: 5,
+                    numberSet: false
+                });
+                const result2 = privacyUtils.sensitiveValue({
+                    input,
+                    fixedLength: 5,
+                    numberSet: false
+                });
+                expect(result1).toBe(result2);
+            });
+
+            it('should generate different values for different fixedLength', () => {
+                const input = 'test';
+                const result1 = privacyUtils.sensitiveValue({
+                    input,
+                    fixedLength: 5
+                });
+                const result2 = privacyUtils.sensitiveValue({
+                    input,
+                    fixedLength: 10
+                });
+                expect(result1).not.toBe(result2);
+                expect((result1 as string).length).toBe(5);
+                expect((result2 as string).length).toBe(10);
+            });
+
+            it('should generate different values for different numberSet', () => {
+                const input = 'test';
+                const result1 = privacyUtils.sensitiveValue({
+                    input,
+                    numberSet: false
+                });
+                const result2 = privacyUtils.sensitiveValue({
+                    input,
+                    numberSet: true
+                });
+                expect(result1).not.toBe(result2);
+            });
+
+            it('should handle undefined input', () => {
+                const result = privacyUtils.sensitiveValue({
+                    input: undefined
+                });
+                expect(result).toBeDefined();
+                expect((result as string).length).toBe(0); // Empty string length
+            });
+
+            it('should handle number input', () => {
+                const result = privacyUtils.sensitiveValue({ input: 12345 });
+                expect(result).toBeDefined();
+                expect((result as string).length).toBe(5); // Length of '12345'
+            });
+
+            it('should handle Date input', () => {
+                const date = new Date('2024-01-01T00:00:00.000Z');
+                const result = privacyUtils.sensitiveValue({ input: date });
+                expect(result).toBeDefined();
+                expect(typeof result).toBe('string');
+            });
+
+            it('should condense long strings before masking when condenseAtLength is provided', () => {
+                const longString = 'a'.repeat(20);
+                const result1 = privacyUtils.sensitiveValue({
+                    input: longString,
+                    condenseAtLength: 10
+                });
+                const result2 = privacyUtils.sensitiveValue({
+                    input: longString,
+                    condenseAtLength: 10
+                });
+                // Should be memoized based on condensed string
+                expect(result1).toBe(result2);
+                // Length is based on original input length, not condensed length
+                expect((result1 as string).length).toBe(20); // Original input length
+            });
+
+            it('should handle fixedLength with null value', () => {
+                const result = privacyUtils.sensitiveValue({
+                    input: 'test',
+                    fixedLength: null
+                });
+                expect(result).toBeDefined();
+                expect((result as string).length).toBe(4); // Should use input length
+            });
+        });
+
+        describe('edge cases', () => {
+            it('should handle missing privacy settings gracefully', () => {
+                (settingsStore as any).settings = {};
+                const result = privacyUtils.sensitiveValue({ input: 'test' });
+                // Should default to false (no masking)
+                expect(result).toBe('test');
+            });
+
+            it('should handle undefined privacy settings gracefully', () => {
+                (settingsStore as any).settings.privacy = undefined;
+                const result = privacyUtils.sensitiveValue({ input: 'test' });
+                // Should default to false (no masking)
+                expect(result).toBe('test');
+            });
+
+            it('should handle empty string input', () => {
+                (settingsStore as any).settings.privacy.lurkerMode = true;
+                const result = privacyUtils.sensitiveValue({ input: '' });
+                expect(result).toBeDefined();
+                expect((result as string).length).toBe(0);
+            });
+
+            it('should handle zero fixedLength', () => {
+                (settingsStore as any).settings.privacy.lurkerMode = true;
+                const result = privacyUtils.sensitiveValue({
+                    input: 'test',
+                    fixedLength: 0
+                });
+                expect(result).toBeDefined();
+                // Zero is falsy, so it falls back to input length
+                expect((result as string).length).toBe(4); // Input length
+            });
+
+            it('should handle very long fixedLength', () => {
+                (settingsStore as any).settings.privacy.lurkerMode = true;
+                const result = privacyUtils.sensitiveValue({
+                    input: 'test',
+                    fixedLength: 100
+                });
+                expect(result).toBeDefined();
+                expect((result as string).length).toBe(100);
+            });
+
+            it('should handle condenseAtLength equal to input length', () => {
+                (settingsStore as any).settings.privacy.lurkerMode = false;
+                const input = 'test';
+                const result = privacyUtils.sensitiveValue({
+                    input,
+                    condenseAtLength: 4
+                });
+                expect(result).toBe('test'); // Should not condense
+            });
+
+            it('should handle condenseAtLength less than 3', () => {
+                (settingsStore as any).settings.privacy.lurkerMode = false;
+                const input = 'test';
+                const result = privacyUtils.sensitiveValue({
+                    input,
+                    condenseAtLength: 2
+                });
+                // Should handle gracefully, likely won't condense
+                expect(result).toBeDefined();
+            });
+        });
+    });
+});

--- a/utils/PrivacyUtils.ts
+++ b/utils/PrivacyUtils.ts
@@ -10,19 +10,35 @@ class PrivacyUtils {
     // Stores generated masked values to prevent regeneration on each render
     private memoizedValues: Map<string, string> = new Map();
 
-    sensitiveValue = (
-        input: string | number | Date | undefined,
-        fixedLength?: number | null,
-        numberSet?: boolean
-    ) => {
+    sensitiveValue = ({
+        input,
+        fixedLength,
+        numberSet,
+        condenseAtLength
+    }: {
+        input: string | number | Date | undefined;
+        fixedLength?: number | null;
+        numberSet?: boolean;
+        condenseAtLength?: number;
+    }) => {
         const { settings } = settingsStore;
         const { privacy } = settings;
         const lurkerMode = (privacy && privacy.lurkerMode) || false;
-        if (!lurkerMode) return input;
 
         // Create unique key for memoization based on input parameters
-        const length = fixedLength || (input && input.toString().length) || 1;
-        const key = `${input}-${length}-${numberSet}`;
+        const inputString = input?.toString() || '';
+        const length = fixedLength || inputString.length;
+
+        let condensedString = input;
+        if (condenseAtLength && inputString.length > condenseAtLength) {
+            condensedString = `${inputString.slice(
+                0,
+                condenseAtLength - 3
+            )}...`;
+        }
+
+        if (!lurkerMode) return condensedString;
+        const key = `${condensedString}-${length}-${numberSet}`;
 
         // Generate and store new masked value only if not already memoized
         if (!this.memoizedValues.has(key)) {

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -119,9 +119,10 @@ const ActivityListItem = React.memo(
                     {keysendMessageOrMemo ? ': ' : ''}
                     {keysendMessageOrMemo ? (
                         <Text style={{ fontStyle: 'italic' }}>
-                            {PrivacyUtils.sensitiveValue(
-                                keysendMessageOrMemo
-                            )?.toString()}
+                            {PrivacyUtils.sensitiveValue({
+                                input: keysendMessageOrMemo,
+                                condenseAtLength: 100
+                            })?.toString()}
                         </Text>
                     ) : (
                         ''
@@ -141,7 +142,10 @@ const ActivityListItem = React.memo(
                     {memo ? ': ' : ''}
                     {memo ? (
                         <Text style={{ fontStyle: 'italic' }}>
-                            {PrivacyUtils.sensitiveValue(memo)?.toString()}
+                            {PrivacyUtils.sensitiveValue({
+                                input: memo,
+                                condenseAtLength: 100
+                            })?.toString()}
                         </Text>
                     ) : (
                         ''
@@ -163,7 +167,10 @@ const ActivityListItem = React.memo(
                     {memo ? ': ' : ''}
                     {memo ? (
                         <Text style={{ fontStyle: 'italic' }}>
-                            {PrivacyUtils.sensitiveValue(memo)?.toString()}
+                            {PrivacyUtils.sensitiveValue({
+                                input: memo,
+                                condenseAtLength: 100
+                            })?.toString()}
                         </Text>
                     ) : (
                         ''
@@ -183,9 +190,10 @@ const ActivityListItem = React.memo(
                     {keysendMessageOrMemo ? ': ' : ''}
                     {keysendMessageOrMemo ? (
                         <Text style={{ fontStyle: 'italic' }}>
-                            {PrivacyUtils.sensitiveValue(
-                                keysendMessageOrMemo
-                            )?.toString()}
+                            {PrivacyUtils.sensitiveValue({
+                                input: keysendMessageOrMemo,
+                                condenseAtLength: 100
+                            })?.toString()}
                         </Text>
                     ) : (
                         ''
@@ -205,9 +213,10 @@ const ActivityListItem = React.memo(
                     {keysendMessageOrMemo ? ': ' : ''}
                     {keysendMessageOrMemo ? (
                         <Text style={{ fontStyle: 'italic' }}>
-                            {PrivacyUtils.sensitiveValue(
-                                keysendMessageOrMemo
-                            )?.toString()}
+                            {PrivacyUtils.sensitiveValue({
+                                input: keysendMessageOrMemo,
+                                condenseAtLength: 100
+                            })?.toString()}
                         </Text>
                     ) : (
                         ''
@@ -376,13 +385,10 @@ const ActivityListItem = React.memo(
                                 }}
                                 ellipsizeMode="tail"
                             >
-                                {note.length > 150
-                                    ? `${PrivacyUtils.sensitiveValue(
-                                          note.substring(0, 150)
-                                      )?.toString()}...`
-                                    : PrivacyUtils.sensitiveValue(
-                                          note
-                                      )?.toString()}
+                                {PrivacyUtils.sensitiveValue({
+                                    input: note,
+                                    condenseAtLength: 100
+                                })?.toString()}
                             </ListItem.Subtitle>
                         </View>
                     )}

--- a/views/Cashu/Mint.tsx
+++ b/views/Cashu/Mint.tsx
@@ -404,7 +404,7 @@ export default class Mint extends React.Component<MintProps, MintState> {
                                                 {`${
                                                     typeof info === 'string' &&
                                                     PrivacyUtils.sensitiveValue(
-                                                        info
+                                                        { input: info }
                                                     )
                                                 }`}
                                             </Text>

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -385,7 +385,10 @@ export default class ChannelView extends React.Component<
             closing
         );
 
-        const peerDisplay = PrivacyUtils.sensitiveValue(displayName, 8);
+        const peerDisplay = PrivacyUtils.sensitiveValue({
+            input: displayName,
+            fixedLength: 8
+        });
 
         const showAliasScids =
             !!aliasScids &&
@@ -457,9 +460,9 @@ export default class ChannelView extends React.Component<
                                     {remotePubkey
                                         ? (() => {
                                               const maskedPubkey: string | any =
-                                                  PrivacyUtils.sensitiveValue(
-                                                      remotePubkey
-                                                  );
+                                                  PrivacyUtils.sensitiveValue({
+                                                      input: remotePubkey
+                                                  });
                                               return (
                                                   maskedPubkey.slice(0, 6) +
                                                   '...' +
@@ -718,9 +721,9 @@ export default class ChannelView extends React.Component<
                                                   'views.Channel.aliasScid'
                                               )
                                     }
-                                    value={PrivacyUtils.sensitiveValue(
-                                        aliasScids.join(', ')
-                                    )}
+                                    value={PrivacyUtils.sensitiveValue({
+                                        input: aliasScids.join(', ')
+                                    })}
                                 />
                             )}
                             {showPeerAliasScid && (
@@ -728,9 +731,9 @@ export default class ChannelView extends React.Component<
                                     keyValue={localeString(
                                         'views.Channel.peerAliasScid'
                                     )}
-                                    value={PrivacyUtils.sensitiveValue(
-                                        peerScidAlias
-                                    )}
+                                    value={PrivacyUtils.sensitiveValue({
+                                        input: peerScidAlias
+                                    })}
                                 />
                             )}
                             {showZeroConfConfirmedScid && (
@@ -738,9 +741,9 @@ export default class ChannelView extends React.Component<
                                     keyValue={localeString(
                                         'views.Channel.zeroConfConfirmedScid'
                                     )}
-                                    value={PrivacyUtils.sensitiveValue(
-                                        zeroConfConfirmedScid
-                                    )}
+                                    value={PrivacyUtils.sensitiveValue({
+                                        input: zeroConfConfirmedScid
+                                    })}
                                 />
                             )}
                         </>

--- a/views/Transaction.tsx
+++ b/views/Transaction.tsx
@@ -119,7 +119,9 @@ export default class TransactionView extends React.Component<
                             >
                                 {`${
                                     typeof address === 'string' &&
-                                    PrivacyUtils.sensitiveValue(address)
+                                    PrivacyUtils.sensitiveValue({
+                                        input: address
+                                    })
                                 }`}
                             </Text>
                         </TouchableOpacity>
@@ -218,7 +220,9 @@ export default class TransactionView extends React.Component<
                                 >
                                     {`${
                                         typeof tx === 'string' &&
-                                        PrivacyUtils.sensitiveValue(tx)
+                                        PrivacyUtils.sensitiveValue({
+                                            input: tx
+                                        })
                                     }`}
                                 </Text>
                             </TouchableOpacity>
@@ -247,9 +251,9 @@ export default class TransactionView extends React.Component<
                                     >
                                         {`${
                                             typeof block_hash === 'string' &&
-                                            PrivacyUtils.sensitiveValue(
-                                                block_hash
-                                            )
+                                            PrivacyUtils.sensitiveValue({
+                                                input: block_hash
+                                            })
                                         }`}
                                     </Text>
                                 </TouchableOpacity>
@@ -280,11 +284,11 @@ export default class TransactionView extends React.Component<
                                         {`${
                                             typeof getBlockHeight ===
                                                 'string' &&
-                                            PrivacyUtils.sensitiveValue(
-                                                getBlockHeight.toString(),
-                                                5,
-                                                true
-                                            )
+                                            PrivacyUtils.sensitiveValue({
+                                                input: getBlockHeight.toString(),
+                                                fixedLength: 5,
+                                                numberSet: true
+                                            })
                                         }`}
                                     </Text>
                                 </TouchableOpacity>

--- a/views/TxHex.tsx
+++ b/views/TxHex.tsx
@@ -578,7 +578,9 @@ export default class TxHex extends React.Component<TxHexProps, TxHexState> {
                                                                                 }}
                                                                             >
                                                                                 {`${PrivacyUtils.sensitiveValue(
-                                                                                    outpoint
+                                                                                    {
+                                                                                        input: outpoint
+                                                                                    }
                                                                                 )}`}
                                                                             </Text>
                                                                         </TouchableOpacity>
@@ -652,7 +654,9 @@ export default class TxHex extends React.Component<TxHexProps, TxHexState> {
                                                                                 }}
                                                                             >
                                                                                 {`${PrivacyUtils.sensitiveValue(
-                                                                                    address
+                                                                                    {
+                                                                                        input: address
+                                                                                    }
                                                                                 )}`}
                                                                             </Text>
                                                                         </TouchableOpacity>


### PR DESCRIPTION
# Description

This PR condenses memos displayed on the `Activity` view if they are over 100 chars long and appends an ellipsis (...) ti them.

The motivation behind this is seeing an absurdly long memo for a subscription in my activity list which took up too much real estate. If I needed to see the full memo I could go to the single `Payment` view.

This PR accomplishes the above by adding a new `condenseAtLength` param to the `PrivacyUtils.sensitiveValue` func. All params are also destructured. Test coverage is also added.

|Before|After|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-07 at 00 42 30" src="https://github.com/user-attachments/assets/f18d3c30-1635-467f-b4e1-22bdfbf2ff08" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-07 at 00 42 02" src="https://github.com/user-attachments/assets/fe803468-1587-46eb-99ce-bba20eb351cf" />|

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
