### PR TITLE
fix: peer connect error handling and open channel button validation

### DIFF
--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -742,7 +742,7 @@ export default class ChannelsStore {
         this.channelRequest = undefined;
         if (!silent) this.connectingToPeer = true;
 
-        if (!request.host) {
+        if (!request.host && !connectPeerOnly) {
             return await new Promise((resolve) => {
                 this.channelRequest = request;
                 resolve(true);

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -1359,7 +1359,7 @@ export default class OpenChannel extends React.Component<
                                             },
                                             false,
                                             connectPeerOnly
-                                        );
+                                        ).catch(() => {});
                                     }}
                                     disabled={
                                         loading ||

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -90,7 +90,6 @@ interface OpenChannelState {
     account: string;
     additionalChannels: Array<AdditionalChannel>;
     isNodePubkeyValid: boolean;
-    isNodeHostValid: boolean;
     nfcSupported: boolean;
 }
 
@@ -133,7 +132,6 @@ export default class OpenChannel extends React.Component<
             account: 'default',
             additionalChannels: [],
             isNodePubkeyValid: true,
-            isNodeHostValid: true,
             nfcSupported: false
         };
     }
@@ -344,7 +342,6 @@ export default class OpenChannel extends React.Component<
             advancedSettingsToggle,
             additionalChannels,
             isNodePubkeyValid,
-            isNodeHostValid,
             nfcSupported
         } = this.state;
         const { implementation } = SettingsStore;
@@ -363,6 +360,8 @@ export default class OpenChannel extends React.Component<
 
         const loading = connectingToPeer || openingChannel;
 
+        const isNodeHostValid =
+            host === '' || ValidationUtils.validateNodeHost(host);
         const isInvalidPeer = !isNodePubkeyValid || !isNodeHostValid;
         const isInvalidFeeRate = sat_per_vbyte === '0' || !sat_per_vbyte;
 
@@ -729,13 +728,15 @@ export default class OpenChannel extends React.Component<
                                                 'Olympus by ZEUS',
                                             node_pubkey_string:
                                                 config.lsps1Pubkey,
-                                            host: config.lsps1Host
+                                            host: config.lsps1Host,
+                                            isNodePubkeyValid: true
                                         });
                                     } else {
                                         this.setState({
                                             channelDestination: 'Custom',
                                             node_pubkey_string: '',
-                                            host: ''
+                                            host: '',
+                                            isNodePubkeyValid: false
                                         });
                                     }
                                 }}
@@ -803,11 +804,7 @@ export default class OpenChannel extends React.Component<
                                             value={host}
                                             onChangeText={(text: string) =>
                                                 this.setState({
-                                                    host: text,
-                                                    isNodeHostValid:
-                                                        ValidationUtils.validateNodeHost(
-                                                            text
-                                                        )
+                                                    host: text
                                                 })
                                             }
                                             autoCapitalize="none"
@@ -874,7 +871,8 @@ export default class OpenChannel extends React.Component<
                                                                 implementation ===
                                                                     'cln-rest'
                                                                     ? 'all'
-                                                                    : ''
+                                                                    : '',
+                                                            satAmount: ''
                                                         });
                                                     }}
                                                 />
@@ -1365,6 +1363,9 @@ export default class OpenChannel extends React.Component<
                                         loading ||
                                         (!connectPeerOnly &&
                                             isInvalidFeeRate) ||
+                                        (!connectPeerOnly &&
+                                            !fundMax &&
+                                            !Number(satAmount)) ||
                                         isInvalidPeer
                                     }
                                 />


### PR DESCRIPTION
# Description

This fixes https://github.com/ZeusLN/zeus/issues/3768.

#### Bug 1: Cryptic proto error when connecting peer by pubkey only
When connecting a peer without a host:port in "Connect Peer only" mode, an early-return code path in `connectPeer()` incorrectly set `channelRequest`, triggering a MobX reaction that called `openChannel()` instead of `connectPeer()`. This caused LND to receive an open-channel request with an empty `local_funding_amount` (uint64 in protobuf), producing the cryptic error `proto: invalid value for uint64 type: ""`.

The early-return (intended for the "open channel, peer already known" path) now only applies when `connectPeerOnly` is false. The actual `connectPeer` backend call proceeds and LND handles gossip lookup, returning an error if the peer is not reachable.
-> I noticed that LND does not return a nice error message, but only "EOF", but this is something that has to be fixed on LND side. Until then I don't think we need a temporary workaround on Zeus side (meaning: display a user friendly error msg), because it is an edge case anyway; usually people will provide host:port.

Also fixed a resulting unhandled promise rejection in `OpenChannel.tsx` where `connectPeer()` was called without `.catch()`.

#### Bug 2: "Open Channel" / "Connect Peer" button active although required fields are empty
Several validation state issues caused the Open Channel / Connect Peer button to remain active when required inputs were empty:
- Switching from "Olympus by ZEUS" to "Custom" did not reset `isNodePubkeyValid` to `false`
- ~~Switching back to "Olympus by ZEUS" did not restore `isNodePubkeyValid`/`isNodeHostValid` to `true`~~
- Switching back to "Olympus by ZEUS" did not restore `isNodePubkeyValid` to true; `isNodeHostValid` was refactored out of state entirely and is now derived from host in render, consistent with how `isInvalidFeeRate` is handled
- `AmountInput` initializes by calling `onAmountChange` with `satAmount = '0'` (string), so `!satAmount` never triggered -> fixed by checking `!Number(satAmount)`
- Disabling the "Use all possible funds" toggle did not reset `satAmount` in parent state, because `AmountInput.componentDidUpdate` does not call `onAmountChange` in its else-branch -> fixed by explicitly resetting `satAmount: '0'` in the toggle handler

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
