### PR TITLE
SeedRecovery: add invalid seed word validation feedback

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1517,6 +1517,7 @@
     "pos.views.Settings.PointOfSale.currencyMustBeEnabledError": "Error: currency must be enabled first",
     "pos.print.taxReceipt": "Receipt",
     "pos.print.invoice": "Invoice",
+    "views.Settings.NodeConfiguration.invalidSeedWord": "Invalid seed word",
     "views.Settings.NodeConfiguration.createMainnetWallet": "Create mainnet wallet",
     "views.Settings.NodeConfiguration.createTestnetWallet": "Create testnet wallet",
     "views.Settings.NodeConfiguration.restoreMainnetWallet": "Restore mainnet wallet",

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -89,6 +89,7 @@ interface SeedRecoveryState {
     restoreRescueKey?: boolean;
     rescueHost: string;
     customRescueHost: string;
+    invalidInput: boolean;
 }
 
 @inject('NodeInfoStore', 'SettingsStore', 'SwapStore')
@@ -126,7 +127,8 @@ export default class SeedRecovery extends React.PureComponent<
             rescueHost: isTestnet
                 ? settings.swaps?.hostTestnet || DEFAULT_SWAP_HOST_TESTNET
                 : settings.swaps?.hostMainnet || DEFAULT_SWAP_HOST_MAINNET,
-            customRescueHost: settings.swaps?.customHost || ''
+            customRescueHost: settings.swaps?.customHost || '',
+            invalidInput: false
         };
     }
 
@@ -474,6 +476,11 @@ export default class SeedRecovery extends React.PureComponent<
                                     prefixStyle={{
                                         color: themeColor('highlight')
                                     }}
+                                    textColor={
+                                        this.state.invalidInput
+                                            ? themeColor('error')
+                                            : undefined
+                                    }
                                     style={{
                                         margin: 20,
                                         marginLeft: 10,
@@ -498,13 +505,19 @@ export default class SeedRecovery extends React.PureComponent<
                                             });
                                         }
 
-                                        if (text && text.length > 0) {
+                                        if (text.length > 0) {
+                                            const filtered = filterData(text);
                                             this.setState({
-                                                filteredData: filterData(text)
+                                                filteredData: filtered,
+                                                invalidInput:
+                                                    selectedInputType ===
+                                                        'word' &&
+                                                    filtered.length === 0
                                             });
-                                        } else if (text && text.length === 0) {
+                                        } else {
                                             this.setState({
-                                                filteredData: BIP39_WORD_LIST
+                                                filteredData: BIP39_WORD_LIST,
+                                                invalidInput: false
                                             });
                                         }
 
@@ -527,6 +540,22 @@ export default class SeedRecovery extends React.PureComponent<
                                     }}
                                 />
                             )}
+                            {selectedInputType === 'word' &&
+                                this.state.invalidInput && (
+                                    <Text
+                                        style={{
+                                            color: themeColor('error'),
+                                            fontFamily: 'PPNeueMontreal-Book',
+                                            fontSize: 14,
+                                            marginTop: 5,
+                                            marginLeft: 30
+                                        }}
+                                    >
+                                        {localeString(
+                                            'views.Settings.NodeConfiguration.invalidSeedWord'
+                                        )}
+                                    </Text>
+                                )}
                         </View>
                         {!showSuggestions && (
                             <>


### PR DESCRIPTION
# Description
This fixes #1818.

When entering seed words during wallet recovery, users now receive immediate visual feedback if they type characters that don't match any valid BIP39 seed words.

- Input text turns red when invalid characters are entered
- "Invalid seed word" error message appears below input field

https://github.com/user-attachments/assets/dbb50658-1aa0-43a2-af01-09cb79207aa8

This helps users catch typos and invalid entries earlier in the recovery process, reducing frustration and preventing incomplete recoveries.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
