### PR TITLE
Add frontend validation for NWC connection inputs

### DIFF
--- a/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
+++ b/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
@@ -322,6 +322,26 @@ export default class AddOrEditNWCConnection extends React.Component<
         return true;
     };
 
+    validateConnectionInputs = () => {
+        const { connectionName, selectedPermissions } = this.state;
+
+        if (!connectionName.trim()) {
+            throw new Error(
+                localeString(
+                    'views.Settings.NostrWalletConnect.validation.connectionNameRequired'
+                )
+            );
+        }
+
+        if (selectedPermissions.length === 0) {
+            throw new Error(
+                localeString(
+                    'views.Settings.NostrWalletConnect.validation.atLeastOnePermissionRequired'
+                )
+            );
+        }
+    };
+
     selectPermissionType = (permissionType: PermissionType) => {
         if (this.state.selectedPermissionType === permissionType) {
             this.updateStateWithChangeTracking({
@@ -498,6 +518,7 @@ export default class AddOrEditNWCConnection extends React.Component<
     };
 
     buildConnectionParams = async (isEdit: boolean, connectionId?: string) => {
+        this.validateConnectionInputs();
         const {
             connectionName,
             selectedRelayUrl,


### PR DESCRIPTION
Adds early frontend validation for Nostr Wallet Connect connection inputs.

Surfaces existing validation errors (connection name and permissions) before
attempting connection creation, improving UX and reducing confusing failures.

Scope intentionally limited to frontend validation only.
