### PR TITLE
fix(cashu): make invoice notes update reactively after save

### DIFF
--- a/views/Cashu/CashuInvoice.tsx
+++ b/views/Cashu/CashuInvoice.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { StyleSheet, ScrollView, View, TouchableOpacity } from 'react-native';
-import { inject } from 'mobx-react';
+import { inject, observer } from 'mobx-react';
 import { Route } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 
@@ -32,30 +32,24 @@ interface CashuInvoiceProps {
 
 interface CashuInvoiceState {
     updatedInvoice?: any;
-    storedNote: string;
 }
 
 @inject('CashuStore', 'SettingsStore')
+@observer
 export default class CashuInvoiceView extends React.Component<
     CashuInvoiceProps,
     CashuInvoiceState
 > {
     state = {
-        updatedInvoice: undefined,
-        storedNote: ''
+        updatedInvoice: undefined
     };
 
     async componentDidMount() {
-        const { CashuStore, navigation, route } = this.props;
+        const { CashuStore, route } = this.props;
         const { checkInvoicePaid, initializeWallet, cashuWallets } =
             CashuStore!!;
         const invoice = route.params?.invoice;
-        const { mintUrl, quote, getNote, isPaid } = invoice;
-
-        navigation.addListener('focus', () => {
-            const note = getNote;
-            this.setState({ storedNote: note });
-        });
+        const { mintUrl, quote, isPaid } = invoice;
 
         if (!isPaid) {
             console.log('invoice not paid last time checked, checking...', {
@@ -89,7 +83,7 @@ export default class CashuInvoiceView extends React.Component<
 
     render() {
         const { navigation, SettingsStore, route } = this.props;
-        const { updatedInvoice, storedNote } = this.state;
+        const { updatedInvoice } = this.state;
         const invoice = updatedInvoice || route.params?.invoice;
         const locale = SettingsStore?.settings.locale;
         invoice.determineFormattedOriginalTimeUntilExpiry(locale);
@@ -102,6 +96,7 @@ export default class CashuInvoiceView extends React.Component<
             formattedTimeUntilExpiry,
             getPaymentRequest,
             getNoteKey,
+            getNote,
             getAmount,
             mintUrl
         } = invoice;
@@ -222,10 +217,10 @@ export default class CashuInvoiceView extends React.Component<
                             />
                         )}
 
-                        {storedNote && (
+                        {getNote && (
                             <KeyValue
                                 keyValue={localeString('general.note')}
-                                value={storedNote}
+                                value={getNote}
                                 sensitive
                                 mempoolLink={() =>
                                     navigation.navigate('AddNotes', {
@@ -240,7 +235,7 @@ export default class CashuInvoiceView extends React.Component<
                     {getNoteKey && (
                         <Button
                             title={
-                                storedNote
+                                getNote
                                     ? localeString(
                                           'views.SendingLightning.UpdateNote'
                                       )


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

Fixes an issue where notes saved in the AddNotes screen did not appear when returning to the CashuInvoice screen. The component now updates the displayed note when the screen regains focus by listening to the navigation focus event and reading the latest note from the invoice model's computed property. This ensures saved notes are displayed immediately after navigation.

Changes:
Added navigation focus listener to update stored note state when screen comes into focus
Note is read from invoice's getNote computed property on each focus event
Ensures notes display correctly after saving and navigating back

Testing:
Save a note on a Cashu invoice
Navigate back to the invoice screen
Verify the note appears immediately


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
