### PR TITLE
enhancement: iOS: DropdownSetting: use translate keys

### DIFF
--- a/components/DropdownSetting.tsx
+++ b/components/DropdownSetting.tsx
@@ -53,16 +53,11 @@ export default class DropdownSetting extends React.Component<
             }
         );
 
-        const displayItem = values.find(
+        const selectedIndex = values.findIndex(
             (value: any) => value.value === selectedValue
         );
-
-        const displayTranslatedKey = displayItem?.translateKey
-            ? localeString(displayItem.translateKey)
-            : undefined;
-        const display = displayItem
-            ? displayTranslatedKey ?? displayItem.key
-            : null;
+        const display =
+            selectedIndex > -1 ? pickerValuesIOS[selectedIndex + 1] : null;
 
         return (
             <React.Fragment>


### PR DESCRIPTION
# Description

The `DropdownSetting` component had an internationalization issue on iOS. It used the key property from `DEFAULT_INVOICE_TYPE_KEYS` for the display text and action sheet options, instead of the value from `translateKey`. This resulted in untranslated text for iOS users with non-English locales.

|Before|After|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-16 at 19 49 31" src="https://github.com/user-attachments/assets/de0857a2-ceb2-479f-83e2-b7362b511dbd" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-16 at 19 49 14" src="https://github.com/user-attachments/assets/2b19835a-2b2c-40c3-b3b0-47291863c85f" />|

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
