### PR TITLE
fix: QR Scanner processing race condition

### DIFF
--- a/components/QRCodeScanner.tsx
+++ b/components/QRCodeScanner.tsx
@@ -62,7 +62,7 @@ export default function QRCodeScanner({
         CameraAuthStatus.UNKNOWN
     );
     const [isTorchOn, setIsTorchOn] = useState(false);
-    const [scannedCache, setScannedCache] = useState(new Set<string>());
+    const scannedCache = useRef(new Set<string>());
     const [cameraIsActive, setCameraIsActive] = useState(true);
 
     useEffect(() => {
@@ -81,11 +81,11 @@ export default function QRCodeScanner({
 
     const handleRead = (data: any) => {
         const hash = createHash('sha256').update(data).digest().toString('hex');
-        if (scannedCache.has(hash)) {
+        if (scannedCache.current.has(hash)) {
             // this QR was already scanned, let's prevent firing duplicate callbacks
             return;
         }
-        scannedCache.add(hash);
+        scannedCache.current.add(hash);
         handleQRScanned(data);
     };
 
@@ -133,7 +133,7 @@ export default function QRCodeScanner({
         }
     };
 
-    const handleFocus = () => setScannedCache(new Set<string>());
+    const handleFocus = () => scannedCache.current.clear();
 
     useEffect(() => {
         (async () => {


### PR DESCRIPTION
# Description

Sometimes scanning a QR code for an invoice would take you to the `Choose Payment Method` page twice in quick succession.

Problem: The `scannedCache` was stored using `useState`, but the code was mutating the `Set` directly with `scannedCache.add(hash)`. When` onCodeScanned` fires rapidly (multiple times per camera frame), the callback had a stale closure reference to `scannedCache`. This allowed multiple callbacks to pass the has(hash) check before any of them added the hash.

Solution: Changed `scannedCache` from `useState` to `useRef`:
  -`useRef` values are accessed via .current and are always up-to-date
  - Mutations to refs are immediately visible to all code, preventing race conditions
  - No re-render needed to see the updated value

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
