### PR TITLE
Reproducible build optimizations

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -169,6 +169,12 @@ android {
         }
     }
 
+    // Reproducible build settings
+    tasks.withType(Zip).configureEach {
+        reproducibleFileOrder = true
+        preserveFileTimestamps = false
+    }
+
     sourceSets {
         main {
             proto {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,7 +17,8 @@ org.gradle.configureondemand=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-org.gradle.parallel=true
+# Disabled for reproducible builds - parallel execution causes non-deterministic file ordering
+org.gradle.parallel=false
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,10 @@ BUILDER_IMAGE="reactnativecommunity/react-native-android@sha256:c390bfb35a15ffdf
 CONTAINER_NAME="zeus_builder_container"
 ZEUS_PATH=/olympus/zeus
 
+# SOURCE_DATE_EPOCH for reproducible builds - set to a fixed timestamp
+# Can use the timestamp of a release commit (or use 0 for epoch)
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-0}"
+
 # Default options for the Docker command
 TTY_FLAG="-it"
 
@@ -16,8 +20,10 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-# Run the Docker command
-docker run --rm $TTY_FLAG --name $CONTAINER_NAME -v "$(pwd):$ZEUS_PATH" $BUILDER_IMAGE bash -c \
+# Run the Docker command with SOURCE_DATE_EPOCH for reproducible builds
+docker run --rm $TTY_FLAG --name $CONTAINER_NAME \
+    -e SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH \
+    -v "$(pwd):$ZEUS_PATH" $BUILDER_IMAGE bash -c \
      'echo -e "\n\n********************************\n*** Building ZEUS...\n********************************\n" && \
       cd /olympus/zeus ; yarn install --frozen-lockfile && \
       cd /olympus/zeus/android ; ./gradlew app:assembleRelease && \


### PR DESCRIPTION
## What These Fixes Address

  | Fix                          | Addresses                                   |
  |------------------------------|---------------------------------------------|
  | org.gradle.parallel=false    | Non-deterministic task execution order      |
  | reproducibleFileOrder=true   | ZIP file entry ordering                     |
  | preserveFileTimestamps=false | Variable timestamps in archive              |
  | SOURCE_DATE_EPOCH            | Timestamps in JS bundle and other artifacts |

## Trade-off

  Disabling parallel builds will increase build time (potentially 2-3x slower). If build speed is critical, you could alternatively keep parallel builds and use a post-processing step to reorder APK contents deterministically using tools like strip-nondeterminism or custom APK re-packaging.

 ## Testing

  Run ./build.sh several times and compare the SHA256 hashes. They should now match consistently.