### PR TITLE
ZEUS-3312: Embedded node: better channel refreshing UX

### DIFF
--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -611,15 +611,14 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                     }, 60000); // 60 seconds
                 }
             }
-            if (implementation === 'embedded-lnd')
-                SyncStore.checkRecoveryStatus();
+
+            SyncStore.checkRecoveryStatus();
             await NodeInfoStore.getNodeInfo();
             NodeInfoStore.getNetworkInfo();
-            if (BackendUtils.supportsAccounts())
-                await UTXOsStore.listAccounts();
+            await UTXOsStore.listAccounts();
             await BalanceStore.getCombinedBalance(false);
-            if (BackendUtils.supportsChannelManagement())
-                await ChannelsStore.getChannels();
+            ChannelsStore.getChannelsWithPolling();
+
             if (rescan) {
                 await updateSettings({
                     rescan: false


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-3312**](https://github.com/ZeusLN/zeus/issues/3312)

Often times when starting your embedded LND node, you have to pull down on the channels list and refresh to have the channels to show online.

This PR adds a new `getChannelsWithPolling` method, used by Embedded LND wallets, on start-up online. It:
  - Polls getChannels every 3 seconds (configurable)
  - Continues polling until at least one channel shows as active/online
  - Stops early if there are no open channels (nothing to wait for)
  - Has a max attempts limit (default 20, ~60 seconds) to prevent infinite polling
  - Uses recursive async/await pattern for clean polling

All other implementations that support channels, still use the original `getChannels` call.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
