### PR TITLE
fix(patches): add crypto.js export to @noble/hashes to resolve Metro warnings

### DIFF
--- a/patches/index.mjs
+++ b/patches/index.mjs
@@ -5,6 +5,7 @@ import { patchSifirAndroid } from './patch-sifir-android.mjs';
 import { patchJcenter } from './patch-jcenter.mjs';
 import { patchNativeEventEmitter } from './patch-native-event-emitter.mjs';
 import { patchReactNativeNotifications } from './patch-react-native-notifications.mjs';
+import { patchNobleHashes } from './patch-noble-hashes.mjs';
 
 console.log('Running postinstall patches...\n');
 
@@ -13,6 +14,7 @@ console.log('Running postinstall patches...\n');
     patchJcenter();
     patchNativeEventEmitter();
     patchReactNativeNotifications();
+    patchNobleHashes();
 
     console.log('\nAll patches applied successfully.');
 })();

--- a/patches/patch-noble-hashes.mjs
+++ b/patches/patch-noble-hashes.mjs
@@ -1,0 +1,71 @@
+// Fix @noble/hashes package exports for Metro/React Native.
+// Dependencies import @noble/hashes/crypto.js but the package only exports ./crypto.
+// Add ./crypto.js to exports so it resolves correctly per Node.js package exports spec.
+
+import fs from 'fs';
+import path from 'path';
+
+const CRYPTO_EXPORT = {
+    node: {
+        import: './esm/cryptoNode.js',
+        default: './cryptoNode.js'
+    },
+    import: './esm/crypto.js',
+    default: './crypto.js'
+};
+
+export function patchNobleHashes() {
+    console.log('Patching @noble/hashes (add ./crypto.js to exports)');
+
+    const nodeModules = './node_modules';
+    const nobleHashesPaths = [...new Set(findNobleHashesPaths(nodeModules))];
+
+    for (const pkgPath of nobleHashesPaths) {
+        const packageJsonPath = path.join(pkgPath, 'package.json');
+        if (!fs.existsSync(packageJsonPath)) continue;
+
+        try {
+            const content = fs.readFileSync(packageJsonPath, 'utf8');
+            const pkg = JSON.parse(content);
+
+            if (!pkg.exports || typeof pkg.exports !== 'object') continue;
+            if (pkg.exports['./crypto.js']) continue;
+
+            pkg.exports['./crypto.js'] = CRYPTO_EXPORT;
+            fs.writeFileSync(
+                packageJsonPath,
+                JSON.stringify(pkg, null, 2),
+                'utf8'
+            );
+            console.log(`  - Patched ${path.relative(nodeModules, pkgPath)}`);
+        } catch (err) {
+            console.warn(`  - Skip ${pkgPath}: ${err.message}`);
+        }
+    }
+}
+
+function findNobleHashesPaths(dir, results = [], depth = 0) {
+    if (!fs.existsSync(dir) || depth > 15) return results;
+
+    const nobleHashes = path.join(dir, '@noble', 'hashes');
+    if (fs.existsSync(nobleHashes)) {
+        results.push(nobleHashes);
+    }
+
+    try {
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+            if (entry.isDirectory() && !entry.name.startsWith('.')) {
+                findNobleHashesPaths(
+                    path.join(dir, entry.name),
+                    results,
+                    depth + 1
+                );
+            }
+        }
+    } catch (err) {
+        console.warn(` - Failed to read directory ${dir}: ${err.message}`);
+    }
+
+    return results;
+}


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

In this PR we are fixing Metro warnings for @noble/hashes crypto.js export

### Problem 
Metro shows warnings when building : 

```
Attempted to import the module ".../node_modules/@noble/hashes/crypto.js" which is not listed in the "exports" of ".../node_modules/@noble/hashes" under the requested subpath "./crypto.js". Falling back to file-based resolution.
These appear for every copy of @noble/hashes (from @scure/bip32, @scure/bip39, nostr-tools, @nostr/tools, @getalby/sdk, etc.) because they import @noble/hashes/crypto.js, which is not exposed in the package exports field.
```

##  Solution

A `postinstall` patch has been added to:
- Locate all instances of `@noble/hashes` inside `node_modules`
- Add `./crypto.js` to their `package.json` `exports` field
- Allow Metro to resolve the module without warnings
- 
The patch is:
- **Recursive** – handles nested dependencies
- **Idempotent** – skips packages that already define `./crypto.js`
- **Safe** – only modifies missing export entries

## Changes

- **Added:** `patches/patch-noble-hashes.mjs`  
  Recursively finds and patches all `@noble/hashes` instances.

- **Updated:** `patches/index.mjs`  
  Runs the new patch during `postinstall`.


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
