### PR TITLE
Show reserved_balance_anchor_chan on On-chain section

### DIFF
--- a/components/LayerBalances/index.tsx
+++ b/components/LayerBalances/index.tsx
@@ -446,7 +446,11 @@ export default class LayerBalances extends Component<LayerBalancesProps, {}> {
         } = this.props;
 
         const { settings } = SettingsStore!;
-        const { totalBlockchainBalance, lightningBalance } = BalanceStore!;
+        const {
+            totalBlockchainBalance,
+            lightningBalance,
+            reservedBalanceAnchorChan
+        } = BalanceStore!;
         const { totalBalanceSats, mintUrls, cashuWallets } = CashuStore!;
 
         const otherAccounts = editMode
@@ -465,7 +469,14 @@ export default class LayerBalances extends Component<LayerBalancesProps, {}> {
         if (BackendUtils.supportsOnchainReceiving()) {
             DATA.push({
                 layer: 'On-chain',
-                balance: Number(totalBlockchainBalance).toFixed(3)
+                balance: Number(totalBlockchainBalance).toFixed(3),
+                ...(Number(reservedBalanceAnchorChan) > 0 && {
+                    subtitle: `${localeString(
+                        'general.reservedBalanceAnchorChan'
+                    )}: ${Number(
+                        reservedBalanceAnchorChan
+                    ).toLocaleString()} ${localeString('general.sats')}`
+                })
             });
         }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -46,6 +46,7 @@
     "general.transaction": "Transaction",
     "general.confirmed": "Confirmed",
     "general.unconfirmed": "Unconfirmed",
+    "general.reservedBalanceAnchorChan": "Reserved for anchor channels",
     "general.sent": "Sent",
     "general.received": "Received",
     "general.date": "Date",

--- a/stores/BalanceStore.ts
+++ b/stores/BalanceStore.ts
@@ -10,6 +10,7 @@ export default class BalanceStore {
     @observable public totalBlockchainBalanceAccounts: number | string;
     @observable public confirmedBlockchainBalance: number | string;
     @observable public unconfirmedBlockchainBalance: number | string;
+    @observable public reservedBalanceAnchorChan: number | string;
     @observable public loadingBlockchainBalance = false;
     @observable public loadingLightningBalance = false;
     @observable public error = false;
@@ -44,6 +45,7 @@ export default class BalanceStore {
         this.unconfirmedBlockchainBalance = 0;
         this.confirmedBlockchainBalance = 0;
         this.totalBlockchainBalance = 0;
+        this.reservedBalanceAnchorChan = 0;
         this.otherAccounts = {};
         this.loadingBlockchainBalance = false;
     };
@@ -92,6 +94,10 @@ export default class BalanceStore {
                 data.total_balance || 0
             );
 
+            const reservedBalanceAnchorChan = Number(
+                data.reserved_balance_anchor_chan || 0
+            );
+
             runInAction(() => {
                 if (set) {
                     if (accounts && accounts.default && data.confirmed_balance)
@@ -105,6 +111,7 @@ export default class BalanceStore {
                     this.totalBlockchainBalance = totalBlockchainBalance;
                     this.totalBlockchainBalanceAccounts =
                         totalBlockchainBalanceAccounts;
+                    this.reservedBalanceAnchorChan = reservedBalanceAnchorChan;
                 }
                 this.loadingBlockchainBalance = false;
             });
@@ -112,6 +119,7 @@ export default class BalanceStore {
                 unconfirmedBlockchainBalance,
                 confirmedBlockchainBalance,
                 totalBlockchainBalance,
+                reservedBalanceAnchorChan,
                 accounts
             };
         } catch {
@@ -166,6 +174,8 @@ export default class BalanceStore {
             this.confirmedBlockchainBalance =
                 onChain?.confirmedBlockchainBalance || 0;
             this.totalBlockchainBalance = onChain?.totalBlockchainBalance || 0;
+            this.reservedBalanceAnchorChan =
+                onChain?.reservedBalanceAnchorChan || 0;
         });
 
         return {


### PR DESCRIPTION
Fixes #3092

# Description

Relates to issue: **ZEUS-3092**

Displays `reserved_balance_anchor_chan` from LND wallet balance API as a subtitle under the On-chain balance row. This makes it explicit to users how much of their on-chain balance is reserved for anchor channel commitments and cannot be spent.

**Changes:**
- Added `reservedBalanceAnchorChan` observable to `BalanceStore`
- Display subtitle "Reserved for anchor channels: X sats" when value > 0
- Added locale string `general.reservedBalanceAnchorChan`

**Screenshots:**

<img width="250" height="" alt="image" src="https://github.com/user-attachments/assets/5fced381-4b8a-4b9b-b6e5-ecf246985449" />
*LND confirmation showing `reserved_balance_anchor_chan: 20000`:*
```json
<img width="2500" height="1000" alt="image" src="https://github.com/user-attachments/assets/86443297-09a4-407d-b4d7-400fdd6857a6" />
This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
-[x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST) - v0.20.0-beta via Polar regtest with anchor channels
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding


