### PR TITLE
fix: prevent app crash when returning from LSPS1 view

### DIFF
--- a/views/LSPS1/index.tsx
+++ b/views/LSPS1/index.tsx
@@ -107,6 +107,13 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
             });
         });
     }
+    componentWillUnmount() {
+        if (this.listener) {
+            this.listener.remove();
+            this.listener = null;
+        }
+        this.props.LSPStore.resetLSPS1Data();
+    }
 
     componentDidUpdate(_prevProps: LSPS1Props) {
         const {
@@ -400,7 +407,6 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                             )}
                         </Row>
                     }
-                    onBack={() => LSPStore.resetLSPS1Data()}
                 />
                 <View style={{ paddingHorizontal: 18 }}>
                     {BackendUtils.supportsLSPScustomMessage() &&
@@ -774,7 +780,7 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                             )}
                                         </Text>
                                     </Row>
-                                    {info.min_initial_lsp_balance_sat && (
+                                    {info?.min_initial_lsp_balance_sat && (
                                         <Slider
                                             style={{
                                                 width: '100%',


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This PR fixes an app crash that occurred when navigating back from the LSPS1 view.

## How to reproduce the bug

https://github.com/user-attachments/assets/132ff31b-e372-4cdb-85c3-44d10d22dc7c



This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
