### PR TITLE
Lightning payment success screen: display amount & fee

### DIFF
--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -304,6 +304,78 @@ export default class SendingLightning extends React.Component<
         }
     };
 
+    renderPaymentSummary = () => {
+        const { currentPayment } = this.state;
+        const { TransactionsStore } = this.props;
+        const { paymentDuration } = TransactionsStore;
+
+        if (!currentPayment) return null;
+
+        const amount =
+            currentPayment.value_sat ||
+            currentPayment.num_satoshis ||
+            currentPayment.amount_msat / 1000;
+
+        if (!amount) return null;
+
+        const fee = currentPayment.fee_msat
+            ? Number(currentPayment.fee_msat) / 1000
+            : 0;
+
+        let feePercentageDisplay = '';
+        if (fee > 0) {
+            const rawPercentage = new BigNumber(fee).div(amount).times(100);
+            const roundedPercentage = Number(rawPercentage.toFixed(3));
+            const shouldShowTilde = !rawPercentage.eq(roundedPercentage);
+            feePercentageDisplay = ` (${
+                shouldShowTilde ? '~' : ''
+            }${roundedPercentage.toString().replace(/-/g, '')}%)`;
+        }
+
+        return (
+            <>
+                <Text
+                    style={{
+                        color: themeColor('secondaryText'),
+                        marginTop: 10,
+                        fontFamily: 'PPNeueMontreal-Book'
+                    }}
+                >
+                    {localeString('views.Send.amount')}:{' '}
+                    <Text style={{ color: themeColor('text') }}>
+                        {amount} {localeString('general.sats')}
+                    </Text>
+                </Text>
+                <Text
+                    style={{
+                        color: themeColor('secondaryText'),
+                        marginTop: 5,
+                        fontFamily: 'PPNeueMontreal-Book'
+                    }}
+                >
+                    {localeString('views.Payment.fee')}:{' '}
+                    <Text style={{ color: themeColor('text') }}>
+                        {fee} {localeString('general.sats')}
+                        {feePercentageDisplay}
+                    </Text>
+                </Text>
+                {paymentDuration !== null && (
+                    <Text
+                        style={{
+                            color: themeColor('secondaryText'),
+                            marginTop: 10,
+                            fontFamily: 'PPNeueMontreal-Book'
+                        }}
+                    >
+                        {localeString('views.SendingLightning.paymentSettled', {
+                            seconds: paymentDuration.toFixed(2)
+                        })}
+                    </Text>
+                )}
+            </>
+        );
+    };
+
     renderInfoModal = () => {
         const {
             showDonationInfo,
@@ -570,8 +642,7 @@ export default class SendingLightning extends React.Component<
             payment_preimage,
             payment_error,
             isIncomplete,
-            noteKey,
-            paymentDuration
+            noteKey
         } = TransactionsStore;
         const { implementation } = SettingsStore;
         const {
@@ -689,28 +760,7 @@ export default class SendingLightning extends React.Component<
                                                 'views.SendingLightning.success'
                                             )}
                                         </Text>
-                                        {paymentDuration !== null && (
-                                            <Text
-                                                style={{
-                                                    color: themeColor(
-                                                        'secondaryText'
-                                                    ),
-                                                    marginTop: 10,
-                                                    fontFamily:
-                                                        'PPNeueMontreal-Book'
-                                                }}
-                                            >
-                                                {localeString(
-                                                    'views.SendingLightning.paymentSettled',
-                                                    {
-                                                        seconds:
-                                                            paymentDuration.toFixed(
-                                                                2
-                                                            )
-                                                    }
-                                                )}
-                                            </Text>
-                                        )}
+                                        {this.renderPaymentSummary()}
                                     </View>
                                 </>
                             )}


### PR DESCRIPTION
# Description

This adds amount & fees to the Lightning payment success screen.

- New `renderPaymentSummary()` consolidates payment details (existing payment duration was moved here)
- Fee percentage shows `~` prefix when rounding (3 decimals) occurs

|Before|After|
|-|-|
|<img width="304" height="625" alt="grafik" src="https://github.com/user-attachments/assets/88187369-6e18-4d80-9680-a4022e157a4d" />|<img width="302" height="620" alt="grafik" src="https://github.com/user-attachments/assets/c7a8fa95-25e3-4cfc-a2a6-85a2a244706e" />|

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
