### PR TITLE
ui: fix Channels list style on themes w/ gradient

### DIFF
--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -414,10 +414,10 @@ export default class ChannelsPane extends React.PureComponent<
             }
         };
 
-        const OpenChannelsScreen = () => {
-            return (
+        const createChannelScreen = (data: Channel[]) => () =>
+            (
                 <FlatList
-                    data={filteredChannels}
+                    data={data}
                     renderItem={this.renderItem}
                     ListFooterComponent={<Spacer height={100} />}
                     onRefresh={() => getChannels()}
@@ -427,37 +427,14 @@ export default class ChannelsPane extends React.PureComponent<
                     }
                 />
             );
-        };
 
-        const PendingChannelsScreen = () => {
-            return (
-                <FlatList
-                    data={filteredPendingChannels}
-                    renderItem={this.renderItem}
-                    ListFooterComponent={<Spacer height={100} />}
-                    onRefresh={() => getChannels()}
-                    refreshing={loading}
-                    keyExtractor={(item, index) =>
-                        `${item.remote_pubkey}-${index}`
-                    }
-                />
-            );
-        };
-
-        const ClosedChannelsScreen = () => {
-            return (
-                <FlatList
-                    data={filteredClosedChannels}
-                    renderItem={this.renderItem}
-                    ListFooterComponent={<Spacer height={100} />}
-                    onRefresh={() => getChannels()}
-                    refreshing={loading}
-                    keyExtractor={(item, index) =>
-                        `${item.remote_pubkey}-${index}`
-                    }
-                />
-            );
-        };
+        const OpenChannelsScreen = createChannelScreen(filteredChannels);
+        const PendingChannelsScreen = createChannelScreen(
+            filteredPendingChannels
+        );
+        const ClosedChannelsScreen = createChannelScreen(
+            filteredClosedChannels
+        );
 
         const openChannelsTabName = `${localeString(
             'views.Wallet.Wallet.open'


### PR DESCRIPTION
# Description

  - Removes duplicate `Screen `wrapper from channel list tab screens that was adding an extra gradient layer on top of the parent screen's gradient
  - Makes tab navigator theme colors transparent so the channel list properlyinherits the background from the parent `Screen` component

|Before|After|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-30 at 00 21 07" src="https://github.com/user-attachments/assets/46c6a2c9-987e-4167-b4f4-f557ca02b6c3" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-30 at 00 20 34" src="https://github.com/user-attachments/assets/42f2d7f4-1275-47fc-886f-83a94012fe64" />|

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
