### PR TITLE
fix(swaps): prevent form reset when navigating to QR scanner or fee editor

### DIFF
--- a/components/OnchainFeeInput.tsx
+++ b/components/OnchainFeeInput.tsx
@@ -15,12 +15,13 @@ interface OnchainFeeInputProps {
     fee?: string;
     onChangeFee: (fee: string) => void;
     onFeeError?: (error: boolean) => void;
+    onNavigateAway?: () => void;
 }
 
 const DEFAULT_FEE = '10';
 
 export default function OnchainFeeInput(props: OnchainFeeInputProps) {
-    const { fee, onChangeFee, navigation } = props;
+    const { fee, onChangeFee, onNavigateAway, navigation } = props;
     const { settings } = settingsStore;
     const enableMempoolRates = settings?.privacy?.enableMempoolRates;
     const preferredMempoolRate =
@@ -70,11 +71,12 @@ export default function OnchainFeeInput(props: OnchainFeeInputProps) {
         <>
             {enableMempoolRates ? (
                 <TouchableWithoutFeedback
-                    onPress={() =>
+                    onPress={() => {
+                        if (onNavigateAway) onNavigateAway();
                         navigation.navigate('EditFee', {
                             fee: newFee
-                        })
-                    }
+                        });
+                    }}
                 >
                     <View
                         style={{

--- a/views/HandleAnythingQRScanner.tsx
+++ b/views/HandleAnythingQRScanner.tsx
@@ -85,7 +85,7 @@ export default class HandleAnythingQRScanner extends React.Component<
                     navigation.goBack();
                     navigation.navigate('Swaps', {
                         initialInvoice: value,
-                        initialAmountSats: satAmount,
+                        initialAmountSats: satAmount || 0,
                         initialReverse: true
                     });
                     return;

--- a/views/Swaps/index.tsx
+++ b/views/Swaps/index.tsx
@@ -148,7 +148,7 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
         flowLspNotConfigured: true
     };
 
-    private isNavigatingToLSPFees = false;
+    private isNavigatingAway = false;
     private _unsubscribe?: () => void;
 
     checkIsValid = () => {
@@ -270,8 +270,8 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
         SwapStore.ECPair = ECPairFactory(ecc);
 
         const unsubBlur = this.props.navigation.addListener('blur', () => {
-            if (this.isNavigatingToLSPFees) {
-                this.isNavigatingToLSPFees = false;
+            if (this.isNavigatingAway) {
+                this.isNavigatingAway = false;
                 return;
             }
             this.resetFields();
@@ -312,6 +312,7 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
             FeeStore,
             SettingsStore,
             SwapStore,
+            navigation,
             route,
             UnitsStore,
             FiatStore
@@ -352,7 +353,13 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
                 initialReverse !== undefined
             ) {
                 this.setState({ paramsProcessed: true }, async () => {
-                    // Use callback to ensure paramsProcessed is set before further calcs
+                    // Clear consumed route params so stale values
+                    // aren't re-processed after a future navigation
+                    navigation.setParams({
+                        initialInvoice: undefined,
+                        initialAmountSats: undefined,
+                        initialReverse: undefined
+                    });
                     const { units } = UnitsStore;
                     const { fiatRates } = FiatStore;
                     const { fiat } = settings;
@@ -1906,7 +1913,7 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
                                                     invoice && (
                                                         <TouchableOpacity
                                                             onPress={() => {
-                                                                this.isNavigatingToLSPFees =
+                                                                this.isNavigatingAway =
                                                                     true;
                                                                 navigation.navigate(
                                                                     new BigNumber(
@@ -1990,12 +1997,13 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
                                                 () => this.checkIsValid()
                                             );
                                         }}
-                                        onScan={() =>
+                                        onScan={() => {
+                                            this.isNavigatingAway = true;
                                             navigation.navigate(
                                                 'HandleAnythingQRScanner',
                                                 { view: 'Swaps' }
-                                            )
-                                        }
+                                            );
+                                        }}
                                         placeholder={
                                             fetchingInvoice
                                                 ? ''
@@ -2205,6 +2213,10 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
                                                                 fee: text
                                                             })
                                                         }
+                                                        onNavigateAway={() => {
+                                                            this.isNavigatingAway =
+                                                                true;
+                                                        }}
                                                         navigation={navigation}
                                                     />
                                                 </>


### PR DESCRIPTION
# Description

Users reported that swap field values were getting cleared when scanning an invoice or changing on-chain fee values.

Root cause: The Swaps screen (views/Swaps/index.tsx:272-278) has a blur event listener that calls `resetFields()` whenever the screen loses focus. This wipes `inputSats`, `outputSats`, `invoice`, and other form state. There was only a guard for navigating to LSP fee explanation screens, but not for the QR scanner or fee customization.

Changes:

  1. `views/Swaps/index.tsx` — Renamed `isNavigatingToLSPFees` to i`sNavigatingAway` (more general) and set the flag before navigating to the QR scanner via `onScan`. Also passed an `onNavigateAway` callback to `OnchainFeeInput` so it can set the flag before navigating to `EditFee`.
  2. `components/OnchainFeeInput.tsx` — Added an optional `onNavigateAway` callbackprop, called before navigating to `EditFee`. This keeps the component generic (the prop is optional) while letting parent screens opt in to the guard.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
