### PR TITLE
feat: Rescan progress bar

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -414,6 +414,8 @@
     "views.Wallet.BalancePane.recovery.title": "Recovery mode",
     "views.Wallet.BalancePane.recovery.text": "Please leave ZEUS open until the process completes.",
     "views.Wallet.BalancePane.recovery.textAlt": "Leave ZEUS open until completion.",
+    "views.Wallet.BalancePane.rescan.title": "Rescanning wallet",
+    "views.Wallet.BalancePane.rescan.text": "Please leave ZEUS open until the rescan completes.",
     "views.Wallet.BalancePane.backup.title": "Back up your funds",
     "views.Wallet.BalancePane.backup.text": "Create a backup to never lose access to your bitcoin.",
     "views.Wallet.BalancePane.backup.action": "Start backup ->",

--- a/stores/Stores.ts
+++ b/stores/Stores.ts
@@ -61,11 +61,11 @@ export const unitsStore = new UnitsStore(settingsStore, fiatStore);
 export const paymentsStore = new PaymentsStore(settingsStore, channelsStore);
 export const lnurlPayStore = new LnurlPayStore(settingsStore, nodeInfoStore);
 export const feeStore = new FeeStore(settingsStore, nodeInfoStore);
-export const utxosStore = new UTXOsStore(settingsStore);
+export const syncStore = new SyncStore(settingsStore);
+export const utxosStore = new UTXOsStore(settingsStore, syncStore);
 export const messageSignStore = new MessageSignStore();
 export const notesStore = new NotesStore();
 export const contactStore = new ContactStore();
-export const syncStore = new SyncStore(settingsStore);
 export const cashuStore = new CashuStore(
     settingsStore,
     invoicesStore,

--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -396,6 +396,10 @@ export async function startLnd({
                 } else if (state.state === lnrpc.WalletState.RPC_ACTIVE) {
                     log.d('Got lnrpc.WalletState.RPC_ACTIVE');
                     syncStore.startSyncing();
+                    // Start rescan tracking if rescan setting is enabled
+                    if (settingsStore?.settings?.rescan) {
+                        syncStore.startRescanTracking(0);
+                    }
                     res(true);
                     LndMobileEventEmitter.removeAllListeners('SubscribeState');
                 } else if (state.state === lnrpc.WalletState.SERVER_ACTIVE) {

--- a/views/Settings/EmbeddedNode/LNDLogs.tsx
+++ b/views/Settings/EmbeddedNode/LNDLogs.tsx
@@ -63,7 +63,10 @@ export default class LNDLogs extends React.Component<
             NativeModules.LndMobileTools.observeLndLogFile(
                 lndDir || 'lnd',
                 network
-            );
+            ).catch((e: any) => {
+                console.log('Could not observe log file:', e);
+            });
+
             this.setState({
                 log
             });

--- a/views/Wallet/BalancePane.tsx
+++ b/views/Wallet/BalancePane.tsx
@@ -95,8 +95,25 @@ export default class BalancePane extends React.PureComponent<
             bestBlockHeight,
             recoveryProgress,
             isSyncing,
-            isRecovering
+            isRecovering,
+            isRescanning,
+            rescanStartHeight,
+            rescanCurrentHeight
         } = SyncStore;
+
+        // Calculate rescan progress (clamped to max 1 in case current exceeds best)
+        // Use explicit null checks since rescanStartHeight can be 0 for genesis rescans
+        const rescanProgress =
+            rescanCurrentHeight !== null &&
+            rescanStartHeight !== null &&
+            bestBlockHeight !== null &&
+            bestBlockHeight > rescanStartHeight
+                ? Math.min(
+                      1,
+                      (rescanCurrentHeight - rescanStartHeight) /
+                          (bestBlockHeight - rescanStartHeight)
+                  )
+                : null;
 
         const pendingUnconfirmedBalance = new BigNumber(pendingOpenBalance)
             .plus(unconfirmedBlockchainBalance)
@@ -181,17 +198,13 @@ export default class BalancePane extends React.PureComponent<
 
         if (!error) {
             balancePane = (
-                <View style={{ minHeight: 200 }}>
+                <View style={styles.balancePaneContainer}>
                     <WalletHeader
                         navigation={navigation}
                         SettingsStore={SettingsStore}
                         loading={loading}
                     />
-                    <View
-                        style={{
-                            marginBottom: 20
-                        }}
-                    >
+                    <View style={styles.contentContainer}>
                         {isRecovering && recoveryProgress !== 1 && (
                             <TouchableOpacity
                                 onPress={() => {
@@ -201,21 +214,19 @@ export default class BalancePane extends React.PureComponent<
                                 }}
                             >
                                 <View
-                                    style={{
-                                        backgroundColor:
-                                            themeColor('highlight'),
-                                        borderRadius: 10,
-                                        margin: 20,
-                                        marginBottom: 0,
-                                        padding: 15,
-                                        borderWidth: 0.5
-                                    }}
+                                    style={[
+                                        styles.card,
+                                        {
+                                            backgroundColor:
+                                                themeColor('highlight')
+                                        }
+                                    ]}
                                 >
                                     <Text
-                                        style={{
-                                            fontFamily: 'PPNeueMontreal-Medium',
-                                            color: themeColor('background')
-                                        }}
+                                        style={[
+                                            styles.cardTitleText,
+                                            { color: themeColor('background') }
+                                        ]}
                                     >
                                         {`${localeString(
                                             'views.Wallet.BalancePane.recovery.title'
@@ -229,12 +240,14 @@ export default class BalancePane extends React.PureComponent<
                                     </Text>
                                     {recoveryProgress && (
                                         <Text
-                                            style={{
-                                                fontFamily:
-                                                    'PPNeueMontreal-Book',
-                                                color: themeColor('background'),
-                                                marginTop: 20
-                                            }}
+                                            style={[
+                                                styles.cardBodyText,
+                                                {
+                                                    color: themeColor(
+                                                        'background'
+                                                    )
+                                                }
+                                            ]}
                                         >
                                             {localeString(
                                                 'views.Wallet.BalancePane.recovery.text'
@@ -242,16 +255,7 @@ export default class BalancePane extends React.PureComponent<
                                         </Text>
                                     )}
                                     {recoveryProgress && (
-                                        <View
-                                            style={{
-                                                marginTop: 30,
-                                                flex: 1,
-                                                flexDirection: 'row',
-                                                display: 'flex',
-                                                justifyContent: 'space-between',
-                                                minWidth: '100%'
-                                            }}
-                                        >
+                                        <View style={styles.progressContainer}>
                                             <LinearProgress
                                                 value={
                                                     Math.floor(
@@ -263,25 +267,88 @@ export default class BalancePane extends React.PureComponent<
                                                 trackColor={themeColor(
                                                     'secondaryBackground'
                                                 )}
-                                                style={{
-                                                    flex: 1,
-                                                    flexDirection: 'row'
-                                                }}
+                                                style={styles.progressBar}
                                             />
                                             <Text
-                                                style={{
-                                                    fontFamily:
-                                                        'PPNeueMontreal-Medium',
-                                                    color: themeColor(
-                                                        'background'
-                                                    ),
-                                                    marginTop: -8,
-                                                    marginLeft: 14,
-                                                    height: 40
-                                                }}
+                                                style={[
+                                                    styles.progressText,
+                                                    {
+                                                        color: themeColor(
+                                                            'background'
+                                                        )
+                                                    }
+                                                ]}
                                             >
                                                 {`${Math.floor(
                                                     recoveryProgress * 100
+                                                ).toString()}%`}
+                                            </Text>
+                                        </View>
+                                    )}
+                                </View>
+                            </TouchableOpacity>
+                        )}
+                        {isRescanning && (
+                            <TouchableOpacity
+                                onPress={() => navigation.navigate('LNDLogs')}
+                            >
+                                <View
+                                    style={[
+                                        styles.card,
+                                        {
+                                            backgroundColor:
+                                                themeColor('secondary'),
+                                            marginBottom: 20
+                                        }
+                                    ]}
+                                >
+                                    <Text
+                                        style={[
+                                            styles.cardTitleText,
+                                            { color: themeColor('text') }
+                                        ]}
+                                    >
+                                        {localeString(
+                                            'views.Wallet.BalancePane.rescan.title'
+                                        )}
+                                    </Text>
+                                    <Text
+                                        style={[
+                                            styles.cardBodyText,
+                                            { color: themeColor('text') }
+                                        ]}
+                                    >
+                                        {localeString(
+                                            'views.Wallet.BalancePane.rescan.text'
+                                        )}
+                                    </Text>
+                                    {rescanProgress !== null && (
+                                        <View style={styles.progressContainer}>
+                                            <LinearProgress
+                                                value={
+                                                    Math.floor(
+                                                        rescanProgress * 100
+                                                    ) / 100
+                                                }
+                                                variant="determinate"
+                                                color={themeColor('highlight')}
+                                                trackColor={themeColor(
+                                                    'secondaryBackground'
+                                                )}
+                                                style={styles.progressBar}
+                                            />
+                                            <Text
+                                                style={[
+                                                    styles.progressText,
+                                                    {
+                                                        color: themeColor(
+                                                            'text'
+                                                        )
+                                                    }
+                                                ]}
+                                            >
+                                                {`${Math.floor(
+                                                    rescanProgress * 100
                                                 ).toString()}%`}
                                             </Text>
                                         </View>
@@ -294,31 +361,30 @@ export default class BalancePane extends React.PureComponent<
                                 onPress={() => navigation.navigate('Sync')}
                             >
                                 <View
-                                    style={{
-                                        backgroundColor:
-                                            themeColor('secondary'),
-                                        borderRadius: 10,
-                                        margin: 20,
-                                        padding: 15,
-                                        borderWidth: 0.5
-                                    }}
+                                    style={[
+                                        styles.card,
+                                        {
+                                            backgroundColor:
+                                                themeColor('secondary'),
+                                            marginBottom: 20
+                                        }
+                                    ]}
                                 >
                                     <Text
-                                        style={{
-                                            fontFamily: 'PPNeueMontreal-Medium',
-                                            color: themeColor('text')
-                                        }}
+                                        style={[
+                                            styles.cardTitleText,
+                                            { color: themeColor('text') }
+                                        ]}
                                     >
                                         {localeString(
                                             'views.Wallet.BalancePane.sync.title'
                                         )}
                                     </Text>
                                     <Text
-                                        style={{
-                                            fontFamily: 'PPNeueMontreal-Book',
-                                            color: themeColor('text'),
-                                            marginTop: 20
-                                        }}
+                                        style={[
+                                            styles.cardBodyText,
+                                            { color: themeColor('text') }
+                                        ]}
                                     >
                                         {localeString(
                                             'views.Wallet.BalancePane.sync.text'
@@ -327,15 +393,7 @@ export default class BalancePane extends React.PureComponent<
                                     {currentBlockHeight !== undefined &&
                                         bestBlockHeight && (
                                             <View
-                                                style={{
-                                                    marginTop: 30,
-                                                    flex: 1,
-                                                    flexDirection: 'row',
-                                                    display: 'flex',
-                                                    justifyContent:
-                                                        'space-between',
-                                                    minWidth: '100%'
-                                                }}
+                                                style={styles.progressContainer}
                                             >
                                                 <LinearProgress
                                                     value={
@@ -352,22 +410,17 @@ export default class BalancePane extends React.PureComponent<
                                                     trackColor={themeColor(
                                                         'secondaryBackground'
                                                     )}
-                                                    style={{
-                                                        flex: 1,
-                                                        flexDirection: 'row'
-                                                    }}
+                                                    style={styles.progressBar}
                                                 />
                                                 <Text
-                                                    style={{
-                                                        fontFamily:
-                                                            'PPNeueMontreal-Medium',
-                                                        color: themeColor(
-                                                            'text'
-                                                        ),
-                                                        marginTop: -8,
-                                                        marginLeft: 14,
-                                                        height: 40
-                                                    }}
+                                                    style={[
+                                                        styles.progressText,
+                                                        {
+                                                            color: themeColor(
+                                                                'text'
+                                                            )
+                                                        }
+                                                    ]}
                                                 >
                                                     {`${Math.floor(
                                                         (currentBlockHeight /
@@ -391,53 +444,46 @@ export default class BalancePane extends React.PureComponent<
                                     onPress={() => navigation.navigate('Seed')}
                                 >
                                     <View
-                                        style={{
-                                            backgroundColor:
-                                                themeColor('secondary'),
-                                            borderRadius: 10,
-                                            borderColor:
-                                                themeColor('highlight'),
-                                            margin: 20,
-                                            padding: 15,
-                                            borderWidth: 1.5
-                                        }}
+                                        style={[
+                                            styles.backupCard,
+                                            {
+                                                backgroundColor:
+                                                    themeColor('secondary'),
+                                                borderColor:
+                                                    themeColor('highlight')
+                                            }
+                                        ]}
                                     >
-                                        <View style={{ marginBottom: 10 }}>
+                                        <View style={styles.lockIconContainer}>
                                             <LockIcon
                                                 fill={themeColor('highlight')}
                                             />
                                         </View>
                                         <Text
-                                            style={{
-                                                fontFamily:
-                                                    'PPNeueMontreal-Medium',
-                                                color: themeColor('text')
-                                            }}
+                                            style={[
+                                                styles.cardTitleText,
+                                                { color: themeColor('text') }
+                                            ]}
                                         >
                                             {localeString(
                                                 'views.Wallet.BalancePane.backup.title'
                                             )}
                                         </Text>
                                         <Text
-                                            style={{
-                                                fontFamily:
-                                                    'PPNeueMontreal-Book',
-                                                color: themeColor('text'),
-                                                marginTop: 20
-                                            }}
+                                            style={[
+                                                styles.cardBodyText,
+                                                { color: themeColor('text') }
+                                            ]}
                                         >
                                             {localeString(
                                                 'views.Wallet.BalancePane.backup.text'
                                             )}
                                         </Text>
                                         <Text
-                                            style={{
-                                                fontFamily:
-                                                    'PPNeueMontreal-Book',
-                                                fontWeight: 'bold',
-                                                color: themeColor('text'),
-                                                marginTop: 20
-                                            }}
+                                            style={[
+                                                styles.cardBodyTextBold,
+                                                { color: themeColor('text') }
+                                            ]}
                                         >
                                             {localeString(
                                                 'views.Wallet.BalancePane.backup.action'
@@ -448,42 +494,22 @@ export default class BalancePane extends React.PureComponent<
                             )}
                         {implementation === 'embedded-lnd' && lndFolderMissing && (
                             <View
-                                style={{
-                                    backgroundColor: themeColor('error'),
-                                    borderRadius: 10,
-                                    margin: 20,
-                                    marginBottom: 0,
-                                    padding: 15
-                                }}
+                                style={[
+                                    styles.errorCard,
+                                    { backgroundColor: themeColor('error') }
+                                ]}
                             >
-                                <Text
-                                    style={{
-                                        fontFamily: 'PPNeueMontreal-Medium',
-                                        color: '#fff',
-                                        fontSize: 16,
-                                        marginBottom: 10
-                                    }}
-                                >
+                                <Text style={styles.errorTitleText}>
                                     {localeString(
                                         'views.Wallet.lndFolderMissing.title'
                                     )}
                                 </Text>
-                                <Text
-                                    style={{
-                                        fontFamily: 'PPNeueMontreal-Book',
-                                        color: '#fff',
-                                        marginBottom: 20
-                                    }}
-                                >
+                                <Text style={styles.errorBodyText}>
                                     {localeString(
                                         'views.Wallet.lndFolderMissing.message'
                                     )}
                                 </Text>
-                                <View
-                                    style={{
-                                        flexDirection: 'row'
-                                    }}
-                                >
+                                <View style={styles.errorButtonRow}>
                                     <Button
                                         title={localeString(
                                             'views.Wallet.lndFolderMissing.deleteWallet'
@@ -523,11 +549,11 @@ export default class BalancePane extends React.PureComponent<
                         )}
                         {implementation === 'lndhub' ||
                         implementation === 'nostr-wallet-connect' ? (
-                            <View style={{ marginTop: 40 }}>
+                            <View style={styles.balanceContainer}>
                                 <LightningBalance />
                             </View>
                         ) : (
-                            <View style={{ marginTop: 40 }}>
+                            <View style={styles.balanceContainer}>
                                 <BalanceViewCombined />
                             </View>
                         )}
@@ -537,29 +563,17 @@ export default class BalancePane extends React.PureComponent<
         } else {
             balancePane = (
                 <View
-                    style={{
-                        backgroundColor: themeColor('error'),
-                        paddingTop: 20,
-                        paddingLeft: 10,
-                        flex: 1
-                    }}
+                    style={[
+                        styles.errorPane,
+                        { backgroundColor: themeColor('error') }
+                    ]}
                 >
                     <ImageBackground
                         source={ErrorZeus}
                         resizeMode="cover"
-                        style={{
-                            flex: 1
-                        }}
+                        style={styles.errorBackground}
                     >
-                        <Text
-                            style={{
-                                fontFamily: 'PPNeueMontreal-Book',
-                                color: '#fff',
-                                fontSize: 20,
-                                marginTop: 20,
-                                marginBottom: 25
-                            }}
-                        >
+                        <Text style={styles.errorText}>
                             {SettingsStore.errorMsg
                                 ? SettingsStore.errorMsg
                                 : NodeInfoStore.errorMsg
@@ -586,5 +600,95 @@ const styles = StyleSheet.create({
     conversionSecondary: {
         top: 3,
         alignItems: 'center'
+    },
+    balancePaneContainer: {
+        minHeight: 200
+    },
+    contentContainer: {
+        marginBottom: 20
+    },
+    card: {
+        borderRadius: 10,
+        margin: 20,
+        marginBottom: 0,
+        padding: 15,
+        borderWidth: 0.5
+    },
+    backupCard: {
+        borderRadius: 10,
+        margin: 20,
+        padding: 15,
+        borderWidth: 1.5
+    },
+    cardTitleText: {
+        fontFamily: 'PPNeueMontreal-Medium'
+    },
+    cardBodyText: {
+        fontFamily: 'PPNeueMontreal-Book',
+        marginTop: 20
+    },
+    cardBodyTextBold: {
+        fontFamily: 'PPNeueMontreal-Book',
+        fontWeight: 'bold',
+        marginTop: 20
+    },
+    progressContainer: {
+        marginTop: 30,
+        flex: 1,
+        flexDirection: 'row',
+        display: 'flex',
+        justifyContent: 'space-between',
+        minWidth: '100%'
+    },
+    progressBar: {
+        flex: 1,
+        flexDirection: 'row'
+    },
+    progressText: {
+        fontFamily: 'PPNeueMontreal-Medium',
+        marginTop: -8,
+        marginLeft: 14,
+        height: 40
+    },
+    lockIconContainer: {
+        marginBottom: 10
+    },
+    errorCard: {
+        borderRadius: 10,
+        margin: 20,
+        marginBottom: 0,
+        padding: 15
+    },
+    errorTitleText: {
+        fontFamily: 'PPNeueMontreal-Medium',
+        color: '#fff',
+        fontSize: 16,
+        marginBottom: 10
+    },
+    errorBodyText: {
+        fontFamily: 'PPNeueMontreal-Book',
+        color: '#fff',
+        marginBottom: 20
+    },
+    errorButtonRow: {
+        flexDirection: 'row'
+    },
+    balanceContainer: {
+        marginTop: 40
+    },
+    errorPane: {
+        paddingTop: 20,
+        paddingLeft: 10,
+        flex: 1
+    },
+    errorBackground: {
+        flex: 1
+    },
+    errorText: {
+        fontFamily: 'PPNeueMontreal-Book',
+        color: '#fff',
+        fontSize: 20,
+        marginTop: 20,
+        marginBottom: 25
     }
 });


### PR DESCRIPTION
# Description

In the past, we had really bad UX for rescans, having to point users to the LND Logs to track their progress.

This PR adds a new progress bar, that looks like our blockchain sync bar, on the `BalancePane` view.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
