### PR TITLE
Automatically add note when opening a Lightning channel

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -667,6 +667,7 @@
     "views.OpenChannel.peerSuccess": "Successfully connected to peer",
     "views.OpenChannel.channelSuccess": "Successfully opened channel",
     "views.OpenChannel.channelsSuccess": "Successfully opened channels",
+    "views.OpenChannel.openedChannelNote": "Opened channel",
     "views.OpenChannel.nodePubkey": "Node pubkey",
     "views.OpenChannel.host": "Host",
     "views.OpenChannel.hostPort": "Hostname:Port",

--- a/stores/Stores.ts
+++ b/stores/Stores.ts
@@ -31,8 +31,9 @@ import NostrWalletConnectStore from './NostrWalletConnectStore';
 export const settingsStore = new SettingsStore();
 export const modalStore = new ModalStore();
 export const offersStore = new OffersStore();
+export const notesStore = new NotesStore();
 export const fiatStore = new FiatStore(settingsStore);
-export const channelsStore = new ChannelsStore(settingsStore);
+export const channelsStore = new ChannelsStore(settingsStore, notesStore);
 export const nodeInfoStore = new NodeInfoStore(channelsStore, settingsStore);
 export const alertStore = new AlertStore(settingsStore, nodeInfoStore);
 export const lspStore = new LSPStore(
@@ -64,7 +65,6 @@ export const feeStore = new FeeStore(settingsStore, nodeInfoStore);
 export const syncStore = new SyncStore(settingsStore);
 export const utxosStore = new UTXOsStore(settingsStore, syncStore);
 export const messageSignStore = new MessageSignStore();
-export const notesStore = new NotesStore();
 export const contactStore = new ContactStore();
 export const cashuStore = new CashuStore(
     settingsStore,


### PR DESCRIPTION
# Description

Relates to issue: **#2444**

When opening a Lightning channel, automatically save a note "Opened channel" for the funding transaction in the Activity list.

**Implementation:**
- Import and pass NotesStore to ChannelsStore
- After successful openChannelSync, save note with funding_txid_str
- Added locale string views.OpenChannel.openedChannelNote

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

---

**If there are any suggestions or changes needed, please let me know!**