### PR TITLE
fix: Lightning address copy value

### DIFF
--- a/views/LightningAddress/index.tsx
+++ b/views/LightningAddress/index.tsx
@@ -227,6 +227,7 @@ export default class LightningAddress extends React.Component<
                     onPress={() =>
                         navigation.navigate('QR', {
                             value: `lightning:${address}`,
+                            copyValue: address,
                             label: address,
                             hideText: true,
                             jumboLabel: true,

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -2142,6 +2142,7 @@ export default class Receive extends React.Component<
                                             lightningAddress && (
                                                 <CollapsedQR
                                                     value={`lightning:${lightningAddress}`}
+                                                    copyValue={lightningAddress}
                                                     iconOnly={true}
                                                     iconContainerStyle={{
                                                         marginRight: 40


### PR DESCRIPTION
# Description

This PR fixes the copy value for Lightning address QRs, removing the `lightning:` prefix. Users often paste this into their Nostr profiles where this is mishandled by most clients.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
