### PR TITLE
ui: fix padding above 'Save Wallet Config' button

### DIFF
--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -1137,7 +1137,7 @@ export default class WalletConfiguration extends React.Component<
                         style={{ flex: 1, paddingHorizontal: 20 }}
                         keyboardShouldPersistTaps="handled"
                     >
-                        <View style={styles.form}>
+                        <View style={{ ...styles.form, marginBottom: 20 }}>
                             {!!importError && (
                                 <ErrorMessage message={importError} />
                             )}
@@ -2313,7 +2313,7 @@ export default class WalletConfiguration extends React.Component<
                         </View>
 
                         {!existingAccount && implementation === 'lndhub' && (
-                            <View style={{ ...styles.button, marginTop: 20 }}>
+                            <View style={{ ...styles.button }}>
                                 <Button
                                     title={localeString(
                                         'views.Settings.AddEditNode.createLndhub'
@@ -2377,7 +2377,7 @@ export default class WalletConfiguration extends React.Component<
                         )}
 
                         {implementation === 'embedded-lnd' && (
-                            <View style={{ ...styles.button, marginTop: 20 }}>
+                            <View style={{ ...styles.button }}>
                                 {!adminMacaroon && !creatingWallet && (
                                     <>
                                         <View style={styles.button}>


### PR DESCRIPTION
# Description

|Before|After|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-07 at 00 58 56" src="https://github.com/user-attachments/assets/3148f67e-f198-475e-b2c5-4e761bee8690" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-07 at 00 59 46" src="https://github.com/user-attachments/assets/65e02131-898d-4407-9e8a-aa87831f18b8" />|

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
