### PR TITLE
fix: skip retry loop when LND is already running on startup

### DIFF
--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -352,22 +352,32 @@ export async function startLnd({
             if (e?.message?.includes("doesn't exist")) {
                 throw new Error(LND_FOLDER_MISSING_ERROR);
             }
-            let started;
-            while (!started) {
-                try {
-                    console.log('error starting LND - retrying momentarily', e);
-                    await sleep(3000);
-                    await startLnd({
-                        args: '',
-                        lndDir,
-                        isTorEnabled,
-                        isTestnet
-                    });
-                    started = true;
-                } catch (e2: any) {
-                    // Stop retrying if folder is missing
-                    if (e2?.message?.includes("doesn't exist")) {
-                        throw new Error(LND_FOLDER_MISSING_ERROR);
+            // LND is already running (e.g. after createLndWallet) - proceed to state subscription
+            if (!e?.message?.includes('already started')) {
+                let started;
+                while (!started) {
+                    try {
+                        console.log(
+                            'error starting LND - retrying momentarily',
+                            e
+                        );
+                        await sleep(3000);
+                        await startLnd({
+                            args: '',
+                            lndDir,
+                            isTorEnabled,
+                            isTestnet
+                        });
+                        started = true;
+                    } catch (e2: any) {
+                        // Stop retrying if folder is missing
+                        if (e2?.message?.includes("doesn't exist")) {
+                            throw new Error(LND_FOLDER_MISSING_ERROR);
+                        }
+                        // LND already running during retry - proceed to state subscription
+                        if (e2?.message?.includes('already started')) {
+                            started = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Description

### Issue:
When creating a new embedded wallet, `createLndWallet()` starts LND to reach the NON_EXISTING state for wallet initialization. After the wallet is created and the app navigates to the wallet view, `fetchData()` calls `stopLnd()` followed by `startLnd()`. If the Go LND runtime has not fully released its internal state by then, the native `startLnd` call throws "lnd already started" which causes an infinite retry loop.

### How to reproduce:
1. Fresh install / clear app data
2. Create a new mainnet embedded node (I could not reproduce for testnet -> probably luck with timing)
3. On first startup after wallet creation, the retry loop would spin indefinitely with `error starting LND - retrying momentarily`

### Solution:
Now we detect the "already started" error in both the initial catch and the retry loop, and fall through to the state subscription instead of retrying.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
