### PR TITLE
fix (Wallet): race condition in wallet balance 

### DIFF
--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -608,7 +608,8 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 SyncStore.checkRecoveryStatus();
             await NodeInfoStore.getNodeInfo();
             NodeInfoStore.getNetworkInfo();
-            if (BackendUtils.supportsAccounts()) UTXOsStore.listAccounts();
+            if (BackendUtils.supportsAccounts())
+                await UTXOsStore.listAccounts();
             await BalanceStore.getCombinedBalance(false);
             if (BackendUtils.supportsChannelManagement())
                 await ChannelsStore.getChannels();
@@ -662,7 +663,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                         await UTXOsStore.listAccounts();
                     await BalanceStore.getCombinedBalance();
                     if (BackendUtils.supportsChannelManagement())
-                        ChannelsStore.getChannels();
+                        await ChannelsStore.getChannels();
                 } catch (connectionError) {
                     console.log('LNC connection failed:', connectionError);
                     return;
@@ -685,10 +686,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             try {
                 await NodeInfoStore.getNodeInfo();
                 if (BackendUtils.supportsAccounts()) {
-                    UTXOsStore.listAccounts();
+                    await UTXOsStore.listAccounts();
                 }
                 await BalanceStore.getCombinedBalance();
-                ChannelsStore.getChannels();
+                await ChannelsStore.getChannels();
             } catch (connectionError) {
                 console.log('Node connection failed:', connectionError);
                 NodeInfoStore.handleGetNodeInfoError();


### PR DESCRIPTION
# Description

This PR fixes a visual bug where the main balance header updates immediately, but the individual balance rows lag behind.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [X] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
