### PR TITLE
fix: exit app instead of navigating on IntroSplash back press

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -290,7 +290,8 @@ export default class App extends React.PureComponent {
     private static SCREENS_WITH_CUSTOM_BACK_HANDLER = [
         'SendingLightning',
         'SendingOnChain',
-        'CashuSendingLightning'
+        'CashuSendingLightning',
+        'IntroSplash'
     ];
 
     private handleBackPress = (navigation: any) => {


### PR DESCRIPTION
# Description

The global back press handler was attempting to pop the stack on IntroSplash, causing a navigation loop. This adds IntroSplash to SCREENS_WITH_CUSTOM_BACK_HANDLER, allowing its own handler to execute `BackHandler.exitApp()` instead.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
