### PR TITLE
fix: amount display for In-transit payments

### DIFF
--- a/models/Payment.test.ts
+++ b/models/Payment.test.ts
@@ -81,4 +81,25 @@ describe('Payment.getAmount with partial HTLC success', () => {
         // Should return 50 sats (50500 - 500) / 1000
         expect(payment.getAmount).toBe(50);
     });
+
+    it('uses amountFromFields for in-transit payments', () => {
+        const payment = new Payment({
+            value_sat: 50000,
+            payment_preimage:
+                '0000000000000000000000000000000000000000000000000000000000000000',
+            htlcs: [
+                {
+                    status: 'IN_FLIGHT',
+                    route: {
+                        total_amt_msat: 50000000,
+                        hops: [{ amt_to_forward_msat: 50000000 }]
+                    }
+                }
+            ]
+        });
+
+        // Should return 50000 sats from value_sat, not 0 from failed HTLC sum
+        expect(payment.isInTransit).toBe(true);
+        expect(payment.getAmount).toBe(50000);
+    });
 });

--- a/models/Payment.ts
+++ b/models/Payment.ts
@@ -247,7 +247,7 @@ export default class Payment extends BaseModel {
     }
 
     @computed public get getAmount(): number | string {
-        if (!this.htlcs || this.htlcs.length === 0) {
+        if (!this.htlcs || this.htlcs.length === 0 || this.isInTransit) {
             return this.amountFromFields;
         }
 


### PR DESCRIPTION
# Description

Another regression from https://github.com/ZeusLN/zeus/pull/3431 - in-transit payments would always display amount as 0. In-transit payments have HTLCs with `IN_FLIGHT` status. The `getAmount` method was only summing `SUCCEEDED` HTLCs, resulting in 0 for in-transit payments.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
