### PR TITLE
fix: add ScrollView to ImportAccount warning

### DIFF
--- a/views/Tools/Accounts/ImportAccount.tsx
+++ b/views/Tools/Accounts/ImportAccount.tsx
@@ -187,30 +187,24 @@ export default class ImportAccount extends React.Component<
                         </View>
                         <Text
                             style={{
-                                color: themeColor('text'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                margin: 10,
-                                fontSize: 20
+                                ...styles.warningText,
+                                color: themeColor('text')
                             }}
                         >
                             {localeString('views.ImportAccount.Warning.text1')}
                         </Text>
                         <Text
                             style={{
-                                color: themeColor('text'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                margin: 10,
-                                fontSize: 20
+                                ...styles.warningText,
+                                color: themeColor('text')
                             }}
                         >
                             {localeString('views.ImportAccount.Warning.text2')}
                         </Text>
                         <Text
                             style={{
-                                color: themeColor('text'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                margin: 10,
-                                fontSize: 20
+                                ...styles.warningText,
+                                color: themeColor('text')
                             }}
                         >
                             {localeString(
@@ -220,10 +214,8 @@ export default class ImportAccount extends React.Component<
                         {implementation !== 'embedded-lnd' && (
                             <Text
                                 style={{
-                                    color: themeColor('text'),
-                                    fontFamily: 'PPNeueMontreal-Book',
-                                    margin: 10,
-                                    fontSize: 20
+                                    ...styles.warningText,
+                                    color: themeColor('text')
                                 }}
                             >
                                 {localeString(
@@ -496,6 +488,11 @@ export default class ImportAccount extends React.Component<
 }
 
 const styles = StyleSheet.create({
+    warningText: {
+        fontFamily: 'PPNeueMontreal-Book',
+        margin: 10,
+        fontSize: 20
+    },
     content: {
         flex: 1,
         paddingTop: 20,


### PR DESCRIPTION
# Description

Added ScrollView for the warning text, because for small screens/large font size the warning could overlap with the button.
For larger screens layout is exactly as before.

|Screen|Before|After|
|-|-|-|
|Small|<img width="413" height="946" alt="grafik" src="https://github.com/user-attachments/assets/35bb00dc-759e-46ee-bfca-f996911f999e" />|<img width="413" height="946" alt="grafik" src="https://github.com/user-attachments/assets/493b7182-93b7-4b53-b897-760ca14cb36a" />|
|Large|<img width="413" height="946" alt="grafik" src="https://github.com/user-attachments/assets/0ee09831-1ae2-4bc8-bac1-80998b1e8253" />|<img width="413" height="946" alt="grafik" src="https://github.com/user-attachments/assets/804369e9-efc9-465b-8bc1-ae668c7f860b" />|

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
