### PR TITLE
fix: spurious lsps7 "peer is not connected" error on startup

### DIFF
--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -72,9 +72,14 @@ export default class LSPStore {
         reaction(
             () => this.channelsStore.channels,
             () => {
+                const lspPubkey = this.getLSPSPubkey();
                 if (
-                    this.channelsStore.channels.length !== 0 &&
-                    BackendUtils.supportsLSPScustomMessage()
+                    BackendUtils.supportsLSPScustomMessage() &&
+                    lspPubkey &&
+                    this.channelsStore.channels.some(
+                        (channel: { remotePubkey: string }) =>
+                            channel.remotePubkey === lspPubkey
+                    )
                 ) {
                     this.getExtendableChannels();
                 }


### PR DESCRIPTION
# Description

On startup, `LSPStore` fires an LSPS7 `get_extendable_channels` custom message whenever channels exist and the backend supports it, regardless of whether any LSP channel is used. This causes a `"peer is not connected"` error if no LSP channel is used.

Fixed by checking that at least one channel's `remotePubkey` matches the configured LSP pubkey before sending the message.

I verified that the error no longer occurs on startup for a remote LND node with no LSP channel, but someone needs to test if `getExtendableChannels` still fires correctly in case an LSP channel is set up.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
