### PR TITLE
fix: stuck red text on keypad input

### DIFF
--- a/utils/KeypadUtils.ts
+++ b/utils/KeypadUtils.ts
@@ -223,6 +223,8 @@ export const startKeypadInvalidInputAnimation = (
     resetKeypadTextAnimation(textAnimation, refs);
     stopKeypadShakeAnimation(refs);
 
+    // This animates text color (text -> red), and color is not supported
+    // by the RN Animated native driver. This is why useNativeDriver is false.
     refs.textAnimationRef = Animated.sequence([
         Animated.timing(textAnimation, {
             toValue: 1,
@@ -259,12 +261,12 @@ export const startKeypadInvalidInputAnimation = (
         })
     ]);
 
-    refs.textAnimationRef.start(() => {
-        refs.textAnimationRef = null;
-    });
-    refs.shakeAnimationRef.start(() => {
-        refs.shakeAnimationRef = null;
-    });
+    Animated.parallel([refs.textAnimationRef, refs.shakeAnimationRef]).start(
+        () => {
+            refs.textAnimationRef = null;
+            refs.shakeAnimationRef = null;
+        }
+    );
 };
 
 /**

--- a/views/AmountKeypad.tsx
+++ b/views/AmountKeypad.tsx
@@ -61,6 +61,10 @@ export default class AmountKeypad extends React.Component<
         textAnimationRef: null,
         shakeAnimationRef: null
     };
+    /*
+     Use this as the latest amount between setState updates.
+     Fast taps can use old state and show wrong red/shake animation.
+    */
     amountInput = '0';
     private currencySelectorModalRef = React.createRef<CurrencySelectorModal>();
 

--- a/views/Wallet/KeypadPane.tsx
+++ b/views/Wallet/KeypadPane.tsx
@@ -91,6 +91,10 @@ export default class KeypadPane extends React.PureComponent<
         textAnimationRef: null,
         shakeAnimationRef: null
     };
+    /*
+     Use this as the latest amount between setState updates.
+     Fast taps can use old state and show wrong red/shake animation.
+    */
     amountInput = '0';
     private clearValueTimeout: ReturnType<typeof setTimeout> | null = null;
     focusListener: any = null;
@@ -210,9 +214,9 @@ export default class KeypadPane extends React.PureComponent<
     };
 
     clearValue = (delayed?: boolean) => {
-        resetKeypadTextAnimation(this.textAnimation, this.animationRefs);
         if (this.clearValueTimeout) clearTimeout(this.clearValueTimeout);
         const clear = () => {
+            resetKeypadTextAnimation(this.textAnimation, this.animationRefs);
             this.amountInput = '0';
             this.setState({
                 amount: '0',

--- a/views/Wallet/StandalonePosKeypadPane.tsx
+++ b/views/Wallet/StandalonePosKeypadPane.tsx
@@ -54,6 +54,10 @@ export default class PosKeypadPane extends React.PureComponent<
         textAnimationRef: null,
         shakeAnimationRef: null
     };
+    /*
+     Use this as the latest amount between setState updates.
+     Fast taps can use old state and show wrong red/shake animation.
+    */
     amountInput = '0';
     state = {
         amount: '0'


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-3610**](https://github.com/ZeusLN/zeus/issues/3610)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
