### PR TITLE
fix: Cashu threshold race condition

### DIFF
--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -617,7 +617,12 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             NodeInfoStore.getNetworkInfo();
             await UTXOsStore.listAccounts();
             await BalanceStore.getCombinedBalance(false);
-            ChannelsStore.getChannelsWithPolling();
+            ChannelsStore.getChannelsWithPolling().then(() => {
+                // Check for sweep to self-custody threshold after channels are online
+                if (connecting && settings?.ecash?.enableCashu) {
+                    CashuStore.checkAndSweepMints();
+                }
+            });
 
             if (rescan) {
                 await updateSettings({
@@ -737,17 +742,6 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 } catch (e) {
                     console.error('Lightning address error', e);
                 }
-            }
-        }
-
-        if (
-            connecting &&
-            implementation === 'embedded-lnd' &&
-            settings?.ecash?.enableCashu
-        ) {
-            // Check for sweep to self-custody threshold
-            if (connecting) {
-                CashuStore.checkAndSweepMints();
             }
         }
 


### PR DESCRIPTION
# Description

In https://github.com/ZeusLN/zeus/pull/3509, we attempted to improve channel refreshing UX for Embedded LND wallets. In doing so we added a race condition in which the Cashu custody warning threshold would trigger before knowing if the user has channels or not.

This PR waits for the new `getChannelsWithPolling` func to complete before running the threshold check.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
