### PR TITLE
fix(android): remove discolored background on channel tabs

### DIFF
--- a/views/Channels/ChannelsPane.tsx
+++ b/views/Channels/ChannelsPane.tsx
@@ -463,6 +463,8 @@ export default class ChannelsPane extends React.PureComponent<
             tabBarInactiveTintColor: 'gray',
             tabBarShowLabel: true,
             tabBarStyle: {
+                backgroundColor: 'transparent',
+                elevation: 0,
                 borderTopWidth: 0.2,
                 borderTopColor: themeColor('secondaryText'),
                 paddingTop: 10,


### PR DESCRIPTION
# Description

On Android, React Navigation's bottom tab bar defaults to an opaque background with elevation, causing a visible discolored box behind the Open/Pending/Closed channel tabs.

Android:

|Before|After|
|-|-|
|<img width="1280" height="2856" alt="Screenshot_1771626793" src="https://github.com/user-attachments/assets/372cf96b-3479-49c0-b5d7-f0d39c1470b8" />|<img width="1280" height="2856" alt="Screenshot_1771626780" src="https://github.com/user-attachments/assets/9c90d772-9ed6-43d7-9ac2-839f2caeb213" />|

iOS (no difference):

|Before|After|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-20 at 17 33 36" src="https://github.com/user-attachments/assets/0b1d1d42-1f45-48fe-bd66-54948d30f7b4" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-20 at 17 34 00" src="https://github.com/user-attachments/assets/2bf86aef-f18d-4f26-8e12-001f78c1c7e8" />|

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x]  iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
