### PR TITLE
fix: clear keypad value after navigating to send or receive screens

### DIFF
--- a/views/Wallet/KeypadPane.tsx
+++ b/views/Wallet/KeypadPane.tsx
@@ -1,3 +1,5 @@
+const CLEAR_VALUE_DELAY = 500;
+
 import * as React from 'react';
 import {
     Animated,
@@ -178,13 +180,19 @@ export default class KeypadPane extends React.PureComponent<
         return true;
     };
 
-    clearValue = () => {
-        this.setState({
-            amount: '0',
-            needInbound: false,
-            belowMinAmount: false,
-            overrideBelowMinAmount: false
-        });
+    clearValue = (delayed?: boolean) => {
+        const clear = () =>
+            this.setState({
+                amount: '0',
+                needInbound: false,
+                belowMinAmount: false,
+                overrideBelowMinAmount: false
+            });
+        if (delayed) {
+            setTimeout(clear, CLEAR_VALUE_DELAY);
+        } else {
+            clear();
+        }
     };
 
     deleteValue = () => {
@@ -480,7 +488,7 @@ export default class KeypadPane extends React.PureComponent<
                                                             : true
                                                 }
                                             );
-                                            this.clearValue();
+                                            this.clearValue(true);
                                         }}
                                         buttonStyle={{ height: 40 }}
                                         disabled={
@@ -510,7 +518,7 @@ export default class KeypadPane extends React.PureComponent<
                                                     amount
                                                 }
                                             );
-                                            this.clearValue();
+                                            this.clearValue(true);
                                         }}
                                         buttonStyle={{ height: 40 }}
                                         disabled={
@@ -536,7 +544,7 @@ export default class KeypadPane extends React.PureComponent<
                                                               )
                                                             : ''
                                                 });
-                                                this.clearValue();
+                                                this.clearValue(true);
                                             }
                                         }}
                                         buttonStyle={{ height: 40 }}
@@ -582,7 +590,7 @@ export default class KeypadPane extends React.PureComponent<
                                     amount: amount !== '0' ? amount : ''
                                 });
                                 this.modalBoxRef.current?.close();
-                                this.clearValue();
+                                this.clearValue(true);
                             }}
                             style={{
                                 ...styles.sendOption,
@@ -617,7 +625,7 @@ export default class KeypadPane extends React.PureComponent<
                                     amount: amount !== '0' ? amount : ''
                                 });
                                 this.modalBoxRef.current?.close();
-                                this.clearValue();
+                                this.clearValue(true);
                             }}
                             style={{
                                 ...styles.sendOption,


### PR DESCRIPTION
# Description

Previously, the keypad would retain the previously entered amount when the user returns from a send/receive screen.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
