### PR TITLE
fix: ensure NWC getInfo returns all required fields with defaults

### DIFF
--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1379,11 +1379,11 @@ export default class NostrWalletConnectStore {
                             'stores.NostrWalletConnectStore.zeusWallet'
                         ),
                     color: nodeInfo?.color || '#3399FF',
-                    pubkey: nodeInfo?.identity_pubkey,
+                    pubkey: nodeInfo?.identity_pubkey || '',
                     network,
-                    block_height: nodeInfo?.block_height,
-                    block_hash: nodeInfo?.block_hash,
-                    methods: connection.permissions,
+                    block_height: nodeInfo?.block_height || 0,
+                    block_hash: nodeInfo?.block_hash || '',
+                    methods: connection.permissions || [],
                     notifications: NostrConnectUtils.getNotifications()
                 },
                 error: undefined


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

In this PR, we fixed the NWC getinfo method. For some nodes, such as Core Lightning, certain nodeInfo fields were being returned as undefined, which caused connection errors with some Nostr clients. We now return default values for those fields, allowing connections to be created successfully

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
