### PR TITLE
Improve Windows development docs and add optional cross-env start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,24 @@ ZEUS is proud to be integrated on the following platforms:
 
 ### Prerequisites
 - Node.js (minimum version: 18.18)
+### Dependency installation notes (npm vs yarn)
+
+ZEUS depends on Nostr Wallet Connect (NWC) libraries, including
+`@nostr-dev-kit/ndk`, which introduces peer dependency constraints
+with `nostr-tools`.
+
+Because of this, **`npm install` may fail** with an `ERESOLVE`
+dependency tree error, especially on Windows.
+
+#### Recommended (preferred)
+Use **Yarn**, which correctly resolves these dependencies:
+
+```bash
+yarn install
+
+If using npm
+use npm install --legacy-peer-deps
+
 
 ### Android
 1. install and setup react-native and its related dependencies under **"Building Projects with Native Code"** on

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ZEUS
+
 <p align="center"><img src="https://github-production-user-asset-6210df.s3.amazonaws.com/1878621/282360800-579c1156-1fc6-45b6-86f2-7b3424502160.png"></p>
 <p align="center"><img width="2250" height="1406" alt="screenshots3" src="https://github.com/user-attachments/assets/3e6e5a34-ee1b-4b8d-876d-f6f64d5d7c38" /></p>
 
@@ -8,69 +9,70 @@ ZEUS is built on TypeScript and React Native. It runs on both Android and iOS.
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ZeusLN/zeus)
 
-
 Read more on our [documentation site](https://docs.zeusln.app/).
 
 ### App Store links
-* [Google Play](https://play.google.com/store/apps/details?id=app.zeusln.zeus)
-* [Apple App Store](https://apps.apple.com/us/app/zeus-ln/id1456038895)
-* [F-Droid](https://zeusln.com/download)
+
+-   [Google Play](https://play.google.com/store/apps/details?id=app.zeusln.zeus)
+-   [Apple App Store](https://apps.apple.com/us/app/zeus-ln/id1456038895)
+-   [F-Droid](https://zeusln.com/download)
 
 ### Get in touch with us
-* Come chat with us on
-[Telegram](https://t.me/zeusLN)
-* Join our
-[developer Slack](https://zeusln.slack.com/join/shared_invite/zt-qw205nqa-o4VJJC0zPI7HiSfToZGoVw#/)
-* Keep up with us on
-[Twitter](https://twitter.com/ZeusLN)
-and
-[Nostr](https://iris.to/npub1xnf02f60r9v0e5kty33a404dm79zr7z2eepyrk5gsq3m7pwvsz2sazlpr5)
-* Open a channel with
-[our node](https://amboss.space/node/031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581)
+
+-   Come chat with us on
+    [Telegram](https://t.me/zeusLN)
+-   Join our
+    [developer Slack](https://zeusln.slack.com/join/shared_invite/zt-qw205nqa-o4VJJC0zPI7HiSfToZGoVw#/)
+-   Keep up with us on
+    [Twitter](https://twitter.com/ZeusLN)
+    and
+    [Nostr](https://iris.to/npub1xnf02f60r9v0e5kty33a404dm79zr7z2eepyrk5gsq3m7pwvsz2sazlpr5)
+-   Open a channel with
+    [our node](https://amboss.space/node/031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581)
 
 ## Features
 
-- [x] Bitcoin only wallet
-- [x] Self-custodial
-- [x] No KYC
-- [x] Fully open source (AGPLv3)
-- [x] [Connect to LND or Core Lightning remote node](https://docs.zeusln.app/category/remote-connections)
-- [x] Manage multiple lightning nodes at once
-- [x] Connect via LNDHub instances
-- [x] Lightning accounts
-- [x] On-chain accounts
-- [x] Easy to use activity menu
-- [x] NFC payments and requests
-- [x] PIN or passphrase encryption
-- [x] Connect over Tor
-- [x] Privacy mode - hide your sensitive data
-- [x] Lightning address send
-- [x] Full LNURL support (pay, withdraw, auth, channel)
-- [x] Lightning channel management
-- [x] Detailed routing reports
-- [x] Set and manage routing fees
-- [x] MPP/AMP support
-- [x] Keysend support
-- [x] SegWit support 
-- [x] Sign & verify messages
-- [x] Fiat currency integrations
-- [x] [Various language support](https://app.transifex.com/ZeusLN/zeus/)
-- [x] Multi-theme
-- [x] On-chain coin control 
-- [x] External signer support
-- [x] Watch-only accounts
-- [x] Contact list for easier payments
-- [x] Nostr contact import
-- [x] Point of Sale (Standalone and Square integration)
-- [x] Lightning address receive
-- [x] Taproot support 
-- [x] Connect a watchtower
-- [ ] Advanced security center
-- [x] Batch on-chain transactions
-- [x] Batch channel opens
-- [ ] PayJoin
-- [x] [Lightning Node Connect](https://docs.lightning.engineering/lightning-network-tools/lightning-terminal/lightning-node-connect)
-- [x] [Self-custodial lightning address (ZEUS Pay)](https://docs.zeusln.app/lightning-address/intro)
+-   [x] Bitcoin only wallet
+-   [x] Self-custodial
+-   [x] No KYC
+-   [x] Fully open source (AGPLv3)
+-   [x] [Connect to LND or Core Lightning remote node](https://docs.zeusln.app/category/remote-connections)
+-   [x] Manage multiple lightning nodes at once
+-   [x] Connect via LNDHub instances
+-   [x] Lightning accounts
+-   [x] On-chain accounts
+-   [x] Easy to use activity menu
+-   [x] NFC payments and requests
+-   [x] PIN or passphrase encryption
+-   [x] Connect over Tor
+-   [x] Privacy mode - hide your sensitive data
+-   [x] Lightning address send
+-   [x] Full LNURL support (pay, withdraw, auth, channel)
+-   [x] Lightning channel management
+-   [x] Detailed routing reports
+-   [x] Set and manage routing fees
+-   [x] MPP/AMP support
+-   [x] Keysend support
+-   [x] SegWit support
+-   [x] Sign & verify messages
+-   [x] Fiat currency integrations
+-   [x] [Various language support](https://app.transifex.com/ZeusLN/zeus/)
+-   [x] Multi-theme
+-   [x] On-chain coin control
+-   [x] External signer support
+-   [x] Watch-only accounts
+-   [x] Contact list for easier payments
+-   [x] Nostr contact import
+-   [x] Point of Sale (Standalone and Square integration)
+-   [x] Lightning address receive
+-   [x] Taproot support
+-   [x] Connect a watchtower
+-   [ ] Advanced security center
+-   [x] Batch on-chain transactions
+-   [x] Batch channel opens
+-   [ ] PayJoin
+-   [x] [Lightning Node Connect](https://docs.lightning.engineering/lightning-network-tools/lightning-terminal/lightning-node-connect)
+-   [x] [Self-custodial lightning address (ZEUS Pay)](https://docs.zeusln.app/lightning-address/intro)
 
 ## Connecting ZEUS to your node
 
@@ -83,59 +85,59 @@ You must provide ZEUS with your node's hostname, port number, and the macaroon y
 
 ZEUS has support for connecting to you node entirely over the Tor network. You can refer to these guides to set up a Tor hidden service on your lnd node. The instructions are generally interchangeable and typically only require you to change your Tor path.
 
-* [ZEUS over Tor guides for StartOS](https://docs.start9.com/0.3.5.x/service-guides/lightning/index)
-* [ZEUS over Tor guide for RaspiBolt](https://raspibolt.org/guide/lightning/mobile-app.html)
-* [ZEUS over Tor guide for FreeNAS by Seth586](https://github.com/seth586/guides/blob/master/FreeNAS/wallets/zeusln.md)
-* [ZEUS over Tor guide for RaspiBlitz by openoms](https://github.com/openoms/bitcoin-tutorials/blob/master/Zeus_to_RaspiBlitz_through_Tor.md)
-* [Tor-Only Bitcoin & Lightning Guide by Lopp](https://blog.lopp.net/tor-only-bitcoin-lightning-guide/)
+-   [ZEUS over Tor guides for StartOS](https://docs.start9.com/0.3.5.x/service-guides/lightning/index)
+-   [ZEUS over Tor guide for RaspiBolt](https://raspibolt.org/guide/lightning/mobile-app.html)
+-   [ZEUS over Tor guide for FreeNAS by Seth586](https://github.com/seth586/guides/blob/master/FreeNAS/wallets/zeusln.md)
+-   [ZEUS over Tor guide for RaspiBlitz by openoms](https://github.com/openoms/bitcoin-tutorials/blob/master/Zeus_to_RaspiBlitz_through_Tor.md)
+-   [Tor-Only Bitcoin & Lightning Guide by Lopp](https://blog.lopp.net/tor-only-bitcoin-lightning-guide/)
 
 ## Integrations
 
 ZEUS is proud to be integrated on the following platforms:
 
 ### Full node solutions
-* [StartOS](https://www.start9.com/), [Guides](https://docs.start9.com/0.3.5.x/service-guides/lightning/index)
-* [nodl](https://www.nodl.it/)
-* [myNode](https://mynodebtc.com/) ([Standard guide](https://mynodebtc.com/guide/zeus), [Tor guide](https://mynodebtc.com/guide/zeus_tor))
-* [RaspiBlitz](https://github.com/rootzoll/raspiblitz)
-* [Umbrel](https://getumbrel.com/)
+
+-   [StartOS](https://www.start9.com/), [Guides](https://docs.start9.com/0.3.5.x/service-guides/lightning/index)
+-   [nodl](https://www.nodl.it/)
+-   [myNode](https://mynodebtc.com/) ([Standard guide](https://mynodebtc.com/guide/zeus), [Tor guide](https://mynodebtc.com/guide/zeus_tor))
+-   [RaspiBlitz](https://github.com/rootzoll/raspiblitz)
+-   [Umbrel](https://getumbrel.com/)
 
 ### Payment platforms
-* [BTCPay Server](https://btcpayserver.org/)
-* [LNBits](https://lnbits.com/)
+
+-   [BTCPay Server](https://btcpayserver.org/)
+-   [LNBits](https://lnbits.com/)
 
 ## Starting development
 
 **Don't trust, verify** the code with your own two eyes. Then when ready proceed to the steps below based on your platform.
 
 ### Prerequisites
-- Node.js (minimum version: 18.18)
-### Dependency installation notes (npm vs yarn)
 
-ZEUS depends on Nostr Wallet Connect (NWC) libraries, including
-`@nostr-dev-kit/ndk`, which introduces peer dependency constraints
-with `nostr-tools`.
+-   Node.js (minimum version: 18.18)
+-   Yarn (recommended)
 
-Because of this, **`npm install` may fail** with an `ERESOLVE`
-dependency tree error, especially on Windows.
+> **Note on dependency installation**  
+> ZEUS depends on Nostr Wallet Connect libraries which currently introduce peer dependency conflicts when using newer versions of npm (especially on Windows).
+>
+> -   **Recommended:** use Yarn
+>     ```bash
+>     yarn install
+>     ```
+> -   **If using npm:**
+>     ```bash
+>     npm install --legacy-peer-deps
+>     ```
 
-#### Recommended (preferred)
-Use **Yarn**, which correctly resolves these dependencies:
-
-```bash
-yarn install
-
-If using npm
-use npm install --legacy-peer-deps
 ### Environment variables on Windows
 
-Some npm scripts require environment variables (e.g. `NODE_ENV`), which
-are not consistently supported across Windows shells (PowerShell / CMD).
+Some scripts rely on environment variables (e.g. `NODE_ENV`) which are not consistently supported across Windows shells.
 
-An optional cross-platform script is provided:
+An optional cross-platform script is available:
 
 ```bash
 yarn start:prod
+
 
 
 
@@ -193,3 +195,4 @@ Thank you.
 ## License
 
 Distributed under the GNU Affero General Public License (AGPL v3). See [LICENSE file](LICENSE).
+```

--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ yarn install
 
 If using npm
 use npm install --legacy-peer-deps
+### Environment variables on Windows
+
+Some npm scripts require environment variables (e.g. `NODE_ENV`), which
+are not consistently supported across Windows shells (PowerShell / CMD).
+
+An optional cross-platform script is provided:
+
+```bash
+yarn start:prod
+
 
 
 ### Android

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "start": "react-native start",
+    "start:prod": "cross-env NODE_ENV=production react-native start",
     "ra": "react-native run-android",
     "ri": "react-native run-ios",
     "postinstall": "rn-nodeify --install --hack & node patches/patch-sifir_android.mjs & npx jetify & yarn run fetch-libraries & pod-install",
@@ -189,6 +190,7 @@
     "babel-jest": "29.7.0",
     "compressing": "1.10.0",
     "concurrently": "9.1.2",
+    "cross-env": "^7.0.3",
     "eslint": "8.45.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-import-resolver-typescript": "3.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4476,6 +4476,13 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@^3.0.4:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.2.0.tgz#34e9192f53bc757d6614304d9e5e6fb4edb782e3"
@@ -4483,7 +4490,7 @@ cross-fetch@^3.0.4:
   dependencies:
     node-fetch "^2.7.0"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==


### PR DESCRIPTION
### Summary
Improves the developer experience for Windows contributors based on issues
encountered during local setup.

### Changes
- Improved README documentation for Windows development:
  - Clarified npm vs Yarn dependency installation behavior
  - Documented peer dependency conflicts and safe workarounds
  - Added notes on Windows shell limitations
- Added an optional `start:prod` npm script using `cross-env` to ensure
  consistent environment variable handling across Windows shells

### Rationale
On Windows, environment variables like `NODE_ENV` are not reliably supported
across PowerShell and CMD. Providing an opt-in `cross-env` based script avoids
modifying existing workflows while offering a cross-platform alternative.

### Scope
Documentation-first changes with a small, opt-in developer script.
No existing scripts or runtime behavior were modified.

Happy to adjust or remove this if you’d prefer a different approach.

