### PR TITLE
refactor: extract shared components from seed and recovery views

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -186,6 +186,7 @@ import SwapDetails from './views/Swaps/SwapDetails';
 import SwapsPane from './views/Swaps/SwapsPane';
 import RefundSwap from './views/Swaps/Refund';
 import SwapSettings from './views/Swaps/Settings';
+import SwapsRecovery from './views/Swaps/SwapsRecovery';
 import SwapsRescueKey from './views/Swaps/SwapsRescueKey';
 
 // POS
@@ -1254,6 +1255,12 @@ export default class App extends React.PureComponent {
                                                     <Stack.Screen
                                                         name="CashuSeed" // @ts-ignore:next-line
                                                         component={CashuSeed}
+                                                    />
+                                                    <Stack.Screen
+                                                        name="SwapsRecovery" // @ts-ignore:next-line
+                                                        component={
+                                                            SwapsRecovery
+                                                        }
                                                     />
                                                     <Stack.Screen
                                                         name="SwapsRescueKey" // @ts-ignore:next-line

--- a/App.tsx
+++ b/App.tsx
@@ -186,6 +186,7 @@ import SwapDetails from './views/Swaps/SwapDetails';
 import SwapsPane from './views/Swaps/SwapsPane';
 import RefundSwap from './views/Swaps/Refund';
 import SwapSettings from './views/Swaps/Settings';
+import SwapsRescueKey from './views/Swaps/SwapsRescueKey';
 
 // POS
 import Order from './views/Order';
@@ -1253,6 +1254,12 @@ export default class App extends React.PureComponent {
                                                     <Stack.Screen
                                                         name="CashuSeed" // @ts-ignore:next-line
                                                         component={CashuSeed}
+                                                    />
+                                                    <Stack.Screen
+                                                        name="SwapsRescueKey" // @ts-ignore:next-line
+                                                        component={
+                                                            SwapsRescueKey
+                                                        }
                                                     />
                                                     <Stack.Screen
                                                         name="LegacySeedRecovery" // @ts-ignore:next-line

--- a/components/DangerousCopySeedButton.tsx
+++ b/components/DangerousCopySeedButton.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { TouchableOpacity, ViewStyle } from 'react-native';
+
+import { themeColor } from '../utils/ThemeUtils';
+
+import Skull from '../assets/images/SVG/Skull.svg';
+
+const DangerousCopySeedButton = ({
+    onPress,
+    style
+}: {
+    onPress: () => void;
+    style?: ViewStyle;
+}) => (
+    <TouchableOpacity onPress={onPress} style={style}>
+        <Skull fill={themeColor('text')} />
+    </TouchableOpacity>
+);
+
+export default DangerousCopySeedButton;

--- a/components/MnemonicWord.tsx
+++ b/components/MnemonicWord.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+
+import { themeColor } from '../utils/ThemeUtils';
+
+const MnemonicWord = ({ index, word }: { index: number; word: string }) => {
+    const [isRevealed, setRevealed] = useState(false);
+    return (
+        <TouchableOpacity
+            key={index}
+            onPress={() => setRevealed(!isRevealed)}
+            style={{
+                padding: 8,
+                backgroundColor: themeColor('secondary'),
+                borderRadius: 5,
+                margin: 6,
+                marginTop: 4,
+                marginBottom: 4,
+                flexDirection: 'row',
+                alignSelf: 'center'
+            }}
+        >
+            <View style={{ width: 35 }}>
+                <Text
+                    style={{
+                        flex: 1,
+                        fontFamily: 'PPNeueMontreal-Book',
+                        color: themeColor('secondaryText'),
+                        fontSize: 18,
+                        alignSelf: 'flex-start'
+                    }}
+                >
+                    {index + 1}
+                </Text>
+            </View>
+            <Text
+                style={{
+                    flex: 1,
+                    fontFamily: 'PPNeueMontreal-Medium',
+                    color: themeColor('text'),
+                    fontSize: 18,
+                    alignSelf: 'flex-end',
+                    margin: 0,
+                    marginLeft: 10,
+                    padding: 0
+                }}
+            >
+                {isRevealed ? word : '********'}
+            </Text>
+        </TouchableOpacity>
+    );
+};
+
+export default MnemonicWord;

--- a/components/Modals/DangerousCopySeedModal.tsx
+++ b/components/Modals/DangerousCopySeedModal.tsx
@@ -28,7 +28,7 @@ const DangerousCopySeedModal = ({
                         <Text
                             style={{
                                 ...seedStyles.blackText,
-                                fontSize: 40,
+                                fontSize: 25,
                                 alignSelf: 'center',
                                 marginBottom: 20
                             }}

--- a/components/Modals/DangerousCopySeedModal.tsx
+++ b/components/Modals/DangerousCopySeedModal.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Modal, Text, View } from 'react-native';
+
+import Button from '../Button';
+import CopyButton from '../CopyButton';
+import seedStyles from '../seedStyles';
+
+import { localeString } from '../../utils/LocaleUtils';
+
+interface DangerousCopySeedModalProps {
+    visible: boolean;
+    seedPhrase: string[];
+    onClose: () => void;
+    dangerousText1Key?: string;
+}
+
+const DangerousCopySeedModal = ({
+    visible,
+    seedPhrase,
+    onClose,
+    dangerousText1Key = 'views.Settings.Seed.dangerousText1'
+}: DangerousCopySeedModalProps) => (
+    <Modal animationType="slide" transparent={true} visible={visible}>
+        <View style={seedStyles.centeredView}>
+            <View style={seedStyles.modal}>
+                {visible && (
+                    <View>
+                        <Text
+                            style={{
+                                ...seedStyles.blackText,
+                                fontSize: 40,
+                                alignSelf: 'center',
+                                marginBottom: 20
+                            }}
+                        >
+                            {localeString('general.danger')}
+                        </Text>
+                        <Text
+                            style={{
+                                color: 'black',
+                                margin: 10
+                            }}
+                        >
+                            {localeString(dangerousText1Key)}
+                        </Text>
+                        <Text
+                            style={{
+                                ...seedStyles.blackText,
+                                color: 'black',
+                                margin: 10
+                            }}
+                        >
+                            {localeString('views.Settings.Seed.dangerousText2')}
+                        </Text>
+                        <View style={seedStyles.button}>
+                            <CopyButton
+                                title={localeString(
+                                    'views.Settings.Seed.dangerousButton'
+                                )}
+                                copyValue={seedPhrase.join(' ')}
+                                icon={{
+                                    name: 'warning',
+                                    size: 25
+                                }}
+                            />
+                        </View>
+                        <View style={seedStyles.button}>
+                            <Button
+                                title={localeString('general.cancel')}
+                                onPress={onClose}
+                            />
+                        </View>
+                    </View>
+                )}
+            </View>
+        </View>
+    </Modal>
+);
+
+export default DangerousCopySeedModal;

--- a/components/SeedWarningDisclaimer.tsx
+++ b/components/SeedWarningDisclaimer.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+
+import { ErrorMessage } from './SuccessErrorMessage';
+import Button from './Button';
+
+import { themeColor } from '../utils/ThemeUtils';
+import { localeString } from '../utils/LocaleUtils';
+
+interface SeedWarningDisclaimerProps {
+    text1Key: string;
+    text2Key: string;
+    onUnderstood: () => void;
+}
+
+const SeedWarningDisclaimer = ({
+    text1Key,
+    text2Key,
+    onUnderstood
+}: SeedWarningDisclaimerProps) => {
+    const textStyle = {
+        color: themeColor('text'),
+        fontFamily: 'PPNeueMontreal-Book',
+        textAlign: 'center' as const,
+        margin: 10,
+        fontSize: 20
+    };
+
+    return (
+        <>
+            <View style={{ marginLeft: 10, marginRight: 10 }}>
+                <ErrorMessage
+                    message={localeString('general.warning').toUpperCase()}
+                />
+            </View>
+            <Text style={textStyle}>{localeString(text1Key)}</Text>
+            <Text style={textStyle}>{localeString(text2Key)}</Text>
+            <Text style={textStyle}>
+                {localeString('views.Settings.Seed.text3').replace(
+                    'Zeus',
+                    'ZEUS'
+                )}
+            </Text>
+            <Text style={textStyle}>
+                {localeString('views.Settings.Seed.text4')}
+            </Text>
+            <View
+                style={{
+                    alignSelf: 'center',
+                    position: 'absolute',
+                    bottom: 35,
+                    width: '100%'
+                }}
+            >
+                <Button
+                    onPress={onUnderstood}
+                    title={localeString('general.iUnderstand')}
+                />
+            </View>
+        </>
+    );
+};
+
+export default SeedWarningDisclaimer;

--- a/components/SeedWordGrid.tsx
+++ b/components/SeedWordGrid.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { ScrollView, View } from 'react-native';
+
+import MnemonicWord from './MnemonicWord';
+import seedStyles from './seedStyles';
+
+const SeedWordGrid = ({ seedPhrase }: { seedPhrase: string[] }) => {
+    const half = Math.ceil(seedPhrase.length / 2);
+    return (
+        <ScrollView
+            contentContainerStyle={{
+                flexGrow: 1,
+                flexDirection: 'row'
+            }}
+        >
+            <View style={seedStyles.column}>
+                {seedPhrase
+                    .slice(0, half)
+                    .map((word: string, index: number) => (
+                        <MnemonicWord
+                            index={index}
+                            word={word}
+                            key={`mnemonic-${index}`}
+                        />
+                    ))}
+            </View>
+            <View style={seedStyles.column}>
+                {seedPhrase.slice(half).map((word: string, index: number) => (
+                    <MnemonicWord
+                        index={index + half}
+                        word={word}
+                        key={`mnemonic-${index + half}`}
+                    />
+                ))}
+            </View>
+        </ScrollView>
+    );
+};
+
+export default SeedWordGrid;

--- a/components/SeedWordInput.tsx
+++ b/components/SeedWordInput.tsx
@@ -1,0 +1,363 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+    Keyboard,
+    ScrollView,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+    TextInput as TextInputRN
+} from 'react-native';
+
+import TextInput from './TextInput';
+
+import { themeColor } from '../utils/ThemeUtils';
+import { localeString } from '../utils/LocaleUtils';
+import { BIP39_WORD_LIST } from '../utils/Bip39Utils';
+
+interface SeedWordInputProps {
+    wordCount: 12 | 24;
+    seedArray: string[];
+    onSeedArrayChange: (seedArray: string[]) => void;
+    channelBackup?: string;
+    onChannelBackupChange?: (text: string) => void;
+    onErrorMsgChange?: (msg: string) => void;
+    onShowSuggestionsChange?: (showing: boolean) => void;
+}
+
+const filterBip39 = (text: string) =>
+    BIP39_WORD_LIST.filter((val: string) =>
+        val?.toLowerCase()?.startsWith(text?.toLowerCase())
+    );
+
+const SeedWordInput = ({
+    wordCount,
+    seedArray,
+    onSeedArrayChange,
+    channelBackup,
+    onChannelBackupChange,
+    onErrorMsgChange,
+    onShowSuggestionsChange
+}: SeedWordInputProps) => {
+    const textInputRef = useRef<TextInputRN>(null);
+    const [selectedInputType, setSelectedInputType] = useState<
+        'word' | 'scb' | null
+    >(null);
+    const [selectedWordIndex, setSelectedWordIndex] = useState<number | null>(
+        null
+    );
+    const [selectedText, setSelectedText] = useState('');
+    const [filteredData, setFilteredData] = useState<string[]>([]);
+    const [showSuggestions, setShowSuggestions] = useState(false);
+    const [invalidInput, setInvalidInput] = useState(false);
+
+    const hasScb = onChannelBackupChange != null;
+    const half = wordCount / 2;
+
+    useEffect(() => {
+        onShowSuggestionsChange?.(showSuggestions);
+    }, [showSuggestions]);
+
+    const setFocus = () => {
+        if (!Keyboard.isVisible()) {
+            textInputRef.current?.blur();
+            textInputRef.current?.focus();
+        }
+    };
+
+    const handleLabelPress = (
+        type: 'mnemonicWord' | 'scb',
+        index?: number,
+        text?: string
+    ) => {
+        if (showSuggestions) {
+            if (type === 'scb') {
+                onChannelBackupChange?.(text || '');
+                setSelectedText(text || '');
+            } else if (selectedWordIndex != null) {
+                const updated = [...seedArray];
+                updated[selectedWordIndex] = text || '';
+                onSeedArrayChange(updated);
+                if (selectedWordIndex < wordCount - 1) {
+                    setSelectedWordIndex(selectedWordIndex + 1);
+                    setSelectedText(updated[selectedWordIndex + 1] || '');
+                } else {
+                    setSelectedText(text || '');
+                    Keyboard.dismiss();
+                }
+            }
+        } else {
+            setSelectedText(text || '');
+            if (index != null) {
+                setSelectedInputType('word');
+                setSelectedWordIndex(index);
+            } else {
+                setSelectedInputType('scb');
+            }
+        }
+
+        setShowSuggestions(false);
+        setFocus();
+    };
+
+    const handleChangeText = (text: string) => {
+        onErrorMsgChange?.('');
+        setSelectedText(text);
+
+        if (selectedInputType === 'word') {
+            setShowSuggestions(text.length > 0);
+        }
+
+        if (text.length > 0) {
+            const filtered = filterBip39(text);
+            setFilteredData(filtered);
+            setInvalidInput(
+                selectedInputType === 'word' && filtered.length === 0
+            );
+        } else {
+            setFilteredData(BIP39_WORD_LIST);
+            setInvalidInput(false);
+        }
+
+        if (selectedInputType === 'scb') {
+            onChannelBackupChange?.(text);
+        }
+        if (selectedWordIndex != null) {
+            const updated = [...seedArray];
+            updated[selectedWordIndex] = text;
+            onSeedArrayChange(updated);
+        }
+    };
+
+    const RecoveryLabel = ({
+        type,
+        index,
+        text
+    }: {
+        type: 'mnemonicWord' | 'scb';
+        index?: number;
+        text?: string;
+    }) => (
+        <TouchableOpacity
+            onPress={() => handleLabelPress(type, index, text)}
+            style={{
+                padding: 8,
+                backgroundColor: themeColor('secondary'),
+                borderRadius: 5,
+                marginTop: 4,
+                marginBottom: 4,
+                marginLeft: 6,
+                marginRight: 6,
+                flexDirection: 'row',
+                maxHeight: type === 'scb' ? 60 : undefined
+            }}
+        >
+            {!showSuggestions && index != null && (
+                <View>
+                    <Text
+                        style={{
+                            fontFamily: 'PPNeueMontreal-Book',
+                            color:
+                                selectedInputType === 'word' &&
+                                selectedWordIndex === index
+                                    ? themeColor('highlight')
+                                    : themeColor('secondaryText'),
+                            fontSize: 18,
+                            alignSelf: 'flex-start'
+                        }}
+                    >
+                        {index + 1}
+                    </Text>
+                </View>
+            )}
+            {!showSuggestions && type === 'scb' && (
+                <Text
+                    style={{
+                        fontFamily: 'PPNeueMontreal-Book',
+                        color:
+                            selectedInputType === 'scb'
+                                ? themeColor('highlight')
+                                : themeColor('secondaryText'),
+                        fontSize: 18,
+                        alignSelf: 'flex-start'
+                    }}
+                >
+                    {localeString(
+                        'views.Settings.AddEditNode.disasterRecoveryBase64'
+                    )}
+                </Text>
+            )}
+            <Text
+                style={{
+                    flex: 1,
+                    fontFamily: 'PPNeueMontreal-Medium',
+                    color: themeColor('text'),
+                    fontSize: 18,
+                    alignSelf: type === 'mnemonicWord' ? 'flex-end' : undefined,
+                    margin: 0,
+                    marginLeft: showSuggestions ? 0 : 10,
+                    padding: 0
+                }}
+            >
+                {index != null &&
+                text &&
+                !(selectedInputType === 'word' && selectedWordIndex === index)
+                    ? '********'
+                    : text}
+            </Text>
+        </TouchableOpacity>
+    );
+
+    const renderTwoColumns = (
+        leftItems: { key: string | number; el: React.ReactNode }[],
+        rightItems: { key: string | number; el: React.ReactNode }[],
+        centerWhenNoInput?: boolean
+    ) => (
+        <ScrollView
+            contentContainerStyle={{ flexGrow: 1, flexDirection: 'row' }}
+            keyboardShouldPersistTaps="handled"
+        >
+            <View
+                style={{
+                    ...styles.column,
+                    alignSelf:
+                        centerWhenNoInput && !selectedInputType
+                            ? 'center'
+                            : undefined
+                }}
+            >
+                {leftItems.map((item) => (
+                    <React.Fragment key={item.key}>{item.el}</React.Fragment>
+                ))}
+            </View>
+            <View
+                style={{
+                    ...styles.column,
+                    alignSelf:
+                        centerWhenNoInput && !selectedInputType
+                            ? 'center'
+                            : undefined
+                }}
+            >
+                {rightItems.map((item) => (
+                    <React.Fragment key={item.key}>{item.el}</React.Fragment>
+                ))}
+            </View>
+        </ScrollView>
+    );
+
+    const wordLabel = (index: number) => ({
+        key: index,
+        el: (
+            <RecoveryLabel
+                type="mnemonicWord"
+                index={index}
+                text={seedArray[index]}
+            />
+        )
+    });
+
+    const suggestionLabel = (word: string) => ({
+        key: word,
+        el: <RecoveryLabel type="mnemonicWord" text={word} />
+    });
+
+    const halfFiltered = Math.ceil(filteredData.length / 2);
+
+    return (
+        <>
+            <View>
+                {selectedInputType != null && (
+                    <TextInput
+                        ref={textInputRef}
+                        onFocus={() => {
+                            if (selectedText?.length === 0) {
+                                setShowSuggestions(true);
+                            }
+                        }}
+                        value={selectedText}
+                        prefix={
+                            selectedInputType === 'word'
+                                ? (selectedWordIndex as number) + 1
+                                : 'SCB'
+                        }
+                        prefixStyle={{ color: themeColor('highlight') }}
+                        textColor={
+                            invalidInput ? themeColor('error') : undefined
+                        }
+                        style={{
+                            margin: 20,
+                            marginLeft: 10,
+                            marginRight: 10,
+                            width: '90%',
+                            alignSelf: 'center'
+                        }}
+                        autoCapitalize="none"
+                        autoFocus
+                        onChangeText={handleChangeText}
+                    />
+                )}
+                {selectedInputType === 'word' && invalidInput && (
+                    <Text
+                        style={{
+                            color: themeColor('error'),
+                            fontFamily: 'PPNeueMontreal-Book',
+                            fontSize: 14,
+                            marginTop: 5,
+                            marginLeft: 30
+                        }}
+                    >
+                        {localeString(
+                            'views.Settings.NodeConfiguration.invalidSeedWord'
+                        )}
+                    </Text>
+                )}
+            </View>
+            {!showSuggestions && (
+                <>
+                    {renderTwoColumns(
+                        Array.from({ length: half }, (_, i) => wordLabel(i)),
+                        Array.from({ length: half }, (_, i) =>
+                            wordLabel(i + half)
+                        ),
+                        true
+                    )}
+                    {hasScb && (
+                        <View style={{ flexGrow: 1, flexDirection: 'row' }}>
+                            <View style={styles.scb}>
+                                <RecoveryLabel
+                                    type="scb"
+                                    text={channelBackup}
+                                />
+                            </View>
+                        </View>
+                    )}
+                </>
+            )}
+            {showSuggestions &&
+                renderTwoColumns(
+                    filteredData.slice(0, halfFiltered).map(suggestionLabel),
+                    filteredData.slice(halfFiltered).map(suggestionLabel)
+                )}
+        </>
+    );
+};
+
+const styles = StyleSheet.create({
+    column: {
+        marginTop: 8,
+        flexWrap: 'wrap',
+        alignItems: 'flex-start',
+        flexDirection: 'row',
+        width: '50%'
+    },
+    scb: {
+        alignItems: 'flex-start',
+        flexDirection: 'column',
+        marginTop: 8,
+        width: '100%',
+        lineHeight: 1
+    }
+});
+
+export default SeedWordInput;

--- a/components/seedStyles.ts
+++ b/components/seedStyles.ts
@@ -1,0 +1,50 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+    text: {
+        fontFamily: 'PPNeueMontreal-Book'
+    },
+    whiteText: {
+        color: 'white',
+        fontFamily: 'PPNeueMontreal-Book'
+    },
+    blackText: {
+        color: 'black',
+        fontFamily: 'PPNeueMontreal-Book'
+    },
+    button: {
+        paddingTop: 10,
+        paddingBottom: 10,
+        width: 350,
+        alignSelf: 'center'
+    },
+    modal: {
+        margin: 20,
+        backgroundColor: 'white',
+        borderRadius: 35,
+        padding: 35,
+        alignItems: 'center',
+        shadowColor: '#000',
+        shadowOffset: {
+            width: 0,
+            height: 2
+        },
+        shadowOpacity: 0.25,
+        shadowRadius: 3.84,
+        elevation: 5
+    },
+    centeredView: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        marginTop: 22
+    },
+    column: {
+        marginTop: 8,
+        flexWrap: 'wrap',
+        alignItems: 'flex-start',
+        alignSelf: 'center',
+        flexDirection: 'column',
+        width: '50%'
+    }
+});

--- a/components/seedStyles.ts
+++ b/components/seedStyles.ts
@@ -1,5 +1,16 @@
 import { StyleSheet } from 'react-native';
 
+import { themeColor } from '../utils/ThemeUtils';
+
+export const buttonContainerStyle = () =>
+    ({
+        alignSelf: 'center',
+        marginTop: 45,
+        bottom: 35,
+        backgroundColor: themeColor('background'),
+        width: '100%'
+    } as const);
+
 export default StyleSheet.create({
     text: {
         fontFamily: 'PPNeueMontreal-Book'

--- a/components/seedStyles.ts
+++ b/components/seedStyles.ts
@@ -12,13 +12,6 @@ export const buttonContainerStyle = () =>
     } as const);
 
 export default StyleSheet.create({
-    text: {
-        fontFamily: 'PPNeueMontreal-Book'
-    },
-    whiteText: {
-        color: 'white',
-        fontFamily: 'PPNeueMontreal-Book'
-    },
     blackText: {
         color: 'black',
         fontFamily: 'PPNeueMontreal-Book'

--- a/views/Cashu/CashuSeed.tsx
+++ b/views/Cashu/CashuSeed.tsx
@@ -1,22 +1,16 @@
-import React, { useState } from 'react';
-import {
-    Modal,
-    ScrollView,
-    StyleSheet,
-    Text,
-    TouchableOpacity,
-    View
-} from 'react-native';
+import React from 'react';
+import { TouchableOpacity, View } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { StackNavigationProp } from '@react-navigation/stack';
 
 import { Row } from '../../components/layout/Row';
-import { ErrorMessage } from '../../components/SuccessErrorMessage';
 
 import Button from '../../components/Button';
-import CopyButton from '../../components/CopyButton';
 import Screen from '../../components/Screen';
 import Header from '../../components/Header';
+import DangerousCopySeedModal from '../../components/Modals/DangerousCopySeedModal';
+import SeedWarningDisclaimer from '../../components/SeedWarningDisclaimer';
+import SeedWordGrid from '../../components/SeedWordGrid';
 
 import CashuStore from '../../stores/CashuStore';
 
@@ -35,54 +29,6 @@ interface CashuSeedState {
     showModal: boolean;
     seedPhrase: string[];
 }
-
-const MnemonicWord = ({ index, word }: { index: any; word: any }) => {
-    const [isRevealed, setRevealed] = useState(false);
-    return (
-        <TouchableOpacity
-            key={index}
-            onPress={() => setRevealed(!isRevealed)}
-            style={{
-                padding: 8,
-                backgroundColor: themeColor('secondary'),
-                borderRadius: 5,
-                margin: 6,
-                marginTop: 4,
-                marginBottom: 4,
-                flexDirection: 'row',
-                alignSelf: 'center'
-            }}
-        >
-            <View style={{ width: 35 }}>
-                <Text
-                    style={{
-                        flex: 1,
-                        fontFamily: 'PPNeueMontreal-Book',
-                        color: themeColor('secondaryText'),
-                        fontSize: 18,
-                        alignSelf: 'flex-start'
-                    }}
-                >
-                    {index + 1}
-                </Text>
-            </View>
-            <Text
-                style={{
-                    flex: 1,
-                    fontFamily: 'PPNeueMontreal-Medium',
-                    color: themeColor('text'),
-                    fontSize: 18,
-                    alignSelf: 'flex-end',
-                    margin: 0,
-                    marginLeft: 10,
-                    padding: 0
-                }}
-            >
-                {isRevealed ? word : '********'}
-            </Text>
-        </TouchableOpacity>
-    );
-};
 
 @inject('CashuStore')
 @observer
@@ -137,185 +83,21 @@ export default class CashuSeed extends React.PureComponent<
                     }
                     navigation={navigation}
                 />
-                <Modal
-                    animationType="slide"
-                    transparent={true}
+                <DangerousCopySeedModal
                     visible={showModal}
-                >
-                    <View style={styles.centeredView}>
-                        <View style={styles.modal}>
-                            {showModal && (
-                                <View>
-                                    <Text
-                                        style={{
-                                            ...styles.blackText,
-                                            fontSize: 40,
-                                            alignSelf: 'center',
-                                            marginBottom: 20
-                                        }}
-                                    >
-                                        {localeString('general.danger')}
-                                    </Text>
-                                    <Text
-                                        style={{
-                                            color: 'black',
-                                            margin: 10
-                                        }}
-                                    >
-                                        {localeString(
-                                            'views.Settings.Seed.dangerousText1'
-                                        )}
-                                    </Text>
-                                    <Text
-                                        style={{
-                                            ...styles.blackText,
-                                            color: 'black',
-                                            margin: 10
-                                        }}
-                                    >
-                                        {localeString(
-                                            'views.Settings.Seed.dangerousText2'
-                                        )}
-                                    </Text>
-                                    <View style={styles.button}>
-                                        <CopyButton
-                                            title={localeString(
-                                                'views.Settings.Seed.dangerousButton'
-                                            )}
-                                            copyValue={seedPhrase.join(' ')}
-                                            icon={{
-                                                name: 'warning',
-                                                size: 25
-                                            }}
-                                        />
-                                    </View>
-                                    <View style={styles.button}>
-                                        <Button
-                                            title={localeString(
-                                                'general.cancel'
-                                            )}
-                                            onPress={() =>
-                                                this.setState({
-                                                    showModal: false
-                                                })
-                                            }
-                                        />
-                                    </View>
-                                </View>
-                            )}
-                        </View>
-                    </View>
-                </Modal>
+                    seedPhrase={seedPhrase}
+                    onClose={() => this.setState({ showModal: false })}
+                />
                 {!understood && (
-                    <>
-                        <View style={{ marginLeft: 10, marginRight: 10 }}>
-                            <ErrorMessage
-                                message={localeString(
-                                    'general.warning'
-                                ).toUpperCase()}
-                            />
-                        </View>
-                        <Text
-                            style={{
-                                color: themeColor('text'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                textAlign: 'center',
-                                margin: 10,
-                                fontSize: 20
-                            }}
-                        >
-                            {localeString('views.Cashu.CashuSeed.text1')}
-                        </Text>
-                        <Text
-                            style={{
-                                color: themeColor('text'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                textAlign: 'center',
-                                margin: 10,
-                                fontSize: 20
-                            }}
-                        >
-                            {localeString('views.Settings.Seed.text2')}
-                        </Text>
-                        <Text
-                            style={{
-                                color: themeColor('text'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                textAlign: 'center',
-                                margin: 10,
-                                fontSize: 20
-                            }}
-                        >
-                            {localeString('views.Settings.Seed.text3').replace(
-                                'Zeus',
-                                'ZEUS'
-                            )}
-                        </Text>
-                        <Text
-                            style={{
-                                color: themeColor('text'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                textAlign: 'center',
-                                margin: 10,
-                                fontSize: 20
-                            }}
-                        >
-                            {localeString('views.Settings.Seed.text4')}
-                        </Text>
-                        <View
-                            style={{
-                                alignSelf: 'center',
-                                position: 'absolute',
-                                bottom: 35,
-                                width: '100%'
-                            }}
-                        >
-                            <Button
-                                onPress={() =>
-                                    this.setState({ understood: true })
-                                }
-                                title={localeString('general.iUnderstand')}
-                            />
-                        </View>
-                    </>
+                    <SeedWarningDisclaimer
+                        text1Key="views.Cashu.CashuSeed.text1"
+                        text2Key="views.Settings.Seed.text2"
+                        onUnderstood={() => this.setState({ understood: true })}
+                    />
                 )}
-                {understood && (
+                {understood && seedPhrase.length > 0 && (
                     <View style={{ flex: 1, justifyContent: 'center' }}>
-                        <ScrollView
-                            contentContainerStyle={{
-                                flexGrow: 1,
-                                flexDirection: 'row'
-                            }}
-                        >
-                            <View style={styles.column}>
-                                {seedPhrase &&
-                                    seedPhrase
-                                        .slice(0, 6)
-                                        .map((word: string, index: number) => {
-                                            return (
-                                                <MnemonicWord
-                                                    index={index}
-                                                    word={word}
-                                                    key={`mnemonic-${index}`}
-                                                />
-                                            );
-                                        })}
-                            </View>
-                            <View style={styles.column}>
-                                {seedPhrase &&
-                                    seedPhrase
-                                        .slice(6, 12)
-                                        .map((word: string, index: number) => {
-                                            return (
-                                                <MnemonicWord
-                                                    index={index + 6}
-                                                    word={word}
-                                                    key={`mnemonic-${index}`}
-                                                />
-                                            );
-                                        })}
-                            </View>
-                        </ScrollView>
+                        <SeedWordGrid seedPhrase={seedPhrase} />
                         <View
                             style={{
                                 alignSelf: 'center',
@@ -340,52 +122,3 @@ export default class CashuSeed extends React.PureComponent<
         );
     }
 }
-
-const styles = StyleSheet.create({
-    text: {
-        fontFamily: 'PPNeueMontreal-Book'
-    },
-    whiteText: {
-        color: 'white',
-        fontFamily: 'PPNeueMontreal-Book'
-    },
-    blackText: {
-        color: 'black',
-        fontFamily: 'PPNeueMontreal-Book'
-    },
-    button: {
-        paddingTop: 10,
-        paddingBottom: 10,
-        width: 350,
-        alignSelf: 'center'
-    },
-    modal: {
-        margin: 20,
-        backgroundColor: 'white',
-        borderRadius: 35,
-        padding: 35,
-        alignItems: 'center',
-        shadowColor: '#000',
-        shadowOffset: {
-            width: 0,
-            height: 2
-        },
-        shadowOpacity: 0.25,
-        shadowRadius: 3.84,
-        elevation: 5
-    },
-    centeredView: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-        marginTop: 22
-    },
-    column: {
-        marginTop: 8,
-        flexWrap: 'wrap',
-        alignItems: 'flex-start',
-        alignSelf: 'center',
-        flexDirection: 'column',
-        width: '50%'
-    }
-});

--- a/views/Cashu/CashuSeed.tsx
+++ b/views/Cashu/CashuSeed.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { View } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { StackNavigationProp } from '@react-navigation/stack';
 
@@ -8,16 +8,16 @@ import { Row } from '../../components/layout/Row';
 import Button from '../../components/Button';
 import Screen from '../../components/Screen';
 import Header from '../../components/Header';
+import DangerousCopySeedButton from '../../components/DangerousCopySeedButton';
 import DangerousCopySeedModal from '../../components/Modals/DangerousCopySeedModal';
 import SeedWarningDisclaimer from '../../components/SeedWarningDisclaimer';
 import SeedWordGrid from '../../components/SeedWordGrid';
+import { buttonContainerStyle } from '../../components/seedStyles';
 
 import CashuStore from '../../stores/CashuStore';
 
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
-
-import Skull from '../../assets/images/SVG/Skull.svg';
 
 interface CashuSeedProps {
     navigation: StackNavigationProp<any, any>;
@@ -55,14 +55,6 @@ export default class CashuSeed extends React.PureComponent<
         const { navigation } = this.props;
         const { understood, showModal, seedPhrase } = this.state;
 
-        const DangerouslyCopySeed = () => (
-            <TouchableOpacity
-                onPress={() => this.setState({ showModal: true })}
-            >
-                <Skull fill={themeColor('text')} />
-            </TouchableOpacity>
-        );
-
         return (
             <Screen>
                 <Header
@@ -75,9 +67,13 @@ export default class CashuSeed extends React.PureComponent<
                         }
                     }}
                     rightComponent={
-                        understood && seedPhrase ? (
+                        understood && seedPhrase.length > 0 ? (
                             <Row>
-                                <DangerouslyCopySeed />
+                                <DangerousCopySeedButton
+                                    onPress={() =>
+                                        this.setState({ showModal: true })
+                                    }
+                                />
                             </Row>
                         ) : undefined
                     }
@@ -98,15 +94,7 @@ export default class CashuSeed extends React.PureComponent<
                 {understood && seedPhrase.length > 0 && (
                     <View style={{ flex: 1, justifyContent: 'center' }}>
                         <SeedWordGrid seedPhrase={seedPhrase} />
-                        <View
-                            style={{
-                                alignSelf: 'center',
-                                marginTop: 45,
-                                bottom: 35,
-                                backgroundColor: themeColor('background'),
-                                width: '100%'
-                            }}
-                        >
+                        <View style={buttonContainerStyle()}>
                             <Button
                                 onPress={async () => {
                                     navigation.popTo('Wallet');

--- a/views/Settings/Seed.tsx
+++ b/views/Settings/Seed.tsx
@@ -1,29 +1,19 @@
 import React from 'react';
-import { Alert, Platform, Text, TouchableOpacity, View } from 'react-native';
-import RNFS from 'react-native-fs';
-import { Icon } from '@rneui/themed';
+import { TouchableOpacity, View } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { Route } from '@react-navigation/native';
 
 import { Row } from '../../components/layout/Row';
 
 import Button from '../../components/Button';
 import Screen from '../../components/Screen';
 import Header from '../../components/Header';
-import ModalBox from '../../components/ModalBox';
 import DangerousCopySeedModal from '../../components/Modals/DangerousCopySeedModal';
 import SeedWarningDisclaimer from '../../components/SeedWarningDisclaimer';
 import SeedWordGrid from '../../components/SeedWordGrid';
 
 import SettingsStore from '../../stores/SettingsStore';
 
-import {
-    SWAPS_KEY,
-    REVERSE_SWAPS_KEY,
-    SWAPS_LAST_USED_KEY,
-    SWAPS_RESCUE_KEY
-} from '../../utils/SwapUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { IS_BACKED_UP_KEY } from '../../utils/MigrationUtils';
@@ -36,18 +26,11 @@ import QR from '../../assets/images/SVG/QR.svg';
 interface SeedProps {
     navigation: StackNavigationProp<any, any>;
     SettingsStore: SettingsStore;
-    route: Route<
-        'Seed',
-        {
-            seedPhrase?: string[];
-        }
-    >;
 }
 
 interface SeedState {
     understood: boolean;
     showModal: boolean;
-    isDeleteModalVisible: boolean;
 }
 
 @inject('SettingsStore')
@@ -55,8 +38,7 @@ interface SeedState {
 export default class Seed extends React.PureComponent<SeedProps, SeedState> {
     state = {
         understood: false,
-        showModal: false,
-        isDeleteModalVisible: false
+        showModal: false
     };
 
     componentDidMount() {
@@ -64,79 +46,10 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
         this.props.SettingsStore.getSettings();
     }
 
-    renderDeleteModal = () => {
-        const { navigation } = this.props;
-        return (
-            <ModalBox
-                isOpen={this.state.isDeleteModalVisible}
-                onClosed={() => this.setState({ isDeleteModalVisible: false })}
-                style={{
-                    backgroundColor: 'transparent'
-                }}
-                position="center"
-                backdropOpacity={0.6}
-            >
-                <View
-                    style={{
-                        flex: 1,
-                        justifyContent: 'center',
-                        alignItems: 'center'
-                    }}
-                >
-                    <View
-                        style={{
-                            backgroundColor: themeColor('background'),
-                            borderRadius: 20,
-                            padding: 20,
-                            alignItems: 'center',
-                            width: '90%'
-                        }}
-                    >
-                        <Text
-                            style={{
-                                color: themeColor('text'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                fontSize: 18,
-                                textAlign: 'center',
-                                marginBottom: 20
-                            }}
-                        >
-                            {localeString(
-                                'views.Swaps.rescueKey.deleteConfirmation'
-                            )}
-                        </Text>
-
-                        <Button
-                            title={localeString('general.confirm')}
-                            onPress={async () => {
-                                await Storage.removeItem(SWAPS_RESCUE_KEY);
-                                await Storage.removeItem(SWAPS_KEY);
-                                await Storage.removeItem(REVERSE_SWAPS_KEY);
-                                await Storage.removeItem(SWAPS_LAST_USED_KEY);
-                                this.setState({ isDeleteModalVisible: false });
-                                navigation.popTo('Swaps');
-                            }}
-                            containerStyle={{ marginBottom: 10 }}
-                            warning
-                        />
-                        <Button
-                            title={localeString('general.cancel')}
-                            onPress={() =>
-                                this.setState({ isDeleteModalVisible: false })
-                            }
-                            secondary
-                        />
-                    </View>
-                </View>
-            </ModalBox>
-        );
-    };
-
     render() {
-        const { navigation, SettingsStore, route } = this.props;
+        const { navigation, SettingsStore } = this.props;
         const { understood, showModal } = this.state;
-        const seedPhrase = route.params?.seedPhrase ?? SettingsStore.seedPhrase;
-        const isRefundRescueKey = !!route.params?.seedPhrase;
+        const seedPhrase = SettingsStore.seedPhrase;
 
         const DangerouslyCopySeed = () => (
             <TouchableOpacity
@@ -150,66 +63,18 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
         const QRExport = () => (
             <TouchableOpacity
                 onPress={() => navigation.navigate('SeedQRExport')}
-                style={{ marginLeft: isRefundRescueKey ? 20 : 14 }}
+                style={{ marginLeft: 14 }}
             >
                 <QR fill={themeColor('text')} />
             </TouchableOpacity>
         );
 
-        const DownloadRescueKey = ({
-            seedPhrase
-        }: {
-            seedPhrase: string[];
-        }) => {
-            const handleDownload = async () => {
-                try {
-                    const mnemonic = seedPhrase.join(' ');
-                    const jsonData = JSON.stringify({ mnemonic }, null, 2);
-
-                    const path =
-                        Platform.OS === 'android'
-                            ? `${RNFS.DownloadDirectoryPath}/rescue_key.json`
-                            : `${RNFS.DocumentDirectoryPath}/rescue_key.json`;
-
-                    await RNFS.writeFile(path, jsonData, 'utf8');
-
-                    Alert.alert(
-                        localeString('general.success'),
-                        `${localeString('views.Swaps.rescueKey.download')}\n\n${
-                            Platform.OS === 'android'
-                                ? localeString('views.Swaps.rescueKey.android')
-                                : localeString('views.Swaps.rescueKey.ios')
-                        }`
-                    );
-
-                    console.log('File written to:', path);
-                } catch (error) {
-                    console.error('Download failed:', error);
-                }
-            };
-
-            return (
-                <TouchableOpacity onPress={handleDownload}>
-                    <Icon
-                        name="download"
-                        type="feather"
-                        color={themeColor('text')}
-                        underlayColor="transparent"
-                        size={26}
-                    />
-                </TouchableOpacity>
-            );
-        };
-
         return (
             <Screen>
-                {this.renderDeleteModal()}
                 <Header
                     leftComponent="Back"
                     centerComponent={{
-                        text: isRefundRescueKey
-                            ? localeString('views.Swaps.rescueKey')
-                            : localeString('views.Settings.Seed.title'),
+                        text: localeString('views.Settings.Seed.title'),
                         style: {
                             color: themeColor('text'),
                             fontFamily: 'PPNeueMontreal-Book'
@@ -218,15 +83,8 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                     rightComponent={
                         understood && seedPhrase ? (
                             <Row>
-                                {isRefundRescueKey ? (
-                                    <DownloadRescueKey
-                                        seedPhrase={seedPhrase}
-                                    />
-                                ) : (
-                                    <></>
-                                )}
                                 <DangerouslyCopySeed />
-                                {isRefundRescueKey ? <></> : <QRExport />}
+                                <QRExport />
                             </Row>
                         ) : undefined
                     }
@@ -236,24 +94,11 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                     visible={showModal}
                     seedPhrase={seedPhrase || []}
                     onClose={() => this.setState({ showModal: false })}
-                    dangerousText1Key={
-                        isRefundRescueKey
-                            ? 'views.Swaps.rescueKey.dangerousText'
-                            : 'views.Settings.Seed.dangerousText1'
-                    }
                 />
                 {!understood && (
                     <SeedWarningDisclaimer
-                        text1Key={
-                            isRefundRescueKey
-                                ? 'views.Swaps.rescueKey.text1'
-                                : 'views.Settings.Seed.text1'
-                        }
-                        text2Key={
-                            isRefundRescueKey
-                                ? 'views.Swaps.rescueKey.text2'
-                                : 'views.Settings.Seed.text2'
-                        }
+                        text1Key="views.Settings.Seed.text1"
+                        text2Key="views.Settings.Seed.text2"
                         onUnderstood={() => this.setState({ understood: true })}
                     />
                 )}
@@ -271,39 +116,16 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                         >
                             <Button
                                 onPress={async () => {
-                                    if (isRefundRescueKey) navigation.goBack();
-                                    else {
-                                        await Storage.setItem(
-                                            IS_BACKED_UP_KEY,
-                                            true
-                                        );
-                                        navigation.popTo('Wallet');
-                                    }
+                                    await Storage.setItem(
+                                        IS_BACKED_UP_KEY,
+                                        true
+                                    );
+                                    navigation.popTo('Wallet');
                                 }}
-                                title={
-                                    isRefundRescueKey
-                                        ? localeString(
-                                              'views.Swaps.rescueKey.backupComplete'
-                                          )
-                                        : localeString(
-                                              'views.Settings.Seed.backupComplete'
-                                          )
-                                }
-                                containerStyle={{ marginBottom: 10 }}
+                                title={localeString(
+                                    'views.Settings.Seed.backupComplete'
+                                )}
                             />
-                            {isRefundRescueKey && (
-                                <Button
-                                    onPress={() =>
-                                        this.setState({
-                                            isDeleteModalVisible: true
-                                        })
-                                    }
-                                    title={localeString(
-                                        'views.Swaps.rescueKey.delete'
-                                    )}
-                                    warning
-                                />
-                            )}
                         </View>
                     </View>
                 )}

--- a/views/Settings/Seed.tsx
+++ b/views/Settings/Seed.tsx
@@ -1,14 +1,5 @@
-import React, { useState } from 'react';
-import {
-    Alert,
-    Modal,
-    Platform,
-    ScrollView,
-    StyleSheet,
-    Text,
-    TouchableOpacity,
-    View
-} from 'react-native';
+import React from 'react';
+import { Alert, Platform, Text, TouchableOpacity, View } from 'react-native';
 import RNFS from 'react-native-fs';
 import { Icon } from '@rneui/themed';
 import { inject, observer } from 'mobx-react';
@@ -16,13 +7,14 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { Route } from '@react-navigation/native';
 
 import { Row } from '../../components/layout/Row';
-import { ErrorMessage } from '../../components/SuccessErrorMessage';
 
 import Button from '../../components/Button';
-import CopyButton from '../../components/CopyButton';
 import Screen from '../../components/Screen';
 import Header from '../../components/Header';
 import ModalBox from '../../components/ModalBox';
+import DangerousCopySeedModal from '../../components/Modals/DangerousCopySeedModal';
+import SeedWarningDisclaimer from '../../components/SeedWarningDisclaimer';
+import SeedWordGrid from '../../components/SeedWordGrid';
 
 import SettingsStore from '../../stores/SettingsStore';
 
@@ -57,54 +49,6 @@ interface SeedState {
     showModal: boolean;
     isDeleteModalVisible: boolean;
 }
-
-const MnemonicWord = ({ index, word }: { index: any; word: any }) => {
-    const [isRevealed, setRevealed] = useState(false);
-    return (
-        <TouchableOpacity
-            key={index}
-            onPress={() => setRevealed(!isRevealed)}
-            style={{
-                padding: 8,
-                backgroundColor: themeColor('secondary'),
-                borderRadius: 5,
-                margin: 6,
-                marginTop: 4,
-                marginBottom: 4,
-                flexDirection: 'row',
-                alignSelf: 'center'
-            }}
-        >
-            <View style={{ width: 35 }}>
-                <Text
-                    style={{
-                        flex: 1,
-                        fontFamily: 'PPNeueMontreal-Book',
-                        color: themeColor('secondaryText'),
-                        fontSize: 18,
-                        alignSelf: 'flex-start'
-                    }}
-                >
-                    {index + 1}
-                </Text>
-            </View>
-            <Text
-                style={{
-                    flex: 1,
-                    fontFamily: 'PPNeueMontreal-Medium',
-                    color: themeColor('text'),
-                    fontSize: 18,
-                    alignSelf: 'flex-end',
-                    margin: 0,
-                    marginLeft: 10,
-                    padding: 0
-                }}
-            >
-                {isRevealed ? word : '********'}
-            </Text>
-        </TouchableOpacity>
-    );
-};
 
 @inject('SettingsStore')
 @observer
@@ -288,206 +232,34 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                     }
                     navigation={navigation}
                 />
-                <Modal
-                    animationType="slide"
-                    transparent={true}
+                <DangerousCopySeedModal
                     visible={showModal}
-                >
-                    <View style={styles.centeredView}>
-                        <View style={styles.modal}>
-                            {showModal && (
-                                <View>
-                                    <Text
-                                        style={{
-                                            ...styles.blackText,
-                                            fontSize: 40,
-                                            alignSelf: 'center',
-                                            marginBottom: 20
-                                        }}
-                                    >
-                                        {localeString('general.danger')}
-                                    </Text>
-                                    <Text
-                                        style={{
-                                            color: 'black',
-                                            margin: 10
-                                        }}
-                                    >
-                                        {isRefundRescueKey
-                                            ? localeString(
-                                                  'views.Swaps.rescueKey.dangerousText'
-                                              )
-                                            : localeString(
-                                                  'views.Settings.Seed.dangerousText1'
-                                              )}
-                                    </Text>
-                                    <Text
-                                        style={{
-                                            ...styles.blackText,
-                                            color: 'black',
-                                            margin: 10
-                                        }}
-                                    >
-                                        {localeString(
-                                            'views.Settings.Seed.dangerousText2'
-                                        )}
-                                    </Text>
-                                    <View style={styles.button}>
-                                        <CopyButton
-                                            title={localeString(
-                                                'views.Settings.Seed.dangerousButton'
-                                            )}
-                                            copyValue={seedPhrase.join(' ')}
-                                            icon={{
-                                                name: 'warning',
-                                                size: 25
-                                            }}
-                                        />
-                                    </View>
-                                    <View style={styles.button}>
-                                        <Button
-                                            title={localeString(
-                                                'general.cancel'
-                                            )}
-                                            onPress={() =>
-                                                this.setState({
-                                                    showModal: false
-                                                })
-                                            }
-                                        />
-                                    </View>
-                                </View>
-                            )}
-                        </View>
-                    </View>
-                </Modal>
+                    seedPhrase={seedPhrase || []}
+                    onClose={() => this.setState({ showModal: false })}
+                    dangerousText1Key={
+                        isRefundRescueKey
+                            ? 'views.Swaps.rescueKey.dangerousText'
+                            : 'views.Settings.Seed.dangerousText1'
+                    }
+                />
                 {!understood && (
-                    <>
-                        <View style={{ marginLeft: 10, marginRight: 10 }}>
-                            <ErrorMessage
-                                message={localeString(
-                                    'general.warning'
-                                ).toUpperCase()}
-                            />
-                        </View>
-                        <Text
-                            style={{
-                                color: themeColor('text'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                textAlign: 'center',
-                                margin: 10,
-                                fontSize: 20
-                            }}
-                        >
-                            {localeString(
-                                isRefundRescueKey
-                                    ? 'views.Swaps.rescueKey.text1'
-                                    : 'views.Settings.Seed.text1'
-                            )}
-                        </Text>
-                        <Text
-                            style={{
-                                color: themeColor('text'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                textAlign: 'center',
-                                margin: 10,
-                                fontSize: 20
-                            }}
-                        >
-                            {localeString(
-                                isRefundRescueKey
-                                    ? 'views.Swaps.rescueKey.text2'
-                                    : 'views.Settings.Seed.text2'
-                            )}
-                        </Text>
-                        <Text
-                            style={{
-                                color: themeColor('text'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                textAlign: 'center',
-                                margin: 10,
-                                fontSize: 20
-                            }}
-                        >
-                            {localeString('views.Settings.Seed.text3').replace(
-                                'Zeus',
-                                'ZEUS'
-                            )}
-                        </Text>
-                        <Text
-                            style={{
-                                color: themeColor('text'),
-                                fontFamily: 'PPNeueMontreal-Book',
-                                textAlign: 'center',
-                                margin: 10,
-                                fontSize: 20
-                            }}
-                        >
-                            {localeString('views.Settings.Seed.text4')}
-                        </Text>
-                        <View
-                            style={{
-                                alignSelf: 'center',
-                                position: 'absolute',
-                                bottom: 35,
-                                width: '100%'
-                            }}
-                        >
-                            <Button
-                                onPress={() =>
-                                    this.setState({ understood: true })
-                                }
-                                title={localeString('general.iUnderstand')}
-                            />
-                        </View>
-                    </>
+                    <SeedWarningDisclaimer
+                        text1Key={
+                            isRefundRescueKey
+                                ? 'views.Swaps.rescueKey.text1'
+                                : 'views.Settings.Seed.text1'
+                        }
+                        text2Key={
+                            isRefundRescueKey
+                                ? 'views.Swaps.rescueKey.text2'
+                                : 'views.Settings.Seed.text2'
+                        }
+                        onUnderstood={() => this.setState({ understood: true })}
+                    />
                 )}
-                {understood && (
+                {understood && seedPhrase && (
                     <View style={{ flex: 1, justifyContent: 'center' }}>
-                        <ScrollView
-                            contentContainerStyle={{
-                                flexGrow: 1,
-                                flexDirection: 'row'
-                            }}
-                        >
-                            <View style={styles.column}>
-                                {seedPhrase &&
-                                    seedPhrase
-                                        .slice(
-                                            0,
-                                            Math.ceil(seedPhrase.length / 2)
-                                        )
-                                        .map((word: string, index: number) => (
-                                            <MnemonicWord
-                                                index={index}
-                                                word={word}
-                                                key={`mnemonic-${index}`}
-                                            />
-                                        ))}
-                            </View>
-                            <View style={styles.column}>
-                                {seedPhrase &&
-                                    seedPhrase
-                                        .slice(Math.ceil(seedPhrase.length / 2))
-                                        .map((word: string, index: number) => (
-                                            <MnemonicWord
-                                                index={
-                                                    index +
-                                                    Math.ceil(
-                                                        seedPhrase.length / 2
-                                                    )
-                                                }
-                                                word={word}
-                                                key={`mnemonic-${
-                                                    index +
-                                                    Math.ceil(
-                                                        seedPhrase.length / 2
-                                                    )
-                                                }`}
-                                            />
-                                        ))}
-                            </View>
-                        </ScrollView>
+                        <SeedWordGrid seedPhrase={seedPhrase} />
                         <View
                             style={{
                                 alignSelf: 'center',
@@ -539,52 +311,3 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
         );
     }
 }
-
-const styles = StyleSheet.create({
-    text: {
-        fontFamily: 'PPNeueMontreal-Book'
-    },
-    whiteText: {
-        color: 'white',
-        fontFamily: 'PPNeueMontreal-Book'
-    },
-    blackText: {
-        color: 'black',
-        fontFamily: 'PPNeueMontreal-Book'
-    },
-    button: {
-        paddingTop: 10,
-        paddingBottom: 10,
-        width: 350,
-        alignSelf: 'center'
-    },
-    modal: {
-        margin: 20,
-        backgroundColor: 'white',
-        borderRadius: 35,
-        padding: 35,
-        alignItems: 'center',
-        shadowColor: '#000',
-        shadowOffset: {
-            width: 0,
-            height: 2
-        },
-        shadowOpacity: 0.25,
-        shadowRadius: 3.84,
-        elevation: 5
-    },
-    centeredView: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-        marginTop: 22
-    },
-    column: {
-        marginTop: 8,
-        flexWrap: 'wrap',
-        alignItems: 'flex-start',
-        alignSelf: 'center',
-        flexDirection: 'column',
-        width: '50%'
-    }
-});

--- a/views/Settings/Seed.tsx
+++ b/views/Settings/Seed.tsx
@@ -8,9 +8,11 @@ import { Row } from '../../components/layout/Row';
 import Button from '../../components/Button';
 import Screen from '../../components/Screen';
 import Header from '../../components/Header';
+import DangerousCopySeedButton from '../../components/DangerousCopySeedButton';
 import DangerousCopySeedModal from '../../components/Modals/DangerousCopySeedModal';
 import SeedWarningDisclaimer from '../../components/SeedWarningDisclaimer';
 import SeedWordGrid from '../../components/SeedWordGrid';
+import { buttonContainerStyle } from '../../components/seedStyles';
 
 import SettingsStore from '../../stores/SettingsStore';
 
@@ -20,7 +22,6 @@ import { IS_BACKED_UP_KEY } from '../../utils/MigrationUtils';
 
 import Storage from '../../storage';
 
-import Skull from '../../assets/images/SVG/Skull.svg';
 import QR from '../../assets/images/SVG/QR.svg';
 
 interface SeedProps {
@@ -51,15 +52,6 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
         const { understood, showModal } = this.state;
         const seedPhrase = SettingsStore.seedPhrase;
 
-        const DangerouslyCopySeed = () => (
-            <TouchableOpacity
-                onPress={() => this.setState({ showModal: true })}
-                style={{ marginLeft: 10 }}
-            >
-                <Skull fill={themeColor('text')} />
-            </TouchableOpacity>
-        );
-
         const QRExport = () => (
             <TouchableOpacity
                 onPress={() => navigation.navigate('SeedQRExport')}
@@ -81,9 +73,14 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                         }
                     }}
                     rightComponent={
-                        understood && seedPhrase ? (
+                        understood && seedPhrase?.length > 0 ? (
                             <Row>
-                                <DangerouslyCopySeed />
+                                <DangerousCopySeedButton
+                                    onPress={() =>
+                                        this.setState({ showModal: true })
+                                    }
+                                    style={{ marginLeft: 10 }}
+                                />
                                 <QRExport />
                             </Row>
                         ) : undefined
@@ -102,18 +99,10 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                         onUnderstood={() => this.setState({ understood: true })}
                     />
                 )}
-                {understood && seedPhrase && (
+                {understood && seedPhrase?.length > 0 && (
                     <View style={{ flex: 1, justifyContent: 'center' }}>
                         <SeedWordGrid seedPhrase={seedPhrase} />
-                        <View
-                            style={{
-                                alignSelf: 'center',
-                                marginTop: 45,
-                                bottom: 35,
-                                backgroundColor: themeColor('background'),
-                                width: '100%'
-                            }}
-                        >
+                        <View style={buttonContainerStyle()}>
                             <Button
                                 onPress={async () => {
                                     await Storage.setItem(

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -44,7 +44,6 @@ interface SeedRecoveryState {
     adminMacaroon: string;
     embeddedLndNetwork: string;
     lndDir: string;
-    recoveryCipherSeed: string;
     channelBackupsBase64: string;
     errorMsg: string;
     showSuggestions: boolean;
@@ -68,7 +67,6 @@ export default class SeedRecovery extends React.PureComponent<
             adminMacaroon: '',
             embeddedLndNetwork: 'mainnet',
             lndDir: '',
-            recoveryCipherSeed: '',
             channelBackupsBase64: '',
             errorMsg: '',
             showSuggestions: false

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -1,24 +1,7 @@
 import * as React from 'react';
-import {
-    Platform,
-    ScrollView,
-    StyleSheet,
-    Text,
-    TouchableOpacity,
-    View,
-    TextInput as TextInputRN,
-    Keyboard,
-    Alert
-} from 'react-native';
+import { Platform, View } from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { inject, observer } from 'mobx-react';
-import RNFS from 'react-native-fs';
-import {
-    pick,
-    types,
-    isErrorWithCode,
-    errorCodes
-} from '@react-native-documents/picker';
 import { Route } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { v4 as uuidv4 } from 'uuid';
@@ -28,9 +11,8 @@ import { ErrorMessage } from '../../components/SuccessErrorMessage';
 import Button from '../../components/Button';
 import Header from '../../components/Header';
 import Screen from '../../components/Screen';
-import TextInput from '../../components/TextInput';
 import LoadingIndicator from '../../components/LoadingIndicator';
-import DropdownSetting from '../../components/DropdownSetting';
+import SeedWordInput from '../../components/SeedWordInput';
 
 import { restartNeeded } from '../../utils/RestartUtils';
 import { themeColor } from '../../utils/ThemeUtils';
@@ -42,40 +24,20 @@ import {
     stopLnd
 } from '../../utils/LndMobileUtils';
 
-import { BIP39_WORD_LIST } from '../../utils/Bip39Utils';
-
-import SettingsStore, {
-    DEFAULT_SWAP_HOST_MAINNET,
-    DEFAULT_SWAP_HOST_TESTNET,
-    SWAP_HOST_KEYS_MAINNET,
-    SWAP_HOST_KEYS_TESTNET
-} from '../../stores/SettingsStore';
+import SettingsStore from '../../stores/SettingsStore';
 import NodeInfoStore from '../../stores/NodeInfoStore';
-import SwapStore from '../../stores/SwapStore';
-import { SWAPS_RESCUE_KEY } from '../../utils/SwapUtils';
-
-import Storage from '../../storage';
 
 interface SeedRecoveryProps {
     navigation: StackNavigationProp<any, any>;
     SettingsStore: SettingsStore;
     NodeInfoStore: NodeInfoStore;
-    SwapStore: SwapStore;
-    route: Route<
-        'SeedRecovery',
-        { network: string; restoreSwaps?: boolean; restoreRescueKey?: boolean }
-    >;
+    route: Route<'SeedRecovery', { network: string }>;
 }
 
 interface SeedRecoveryState {
     loading: boolean;
     network: string;
-    selectedInputType: 'word' | 'scb' | null;
-    selectedWordIndex: number | null;
-    selectedText: string;
     seedArray: string[];
-    filteredData: string[];
-    showSuggestions: boolean;
     seedPhrase: string[];
     walletPassword: string;
     adminMacaroon: string;
@@ -85,37 +47,23 @@ interface SeedRecoveryState {
     channelBackupsBase64: string;
     errorCreatingWallet: boolean;
     errorMsg: string;
-    restoreSwaps?: boolean;
-    restoreRescueKey?: boolean;
-    rescueHost: string;
-    customRescueHost: string;
-    invalidInput: boolean;
+    showSuggestions: boolean;
 }
 
-@inject('NodeInfoStore', 'SettingsStore', 'SwapStore')
+@inject('NodeInfoStore', 'SettingsStore')
 @observer
 export default class SeedRecovery extends React.PureComponent<
     SeedRecoveryProps,
     SeedRecoveryState
 > {
-    textInput: React.RefObject<TextInputRN | null>;
     constructor(props: SeedRecoveryProps) {
         super(props);
 
-        const isTestnet = props.NodeInfoStore?.nodeInfo?.isTestNet;
-        const { settings } = props.SettingsStore;
-
-        this.textInput = React.createRef<TextInputRN>();
         this.state = {
             loading: false,
             network: 'mainnet',
-            selectedInputType: null,
-            selectedWordIndex: null,
-            selectedText: '',
             seedArray: [],
             seedPhrase: [],
-            filteredData: [],
-            showSuggestions: false,
             walletPassword: '',
             adminMacaroon: '',
             embeddedLndNetwork: 'mainnet',
@@ -124,11 +72,7 @@ export default class SeedRecovery extends React.PureComponent<
             channelBackupsBase64: '',
             errorCreatingWallet: false,
             errorMsg: '',
-            rescueHost: isTestnet
-                ? settings.swaps?.hostTestnet || DEFAULT_SWAP_HOST_TESTNET
-                : settings.swaps?.hostMainnet || DEFAULT_SWAP_HOST_MAINNET,
-            customRescueHost: settings.swaps?.customHost || '',
-            invalidInput: false
+            showSuggestions: false
         };
     }
 
@@ -156,9 +100,7 @@ export default class SeedRecovery extends React.PureComponent<
 
     async initFromProps(props: SeedRecoveryProps) {
         const network = props.route.params?.network ?? 'mainnet';
-        const restoreSwaps = props.route.params?.restoreSwaps ?? false;
-        const restoreRescueKey = props.route.params?.restoreRescueKey ?? false;
-        this.setState({ network, restoreSwaps, restoreRescueKey });
+        this.setState({ network });
     }
 
     saveWalletConfiguration = (recoveryCipherSeed?: string) => {
@@ -214,172 +156,15 @@ export default class SeedRecovery extends React.PureComponent<
     };
 
     render() {
-        const { navigation, NodeInfoStore, SwapStore } = this.props;
+        const { navigation } = this.props;
         const {
             loading,
             network,
-            selectedWordIndex,
-            selectedInputType,
-            selectedText,
             seedArray,
             channelBackupsBase64,
             showSuggestions,
-            filteredData,
-            errorMsg,
-            restoreSwaps,
-            restoreRescueKey,
-            rescueHost,
-            customRescueHost
+            errorMsg
         } = this.state;
-
-        const isTestnet = NodeInfoStore?.nodeInfo?.isTestNet;
-
-        const filterData = (text: string) =>
-            BIP39_WORD_LIST.filter((val: string) =>
-                val?.toLowerCase()?.startsWith(text?.toLowerCase())
-            );
-
-        const RecoveryLabel = ({
-            type,
-            index,
-            text
-        }: {
-            type: 'mnemonicWord' | 'scb';
-            index?: number;
-            text?: string;
-        }) => {
-            return (
-                <TouchableOpacity
-                    onPress={() => {
-                        if (showSuggestions) {
-                            if (type === 'scb') {
-                                this.setState({
-                                    channelBackupsBase64: text || '',
-                                    selectedText: text || ''
-                                });
-                            } else if (selectedWordIndex != null) {
-                                seedArray[selectedWordIndex] = text || '';
-                                this.setState({ seedArray } as any);
-                                const isRestoreMode =
-                                    restoreSwaps || restoreRescueKey;
-                                if (
-                                    (isRestoreMode && selectedWordIndex < 11) ||
-                                    (!isRestoreMode && selectedWordIndex < 23)
-                                ) {
-                                    this.setState({
-                                        selectedWordIndex:
-                                            selectedWordIndex + 1,
-                                        selectedText:
-                                            seedArray[selectedWordIndex + 1]
-                                    });
-                                } else {
-                                    this.setState({
-                                        selectedText: text || ''
-                                    });
-                                    Keyboard.dismiss();
-                                }
-                            }
-                        } else {
-                            this.setState({ selectedText: text || '' });
-                            if (index != null) {
-                                this.setState({
-                                    selectedInputType: 'word',
-                                    selectedWordIndex: index
-                                });
-                            } else {
-                                this.setState({ selectedInputType: 'scb' });
-                            }
-                        }
-
-                        this.setState({ showSuggestions: false });
-
-                        // set focus
-                        if (!Keyboard.isVisible()) {
-                            this.textInput?.current?.blur();
-                            this.textInput?.current?.focus();
-                        }
-                    }}
-                    style={{
-                        padding: 8,
-                        backgroundColor: themeColor('secondary'),
-                        borderRadius: 5,
-                        marginTop: 4,
-                        marginBottom: 4,
-                        marginLeft: 6,
-                        marginRight: 6,
-                        flexDirection: 'row',
-                        maxHeight: type === 'scb' ? 60 : undefined
-                    }}
-                >
-                    {!showSuggestions && index != null && (
-                        <View>
-                            <Text
-                                style={{
-                                    fontFamily: 'PPNeueMontreal-Book',
-                                    color:
-                                        selectedInputType === 'word' &&
-                                        selectedWordIndex === index
-                                            ? themeColor('highlight')
-                                            : themeColor('secondaryText'),
-                                    fontSize: 18,
-                                    alignSelf: 'flex-start'
-                                }}
-                            >
-                                {index + 1}
-                            </Text>
-                        </View>
-                    )}
-                    {!showSuggestions && type === 'scb' && (
-                        <Text
-                            style={{
-                                fontFamily: 'PPNeueMontreal-Book',
-                                color:
-                                    selectedInputType === 'scb'
-                                        ? themeColor('highlight')
-                                        : themeColor('secondaryText'),
-                                fontSize: 18,
-                                alignSelf: 'flex-start'
-                            }}
-                        >
-                            {localeString(
-                                'views.Settings.AddEditNode.disasterRecoveryBase64'
-                            )}
-                        </Text>
-                    )}
-                    <Text
-                        style={{
-                            flex: 1,
-                            fontFamily: 'PPNeueMontreal-Medium',
-                            color: themeColor('text'),
-                            fontSize: 18,
-                            alignSelf:
-                                type === 'mnemonicWord'
-                                    ? 'flex-end'
-                                    : undefined,
-                            margin: 0,
-                            marginLeft: showSuggestions ? 0 : 10,
-                            padding: 0
-                        }}
-                    >
-                        {index != null &&
-                        text &&
-                        !(
-                            selectedInputType === 'word' &&
-                            selectedWordIndex === index
-                        )
-                            ? '********'
-                            : text}
-                    </Text>
-                </TouchableOpacity>
-            );
-        };
-
-        const halfwayThrough = Math.ceil(filteredData.length / 2);
-        const suggestionsOne = filteredData.slice(0, halfwayThrough);
-        const suggestionsTwo = filteredData.slice(
-            halfwayThrough,
-            filteredData.length
-        );
 
         const restore = async () => {
             this.setState({ loading: true });
@@ -438,13 +223,7 @@ export default class SeedRecovery extends React.PureComponent<
                 <Header
                     leftComponent="Back"
                     centerComponent={{
-                        text: restoreSwaps
-                            ? localeString(
-                                  'views.Swaps.SwapsPane.swapsRecovery'
-                              )
-                            : restoreRescueKey
-                            ? localeString('views.Swaps.rescueKey.recovery')
-                            : localeString('views.Settings.SeedRecovery.title'),
+                        text: localeString('views.Settings.SeedRecovery.title'),
                         style: {
                             color: themeColor('text'),
                             fontFamily: 'PPNeueMontreal-Book'
@@ -456,410 +235,25 @@ export default class SeedRecovery extends React.PureComponent<
                 {loading && <LoadingIndicator />}
                 {!loading && (
                     <View style={{ flex: 1, justifyContent: 'center' }}>
-                        <View>
-                            {selectedInputType != null && (
-                                <TextInput
-                                    ref={this.textInput}
-                                    onFocus={() => {
-                                        if (selectedText?.length === 0) {
-                                            this.setState({
-                                                showSuggestions: true
-                                            });
-                                        }
-                                    }}
-                                    value={selectedText}
-                                    prefix={
-                                        selectedInputType === 'word'
-                                            ? (selectedWordIndex as number) + 1
-                                            : 'SCB'
-                                    }
-                                    prefixStyle={{
-                                        color: themeColor('highlight')
-                                    }}
-                                    textColor={
-                                        this.state.invalidInput
-                                            ? themeColor('error')
-                                            : undefined
-                                    }
-                                    style={{
-                                        margin: 20,
-                                        marginLeft: 10,
-                                        marginRight: 10,
-                                        width: '90%',
-                                        alignSelf: 'center'
-                                    }}
-                                    autoCapitalize="none"
-                                    autoFocus
-                                    onChangeText={(text: string) => {
-                                        this.setState({
-                                            errorMsg: '',
-                                            selectedText: text
-                                        });
-
-                                        if (selectedInputType === 'word') {
-                                            this.setState({
-                                                showSuggestions:
-                                                    text.length > 0
-                                                        ? true
-                                                        : false
-                                            });
-                                        }
-
-                                        if (text.length > 0) {
-                                            const filtered = filterData(text);
-                                            this.setState({
-                                                filteredData: filtered,
-                                                invalidInput:
-                                                    selectedInputType ===
-                                                        'word' &&
-                                                    filtered.length === 0
-                                            });
-                                        } else {
-                                            this.setState({
-                                                filteredData: BIP39_WORD_LIST,
-                                                invalidInput: false
-                                            });
-                                        }
-
-                                        if (selectedInputType === 'scb') {
-                                            this.setState({
-                                                channelBackupsBase64: text
-                                            });
-                                        }
-                                        if (
-                                            (restoreSwaps ||
-                                                restoreRescueKey) &&
-                                            (selectedWordIndex == null ||
-                                                selectedWordIndex >= 12)
-                                        ) {
-                                            return;
-                                        } else if (selectedWordIndex != null) {
-                                            seedArray[selectedWordIndex] = text;
-                                            this.setState({ seedArray });
-                                        }
-                                    }}
-                                />
-                            )}
-                            {selectedInputType === 'word' &&
-                                this.state.invalidInput && (
-                                    <Text
-                                        style={{
-                                            color: themeColor('error'),
-                                            fontFamily: 'PPNeueMontreal-Book',
-                                            fontSize: 14,
-                                            marginTop: 5,
-                                            marginLeft: 30
-                                        }}
-                                    >
-                                        {localeString(
-                                            'views.Settings.NodeConfiguration.invalidSeedWord'
-                                        )}
-                                    </Text>
-                                )}
-                        </View>
-                        {!showSuggestions && (
-                            <>
-                                <ScrollView
-                                    contentContainerStyle={{
-                                        flexGrow: 1,
-                                        flexDirection: 'row'
-                                    }}
-                                    keyboardShouldPersistTaps="handled"
-                                >
-                                    {restoreSwaps || restoreRescueKey ? (
-                                        <>
-                                            <View
-                                                style={{
-                                                    ...styles.column,
-                                                    alignSelf:
-                                                        !selectedInputType
-                                                            ? 'center'
-                                                            : undefined
-                                                }}
-                                            >
-                                                {[0, 1, 2, 3, 4, 5].map((i) => (
-                                                    <RecoveryLabel
-                                                        key={i}
-                                                        type="mnemonicWord"
-                                                        index={i}
-                                                        text={
-                                                            this.state
-                                                                .seedArray[i]
-                                                        }
-                                                    />
-                                                ))}
-                                            </View>
-                                            <View
-                                                style={{
-                                                    ...styles.column,
-                                                    alignSelf:
-                                                        !selectedInputType
-                                                            ? 'center'
-                                                            : undefined
-                                                }}
-                                            >
-                                                {[6, 7, 8, 9, 10, 11].map(
-                                                    (i) => (
-                                                        <RecoveryLabel
-                                                            key={i}
-                                                            type="mnemonicWord"
-                                                            index={i}
-                                                            text={
-                                                                this.state
-                                                                    .seedArray[
-                                                                    i
-                                                                ]
-                                                            }
-                                                        />
-                                                    )
-                                                )}
-                                            </View>
-                                        </>
-                                    ) : (
-                                        <>
-                                            <View
-                                                style={{
-                                                    ...styles.column,
-                                                    alignSelf:
-                                                        !selectedInputType
-                                                            ? 'center'
-                                                            : undefined
-                                                }}
-                                            >
-                                                {[
-                                                    0, 1, 2, 3, 4, 5, 6, 7, 8,
-                                                    9, 10, 11
-                                                ].map((index: number) => {
-                                                    return (
-                                                        <RecoveryLabel
-                                                            key={index}
-                                                            type="mnemonicWord"
-                                                            index={index}
-                                                            text={
-                                                                seedArray[index]
-                                                            }
-                                                        />
-                                                    );
-                                                })}
-                                            </View>
-                                            <View
-                                                style={{
-                                                    ...styles.column,
-                                                    alignSelf:
-                                                        !selectedInputType
-                                                            ? 'center'
-                                                            : undefined
-                                                }}
-                                            >
-                                                {[
-                                                    12, 13, 14, 15, 16, 17, 18,
-                                                    19, 20, 21, 22, 23
-                                                ].map((index: number) => {
-                                                    return (
-                                                        <RecoveryLabel
-                                                            key={index}
-                                                            type="mnemonicWord"
-                                                            index={index}
-                                                            text={
-                                                                seedArray[index]
-                                                            }
-                                                        />
-                                                    );
-                                                })}
-                                            </View>
-                                        </>
-                                    )}
-                                </ScrollView>
-
-                                {!(restoreSwaps || restoreRescueKey) && (
-                                    <View
-                                        style={{
-                                            flexGrow: 1,
-                                            flexDirection: 'row'
-                                        }}
-                                    >
-                                        <View style={styles.scb}>
-                                            <RecoveryLabel
-                                                type="scb"
-                                                text={channelBackupsBase64}
-                                            />
-                                        </View>
-                                    </View>
-                                )}
-                            </>
-                        )}
-                        {showSuggestions && (
-                            <ScrollView
-                                contentContainerStyle={{
-                                    flexGrow: 1,
-                                    flexDirection: 'row'
-                                }}
-                                keyboardShouldPersistTaps="handled"
-                            >
-                                <View style={styles.column}>
-                                    {suggestionsOne.map((key) => {
-                                        return (
-                                            <RecoveryLabel
-                                                key={key}
-                                                type="mnemonicWord"
-                                                text={key}
-                                            />
-                                        );
-                                    })}
-                                </View>
-                                <View style={styles.column}>
-                                    {suggestionsTwo.map((key) => {
-                                        return (
-                                            <RecoveryLabel
-                                                key={key}
-                                                type="mnemonicWord"
-                                                text={key}
-                                            />
-                                        );
-                                    })}
-                                </View>
-                            </ScrollView>
-                        )}
-                        {!showSuggestions && (
-                            <>
-                                {restoreSwaps && (
-                                    <View style={{ paddingHorizontal: 20 }}>
-                                        <DropdownSetting
-                                            title={localeString(
-                                                'general.serviceProvider'
-                                            )}
-                                            selectedValue={rescueHost}
-                                            onValueChange={async (
-                                                value: string
-                                            ) => {
-                                                this.setState({
-                                                    rescueHost: value,
-                                                    errorMsg: ''
-                                                });
-                                            }}
-                                            values={(isTestnet
-                                                ? SWAP_HOST_KEYS_TESTNET
-                                                : SWAP_HOST_KEYS_MAINNET
-                                            ).filter(
-                                                (provider) =>
-                                                    provider.supportsRescue
-                                            )}
-                                        />
-                                        {rescueHost === 'Custom' && (
-                                            <>
-                                                <Text
-                                                    style={{
-                                                        color: themeColor(
-                                                            'secondaryText'
-                                                        ),
-                                                        fontFamily:
-                                                            'PPNeueMontreal-Book'
-                                                    }}
-                                                >
-                                                    {localeString(
-                                                        'views.OpenChannel.host'
-                                                    )}
-                                                </Text>
-                                                <TextInput
-                                                    value={customRescueHost}
-                                                    placeholder={
-                                                        isTestnet
-                                                            ? DEFAULT_SWAP_HOST_TESTNET
-                                                            : DEFAULT_SWAP_HOST_MAINNET
-                                                    }
-                                                    onChangeText={async (
-                                                        text: string
-                                                    ) => {
-                                                        this.setState({
-                                                            customRescueHost:
-                                                                text
-                                                        });
-                                                    }}
-                                                    autoCapitalize="none"
-                                                    error={!customRescueHost}
-                                                />
-                                            </>
-                                        )}
-                                    </View>
-                                )}
-                                {(restoreSwaps || restoreRescueKey) && (
-                                    <Button
-                                        title={localeString(
-                                            'views.Swaps.rescueKey.upload'
-                                        )}
-                                        secondary
-                                        onPress={async () => {
-                                            this.setState({
-                                                errorMsg: '',
-                                                seedArray: [],
-                                                selectedText: '',
-                                                selectedInputType: null,
-                                                selectedWordIndex: null
-                                            });
-                                            try {
-                                                const [res] = await pick({
-                                                    type: [types.allFiles]
-                                                });
-
-                                                const content =
-                                                    await RNFS.readFile(
-                                                        res.uri,
-                                                        'utf8'
-                                                    );
-                                                const importedData =
-                                                    JSON.parse(content);
-
-                                                if (importedData.mnemonic) {
-                                                    const words =
-                                                        importedData.mnemonic
-                                                            .trim()
-                                                            .split(/\s+/);
-                                                    if (words.length === 12) {
-                                                        this.setState({
-                                                            seedArray: words
-                                                        });
-                                                    } else {
-                                                        Alert.alert(
-                                                            localeString(
-                                                                'views.Swaps.rescueKey.invalid'
-                                                            )
-                                                        );
-                                                    }
-                                                } else {
-                                                    Alert.alert(
-                                                        localeString(
-                                                            'general.error'
-                                                        ),
-                                                        localeString(
-                                                            'views.Tools.nodeConfigExportImport.importError'
-                                                        )
-                                                    );
-                                                }
-                                            } catch (err) {
-                                                if (
-                                                    isErrorWithCode(err) &&
-                                                    err.code ===
-                                                        errorCodes.OPERATION_CANCELED
-                                                ) {
-                                                    this.setState({
-                                                        loading: false
-                                                    });
-                                                } else {
-                                                    Alert.alert(
-                                                        localeString(
-                                                            'general.error'
-                                                        ),
-                                                        localeString(
-                                                            'views.Tools.nodeConfigExportImport.importError'
-                                                        )
-                                                    );
-                                                }
-                                            }
-                                        }}
-                                    />
-                                )}
-                            </>
-                        )}
+                        <SeedWordInput
+                            wordCount={24}
+                            seedArray={seedArray}
+                            onSeedArrayChange={(arr) =>
+                                this.setState({ seedArray: arr })
+                            }
+                            channelBackup={channelBackupsBase64}
+                            onChannelBackupChange={(text) =>
+                                this.setState({
+                                    channelBackupsBase64: text
+                                })
+                            }
+                            onErrorMsgChange={(msg) =>
+                                this.setState({ errorMsg: msg })
+                            }
+                            onShowSuggestionsChange={(showing) =>
+                                this.setState({ showSuggestions: showing })
+                            }
+                        />
                         {!showSuggestions && (
                             <View
                                 style={{
@@ -871,75 +265,9 @@ export default class SeedRecovery extends React.PureComponent<
                                 }}
                             >
                                 <Button
-                                    onPress={async () => {
-                                        if (restoreSwaps) {
-                                            this.setState(
-                                                { loading: true },
-                                                async () => {
-                                                    this.setState({
-                                                        errorMsg: ''
-                                                    });
-                                                    const result =
-                                                        await SwapStore.getRescuableSwaps(
-                                                            {
-                                                                seedArray,
-                                                                host:
-                                                                    rescueHost ===
-                                                                    'Custom'
-                                                                        ? customRescueHost
-                                                                        : rescueHost
-                                                            }
-                                                        );
-                                                    this.setState({
-                                                        loading: false
-                                                    });
-                                                    if (result?.success) {
-                                                        navigation.navigate(
-                                                            'SwapsPane'
-                                                        );
-                                                    } else {
-                                                        this.setState({
-                                                            errorMsg:
-                                                                result?.error ||
-                                                                ''
-                                                        });
-                                                    }
-                                                }
-                                            );
-                                        } else if (restoreRescueKey) {
-                                            console.log(
-                                                'Verifying rescue key...'
-                                            );
-
-                                            const mnemonic = seedArray
-                                                .join(' ')
-                                                .trim();
-
-                                            await Storage.setItem(
-                                                SWAPS_RESCUE_KEY,
-                                                mnemonic
-                                            );
-
-                                            console.log(
-                                                'Rescue key verified and saved!',
-                                                mnemonic
-                                            );
-
-                                            navigation.goBack();
-                                        } else {
-                                            restore();
-                                        }
-                                    }}
+                                    onPress={() => restore()}
                                     title={
-                                        restoreSwaps
-                                            ? localeString(
-                                                  'views.Swaps.SwapsPane.restoreSwaps'
-                                              )
-                                            : restoreRescueKey
-                                            ? localeString(
-                                                  'views.Swaps.rescueKey.restore'
-                                              )
-                                            : network === 'mainnet'
+                                        network === 'mainnet'
                                             ? localeString(
                                                   'views.Settings.NodeConfiguration.restoreMainnetWallet'
                                               )
@@ -948,13 +276,8 @@ export default class SeedRecovery extends React.PureComponent<
                                               )
                                     }
                                     disabled={
-                                        restoreSwaps || restoreRescueKey
-                                            ? (rescueHost === 'Custom' &&
-                                                  !customRescueHost) ||
-                                              seedArray.length !== 12 ||
-                                              seedArray.some((seed) => !seed)
-                                            : seedArray.length !== 24 ||
-                                              seedArray.some((seed) => !seed)
+                                        seedArray.length !== 24 ||
+                                        seedArray.some((seed) => !seed)
                                     }
                                 />
                             </View>
@@ -965,58 +288,3 @@ export default class SeedRecovery extends React.PureComponent<
         );
     }
 }
-
-const styles = StyleSheet.create({
-    text: {
-        fontFamily: 'PPNeueMontreal-Book'
-    },
-    whiteText: {
-        color: 'white',
-        fontFamily: 'PPNeueMontreal-Book'
-    },
-    blackText: {
-        color: 'black',
-        fontFamily: 'PPNeueMontreal-Book'
-    },
-    button: {
-        paddingTop: 10,
-        paddingBottom: 10,
-        width: 350,
-        alignSelf: 'center'
-    },
-    modal: {
-        margin: 20,
-        backgroundColor: 'white',
-        borderRadius: 35,
-        padding: 35,
-        alignItems: 'center',
-        shadowColor: '#000',
-        shadowOffset: {
-            width: 0,
-            height: 2
-        },
-        shadowOpacity: 0.25,
-        shadowRadius: 3.84,
-        elevation: 5
-    },
-    centeredView: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-        marginTop: 22
-    },
-    column: {
-        marginTop: 8,
-        flexWrap: 'wrap',
-        alignItems: 'flex-start',
-        flexDirection: 'row',
-        width: '50%'
-    },
-    scb: {
-        alignItems: 'flex-start',
-        flexDirection: 'column',
-        marginTop: 8,
-        width: '100%',
-        lineHeight: 1
-    }
-});

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -13,6 +13,7 @@ import Header from '../../components/Header';
 import Screen from '../../components/Screen';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import SeedWordInput from '../../components/SeedWordInput';
+import { buttonContainerStyle } from '../../components/seedStyles';
 
 import { restartNeeded } from '../../utils/RestartUtils';
 import { themeColor } from '../../utils/ThemeUtils';
@@ -45,7 +46,6 @@ interface SeedRecoveryState {
     lndDir: string;
     recoveryCipherSeed: string;
     channelBackupsBase64: string;
-    errorCreatingWallet: boolean;
     errorMsg: string;
     showSuggestions: boolean;
 }
@@ -70,7 +70,6 @@ export default class SeedRecovery extends React.PureComponent<
             lndDir: '',
             recoveryCipherSeed: '',
             channelBackupsBase64: '',
-            errorCreatingWallet: false,
             errorMsg: '',
             showSuggestions: false
         };
@@ -206,12 +205,13 @@ export default class SeedRecovery extends React.PureComponent<
                 } else {
                     this.setState({
                         loading: false,
-                        errorCreatingWallet: true
+                        errorMsg: localeString(
+                            'views.Intro.errorCreatingWallet'
+                        )
                     });
                 }
             } catch (e: any) {
                 this.setState({
-                    errorCreatingWallet: true,
                     errorMsg: e.toString(),
                     loading: false
                 });
@@ -255,15 +255,7 @@ export default class SeedRecovery extends React.PureComponent<
                             }
                         />
                         {!showSuggestions && (
-                            <View
-                                style={{
-                                    alignSelf: 'center',
-                                    marginTop: 45,
-                                    bottom: 35,
-                                    backgroundColor: themeColor('background'),
-                                    width: '100%'
-                                }}
-                            >
+                            <View style={buttonContainerStyle()}>
                                 <Button
                                     onPress={() => restore()}
                                     title={

--- a/views/Swaps/SwapsPane.tsx
+++ b/views/Swaps/SwapsPane.tsx
@@ -290,7 +290,7 @@ export default class SwapsPane extends React.Component<SwapsPaneProps, {}> {
                         )}
                         secondary
                         onPress={async () => {
-                            navigation.navigate('SeedRecovery', {
+                            navigation.navigate('SwapsRecovery', {
                                 restoreSwaps: true
                             });
                         }}

--- a/views/Swaps/SwapsRecovery.tsx
+++ b/views/Swaps/SwapsRecovery.tsx
@@ -19,6 +19,7 @@ import TextInput from '../../components/TextInput';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import DropdownSetting from '../../components/DropdownSetting';
 import SeedWordInput from '../../components/SeedWordInput';
+import { buttonContainerStyle } from '../../components/seedStyles';
 
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
@@ -275,15 +276,7 @@ export default class SwapsRecovery extends React.PureComponent<
                             </>
                         )}
                         {!showSuggestions && (
-                            <View
-                                style={{
-                                    alignSelf: 'center',
-                                    marginTop: 45,
-                                    bottom: 35,
-                                    backgroundColor: themeColor('background'),
-                                    width: '100%'
-                                }}
-                            >
+                            <View style={buttonContainerStyle()}>
                                 <Button
                                     onPress={async () => {
                                         if (restoreSwaps) {

--- a/views/Swaps/SwapsRecovery.tsx
+++ b/views/Swaps/SwapsRecovery.tsx
@@ -56,6 +56,7 @@ interface SwapsRecoveryState {
     rescueHost: string;
     customRescueHost: string;
     showSuggestions: boolean;
+    seedInputKey: number;
 }
 
 @inject('NodeInfoStore', 'SettingsStore', 'SwapStore')
@@ -80,7 +81,8 @@ export default class SwapsRecovery extends React.PureComponent<
                 ? settings.swaps?.hostTestnet || DEFAULT_SWAP_HOST_TESTNET
                 : settings.swaps?.hostMainnet || DEFAULT_SWAP_HOST_MAINNET,
             customRescueHost: settings.swaps?.customHost || '',
-            showSuggestions: false
+            showSuggestions: false,
+            seedInputKey: 0
         };
     }
 
@@ -102,7 +104,8 @@ export default class SwapsRecovery extends React.PureComponent<
             restoreSwaps,
             rescueHost,
             customRescueHost,
-            showSuggestions
+            showSuggestions,
+            seedInputKey
         } = this.state;
 
         const isTestnet = NodeInfoStore?.nodeInfo?.isTestNet;
@@ -129,6 +132,7 @@ export default class SwapsRecovery extends React.PureComponent<
                 {!loading && (
                     <View style={{ flex: 1, justifyContent: 'center' }}>
                         <SeedWordInput
+                            key={seedInputKey}
                             wordCount={12}
                             seedArray={seedArray}
                             onSeedArrayChange={(arr) =>
@@ -209,10 +213,11 @@ export default class SwapsRecovery extends React.PureComponent<
                                     )}
                                     secondary
                                     onPress={async () => {
-                                        this.setState({
+                                        this.setState((prev) => ({
                                             errorMsg: '',
-                                            seedArray: []
-                                        });
+                                            seedArray: [],
+                                            seedInputKey: prev.seedInputKey + 1
+                                        }));
                                         try {
                                             const [res] = await pick({
                                                 type: [types.allFiles]

--- a/views/Swaps/SwapsRecovery.tsx
+++ b/views/Swaps/SwapsRecovery.tsx
@@ -1,0 +1,369 @@
+import * as React from 'react';
+import { Alert, Text, View } from 'react-native';
+import { inject, observer } from 'mobx-react';
+import RNFS from 'react-native-fs';
+import {
+    pick,
+    types,
+    isErrorWithCode,
+    errorCodes
+} from '@react-native-documents/picker';
+import { Route } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+
+import { ErrorMessage } from '../../components/SuccessErrorMessage';
+import Button from '../../components/Button';
+import Header from '../../components/Header';
+import Screen from '../../components/Screen';
+import TextInput from '../../components/TextInput';
+import LoadingIndicator from '../../components/LoadingIndicator';
+import DropdownSetting from '../../components/DropdownSetting';
+import SeedWordInput from '../../components/SeedWordInput';
+
+import { themeColor } from '../../utils/ThemeUtils';
+import { localeString } from '../../utils/LocaleUtils';
+import { SWAPS_RESCUE_KEY } from '../../utils/SwapUtils';
+
+import SettingsStore, {
+    DEFAULT_SWAP_HOST_MAINNET,
+    DEFAULT_SWAP_HOST_TESTNET,
+    SWAP_HOST_KEYS_MAINNET,
+    SWAP_HOST_KEYS_TESTNET
+} from '../../stores/SettingsStore';
+import NodeInfoStore from '../../stores/NodeInfoStore';
+import SwapStore from '../../stores/SwapStore';
+
+import Storage from '../../storage';
+
+interface SwapsRecoveryProps {
+    navigation: StackNavigationProp<any, any>;
+    SettingsStore: SettingsStore;
+    NodeInfoStore: NodeInfoStore;
+    SwapStore: SwapStore;
+    route: Route<
+        'SwapsRecovery',
+        { restoreSwaps?: boolean; restoreRescueKey?: boolean }
+    >;
+}
+
+interface SwapsRecoveryState {
+    loading: boolean;
+    seedArray: string[];
+    errorMsg: string;
+    restoreSwaps: boolean;
+    restoreRescueKey: boolean;
+    rescueHost: string;
+    customRescueHost: string;
+    showSuggestions: boolean;
+}
+
+@inject('NodeInfoStore', 'SettingsStore', 'SwapStore')
+@observer
+export default class SwapsRecovery extends React.PureComponent<
+    SwapsRecoveryProps,
+    SwapsRecoveryState
+> {
+    constructor(props: SwapsRecoveryProps) {
+        super(props);
+
+        const isTestnet = props.NodeInfoStore?.nodeInfo?.isTestNet;
+        const { settings } = props.SettingsStore;
+
+        this.state = {
+            loading: false,
+            seedArray: [],
+            errorMsg: '',
+            restoreSwaps: props.route.params?.restoreSwaps ?? false,
+            restoreRescueKey: props.route.params?.restoreRescueKey ?? false,
+            rescueHost: isTestnet
+                ? settings.swaps?.hostTestnet || DEFAULT_SWAP_HOST_TESTNET
+                : settings.swaps?.hostMainnet || DEFAULT_SWAP_HOST_MAINNET,
+            customRescueHost: settings.swaps?.customHost || '',
+            showSuggestions: false
+        };
+    }
+
+    async componentDidUpdate(prevProps: SwapsRecoveryProps) {
+        if (this.props.route.params !== prevProps.route.params) {
+            const restoreSwaps = this.props.route.params?.restoreSwaps ?? false;
+            const restoreRescueKey =
+                this.props.route.params?.restoreRescueKey ?? false;
+            this.setState({ restoreSwaps, restoreRescueKey });
+        }
+    }
+
+    render() {
+        const { navigation, NodeInfoStore, SwapStore } = this.props;
+        const {
+            loading,
+            seedArray,
+            errorMsg,
+            restoreSwaps,
+            rescueHost,
+            customRescueHost,
+            showSuggestions
+        } = this.state;
+
+        const isTestnet = NodeInfoStore?.nodeInfo?.isTestNet;
+
+        return (
+            <Screen>
+                <Header
+                    leftComponent="Back"
+                    centerComponent={{
+                        text: restoreSwaps
+                            ? localeString(
+                                  'views.Swaps.SwapsPane.swapsRecovery'
+                              )
+                            : localeString('views.Swaps.rescueKey.recovery'),
+                        style: {
+                            color: themeColor('text'),
+                            fontFamily: 'PPNeueMontreal-Book'
+                        }
+                    }}
+                    navigation={navigation}
+                />
+                {errorMsg && <ErrorMessage message={errorMsg} dismissable />}
+                {loading && <LoadingIndicator />}
+                {!loading && (
+                    <View style={{ flex: 1, justifyContent: 'center' }}>
+                        <SeedWordInput
+                            wordCount={12}
+                            seedArray={seedArray}
+                            onSeedArrayChange={(arr) =>
+                                this.setState({ seedArray: arr })
+                            }
+                            onErrorMsgChange={(msg) =>
+                                this.setState({ errorMsg: msg })
+                            }
+                            onShowSuggestionsChange={(showing) =>
+                                this.setState({ showSuggestions: showing })
+                            }
+                        />
+                        {!showSuggestions && (
+                            <>
+                                {restoreSwaps && (
+                                    <View style={{ paddingHorizontal: 20 }}>
+                                        <DropdownSetting
+                                            title={localeString(
+                                                'general.serviceProvider'
+                                            )}
+                                            selectedValue={rescueHost}
+                                            onValueChange={async (
+                                                value: string
+                                            ) => {
+                                                this.setState({
+                                                    rescueHost: value,
+                                                    errorMsg: ''
+                                                });
+                                            }}
+                                            values={(isTestnet
+                                                ? SWAP_HOST_KEYS_TESTNET
+                                                : SWAP_HOST_KEYS_MAINNET
+                                            ).filter(
+                                                (provider) =>
+                                                    provider.supportsRescue
+                                            )}
+                                        />
+                                        {rescueHost === 'Custom' && (
+                                            <>
+                                                <Text
+                                                    style={{
+                                                        color: themeColor(
+                                                            'secondaryText'
+                                                        ),
+                                                        fontFamily:
+                                                            'PPNeueMontreal-Book'
+                                                    }}
+                                                >
+                                                    {localeString(
+                                                        'views.OpenChannel.host'
+                                                    )}
+                                                </Text>
+                                                <TextInput
+                                                    value={customRescueHost}
+                                                    placeholder={
+                                                        isTestnet
+                                                            ? DEFAULT_SWAP_HOST_TESTNET
+                                                            : DEFAULT_SWAP_HOST_MAINNET
+                                                    }
+                                                    onChangeText={async (
+                                                        text: string
+                                                    ) => {
+                                                        this.setState({
+                                                            customRescueHost:
+                                                                text
+                                                        });
+                                                    }}
+                                                    autoCapitalize="none"
+                                                    error={!customRescueHost}
+                                                />
+                                            </>
+                                        )}
+                                    </View>
+                                )}
+                                <Button
+                                    title={localeString(
+                                        'views.Swaps.rescueKey.upload'
+                                    )}
+                                    secondary
+                                    onPress={async () => {
+                                        this.setState({
+                                            errorMsg: '',
+                                            seedArray: []
+                                        });
+                                        try {
+                                            const [res] = await pick({
+                                                type: [types.allFiles]
+                                            });
+
+                                            const content = await RNFS.readFile(
+                                                res.uri,
+                                                'utf8'
+                                            );
+                                            const importedData =
+                                                JSON.parse(content);
+
+                                            if (importedData.mnemonic) {
+                                                const words =
+                                                    importedData.mnemonic
+                                                        .trim()
+                                                        .split(/\s+/);
+                                                if (words.length === 12) {
+                                                    this.setState({
+                                                        seedArray: words
+                                                    });
+                                                } else {
+                                                    Alert.alert(
+                                                        localeString(
+                                                            'views.Swaps.rescueKey.invalid'
+                                                        )
+                                                    );
+                                                }
+                                            } else {
+                                                Alert.alert(
+                                                    localeString(
+                                                        'general.error'
+                                                    ),
+                                                    localeString(
+                                                        'views.Tools.nodeConfigExportImport.importError'
+                                                    )
+                                                );
+                                            }
+                                        } catch (err) {
+                                            if (
+                                                isErrorWithCode(err) &&
+                                                err.code ===
+                                                    errorCodes.OPERATION_CANCELED
+                                            ) {
+                                                this.setState({
+                                                    loading: false
+                                                });
+                                            } else {
+                                                Alert.alert(
+                                                    localeString(
+                                                        'general.error'
+                                                    ),
+                                                    localeString(
+                                                        'views.Tools.nodeConfigExportImport.importError'
+                                                    )
+                                                );
+                                            }
+                                        }
+                                    }}
+                                />
+                            </>
+                        )}
+                        {!showSuggestions && (
+                            <View
+                                style={{
+                                    alignSelf: 'center',
+                                    marginTop: 45,
+                                    bottom: 35,
+                                    backgroundColor: themeColor('background'),
+                                    width: '100%'
+                                }}
+                            >
+                                <Button
+                                    onPress={async () => {
+                                        if (restoreSwaps) {
+                                            this.setState(
+                                                { loading: true },
+                                                async () => {
+                                                    this.setState({
+                                                        errorMsg: ''
+                                                    });
+                                                    const result =
+                                                        await SwapStore.getRescuableSwaps(
+                                                            {
+                                                                seedArray,
+                                                                host:
+                                                                    rescueHost ===
+                                                                    'Custom'
+                                                                        ? customRescueHost
+                                                                        : rescueHost
+                                                            }
+                                                        );
+                                                    this.setState({
+                                                        loading: false
+                                                    });
+                                                    if (result?.success) {
+                                                        navigation.navigate(
+                                                            'SwapsPane'
+                                                        );
+                                                    } else {
+                                                        this.setState({
+                                                            errorMsg:
+                                                                result?.error ||
+                                                                ''
+                                                        });
+                                                    }
+                                                }
+                                            );
+                                        } else {
+                                            console.log(
+                                                'Verifying rescue key...'
+                                            );
+
+                                            const mnemonic = seedArray
+                                                .join(' ')
+                                                .trim();
+
+                                            await Storage.setItem(
+                                                SWAPS_RESCUE_KEY,
+                                                mnemonic
+                                            );
+
+                                            console.log(
+                                                'Rescue key verified and saved!',
+                                                mnemonic
+                                            );
+
+                                            navigation.goBack();
+                                        }
+                                    }}
+                                    title={
+                                        restoreSwaps
+                                            ? localeString(
+                                                  'views.Swaps.SwapsPane.restoreSwaps'
+                                              )
+                                            : localeString(
+                                                  'views.Swaps.rescueKey.restore'
+                                              )
+                                    }
+                                    disabled={
+                                        (restoreSwaps &&
+                                            rescueHost === 'Custom' &&
+                                            !customRescueHost) ||
+                                        seedArray.length !== 12 ||
+                                        seedArray.some((seed) => !seed)
+                                    }
+                                />
+                            </View>
+                        )}
+                    </View>
+                )}
+            </Screen>
+        );
+    }
+}

--- a/views/Swaps/SwapsRescueKey.tsx
+++ b/views/Swaps/SwapsRescueKey.tsx
@@ -1,0 +1,255 @@
+import React from 'react';
+import { Alert, Platform, Text, TouchableOpacity, View } from 'react-native';
+import RNFS from 'react-native-fs';
+import { Icon } from '@rneui/themed';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { Route } from '@react-navigation/native';
+
+import { Row } from '../../components/layout/Row';
+
+import Button from '../../components/Button';
+import Screen from '../../components/Screen';
+import Header from '../../components/Header';
+import ModalBox from '../../components/ModalBox';
+import DangerousCopySeedModal from '../../components/Modals/DangerousCopySeedModal';
+import SeedWarningDisclaimer from '../../components/SeedWarningDisclaimer';
+import SeedWordGrid from '../../components/SeedWordGrid';
+
+import {
+    SWAPS_KEY,
+    REVERSE_SWAPS_KEY,
+    SWAPS_LAST_USED_KEY,
+    SWAPS_RESCUE_KEY
+} from '../../utils/SwapUtils';
+import { themeColor } from '../../utils/ThemeUtils';
+import { localeString } from '../../utils/LocaleUtils';
+
+import Storage from '../../storage';
+
+import Skull from '../../assets/images/SVG/Skull.svg';
+
+interface SwapsRescueKeyProps {
+    navigation: StackNavigationProp<any, any>;
+    route: Route<
+        'SwapsRescueKey',
+        {
+            seedPhrase: string[];
+        }
+    >;
+}
+
+interface SwapsRescueKeyState {
+    understood: boolean;
+    showModal: boolean;
+    isDeleteModalVisible: boolean;
+}
+
+export default class SwapsRescueKey extends React.PureComponent<
+    SwapsRescueKeyProps,
+    SwapsRescueKeyState
+> {
+    state = {
+        understood: false,
+        showModal: false,
+        isDeleteModalVisible: false
+    };
+
+    renderDeleteModal = () => {
+        const { navigation } = this.props;
+        return (
+            <ModalBox
+                isOpen={this.state.isDeleteModalVisible}
+                onClosed={() => this.setState({ isDeleteModalVisible: false })}
+                style={{
+                    backgroundColor: 'transparent'
+                }}
+                position="center"
+                backdropOpacity={0.6}
+            >
+                <View
+                    style={{
+                        flex: 1,
+                        justifyContent: 'center',
+                        alignItems: 'center'
+                    }}
+                >
+                    <View
+                        style={{
+                            backgroundColor: themeColor('background'),
+                            borderRadius: 20,
+                            padding: 20,
+                            alignItems: 'center',
+                            width: '90%'
+                        }}
+                    >
+                        <Text
+                            style={{
+                                color: themeColor('text'),
+                                fontFamily: 'PPNeueMontreal-Book',
+                                fontSize: 18,
+                                textAlign: 'center',
+                                marginBottom: 20
+                            }}
+                        >
+                            {localeString(
+                                'views.Swaps.rescueKey.deleteConfirmation'
+                            )}
+                        </Text>
+
+                        <Button
+                            title={localeString('general.confirm')}
+                            onPress={async () => {
+                                await Storage.removeItem(SWAPS_RESCUE_KEY);
+                                await Storage.removeItem(SWAPS_KEY);
+                                await Storage.removeItem(REVERSE_SWAPS_KEY);
+                                await Storage.removeItem(SWAPS_LAST_USED_KEY);
+                                this.setState({ isDeleteModalVisible: false });
+                                navigation.popTo('Swaps');
+                            }}
+                            containerStyle={{ marginBottom: 10 }}
+                            warning
+                        />
+                        <Button
+                            title={localeString('general.cancel')}
+                            onPress={() =>
+                                this.setState({ isDeleteModalVisible: false })
+                            }
+                            secondary
+                        />
+                    </View>
+                </View>
+            </ModalBox>
+        );
+    };
+
+    render() {
+        const { navigation, route } = this.props;
+        const { understood, showModal } = this.state;
+        const seedPhrase = route.params?.seedPhrase;
+
+        const DangerouslyCopySeed = () => (
+            <TouchableOpacity
+                onPress={() => this.setState({ showModal: true })}
+                style={{ marginLeft: 10 }}
+            >
+                <Skull fill={themeColor('text')} />
+            </TouchableOpacity>
+        );
+
+        const DownloadRescueKey = ({
+            seedPhrase
+        }: {
+            seedPhrase: string[];
+        }) => {
+            const handleDownload = async () => {
+                try {
+                    const mnemonic = seedPhrase.join(' ');
+                    const jsonData = JSON.stringify({ mnemonic }, null, 2);
+
+                    const path =
+                        Platform.OS === 'android'
+                            ? `${RNFS.DownloadDirectoryPath}/rescue_key.json`
+                            : `${RNFS.DocumentDirectoryPath}/rescue_key.json`;
+
+                    await RNFS.writeFile(path, jsonData, 'utf8');
+
+                    Alert.alert(
+                        localeString('general.success'),
+                        `${localeString('views.Swaps.rescueKey.download')}\n\n${
+                            Platform.OS === 'android'
+                                ? localeString('views.Swaps.rescueKey.android')
+                                : localeString('views.Swaps.rescueKey.ios')
+                        }`
+                    );
+
+                    console.log('File written to:', path);
+                } catch (error) {
+                    console.error('Download failed:', error);
+                }
+            };
+
+            return (
+                <TouchableOpacity onPress={handleDownload}>
+                    <Icon
+                        name="download"
+                        type="feather"
+                        color={themeColor('text')}
+                        underlayColor="transparent"
+                        size={26}
+                    />
+                </TouchableOpacity>
+            );
+        };
+
+        return (
+            <Screen>
+                {this.renderDeleteModal()}
+                <Header
+                    leftComponent="Back"
+                    centerComponent={{
+                        text: localeString('views.Swaps.rescueKey'),
+                        style: {
+                            color: themeColor('text'),
+                            fontFamily: 'PPNeueMontreal-Book'
+                        }
+                    }}
+                    rightComponent={
+                        understood && seedPhrase ? (
+                            <Row>
+                                <DownloadRescueKey seedPhrase={seedPhrase} />
+                                <DangerouslyCopySeed />
+                            </Row>
+                        ) : undefined
+                    }
+                    navigation={navigation}
+                />
+                <DangerousCopySeedModal
+                    visible={showModal}
+                    seedPhrase={seedPhrase || []}
+                    onClose={() => this.setState({ showModal: false })}
+                    dangerousText1Key="views.Swaps.rescueKey.dangerousText"
+                />
+                {!understood && (
+                    <SeedWarningDisclaimer
+                        text1Key="views.Swaps.rescueKey.text1"
+                        text2Key="views.Swaps.rescueKey.text2"
+                        onUnderstood={() => this.setState({ understood: true })}
+                    />
+                )}
+                {understood && seedPhrase && (
+                    <View style={{ flex: 1, justifyContent: 'center' }}>
+                        <SeedWordGrid seedPhrase={seedPhrase} />
+                        <View
+                            style={{
+                                alignSelf: 'center',
+                                marginTop: 45,
+                                bottom: 35,
+                                backgroundColor: themeColor('background'),
+                                width: '100%'
+                            }}
+                        >
+                            <Button
+                                onPress={() => navigation.goBack()}
+                                title={localeString(
+                                    'views.Swaps.rescueKey.backupComplete'
+                                )}
+                                containerStyle={{ marginBottom: 10 }}
+                            />
+                            <Button
+                                onPress={() =>
+                                    this.setState({
+                                        isDeleteModalVisible: true
+                                    })
+                                }
+                                title={localeString(
+                                    'views.Swaps.rescueKey.delete'
+                                )}
+                                warning
+                            />
+                        </View>
+                    </View>
+                )}
+            </Screen>
+        );
+    }
+}

--- a/views/Swaps/SwapsRescueKey.tsx
+++ b/views/Swaps/SwapsRescueKey.tsx
@@ -11,9 +11,11 @@ import Button from '../../components/Button';
 import Screen from '../../components/Screen';
 import Header from '../../components/Header';
 import ModalBox from '../../components/ModalBox';
+import DangerousCopySeedButton from '../../components/DangerousCopySeedButton';
 import DangerousCopySeedModal from '../../components/Modals/DangerousCopySeedModal';
 import SeedWarningDisclaimer from '../../components/SeedWarningDisclaimer';
 import SeedWordGrid from '../../components/SeedWordGrid';
+import { buttonContainerStyle } from '../../components/seedStyles';
 
 import {
     SWAPS_KEY,
@@ -25,8 +27,6 @@ import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
 
 import Storage from '../../storage';
-
-import Skull from '../../assets/images/SVG/Skull.svg';
 
 interface SwapsRescueKeyProps {
     navigation: StackNavigationProp<any, any>;
@@ -127,15 +127,6 @@ export default class SwapsRescueKey extends React.PureComponent<
         const { understood, showModal } = this.state;
         const seedPhrase = route.params?.seedPhrase;
 
-        const DangerouslyCopySeed = () => (
-            <TouchableOpacity
-                onPress={() => this.setState({ showModal: true })}
-                style={{ marginLeft: 10 }}
-            >
-                <Skull fill={themeColor('text')} />
-            </TouchableOpacity>
-        );
-
         const DownloadRescueKey = ({
             seedPhrase
         }: {
@@ -194,10 +185,15 @@ export default class SwapsRescueKey extends React.PureComponent<
                         }
                     }}
                     rightComponent={
-                        understood && seedPhrase ? (
+                        understood && seedPhrase?.length > 0 ? (
                             <Row>
                                 <DownloadRescueKey seedPhrase={seedPhrase} />
-                                <DangerouslyCopySeed />
+                                <DangerousCopySeedButton
+                                    onPress={() =>
+                                        this.setState({ showModal: true })
+                                    }
+                                    style={{ marginLeft: 10 }}
+                                />
                             </Row>
                         ) : undefined
                     }
@@ -216,18 +212,10 @@ export default class SwapsRescueKey extends React.PureComponent<
                         onUnderstood={() => this.setState({ understood: true })}
                     />
                 )}
-                {understood && seedPhrase && (
+                {understood && seedPhrase?.length > 0 && (
                     <View style={{ flex: 1, justifyContent: 'center' }}>
                         <SeedWordGrid seedPhrase={seedPhrase} />
-                        <View
-                            style={{
-                                alignSelf: 'center',
-                                marginTop: 45,
-                                bottom: 35,
-                                backgroundColor: themeColor('background'),
-                                width: '100%'
-                            }}
-                        >
+                        <View style={buttonContainerStyle()}>
                             <Button
                                 onPress={() => navigation.goBack()}
                                 title={localeString(

--- a/views/Swaps/index.tsx
+++ b/views/Swaps/index.tsx
@@ -655,7 +655,7 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
                                     showRescueKeyBtn: true
                                 });
 
-                                navigation.navigate('Seed', {
+                                navigation.navigate('SwapsRescueKey', {
                                     seedPhrase: mnemonic.split(' ')
                                 });
                             }}
@@ -772,7 +772,7 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
                 <TouchableOpacity style={{ marginTop: -10, marginRight: 6 }}>
                     <KeyIcon
                         onPress={() => {
-                            navigation.navigate('Seed', {
+                            navigation.navigate('SwapsRescueKey', {
                                 seedPhrase: this.state.seedPhrase
                             });
                         }}

--- a/views/Swaps/index.tsx
+++ b/views/Swaps/index.tsx
@@ -672,7 +672,7 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
                                     isModalVisible: false,
                                     isIntroModalVisible: false
                                 });
-                                navigation.navigate('SeedRecovery', {
+                                navigation.navigate('SwapsRecovery', {
                                     restoreRescueKey: true
                                 });
                             }}


### PR DESCRIPTION
## Summary

- Extracted shared code from `Seed.tsx`, `CashuSeed.tsx`, and `SeedRecovery.tsx` into 8 reusable components
- Extracted `SwapsRescueKey` and `SwapsRecovery` into standalone views (previously inlined in `Seed.tsx` and `SeedRecovery.tsx`)
- Eliminates ~1600 lines of duplicated code across seed display, seed input, and recovery flows
- Future UI changes to seed/recovery views now only need a single edit
- Fixed silent failure bug: wallet creation error now shows user-facing message instead of silently stopping the loading indicator

## New shared components

| File | Purpose |
|------|---------|
| `components/seedStyles.ts` | Shared `StyleSheet` + `buttonContainerStyle()` |
| `components/MnemonicWord.tsx` | Tap-to-reveal mnemonic word component |
| `components/SeedWordGrid.tsx` | Two-column read-only grid layout for seed words |
| `components/SeedWordInput.tsx` | Interactive seed word input with BIP39 autocomplete (12 or 24 words) |
| `components/Modals/DangerousCopySeedModal.tsx` | Skull-themed copy-to-clipboard modal |
| `components/SeedWarningDisclaimer.tsx` | Warning disclaimer with "I Understand" button |
| `components/DangerousCopySeedButton.tsx` | Skull button that triggers copy modal |

## New views

| File | Purpose |
|------|---------|
| `views/Swaps/SwapsRecovery.tsx` | 12-word seed recovery for swaps/rescue key (extracted from `SeedRecovery.tsx`) |
| `views/Swaps/SwapsRescueKey.tsx` | Rescue key display, download, and deletion (extracted from `Seed.tsx`) |

## View reduction

| File | Before | After | Reduction |
|------|--------|-------|-----------|
| `views/Settings/Seed.tsx` | 590 lines | 124 lines | -79% |
| `views/Cashu/CashuSeed.tsx` | 391 lines | 112 lines | -71% |
| `views/Settings/SeedRecovery.tsx` | 1022 lines | 282 lines | -72% |

## Test plan

- [ ] Settings → Seed: warning disclaimer → tap "I Understand" → seed grid displays → skull copy modal works → "Backup Complete" button works
- [ ] Cashu → CashuSeed: same flow with cashu-specific text and "Go to Wallet" button
- [ ] Settings → Node Config → Restore: 24-word grid + SCB field + submit button restores wallet
- [ ] Swaps tab → Restore Swaps: 12-word grid + host dropdown + file upload + submit
- [ ] Swaps intro → Restore rescue key: 12-word grid + file upload + submit
- [ ] Swaps → Rescue Key: display, download JSON, skull copy modal, delete confirmation all functional

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
