### PR TITLE
fix: Activity label clipping on balance view

### DIFF
--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1112,15 +1112,12 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
 
                             <Animated.View
                                 style={{
-                                    flex: 1,
-                                    maxHeight: 80,
-                                    justifyContent: 'flex-end',
-                                    alignSelf: 'center',
+                                    position: 'absolute',
                                     bottom: 10,
-                                    paddingTop: 40,
-                                    paddingBottom: 35,
                                     width: '100%',
+                                    height: 80,
                                     transform: [{ translateY: this.pan.y }],
+                                    justifyContent: 'center',
                                     alignItems: 'center'
                                 }}
                                 {...this.panResponder.panHandlers}
@@ -1135,7 +1132,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                                     accessibilityLabel={localeString(
                                         'general.activity'
                                     )}
-                                    style={{ alignItems: 'center' }}
+                                    style={{
+                                        alignItems: 'center',
+                                        padding: 10
+                                    }}
                                 >
                                     <CaretUp fill={themeColor('text')} />
                                     <Text


### PR DESCRIPTION
# Description

This fixes a clipping issue for the "Activity" label on balance view. Depending on font and display size there could be parts of the label cut off (see below).

I moved hit area expansion (yellow border) to TouchableOpacity (`padding: 10`) so it is easy to tap on the CaretUp or Activity label.
To pull up, a larger area (green border) can be used, just like before:
<img width="412" height="946" alt="grafik" src="https://github.com/user-attachments/assets/89ee7d21-a83a-4637-b604-3cd30b637fa4" />

I tried to create problems (running out of space) by increasing font and display size (android settings), and adding external accounts, but no issues:
|Before|After|
|-|-|
|<img width="413" height="946" alt="grafik" src="https://github.com/user-attachments/assets/1d7411d3-f26b-40cd-9f74-f594f3120ed6" />|<img width="413" height="946" alt="grafik" src="https://github.com/user-attachments/assets/a4e18f96-b0a8-4d97-8cb7-08c751f6769a" />|

**Please check, if it is also working fine on iOS.**

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
