### PR TITLE
Clear stale CMake cache before gradle clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prettier-write": "prettier --check --write \"**/*.ts*\"",
     "gen-proto": "pbjs -t static-module --keep-case -w es6 --force-long -o proto/lightning.js proto/*.proto proto/*/*.proto && pbts -o proto/lightning.d.ts proto/lightning.js",
     "gradlew": "cd android && ./gradlew",
-    "android:clean": "yarn gradlew clean && rm -rf android/build",
+    "android:clean": "rm -rf android/app/.cxx android/build && yarn gradlew clean",
     "fetch-libraries": "bash fetch-libraries.sh",
     "fix-all": "yarn prettier-write && yarn lint-fix",
     "lint-fix": "eslint . --fix"


### PR DESCRIPTION
# Description

On latest RN upgrade, I noticed that `./gradlew clean` failed. AI says: "because Ninja tries to re-run CMake using the stale cache in `android/app/.cxx/`. That cache references per-module codegen JNI directories that only exist after a completed build, causing CMake to error out before clean can run."

Fix: delete `android/app/.cxx` before invoking Gradle.

I also confirmed `./gradlew clean` does not remove the root project build directory, so we should keep `rm -rf android/build` at the end.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
