### PR TITLE
deps: remove unused doki library and jetifier dependency

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -220,10 +220,6 @@ dependencies {
 
     // implementation 'info.guardianproject:tor-android:0.4.7.8'
     // implementation 'info.guardianproject:jtorctl:0.4.5.7'
-
-    implementation('dev.doubledot.doki:library:0.0.1@aar') {
-        transitive = true
-    }
 }
 
 configurations.configureEach {

--- a/android/app/src/main/java/com/zeus/MainActivity.kt
+++ b/android/app/src/main/java/com/zeus/MainActivity.kt
@@ -8,7 +8,6 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
-import dev.doubledot.doki.ui.DokiActivity
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileInputStream
@@ -104,10 +103,6 @@ class MainActivity : ReactActivity() {
                 Toast.makeText(this, "Error " + e.message, Toast.LENGTH_LONG).show()
             }
         }
-    }
-
-    fun showMsg() {
-        startActivity(Intent(this@MainActivity, DokiActivity::class.java))
     }
 
     companion object {


### PR DESCRIPTION
# Description

Related to https://github.com/ZeusLN/zeus/issues/1054#issuecomment-3793905918.

This removes dead code from MainActivity and obsolete Android dependencies:
- Removed `DokiActivity` import and `showMsg()` method from MainActivity
- Removed `dev.doubledot.doki:library:0.0.1` dependency from build.gradle

The doki library was pulling in old Android Support Library dependencies (com.android.support:support-annotations:28.0.0) which required jetifier for AndroidX compatibility.

Tested: Afer `yarn android:clean` app builds and runs successfully.

https://github.com/ZeusLN/zeus/pull/3587 can be merged now.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
