### PR TITLE
refactor: replace negative offsets with clean flex structure in PaymentPath view

### DIFF
--- a/components/PaymentPath.tsx
+++ b/components/PaymentPath.tsx
@@ -32,17 +32,15 @@ const Hop = (props: any) => {
                 style={{
                     backgroundColor: themeColor('secondary'),
                     borderRadius: 6,
-                    margin: 10,
+                    marginTop: 10,
                     marginBottom: 20,
                     width: '100%',
-                    left: -10,
                     paddingLeft: 5,
-                    paddingTop: 10,
-                    paddingBottom: 10
+                    paddingVertical: 20
                 }}
             >
-                <Row align="flex-end">
-                    <View style={{ top: -8, left: 4 }}>
+                <Row>
+                    <View style={{ marginLeft: 4 }}>
                         {expanded.get(index) ? (
                             <CaretDown
                                 fill={themeColor('text')}
@@ -59,18 +57,20 @@ const Hop = (props: any) => {
                     </View>
                     <Text
                         style={{
+                            flex: 1,
                             fontSize: 17,
                             color: themeColor('text'),
                             fontFamily: 'PPNeueMontreal-Medium',
-                            margin: 10
+                            marginLeft: 10,
+                            paddingRight: 55
                         }}
                     >
                         {title}
                     </Text>
                     <View
                         style={{
-                            height: 40, //any of height
-                            width: 40, //any of width
+                            height: 40,
+                            width: 40,
                             justifyContent: 'center',
                             borderRadius: 20,
                             backgroundColor: themeColor('highlight'),
@@ -106,29 +106,16 @@ const ExpandedHop = (props: any) => {
     });
 
     return (
-        <View
-            key={pathIndex}
-            style={{
-                left: 20,
-                marginRight: 20,
-                borderStyle: 'dotted',
-                borderLeftWidth: 3,
-                borderColor: isDestination
-                    ? 'transparent'
-                    : themeColor('secondaryText')
-            }}
-        >
-            <Row>
+        <Row style={{ alignItems: 'stretch' }}>
+            <View style={{ width: 44, alignItems: 'center' }}>
                 <View
                     style={{
-                        height: 44, //any of height
-                        width: 44, //any of width
-                        justifyContent: 'center',
+                        height: 44,
+                        width: 44,
                         borderRadius: 22,
                         backgroundColor: themeColor('highlight'),
-                        alignSelf: 'center',
-                        alignItems: 'center',
-                        left: -25
+                        justifyContent: 'center',
+                        alignItems: 'center'
                     }}
                 >
                     <Text
@@ -141,80 +128,95 @@ const ExpandedHop = (props: any) => {
                         {`${pathIndex + 1}`}
                     </Text>
                 </View>
-                <TouchableOpacity
-                    onPress={() => {
-                        if (!hop.pubKey) return;
-                        UrlUtils.goToBlockExplorerPubkey(
-                            hop.pubKey,
-                            nodeInfoStore.testnet
-                        );
-                    }}
-                >
-                    {loading ? (
-                        <LoadingIndicator />
-                    ) : (
-                        <Text
-                            style={{
-                                fontSize: 15,
-                                color: themeColor('highlight'),
-                                fontFamily: 'PPNeueMontreal-Medium'
-                            }}
-                        >
-                            {`${
-                                isOrigin
-                                    ? localeString('views.Channel.yourNode')
-                                    : aliasMap.get(hop.pubKey)
-                                    ? pubkeyValue
-                                    : typeof hop.node === 'string' &&
-                                      hop.node.length >= 66
-                                    ? `${
-                                          typeof nodeValue === 'string'
-                                              ? (nodeValue as string).slice(
-                                                    0,
-                                                    14
-                                                )
-                                              : ''
-                                      }...${
-                                          typeof nodeValue === 'string'
-                                              ? (nodeValue as string).slice(-14)
-                                              : ''
-                                      }`
-                                    : typeof nodeValue === 'string'
-                                    ? nodeValue
-                                    : ''
-                            }`}
-                        </Text>
-                    )}
-                </TouchableOpacity>
-            </Row>
-
-            <View style={{ marginLeft: 50, marginBottom: 15 }}>
-                {hop.sent ? (
-                    <KeyValue
-                        keyValue={localeString('general.sent')}
-                        value={<Amount sats={hop.sent} toggleable />}
-                        sensitive
-                    />
-                ) : (
-                    <KeyValue
-                        keyValue={
-                            isDestination
-                                ? localeString('general.received')
-                                : localeString('models.Payment.forwarded')
-                        }
-                        value={<Amount sats={hop.forwarded} toggleable />}
-                        sensitive
-                    />
-                )}
-                {!isOrigin && !isDestination && (
-                    <KeyValue
-                        keyValue={localeString('models.Payment.fee')}
-                        value={<Amount sats={hop.fee} toggleable />}
-                        sensitive
+                {!isDestination && (
+                    <View
+                        style={{
+                            flex: 1,
+                            borderStyle: 'dotted',
+                            borderLeftWidth: 3,
+                            borderColor: themeColor('secondaryText')
+                        }}
                     />
                 )}
             </View>
-        </View>
+            <View style={{ flex: 1, marginLeft: 20 }}>
+                <View style={{ height: 44, justifyContent: 'center' }}>
+                    <TouchableOpacity
+                        onPress={() => {
+                            if (!hop.pubKey) return;
+                            UrlUtils.goToBlockExplorerPubkey(
+                                hop.pubKey,
+                                nodeInfoStore.testnet
+                            );
+                        }}
+                    >
+                        {loading ? (
+                            <LoadingIndicator />
+                        ) : (
+                            <Text
+                                style={{
+                                    fontSize: 15,
+                                    color: themeColor('highlight'),
+                                    fontFamily: 'PPNeueMontreal-Medium'
+                                }}
+                            >
+                                {`${
+                                    isOrigin
+                                        ? localeString('views.Channel.yourNode')
+                                        : aliasMap.get(hop.pubKey)
+                                        ? pubkeyValue
+                                        : typeof hop.node === 'string' &&
+                                          hop.node.length >= 66
+                                        ? `${
+                                              typeof nodeValue === 'string'
+                                                  ? (nodeValue as string).slice(
+                                                        0,
+                                                        14
+                                                    )
+                                                  : ''
+                                          }...${
+                                              typeof nodeValue === 'string'
+                                                  ? (nodeValue as string).slice(
+                                                        -14
+                                                    )
+                                                  : ''
+                                          }`
+                                        : typeof nodeValue === 'string'
+                                        ? nodeValue
+                                        : ''
+                                }`}
+                            </Text>
+                        )}
+                    </TouchableOpacity>
+                </View>
+                <View style={{ marginBottom: 15 }}>
+                    {hop.sent ? (
+                        <KeyValue
+                            keyValue={localeString('general.sent')}
+                            value={<Amount sats={hop.sent} toggleable />}
+                            sensitive
+                        />
+                    ) : (
+                        <KeyValue
+                            keyValue={
+                                isDestination
+                                    ? localeString('general.received')
+                                    : localeString('models.Payment.forwarded')
+                            }
+                            value={<Amount sats={hop.forwarded} toggleable />}
+                            sensitive
+                        />
+                    )}
+                    {!isOrigin && !isDestination && (
+                        <KeyValue
+                            keyValue={localeString('models.Payment.fee')}
+                            value={<Amount sats={hop.fee} toggleable />}
+                            sensitive
+                        />
+                    )}
+                </View>
+            </View>
+        </Row>
     );
 };
 

--- a/components/PaymentPath.tsx
+++ b/components/PaymentPath.tsx
@@ -160,31 +160,19 @@ const ExpandedHop = (props: any) => {
                                     fontFamily: 'PPNeueMontreal-Medium'
                                 }}
                             >
-                                {`${
-                                    isOrigin
-                                        ? localeString('views.Channel.yourNode')
-                                        : aliasMap.get(hop.pubKey)
-                                        ? pubkeyValue
-                                        : typeof hop.node === 'string' &&
-                                          hop.node.length >= 66
-                                        ? `${
-                                              typeof nodeValue === 'string'
-                                                  ? (nodeValue as string).slice(
-                                                        0,
-                                                        14
-                                                    )
-                                                  : ''
-                                          }...${
-                                              typeof nodeValue === 'string'
-                                                  ? (nodeValue as string).slice(
-                                                        -14
-                                                    )
-                                                  : ''
-                                          }`
-                                        : typeof nodeValue === 'string'
-                                        ? nodeValue
-                                        : ''
-                                }`}
+                                {isOrigin
+                                    ? localeString('views.Channel.yourNode')
+                                    : aliasMap.get(hop.pubKey)
+                                    ? pubkeyValue
+                                    : typeof nodeValue === 'string'
+                                    ? typeof hop.node === 'string' &&
+                                      hop.node.length >= 66
+                                        ? `${nodeValue.slice(
+                                              0,
+                                              14
+                                          )}...${nodeValue.slice(-14)}`
+                                        : nodeValue
+                                    : ''}
                             </Text>
                         )}
                     </TouchableOpacity>
@@ -193,8 +181,9 @@ const ExpandedHop = (props: any) => {
                     {hop.sent ? (
                         <KeyValue
                             keyValue={localeString('general.sent')}
-                            value={<Amount sats={hop.sent} toggleable />}
-                            sensitive
+                            value={
+                                <Amount sats={hop.sent} toggleable sensitive />
+                            }
                         />
                     ) : (
                         <KeyValue
@@ -203,15 +192,21 @@ const ExpandedHop = (props: any) => {
                                     ? localeString('general.received')
                                     : localeString('models.Payment.forwarded')
                             }
-                            value={<Amount sats={hop.forwarded} toggleable />}
-                            sensitive
+                            value={
+                                <Amount
+                                    sats={hop.forwarded}
+                                    toggleable
+                                    sensitive
+                                />
+                            }
                         />
                     )}
                     {!isOrigin && !isDestination && (
                         <KeyValue
                             keyValue={localeString('models.Payment.fee')}
-                            value={<Amount sats={hop.fee} toggleable />}
-                            sensitive
+                            value={
+                                <Amount sats={hop.fee} toggleable sensitive />
+                            }
                         />
                     )}
                 </View>


### PR DESCRIPTION
# Description
This replaces negative offsets and positional hacks in the `Hop` and `ExpandedHop` components with a clean flex-based layout.

`Hop` (MPP summary box):
- Removed `left: -10` container offset
- Fixed caret vertical alignment by removing `align="flex-end"` + `top: -8` hack; Row now uses its default `center` alignment
- Added `flex: 1` with `paddingRight: 55` to the title text to prevent overflow behind the path count badge (see last screenshots with long node aliases)

`ExpandedHop` (individual hop rows):
- Replaced the `borderLeftWidth` dotted line + `left: -25` circle offset approach with a proper two-column layout
- Left column (44px): circle + `flex: 1` line element that naturally fills the space below
- Right column: node name vertically centered against the circle, followed by the key-value details
- All negative `left`/`top` values removed

|Before|After|
|-|-|
|<img width="413" height="946" alt="grafik" src="https://github.com/user-attachments/assets/d9cfe3b8-a73c-4954-8e2a-3ac4b79da8df" />|<img width="413" height="946" alt="grafik" src="https://github.com/user-attachments/assets/d042522f-a2fa-4bf7-8e5d-138df926823d" />|
|<img width="413" height="946" alt="grafik" src="https://github.com/user-attachments/assets/a59acfc3-d871-4387-b2d6-95a09ec8cbca" />|<img width="413" height="946" alt="grafik" src="https://github.com/user-attachments/assets/95f9885d-ade4-4764-b4a0-e93524a7fd26" />|
|<img width="413" height="946" alt="grafik" src="https://github.com/user-attachments/assets/db2a0bb2-06e0-4e6f-9740-ac9d5bff33cb" />|<img width="413" height="946" alt="grafik" src="https://github.com/user-attachments/assets/88628779-c123-487f-bb4b-c51babad185c" />|

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
