### PR TITLE
fix: MoneyBadger: preserve URL-encoded casing for cryptoqr.net Lightning Addresses

### DIFF
--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -543,16 +543,18 @@ const handleAnything = async (
 
         // try BOLT 11 address
         const [username, bolt11Domain] = value.split('@');
+        // LUD-16: domain MUST be lowercased
+        const normalizedDomain = bolt11Domain.toLowerCase();
         // Skip lowercasing for cryptoqr.net addresses as they contain URL-encoded
         // data where hex digit casing matters for server-side lookup
-        const isCryptoQR = bolt11Domain.endsWith('cryptoqr.net');
+        const isCryptoQR = normalizedDomain.endsWith('cryptoqr.net');
         const normalizedUsername = isCryptoQR
             ? username
             : username.toLowerCase();
-        if (bolt11Domain.includes('.onion')) {
-            url = `http://${bolt11Domain}/.well-known/lnurlp/${normalizedUsername}`;
+        if (normalizedDomain.includes('.onion')) {
+            url = `http://${normalizedDomain}/.well-known/lnurlp/${normalizedUsername}`;
         } else {
-            url = `https://${bolt11Domain}/.well-known/lnurlp/${normalizedUsername}`;
+            url = `https://${normalizedDomain}/.well-known/lnurlp/${normalizedUsername}`;
         }
         const error = localeString(
             'utils.handleAnything.lightningAddressError'


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-3427**](https://github.com/ZeusLN/zeus/issues/3427)

Moneybadger QR codes are converted to Lightning Addresses with URL-encoded usernames like:
  `https%3A%2F%2Fpay.cryptoqr.net%2F3458967@cryptoqr.net`

  When fetching the LNURL endpoint, `.toLowerCase()` was converting the hex digits from uppercase (`%3A`, `%2F`) to lowercase (`%3a`, `%2f`). The cryptoqr.net server performs case-sensitive lookups and failed to find entries with lowercased hex digits.

  ## Solution
  Skip lowercasing for `cryptoqr.net` and `staging.cryptoqr.net` domains since their usernames contain URL-encoded data where hex digit casing matters. Standard Lightning Address domains continue to be lowercased per LUD-16 spec

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
