### PR TITLE
Add PPM toggle for channel fees

### DIFF
--- a/components/FeeBreakdown.tsx
+++ b/components/FeeBreakdown.tsx
@@ -7,6 +7,7 @@ import LoadingIndicator from '../components/LoadingIndicator';
 
 import ChannelsStore from '../stores/ChannelsStore';
 import NodeInfoStore from '../stores/NodeInfoStore';
+import SettingsStore from '../stores/SettingsStore';
 
 import DateTimeUtils from '../utils/DateTimeUtils';
 import { localeString } from '../utils/LocaleUtils';
@@ -20,6 +21,7 @@ import KeyValue from './KeyValue';
 interface FeeBreakdownProps {
     ChannelsStore?: ChannelsStore;
     NodeInfoStore?: NodeInfoStore;
+    SettingsStore?: SettingsStore;
     channelId: string | any;
     channelPoint: string;
     peerDisplay?: string | any;
@@ -34,7 +36,7 @@ interface FeeBreakdownProps {
     label?: string;
 }
 
-@inject('ChannelsStore', 'NodeInfoStore')
+@inject('ChannelsStore', 'NodeInfoStore', 'SettingsStore')
 @observer
 export default class FeeBreakdown extends React.Component<
     FeeBreakdownProps,
@@ -48,6 +50,7 @@ export default class FeeBreakdown extends React.Component<
             initiator,
             ChannelsStore,
             NodeInfoStore,
+            SettingsStore,
             isActive,
             isClosed,
             total_satoshis_received,
@@ -59,6 +62,8 @@ export default class FeeBreakdown extends React.Component<
         } = this.props;
         const { loading, chanInfo } = ChannelsStore!;
         const { nodeInfo, testnet } = NodeInfoStore!;
+        const feeRateDisplayMode =
+            SettingsStore!.implementation === 'cln-rest' ? 'ppm' : 'percent';
         const { nodeId } = nodeInfo;
 
         let localPolicy, remotePolicy;
@@ -124,9 +129,17 @@ export default class FeeBreakdown extends React.Component<
                             keyValue={localeString(
                                 'views.Channel.localFeeRate'
                             )}
-                            value={`${
-                                Number(localPolicy.fee_rate_milli_msat) / 10000
-                            }%`}
+                            value={
+                                feeRateDisplayMode === 'ppm'
+                                    ? `${Number(
+                                          localPolicy.fee_rate_milli_msat
+                                      )} PPM`
+                                    : `${
+                                          Number(
+                                              localPolicy.fee_rate_milli_msat
+                                          ) / 10000
+                                      }%`
+                            }
                             sensitive
                         />
                         <KeyValue
@@ -148,9 +161,17 @@ export default class FeeBreakdown extends React.Component<
                             keyValue={localeString(
                                 'views.Channel.remoteFeeRate'
                             )}
-                            value={`${
-                                Number(remotePolicy.fee_rate_milli_msat) / 10000
-                            }%`}
+                            value={
+                                feeRateDisplayMode === 'ppm'
+                                    ? `${Number(
+                                          remotePolicy.fee_rate_milli_msat
+                                      )} PPM`
+                                    : `${
+                                          Number(
+                                              remotePolicy.fee_rate_milli_msat
+                                          ) / 10000
+                                      }%`
+                            }
                             sensitive
                         />
                         {BackendUtils.supportInboundFees() && (
@@ -178,11 +199,17 @@ export default class FeeBreakdown extends React.Component<
                                         keyValue={localeString(
                                             'views.Channel.localInboundFeeRate'
                                         )}
-                                        value={`${
-                                            Number(
-                                                localPolicy.inbound_fee_rate_milli_msat
-                                            ) / 10000
-                                        }%`}
+                                        value={
+                                            feeRateDisplayMode === 'ppm'
+                                                ? `${Number(
+                                                      localPolicy.inbound_fee_rate_milli_msat
+                                                  )} PPM`
+                                                : `${
+                                                      Number(
+                                                          localPolicy.inbound_fee_rate_milli_msat
+                                                      ) / 10000
+                                                  }%`
+                                        }
                                         sensitive
                                     />
                                 )}
@@ -209,11 +236,17 @@ export default class FeeBreakdown extends React.Component<
                                         keyValue={localeString(
                                             'views.Channel.remoteInboundFeeRate'
                                         )}
-                                        value={`${
-                                            Number(
-                                                remotePolicy.inbound_fee_rate_milli_msat
-                                            ) / 10000
-                                        }%`}
+                                        value={
+                                            feeRateDisplayMode === 'ppm'
+                                                ? `${Number(
+                                                      remotePolicy.inbound_fee_rate_milli_msat
+                                                  )} PPM`
+                                                : `${
+                                                      Number(
+                                                          remotePolicy.inbound_fee_rate_milli_msat
+                                                      ) / 10000
+                                                  }%`
+                                        }
                                         sensitive
                                     />
                                 )}

--- a/components/SetFeesForm.tsx
+++ b/components/SetFeesForm.tsx
@@ -65,7 +65,10 @@ export default class SetFeesForm extends React.Component<
             newTimeLockDelta: props.timeLockDelta || '',
             newMinHtlc: props.minHtlc || '',
             newMaxHtlc: props.maxHtlc || '',
-            feeRateMode: 'percent'
+            feeRateMode:
+                props.SettingsStore?.implementation === 'cln-rest'
+                    ? 'ppm'
+                    : 'percent'
         };
     }
 
@@ -143,7 +146,8 @@ export default class SetFeesForm extends React.Component<
                     autoCorrect={false}
                 />
 
-                {BackendUtils.isLNDBased() && (
+                {(BackendUtils.isLNDBased() ||
+                    implementation === 'cln-rest') && (
                     <View style={{ marginVertical: 10 }}>
                         <ToggleButton
                             options={[
@@ -188,13 +192,7 @@ export default class SetFeesForm extends React.Component<
                 </Text>
                 <TextInput
                     keyboardType="numeric"
-                    placeholder={
-                        implementation === 'cln-rest'
-                            ? '1'
-                            : feeRateMode === 'ppm'
-                            ? '1000'
-                            : '0.001'
-                    }
+                    placeholder={feeRateMode === 'ppm' ? '1000' : '0.001'}
                     value={newFeeRate}
                     onChangeText={(text: string) =>
                         this.setState({

--- a/stores/FeeStore.ts
+++ b/stores/FeeStore.ts
@@ -8,6 +8,7 @@ import NodeInfoStore from './NodeInfoStore';
 import BackendUtils from '../utils/BackendUtils';
 import Base64Utils from '../utils/Base64Utils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
+import FeeUtils from '../utils/FeeUtils';
 import ForwardEvent from '../models/ForwardEvent';
 
 export default class FeeStore {
@@ -151,7 +152,7 @@ export default class FeeStore {
 
         // convert PPM to decimal rate for LND
         if (feeRateMode === 'ppm' && BackendUtils.isLNDBased() && feeRate) {
-            feeRate = new BigNumber(feeRate).dividedBy(1000000).toString();
+            feeRate = FeeUtils.ppmToPercent(feeRate);
         }
 
         const data: any = {

--- a/stores/FeeStore.ts
+++ b/stores/FeeStore.ts
@@ -137,7 +137,8 @@ export default class FeeStore {
         channelPoint?: string,
         channelId?: string,
         minHtlc?: string,
-        maxHtlc?: string
+        maxHtlc?: string,
+        feeRateMode: 'percent' | 'ppm' = 'percent'
     ) => {
         this.loading = true;
         this.setFeesError = false;
@@ -146,7 +147,12 @@ export default class FeeStore {
 
         // handle commas in place of decimals
         const baseFee = newBaseFee.replace(/,/g, '.');
-        const feeRate = newFeeRate.replace(/,/g, '.');
+        let feeRate = newFeeRate.replace(/,/g, '.');
+
+        // convert PPM to percentage for LND
+        if (feeRateMode === 'ppm' && BackendUtils.isLNDBased()) {
+            feeRate = new BigNumber(feeRate).dividedBy(10000).toString();
+        }
 
         const data: any = {
             base_fee_msat: `${Number(baseFee) * 1000}`,

--- a/stores/FeeStore.ts
+++ b/stores/FeeStore.ts
@@ -149,9 +149,9 @@ export default class FeeStore {
         const baseFee = newBaseFee.replace(/,/g, '.');
         let feeRate = newFeeRate.replace(/,/g, '.');
 
-        // convert PPM to percentage for LND
-        if (feeRateMode === 'ppm' && BackendUtils.isLNDBased()) {
-            feeRate = new BigNumber(feeRate).dividedBy(10000).toString();
+        // convert PPM to decimal rate for LND
+        if (feeRateMode === 'ppm' && BackendUtils.isLNDBased() && feeRate) {
+            feeRate = new BigNumber(feeRate).dividedBy(1000000).toString();
         }
 
         const data: any = {

--- a/utils/FeeUtils.test.ts
+++ b/utils/FeeUtils.test.ts
@@ -3,6 +3,16 @@ import FeeUtils from './FeeUtils';
 const satoshisPerBTC = 100_000_000;
 
 describe('FeeUtils', () => {
+    describe('ppmToPercent', () => {
+        it('converts PPM to decimal rate', () => {
+            expect(FeeUtils.ppmToPercent(1000000)).toEqual('1');
+            expect(FeeUtils.ppmToPercent(500000)).toEqual('0.5');
+            expect(FeeUtils.ppmToPercent(100)).toEqual('0.0001');
+            expect(FeeUtils.ppmToPercent('250000')).toEqual('0.25');
+            expect(FeeUtils.ppmToPercent(0)).toEqual('0');
+        });
+    });
+
     describe('calculateDefaultRoutingFee', () => {
         it('Calculates a fee based on the amount', () => {
             expect(FeeUtils.calculateDefaultRoutingFee(0)).toEqual('0');

--- a/utils/FeeUtils.ts
+++ b/utils/FeeUtils.ts
@@ -1,5 +1,12 @@
+import BigNumber from 'bignumber.js';
+
 class FeeUtils {
     static DEFAULT_ROUTING_FEE_PERCENT = 0.05;
+
+    ppmToPercent = (ppm: string | number): string => {
+        const ppmValue = new BigNumber(ppm);
+        return ppmValue.dividedBy(1000000).toString();
+    };
 
     calculateDefaultRoutingFee = (amount: number) => {
         if (amount > 1000) {


### PR DESCRIPTION
fixes #1411
Adds a toggle to switch between percentage and PPM input for fee rate when setting channel fees. Only shows for LND-based backends since CLN already uses PPM natively