### PR TITLE
ZEUS-3755: fix:  resolve race condition in LnurlAuth by passing sign result directly to sendValues

### DIFF
--- a/views/LnurlAuth.tsx
+++ b/views/LnurlAuth.tsx
@@ -41,7 +41,7 @@ interface LnurlAuthState {
     action: string;
     k1: string;
     linkingKeyPub: string;
-    signedMessageDER: string;
+    signedMessageDERHex: string;
     preparingSignature: boolean;
     authenticating: boolean;
     signatureSuccess: boolean;
@@ -68,7 +68,7 @@ export default class LnurlAuth extends React.Component<
                 action: '',
                 k1: '',
                 linkingKeyPub: '',
-                signedMessageDER: '',
+                signedMessageDERHex: '',
                 preparingSignature: false,
                 authenticating: false,
                 signatureSuccess: false,
@@ -96,7 +96,7 @@ export default class LnurlAuth extends React.Component<
             action: lnurl.action,
             k1: lnurl.k1,
             linkingKeyPub: '',
-            signedMessageDER: '',
+            signedMessageDERHex: '',
             preparingSignature: false,
             authenticating: false,
             signatureSuccess: false,
@@ -112,7 +112,7 @@ export default class LnurlAuth extends React.Component<
 
         const body = LNURLAUTH_CANONICAL_PHRASE;
 
-        BackendUtils.lnurlAuth(body)
+        return BackendUtils.lnurlAuth(body)
             .then((signature: any) => {
                 // got the signed message, now build linkingkey
 
@@ -136,13 +136,17 @@ export default class LnurlAuth extends React.Component<
                     { canonical: true }
                 );
                 const signedMessageDER = signedMessage.toDER();
+                const signedMessageDERHex =
+                    Base64Utils.bytesToHex(signedMessageDER);
 
                 this.setState({
                     linkingKeyPub,
-                    signedMessageDER: Base64Utils.bytesToHex(signedMessageDER),
+                    signedMessageDERHex,
                     preparingSignature: false,
                     signatureSuccess: true
                 });
+
+                return { linkingKeyPub, signedMessageDERHex };
             })
             .catch((error: any) => {
                 // handle error
@@ -152,6 +156,7 @@ export default class LnurlAuth extends React.Component<
                 });
             });
     }
+
     componentDidMount() {
         const { implementation } = this.props.SettingsStore;
         if (implementation === 'lndhub') {
@@ -164,15 +169,23 @@ export default class LnurlAuth extends React.Component<
         }
     }
 
-    sendValues() {
+    sendValues(signResult?: {
+        linkingKeyPub: string;
+        signedMessageDERHex: string;
+    }) {
         this.setState({ authenticating: true });
+
+        const linkingKeyPub =
+            signResult?.linkingKeyPub ?? this.state.linkingKeyPub;
+        const signedMessageDERHex =
+            signResult?.signedMessageDERHex ?? this.state.signedMessageDERHex;
 
         const { route } = this.props;
         const lnurl = route.params?.lnurlParams;
         const u = url.parse(lnurl.callback);
         const qs = querystring.parse(u.query);
-        qs.key = this.state.linkingKeyPub;
-        qs.sig = this.state.signedMessageDER;
+        qs.key = linkingKeyPub;
+        qs.sig = signedMessageDERHex;
 
         u.search = querystring.stringify(qs);
         u.query = querystring.stringify(qs);
@@ -326,8 +339,10 @@ export default class LnurlAuth extends React.Component<
                                         this.setState({
                                             chooseAuthMode: false
                                         });
-                                        await this.triggerSign();
-                                        this.sendValues();
+                                        const signResult =
+                                            await this.triggerSign();
+                                        if (signResult)
+                                            this.sendValues(signResult);
                                     } else {
                                         this.sendValues();
                                     }


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-3755**](https://github.com/ZeusLN/zeus/issues/3755)

The issue was two-fold:

1. `triggerSign` wasn't returning the promise — fixed previously with return
2. `setState` is async — even after awaiting the promise, `this.state.linkingKeyPub` and `this.state.signedMessageDER` haven't flushed yet when `sendValues() `reads them

The fix: triggerSign now returns `{ linkingKeyPub, signedMessageDERHex }` from its resolved promise, and the button handler passes that result directly to `sendValues(signResult)`, bypassing state entirely. The `sendValues` method falls back to this.state for the existing call path (line 341) where state is already populated.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
