### PR TITLE
[feat] ZEUS-3402: fix: Intent: wait for wallet to load before processing invoice

### DIFF
--- a/views/HandleAnythingQRScanner.tsx
+++ b/views/HandleAnythingQRScanner.tsx
@@ -47,6 +47,9 @@ export default class HandleAnythingQRScanner extends React.Component<
     HandleAnythingQRState
 > {
     decoder: any;
+    // Flag to prevent duplicate navigation after QR scan
+    private hasNavigated: boolean = false;
+
     constructor(props: any) {
         super(props);
 
@@ -62,6 +65,15 @@ export default class HandleAnythingQRScanner extends React.Component<
         this.decoder = null;
         this.setState({ parts: [], totalParts: 0 });
     };
+
+    // Helper to prevent duplicate navigation - returns true if already navigated
+    private checkAndSetNavigated(): boolean {
+        if (this.hasNavigated) {
+            return true;
+        }
+        this.hasNavigated = true;
+        return false;
+    }
 
     handleAnythingScanned = async (data: string) => {
         const { navigation, route } = this.props;
@@ -82,6 +94,7 @@ export default class HandleAnythingQRScanner extends React.Component<
                         isTestNet || isRegTest || isSigNet
                     )
                 ) {
+                    if (this.checkAndSetNavigated()) return;
                     navigation.goBack();
                     navigation.navigate('Swaps', {
                         initialInvoice: value,
@@ -105,6 +118,7 @@ export default class HandleAnythingQRScanner extends React.Component<
                     const invoiceModel = new Invoice(decodedInvoice);
                     const amount = invoiceModel.getRequestAmount;
 
+                    if (this.checkAndSetNavigated()) return;
                     navigation.goBack();
                     navigation.navigate('Swaps', {
                         initialInvoice: value,
@@ -149,6 +163,7 @@ export default class HandleAnythingQRScanner extends React.Component<
                         isTestNet || isRegTest || isSigNet
                     )
                 ) {
+                    if (this.checkAndSetNavigated()) return;
                     navigation.goBack();
                     navigation.navigate('RefundSwap', {
                         scannedAddress: value
@@ -358,6 +373,8 @@ export default class HandleAnythingQRScanner extends React.Component<
                 this.setState({
                     loading: false
                 });
+                if (this.checkAndSetNavigated()) return;
+
                 if (response) {
                     const [route, props] = response;
                     navigation.goBack();
@@ -383,6 +400,7 @@ export default class HandleAnythingQRScanner extends React.Component<
                     loading: false
                 });
 
+                if (this.checkAndSetNavigated()) return;
                 navigation.goBack();
             });
     };


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-3402**](https://github.com/ZeusLN/zeus/issues/3402)

Often times you will see you balance as zero as the invoice or `Choose Payment Method` view is pulled up before the balance calls are completed.Similarly, sometimes scanning a QR code for an invoice takes you to the `Choose Payment Method` page twice in quick succession.

Summary of Changes

  1. `views/Wallet/Wallet.tsx`

  - Added `previousAppState` tracking to distinguish real background→active transitions from brief inactive→active transitions (like returning from camera)
  - Added `lastSettingsNavigateTime` for debouncing
  - Modified `handleAppStateChange` to only call `getSettingsAndNavigate()` when:
    - Coming from actual `background` state (not `inactive`)
    - More than 1 second has passed since the last call

  2. `App.tsx`

  - Added same `previousAppState` tracking
  - Added `lastInitialUrlTime` for debouncing
  - Modified `handleAppStateChange` to only call `LinkingUtils.handleInitialUrl()` when:
    - Coming from actual `background` state (not `inactive`)
    - More than 1 second has passed since the last call

  3. `views/HandleAnythingQRScanner.tsx`

  - Added `hasNavigated` flag to prevent duplicate navigations
  - All navigation paths (Swaps, RefundSwap, and general handleAnything) now check this flag before navigating

## How This Fixes the Issues

Balance showing as zero: The app no longer triggers `getSettingsAndNavigate()` when returning from the QR scanner camera. The brief `inactive`→`active` state change that occurs when closing the camera is now ignored, preventing unnecessary balance resets.

Double navigation: Three layers of protection:
  1. `App.tsx` and `Wallet.tsx` only respond to real background→foreground transitions
  2. Both have 1-second debouncing to prevent rapid successive calls
  3. `HandleAnythingQRScanner` has a `hasNavigated` flag ensuring only one navigation per scan

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
