### PR TITLE
refactor: deduplicate invoice option calculations in `Receive` view

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -291,6 +291,22 @@ export default class Receive extends React.Component<
             BackendUtils.supportsFlowLSP() &&
             !flowLspNotConfigured;
 
+        // Calculate invoice options once to avoid duplication
+        const routeHints =
+            (settings?.invoices?.routeHints ||
+                !this.props.ChannelsStore.haveAnnouncedChannels) &&
+            !(
+                settings?.invoices?.blindedPaths &&
+                BackendUtils.supportsBolt11BlindedRoutes()
+            );
+        const ampInvoice =
+            (settings?.invoices?.ampInvoice && BackendUtils.supportsAMP()) ||
+            false;
+        const blindedPaths =
+            (settings?.invoices?.blindedPaths &&
+                BackendUtils.supportsBolt11BlindedRoutes()) ||
+            false;
+
         this.setState({
             addressType: settings?.invoices?.addressType || '0',
             expirationIndex,
@@ -299,23 +315,9 @@ export default class Receive extends React.Component<
             expiry: settings?.invoices?.expiry || '1',
             timePeriod: settings?.invoices?.timePeriod || 'Hours',
             expirySeconds: newExpirySeconds,
-            routeHints:
-                (settings?.invoices?.routeHints ||
-                    !this.props.ChannelsStore.haveAnnouncedChannels) &&
-                !(
-                    settings?.invoices?.blindedPaths &&
-                    BackendUtils.supportsBolt11BlindedRoutes()
-                )
-                    ? true
-                    : false,
-            ampInvoice:
-                (settings?.invoices?.ampInvoice &&
-                    BackendUtils.supportsAMP()) ||
-                false,
-            blindedPaths:
-                (settings?.invoices?.blindedPaths &&
-                    BackendUtils.supportsBolt11BlindedRoutes()) ||
-                false,
+            routeHints,
+            ampInvoice,
+            blindedPaths,
             enableLSP: settings?.enableLSP,
             lspIsActive,
             flowLspNotConfigured
@@ -357,22 +359,6 @@ export default class Receive extends React.Component<
         } else if (!lnOnly && !onChainOnly) {
             this.setState({ selectedIndex: this.getDefaultIndex() });
         }
-
-        const expirySeconds = settings?.invoices?.expirySeconds || '3600';
-        const routeHints =
-            (settings?.invoices?.routeHints ||
-                !this.props.ChannelsStore.haveAnnouncedChannels) &&
-            !(
-                settings?.invoices?.blindedPaths &&
-                BackendUtils.supportsBolt11BlindedRoutes()
-            );
-        const ampInvoice =
-            (settings?.invoices?.ampInvoice && BackendUtils.supportsAMP()) ||
-            false;
-        const blindedPaths =
-            (settings?.invoices?.blindedPaths &&
-                BackendUtils.supportsBolt11BlindedRoutes()) ||
-            false;
 
         const addressType =
             route.params?.addressType || settings?.invoices?.addressType || '0';
@@ -445,7 +431,7 @@ export default class Receive extends React.Component<
             this.autoGenerateInvoice(
                 getSatAmount(amount).toString(),
                 memo,
-                expirySeconds,
+                newExpirySeconds,
                 routeHints,
                 ampInvoice,
                 blindedPaths,


### PR DESCRIPTION
# Description

**Before**: The values were calculated twice:
  - Lines 302-318: Inline within `setState`
  - Lines 361-375: As separate constants before `autoGenerateInvoice`

**After**: Values are calculated once at lines 294-308 and reused:
  - `routeHints`, `ampInvoice`, `blindedPaths` are now constants defined before `setState`
  - The same constants are passed to both `setState` (lines 318-320) and `autoGenerateInvoice` (lines 435-437)
  - `newExpirySeconds` (already existed at line 274) is now consistently used in both places

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
