### PR TITLE
feat: Express Graph Sync prompt: reload invoice on restart

### DIFF
--- a/utils/GraphSyncUtils.ts
+++ b/utils/GraphSyncUtils.ts
@@ -1,7 +1,15 @@
 import { settingsStore, transactionsStore } from '../stores/Stores';
 import { restartNeeded } from './RestartUtils';
+import storage from '../storage';
+import { SendPaymentReq } from '../stores/TransactionsStore';
+
+const PENDING_PAYMENT_STORAGE_KEY = 'zeus-pending-payment-after-graph-sync';
 
 export const handleEnableGraphSync = async (): Promise<void> => {
+    if (transactionsStore.pendingPaymentData) {
+        await savePendingPaymentData(transactionsStore.pendingPaymentData);
+    }
+
     await settingsStore.updateSettings({
         expressGraphSync: true,
         graphSyncPromptIgnoreOnce: false
@@ -23,6 +31,42 @@ export const handleNeverAskAgain = async (): Promise<void> => {
         graphSyncPromptNeverAsk: true,
         graphSyncPromptIgnoreOnce: false
     });
+};
+
+export const savePendingPaymentData = async (
+    paymentData: SendPaymentReq
+): Promise<void> => {
+    try {
+        await storage.setItem(
+            PENDING_PAYMENT_STORAGE_KEY,
+            JSON.stringify(paymentData)
+        );
+    } catch (error) {
+        console.error('Error saving pending payment data:', error);
+        throw error;
+    }
+};
+
+export const loadPendingPaymentData =
+    async (): Promise<SendPaymentReq | null> => {
+        try {
+            const data = await storage.getItem(PENDING_PAYMENT_STORAGE_KEY);
+            if (data) {
+                return JSON.parse(data);
+            }
+        } catch (error) {
+            console.error('Error loading pending payment data:', error);
+        }
+        return null;
+    };
+
+export const clearPendingPaymentData = async (): Promise<void> => {
+    try {
+        await storage.removeItem(PENDING_PAYMENT_STORAGE_KEY);
+    } catch (error) {
+        console.error('Error clearing pending payment data:', error);
+        throw error;
+    }
 };
 
 export const checkGraphSyncBeforePayment = (

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import Slider from '@react-native-community/slider';
+import { Route } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { ButtonGroup } from '@rneui/themed';
 
@@ -50,6 +51,7 @@ import {
     calculateDonationAmount,
     findDonationPercentageIndex
 } from '../utils/DonationUtils';
+import { clearPendingPaymentData } from '../utils/GraphSyncUtils';
 
 import CaretDown from '../assets/images/SVG/Caret Down.svg';
 import CaretRight from '../assets/images/SVG/Caret Right.svg';
@@ -66,6 +68,7 @@ const zaplockerDestinations = [
 interface InvoiceProps {
     exitSetup: any;
     navigation: StackNavigationProp<any, any>;
+    route: Route<'PaymentRequest', { fromGraphSync?: boolean }>;
     BalanceStore: BalanceStore;
     InvoicesStore: InvoicesStore;
     SwapStore: SwapStore;
@@ -148,9 +151,18 @@ export default class PaymentRequest extends React.Component<
 
     async componentDidMount() {
         this.isComponentMounted = true;
-        const { SettingsStore, InvoicesStore } = this.props;
+        const { SettingsStore, InvoicesStore, route } = this.props;
         const { getSettings, implementation } = SettingsStore;
         const settings = await getSettings();
+
+        if (route?.params?.fromGraphSync) {
+            clearPendingPaymentData().catch((error) => {
+                console.error(
+                    'Failed to clear pending payment data on PaymentRequest:',
+                    error
+                );
+            });
+        }
 
         const { defaultDonationPercentage } = settings.payments;
 

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -57,6 +57,7 @@ import NFCUtils from '../utils/NFCUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
 import { getUnformattedAmount, getAmountFromSats } from '../utils/AmountUtils';
+import { clearPendingPaymentData } from '../utils/GraphSyncUtils';
 
 import NFC from '../assets/images/SVG/NFC-alt.svg';
 import ContactIcon from '../assets/images/SVG/PeersContact.svg';
@@ -89,6 +90,7 @@ interface SendProps {
             isValid: boolean;
             contactName: string;
             clearOnBackPress: boolean;
+            fromGraphSync: boolean;
         }
     >;
 }
@@ -295,9 +297,18 @@ export default class Send extends React.Component<SendProps, SendState> {
     };
 
     async componentDidMount() {
-        const { SettingsStore } = this.props;
+        const { SettingsStore, route } = this.props;
         const { getSettings } = SettingsStore;
         const settings = await getSettings();
+
+        if (route.params?.fromGraphSync) {
+            clearPendingPaymentData().catch((error) => {
+                console.error(
+                    'Failed to clear pending payment data on Send:',
+                    error
+                );
+            });
+        }
 
         if (settings.privacy && settings.privacy.clipboard) {
             const clipboard = await Clipboard.getString();


### PR DESCRIPTION
# Description

Relates to issue: **[ZEUS-3361](https://github.com/ZeusLN/zeus/issues/3361)**

Saves pending payment data to storage when enabling Express Graph Sync, then automatically restores and displays the invoice/payment after app restart. Handles both Lightning invoices and keysend payments.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding