### PR TITLE
fix: include routing hints when autogenerating 0 amount invoice

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -556,7 +556,7 @@ export default class Receive extends React.Component<
                     : expirySeconds || '3600',
                 ampInvoice: lspIsActive ? false : ampInvoice || false,
                 blindedPaths: lspIsActive ? false : blindedPaths || false,
-                routeHints: lspIsActive ? false : routeHints || false,
+                routeHints,
                 addressType: BackendUtils.supportsAddressTypeSelection()
                     ? addressType || '1'
                     : undefined,


### PR DESCRIPTION
# Description

When auto-generating invoices (hitting the `Request` button on the `Keypad` view) without an amount, we inform the user that the LSP has been disabled and that their pubkey will be exposed, because the LSP does not support 0-amount invoices. When doing so, we had a bug that would default `Routing hints` to false. In doing so, this became problematic for user that only had unannounced channels (eg. Olympus LSP channels), because this would lead to the user unable to be paid on Lightning.

This PR fixes the logic for the `routeHints` bool param in case of auto-generation and makes it uniform with the rest of the `Receive` view.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
