### PR TITLE
fix: ui: prevent NewChannelModal title from appearing on next screen

### DIFF
--- a/components/Modals/NewChannelModal.tsx
+++ b/components/Modals/NewChannelModal.tsx
@@ -59,7 +59,11 @@ export default class NewChannelModal extends React.Component<
                 backdrop={true}
                 position="bottom"
                 isOpen={showNewChannelModal}
-                onClosed={() => toggleNewChannelModal()}
+                onClosed={() => {
+                    if (showNewChannelModal) {
+                        toggleNewChannelModal();
+                    }
+                }}
             >
                 <View>
                     <Text
@@ -78,8 +82,8 @@ export default class NewChannelModal extends React.Component<
                             <TouchableOpacity
                                 key="jit"
                                 onPress={async () => {
-                                    NavigationService.navigate('Receive');
                                     closeVisibleModalDialog();
+                                    NavigationService.navigate('Receive');
                                 }}
                                 style={{
                                     ...styles.option,
@@ -183,8 +187,8 @@ export default class NewChannelModal extends React.Component<
                             <TouchableOpacity
                                 key="lsps1"
                                 onPress={async () => {
-                                    NavigationService.navigate('LSPS1');
                                     closeVisibleModalDialog();
+                                    NavigationService.navigate('LSPS1');
                                 }}
                                 style={{
                                     ...styles.option,
@@ -287,8 +291,8 @@ export default class NewChannelModal extends React.Component<
                         <TouchableOpacity
                             key="on-chain"
                             onPress={async () => {
-                                NavigationService.navigate('OpenChannel');
                                 closeVisibleModalDialog();
+                                NavigationService.navigate('OpenChannel');
                             }}
                             style={{
                                 ...styles.option,


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

Before Screen Recording: 

https://github.com/user-attachments/assets/89eef84a-f752-4af5-8e44-41b04a4b77cb


After Screen Recording: 

https://github.com/user-attachments/assets/79c798e6-e406-4b42-a27f-c03f9a676bad






This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
