### PR TITLE
enhancement: QR: Add 'Open Settings' button when camera permission denied

### DIFF
--- a/components/QRCodeScanner.tsx
+++ b/components/QRCodeScanner.tsx
@@ -6,7 +6,8 @@ import {
     TouchableOpacity,
     BackHandler,
     AppState,
-    Alert
+    Alert,
+    Linking
 } from 'react-native';
 import {
     Camera,
@@ -141,7 +142,15 @@ export default function QRCodeScanner({
             navigation.addListener('focus', handleFocus);
             const appStateChangeSubscription = AppState.addEventListener(
                 'change',
-                (state) => setCameraIsActive(state === 'active')
+                (state) => {
+                    setCameraIsActive(state === 'active');
+                    if (state === 'active') {
+                        const permission = Camera.getCameraPermissionStatus();
+                        if (permission === 'granted') {
+                            setCameraStatus(CameraAuthStatus.AUTHORIZED);
+                        }
+                    }
+                }
             );
 
             const hasPermission = Camera.getCameraPermissionStatus();
@@ -288,6 +297,14 @@ export default function QRCodeScanner({
                             'components.QRCodeScanner.noCameraAccess'
                         )}
                     </Text>
+                    <Button
+                        title={localeString(
+                            'components.QRCodeScanner.openSettings'
+                        )}
+                        onPress={() => Linking.openSettings()}
+                        containerStyle={{ width: 200, marginBottom: 10 }}
+                        adaptiveWidth
+                    />
                     <Button
                         title={localeString('general.goBack')}
                         onPress={() => goBack()}

--- a/locales/en.json
+++ b/locales/en.json
@@ -242,6 +242,7 @@
     "components.UTXOPicker.defaultTitle": "UTXOs to use",
     "components.UTXOPicker.selectUTXOs": "Select UTXOs to use",
     "components.QRCodeScanner.noCameraAccess": "No access to camera",
+    "components.QRCodeScanner.openSettings": "Open Settings",
     "components.QRCodeScanner.noCameraFound": "No camera device found",
     "components.QRCodeScanner.notRecognized": "QR code could not be recognized",
     "components.NWCPendingPayInvoiceModal.title": "Pending Payment Requests",


### PR DESCRIPTION
# Description

- Added an "Open Settings" button (primary style) above the existing "Go Back" button (secondary style) on the denied-permission screen. It calls `Linking.openSettings()` which takes the user directly to the app's settings page on both iOS and Android.
- Enhanced the `AppState` change listener (lines 145-154) to re-check camera permission when the app returns to the foreground. This way, if the user grants permission in Settings and switches back to Zeus, the camera will activate automatically without needing to re-navigate.

<img width="500" alt="simulator_screenshot_29744825-938B-4FF9-9E8A-27C49A31B62B" src="https://github.com/user-attachments/assets/7aa3c06e-8e37-42bd-a455-bdce201b2165" />

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
