### PR TITLE
fix: Graph Sync prompt: mainnet only

### DIFF
--- a/utils/GraphSyncUtils.test.ts
+++ b/utils/GraphSyncUtils.test.ts
@@ -21,7 +21,8 @@ import storage from '../storage';
 
 jest.mock('../stores/Stores', () => ({
     settingsStore: {
-        updateSettings: jest.fn()
+        updateSettings: jest.fn(),
+        embeddedLndNetwork: 'Mainnet'
     },
     transactionsStore: {
         proceedWithPayment: jest.fn(),
@@ -46,6 +47,8 @@ const mockStorage = storage as jest.Mocked<typeof storage>;
 describe('GraphSyncUtils', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockTransactionsStore.pendingPaymentData = null;
+        mockTransactionsStore.showGraphSyncPrompt = false;
     });
 
     describe('handleEnableGraphSync', () => {
@@ -118,6 +121,25 @@ describe('GraphSyncUtils', () => {
             );
 
             expect(result).toBe(true);
+        });
+
+        it('should return true and not show prompt on testnet', () => {
+            // Temporarily set to testnet
+            (mockSettingsStore as any).embeddedLndNetwork = 'Testnet';
+
+            const result = checkGraphSyncBeforePayment(
+                mockSettings,
+                'embedded-lnd',
+                { payment_request: 'test' },
+                mockTransactionsStore
+            );
+
+            expect(result).toBe(true);
+            expect(mockTransactionsStore.showGraphSyncPrompt).toBe(false);
+            expect(mockTransactionsStore.pendingPaymentData).toBeNull();
+
+            // Restore to mainnet for other tests
+            (mockSettingsStore as any).embeddedLndNetwork = 'Mainnet';
         });
 
         it('should return true when graph sync is enabled', () => {

--- a/utils/GraphSyncUtils.ts
+++ b/utils/GraphSyncUtils.ts
@@ -80,6 +80,12 @@ export const checkGraphSyncBeforePayment = (
         return true;
     }
 
+    // Only show prompt on mainnet, not testnet
+    const isMainnet = settingsStore.embeddedLndNetwork === 'Mainnet';
+    if (!isMainnet) {
+        return true;
+    }
+
     const isGraphSyncEnabled = settings.expressGraphSync === true;
     if (isGraphSyncEnabled) {
         return true;


### PR DESCRIPTION
# Description

The Express Graph Sync prompt should only be show on mainnet, not on testnet.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
