### PR TITLE
enhancement: Refresh channel data after payment sent or received

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -777,7 +777,8 @@ export default class Receive extends React.Component<
             PosStore,
             SettingsStore,
             NodeInfoStore,
-            BalanceStore
+            BalanceStore,
+            ChannelsStore
         } = this.props;
         const { orderId, orderTotal, orderTip, exchangeRate, rate, value } =
             this.state;
@@ -824,6 +825,7 @@ export default class Receive extends React.Component<
                                     Number(invoice.amt_paid_sat)
                                 );
                                 BalanceStore.getCombinedBalance();
+                                ChannelsStore.getChannels();
 
                                 if (orderId) {
                                     PosStore.recordPayment({
@@ -943,6 +945,7 @@ export default class Receive extends React.Component<
                                 if (result.settled) {
                                     setWatchedInvoicePaid(result.amt_paid_sat);
                                     BalanceStore.getCombinedBalance();
+                                    ChannelsStore.getChannels();
 
                                     if (orderId) {
                                         PosStore.recordPayment({
@@ -1046,6 +1049,7 @@ export default class Receive extends React.Component<
                                 ) {
                                     setWatchedInvoicePaid(result.amt_paid_sat);
                                     BalanceStore.getCombinedBalance();
+                                    ChannelsStore.getChannels();
 
                                     if (orderId) {
                                         PosStore.recordPayment({
@@ -1152,6 +1156,8 @@ export default class Receive extends React.Component<
                                     setWatchedInvoicePaid(
                                         result.amount_received_msat / 1000
                                     );
+                                    BalanceStore.getCombinedBalance();
+                                    ChannelsStore.getChannels();
                                     if (orderId) {
                                         PosStore.recordPayment({
                                             orderId,

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -27,6 +27,7 @@ import Amount from '../components/Amount';
 import ModalBox from '../components/ModalBox';
 
 import BalanceStore from '../stores/BalanceStore';
+import ChannelsStore from '../stores/ChannelsStore';
 import ContactStore from '../stores/ContactStore';
 import LnurlPayStore from '../stores/LnurlPayStore';
 import PaymentsStore from '../stores/PaymentsStore';
@@ -55,6 +56,7 @@ import { getFeePercentage } from '../utils/AmountUtils';
 interface SendingLightningProps {
     navigation: StackNavigationProp<any, any>;
     BalanceStore: BalanceStore;
+    ChannelsStore: ChannelsStore;
     ContactStore: ContactStore;
     LnurlPayStore: LnurlPayStore;
     PaymentsStore: PaymentsStore;
@@ -89,6 +91,7 @@ interface SendingLightningState {
 
 @inject(
     'BalanceStore',
+    'ChannelsStore',
     'ContactStore',
     'LnurlPayStore',
     'PaymentsStore',
@@ -150,8 +153,13 @@ export default class SendingLightning extends React.Component<
     }
 
     componentDidUpdate(_prevProps: SendingLightningProps) {
-        const { TransactionsStore, BalanceStore, NodeInfoStore, route } =
-            this.props;
+        const {
+            TransactionsStore,
+            BalanceStore,
+            ChannelsStore,
+            NodeInfoStore,
+            route
+        } = this.props;
 
         const { donationIsPaid } = TransactionsStore;
 
@@ -162,6 +170,9 @@ export default class SendingLightning extends React.Component<
             this.setState({ wasSuccessful: true }, () => {
                 this.fetchPayments();
                 BalanceStore.getCombinedBalance();
+                if (BackendUtils.supportsChannelManagement()) {
+                    ChannelsStore.getChannels();
+                }
             });
         } else if (!wasSuccessful && this.state.wasSuccessful) {
             this.setState({ wasSuccessful: false });


### PR DESCRIPTION
# Description

Channel capacity in the channels pane was showing stale data after sending or receiving a Lightning payment, requiring a manual pull-to-refresh.

This adds a `getChannels()` call alongside the existing `getCombinedBalance()` call that already fires on payment success, so channel data is up to date by the time the user navigates to the channels pane.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
