### PR TITLE
fix: multiline TextInput clipping on some devices

### DIFF
--- a/components/TextInput.tsx
+++ b/components/TextInput.tsx
@@ -168,7 +168,8 @@ const TextInput = React.forwardRef<TextInputRN, TextInputProps>(
                             textColor ||
                             (locked
                                 ? themeColor('secondaryText')
-                                : themeColor('text'))
+                                : themeColor('text')),
+                        ...(multiline ? { paddingVertical: 10 } : {})
                     }}
                     placeholderTextColor={
                         placeholderTextColor || themeColor('secondaryText')


### PR DESCRIPTION
# Description

I noticed this issue on a Pixel 9 Pro XL (happens for placeholder, but also user input):
<img width="380" height="810" alt="grafik" src="https://github.com/user-attachments/assets/45d935c4-fece-498e-85c3-3e6c89209a0b" />

I cannot reproduce it on emulator or my physical testing device. But the fix is pretty straight forward and should work.

I tested on emulator and physical device to make sure there is no regression (also checked other screens with multine TextInput and found no issue):
|Before|After|
|-|-|
|<img width="340" height="784" alt="grafik" src="https://github.com/user-attachments/assets/f8760b5e-cd67-4651-8316-6a07411ef5a9" />|<img width="340" height="784" alt="grafik" src="https://github.com/user-attachments/assets/6ce9fa88-6a82-4070-a293-7c9cf56ce6d0" />|

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
