### PR TITLE
[rn-upgrade]: fix: display existing NWC connection budget on edit screen

### DIFF
--- a/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
+++ b/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
@@ -110,39 +110,32 @@ export default class AddOrEditNWCConnection extends React.Component<
 
     private unsubscribeFocus?: () => void;
 
-    async componentDidMount() {
-        const { route, navigation, NostrWalletConnectStore } = this.props;
+    loadData = async () => {
+        const { route, NostrWalletConnectStore } = this.props;
         const connectionId = route.params?.connectionId;
         await NostrWalletConnectStore.loadMaxBudget();
-        await this.updateMaxBudgetLimit();
         if (connectionId) {
             await this.loadConnectionForEdit(connectionId);
+        } else {
             await this.updateMaxBudgetLimit();
         }
+    };
+
+    async componentDidMount() {
+        const { navigation } = this.props;
+        await this.loadData();
         this.unsubscribeFocus = navigation.addListener('focus', async () => {
-            await this.updateMaxBudgetLimit();
-            const currentConnectionId = route.params?.connectionId;
-            if (currentConnectionId) {
-                await this.loadConnectionForEdit(currentConnectionId);
-                await this.updateMaxBudgetLimit();
-            }
+            await this.loadData();
         });
     }
 
     updateMaxBudgetLimit = async () => {
         const { NostrWalletConnectStore } = this.props;
         const maxLimit = NostrWalletConnectStore.maxBudgetLimit;
-        const clampedMaxLimit = Math.max(0, maxLimit);
-
         const existingBudgetValue = this.state.budgetValue || 0;
-        const currentBudgetValue = Math.min(
-            existingBudgetValue,
-            clampedMaxLimit
-        );
-
         this.setState({
-            maxBudgetLimit: clampedMaxLimit,
-            budgetValue: currentBudgetValue
+            maxBudgetLimit: Math.max(0, maxLimit),
+            budgetValue: existingBudgetValue
         });
     };
 
@@ -180,6 +173,7 @@ export default class AddOrEditNWCConnection extends React.Component<
             const isCustomRelay = !DEFAULT_NOSTR_RELAYS.find(
                 (relay) => relay === connection.relayUrl
             );
+            const maxBudgetLimit = NostrWalletConnectStore.maxBudgetLimit;
             this.setState({
                 connectionName: connection.name,
                 selectedRelayUrl: isCustomRelay
@@ -197,6 +191,7 @@ export default class AddOrEditNWCConnection extends React.Component<
                 customExpiryValue,
                 customExpiryUnit,
                 budgetValue,
+                maxBudgetLimit: Math.max(0, maxBudgetLimit),
                 showAdvancedSettings: false,
                 showCustomPermissions: false
             });
@@ -496,15 +491,9 @@ export default class AddOrEditNWCConnection extends React.Component<
             return;
         }
         const clampedValue = Math.min(value, this.state.maxBudgetLimit);
-        const wasClamped = value > this.state.maxBudgetLimit;
-
         this.updateStateWithChangeTracking({
             budgetValue: clampedValue,
-            error: wasClamped
-                ? localeString(
-                      'views.Settings.NostrWalletConnect.validation.budgetAmountInvalid'
-                  )
-                : ''
+            error: ''
         });
     };
 


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

Related to https://github.com/ZeusLN/zeus/pull/3501#pullrequestreview-3638544769

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
