### PR TITLE
[zeus-3142] fix(android): wallet does not close when swiped away

### DIFF
--- a/android/app/src/main/java/com/zeus/MainActivity.kt
+++ b/android/app/src/main/java/com/zeus/MainActivity.kt
@@ -41,6 +41,13 @@ class MainActivity : ReactActivity() {
         started = true
     }
 
+    override fun onDestroy() {
+        // When activity is destroyed, mark as not started
+        // The service's onTaskRemoved will handle stopping services if persistent mode is off
+        started = false
+        super.onDestroy()
+    }
+
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)


### PR DESCRIPTION
# Description

Relates to issue: [ZEUS-3142](https://github.com/ZeusLN/zeus/issues/3142)

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This PR fixes an Android bug where, after enabling persistent mode once and off this mode, the app continues running in the background even after it is closed. As a result, the app does not fully terminate when swiped away. This changes ensures the app closes properly when dismissed.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
