### PR TITLE
Speed up transaction screen: Add descriptive input label for target confirmations

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1327,6 +1327,7 @@
     "views.BumpFee.titleClose": "Speed up channel close",
     "views.BumpFee.titleForceClose": "Speed up channel force close",
     "views.BumpFee.targetConfs": "Target confirmations",
+    "views.BumpFee.targetConfsInputDescription": "Desired blocks until confirmation",
     "views.BumpFee.success": "Successfully bumped fee!",
     "views.BumpFee.error": "Error bumping fee",
     "views.BumpFee.outpoint.explainer1": "An outpoint is a reference to a particular output of a previous transaction. It consists of two parts:",

--- a/views/Tools/BumpFee.tsx
+++ b/views/Tools/BumpFee.tsx
@@ -296,7 +296,9 @@ export default class BumpFee extends React.PureComponent<
                                     color: themeColor('secondaryText')
                                 }}
                             >
-                                {localeString('views.BumpFee.targetConfs')}
+                                {localeString(
+                                    'views.BumpFee.targetConfsInputDescription'
+                                )}
                             </Text>
                             <View style={styles.targetForm}>
                                 <TextInput


### PR DESCRIPTION
# Description

This adds a new locale string ("Desired blocks until confirmation") to be used as the input label when entering target confirmations in the "Speed up transaction" screen.

This allows translators to use a short term for the button and a more descriptive label for the input field, improving clarity especially in languages where "target confirmations" is hard to translate concisely (e.g. German). Personally I think it is improving clarity of the feature generally (also in English).

<img width="340" height="784" alt="grafik" src="https://github.com/user-attachments/assets/f7d2c4be-8791-4340-a4b7-508f34df6aba" />

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
