### PR TITLE
fix: async state read in `Receive`

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -358,10 +358,24 @@ export default class Receive extends React.Component<
             this.setState({ selectedIndex: this.getDefaultIndex() });
         }
 
-        const { expirySeconds, routeHints, ampInvoice, blindedPaths } =
-            this.state;
+        const expirySeconds = settings?.invoices?.expirySeconds || '3600';
+        const routeHints =
+            (settings?.invoices?.routeHints ||
+                !this.props.ChannelsStore.haveAnnouncedChannels) &&
+            !(
+                settings?.invoices?.blindedPaths &&
+                BackendUtils.supportsBolt11BlindedRoutes()
+            );
+        const ampInvoice =
+            (settings?.invoices?.ampInvoice && BackendUtils.supportsAMP()) ||
+            false;
+        const blindedPaths =
+            (settings?.invoices?.blindedPaths &&
+                BackendUtils.supportsBolt11BlindedRoutes()) ||
+            false;
 
-        const addressType = route.params?.addressType || this.state.addressType;
+        const addressType =
+            route.params?.addressType || settings?.invoices?.addressType || '0';
 
         // POS
         const memo = route.params?.memo ?? this.state.memo;


### PR DESCRIPTION
# Description

I noticed that when using on-chain swipeable row -> receive, the generated address ignored the configured address type=taproot (type 4) global setting, but defaulted to segwit (type 0).

Root Cause:
In `componentDidMount`, invoice settings were read from `this.state` immediately after calling `setState()`. Since `setState` is asynchronous, the destructured values (`expirySeconds`, `routeHints`, `ampInvoice`, `blindedPaths`, `addressType`) contained possibly stale values from the constructor instead of the freshly loaded settings. For addressType this was noticable, the others worked fine (but probably luck).

Now these values are read directly from the `settings` object.

I verified that setting addressType to Taproot in Settings -> Invoices now correctly generates taproot addresses when using on-chain swipeable row -> receive.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
