### PR TITLE
fix: CollapsedQR: don't diplay amount under QR when 0

### DIFF
--- a/components/CollapsedQR.tsx
+++ b/components/CollapsedQR.tsx
@@ -336,40 +336,44 @@ export default class CollapsedQR extends React.Component<
                                 quietZone={width / 40}
                             />
                         </TouchableOpacity>
-                        {satAmount != null && this.props.displayAmount && (
-                            <View
-                                style={{
-                                    flexDirection: 'column',
-                                    alignItems: 'center',
-                                    alignSelf: 'center',
-                                    backgroundColor:
-                                        themeColor('buttonBackground') ||
-                                        themeColor('secondary'),
-                                    width:
-                                        height > width
-                                            ? width * 0.75
-                                            : height * 0.6,
-                                    borderBottomLeftRadius: 12,
-                                    borderBottomRightRadius: 12,
-                                    marginTop: -10,
-                                    margin: 15,
-                                    padding: 15
-                                }}
-                            >
-                                <Amount
-                                    sats={satAmount}
-                                    toggleable
-                                    jumboText
-                                    colorOverride={themeColor('buttonText')}
-                                ></Amount>
-                                <View>
-                                    <Conversion
+                        {satAmount != null &&
+                            satAmount != 0 &&
+                            this.props.displayAmount && (
+                                <View
+                                    style={{
+                                        flexDirection: 'column',
+                                        alignItems: 'center',
+                                        alignSelf: 'center',
+                                        backgroundColor:
+                                            themeColor('buttonBackground') ||
+                                            themeColor('secondary'),
+                                        width:
+                                            height > width
+                                                ? width * 0.75
+                                                : height * 0.6,
+                                        borderBottomLeftRadius: 12,
+                                        borderBottomRightRadius: 12,
+                                        marginTop: -10,
+                                        margin: 15,
+                                        padding: 15
+                                    }}
+                                >
+                                    <Amount
                                         sats={satAmount}
+                                        toggleable
+                                        jumboText
                                         colorOverride={themeColor('buttonText')}
-                                    />
+                                    ></Amount>
+                                    <View>
+                                        <Conversion
+                                            sats={satAmount}
+                                            colorOverride={themeColor(
+                                                'buttonText'
+                                            )}
+                                        />
+                                    </View>
                                 </View>
-                            </View>
-                        )}
+                            )}
                     </View>
                 )}
                 {!hideText && textBottom && (


### PR DESCRIPTION
# Description

In our new amount under QR style, we are displaying `0 sats` below amountless invoices. This PR ensures that we only display amounts below QRs, when the amount is defined and not zero.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
