### PR TITLE
refactor: extract invoice expiry calculation into ExpiryUtils

### DIFF
--- a/utils/ExpiryUtils.test.ts
+++ b/utils/ExpiryUtils.test.ts
@@ -1,4 +1,8 @@
-import { expirySecondsFromInput } from './ExpiryUtils';
+import {
+    ExpirationPreset,
+    expirationIndexFromSeconds,
+    expirySecondsFromInput
+} from './ExpiryUtils';
 
 describe('ExpiryUtils', () => {
     describe('expirySecondsFromInput', () => {
@@ -25,6 +29,50 @@ describe('ExpiryUtils', () => {
         it('converts Weeks to seconds', () => {
             expect(expirySecondsFromInput('1', 'Weeks')).toBe('604800');
             expect(expirySecondsFromInput('2', 'Weeks')).toBe('1209600');
+        });
+
+        it('returns fallback for empty string', () => {
+            expect(expirySecondsFromInput('', 'Hours')).toBe('3600');
+            expect(expirySecondsFromInput('', 'Minutes')).toBe('3600');
+        });
+
+        it('returns fallback for zero', () => {
+            expect(expirySecondsFromInput('0', 'Hours')).toBe('3600');
+            expect(expirySecondsFromInput('0', 'Seconds')).toBe('3600');
+        });
+
+        it('returns fallback for negative values', () => {
+            expect(expirySecondsFromInput('-1', 'Hours')).toBe('3600');
+            expect(expirySecondsFromInput('-100', 'Minutes')).toBe('3600');
+        });
+
+        it('returns fallback for non-numeric input', () => {
+            expect(expirySecondsFromInput('abc', 'Hours')).toBe('3600');
+            expect(expirySecondsFromInput('1a', 'Minutes')).toBe('3600');
+            expect(expirySecondsFromInput('NaN', 'Hours')).toBe('3600');
+        });
+    });
+
+    describe('expirationIndexFromSeconds', () => {
+        it('returns correct preset for known values', () => {
+            expect(expirationIndexFromSeconds('600')).toBe(
+                ExpirationPreset.TenMinutes
+            );
+            expect(expirationIndexFromSeconds('3600')).toBe(
+                ExpirationPreset.OneHour
+            );
+            expect(expirationIndexFromSeconds('86400')).toBe(
+                ExpirationPreset.OneDay
+            );
+            expect(expirationIndexFromSeconds('604800')).toBe(
+                ExpirationPreset.OneWeek
+            );
+        });
+
+        it('returns null for unknown values', () => {
+            expect(expirationIndexFromSeconds('999')).toBeNull();
+            expect(expirationIndexFromSeconds('')).toBeNull();
+            expect(expirationIndexFromSeconds('NaN')).toBeNull();
         });
     });
 });

--- a/utils/ExpiryUtils.ts
+++ b/utils/ExpiryUtils.ts
@@ -1,17 +1,27 @@
 import BigNumber from 'bignumber.js';
 
+export type TimePeriod = 'Seconds' | 'Minutes' | 'Hours' | 'Days' | 'Weeks';
+
+export enum ExpirationPreset {
+    TenMinutes = 0,
+    OneHour = 1,
+    OneDay = 2,
+    OneWeek = 3
+}
+
 const SECONDS_IN_MINUTE = 60;
 const SECONDS_IN_HOUR = SECONDS_IN_MINUTE * 60;
 const SECONDS_IN_DAY = SECONDS_IN_HOUR * 24;
 const SECONDS_IN_WEEK = SECONDS_IN_DAY * 7;
 
 // Converts a user-entered value + time period into expiry seconds.
+// Returns '3600' for invalid input (empty, zero, negative, non-numeric).
 // e.g. ('2', 'Hours') → '7200'
-
 export const expirySecondsFromInput = (
     value: string,
-    timePeriod: string
+    timePeriod: TimePeriod
 ): string => {
+    if (!value || !(Number(value) > 0)) return '3600';
     switch (timePeriod) {
         case 'Seconds':
             return value;
@@ -31,5 +41,22 @@ export const expirySecondsFromInput = (
                 .toString();
         default:
             return '3600';
+    }
+};
+
+export const expirationIndexFromSeconds = (
+    expirySeconds: string
+): ExpirationPreset | null => {
+    switch (expirySeconds) {
+        case '600':
+            return ExpirationPreset.TenMinutes;
+        case '3600':
+            return ExpirationPreset.OneHour;
+        case '86400':
+            return ExpirationPreset.OneDay;
+        case '604800':
+            return ExpirationPreset.OneWeek;
+        default:
+            return null;
     }
 };

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -83,7 +83,12 @@ import NFCUtils from '../utils/NFCUtils';
 import { themeColor } from '../utils/ThemeUtils';
 import { SATS_PER_BTC } from '../utils/UnitsUtils';
 import { getAmountFromSats } from '../utils/AmountUtils';
-import { expirySecondsFromInput } from '../utils/ExpiryUtils';
+import {
+    ExpirationPreset,
+    TimePeriod,
+    expirationIndexFromSeconds,
+    expirySecondsFromInput
+} from '../utils/ExpiryUtils';
 
 import lndMobile from '../lndmobile/LndMobileInjection';
 import { decodeSubscribeTransactionsResult } from '../lndmobile/onchain';
@@ -142,7 +147,7 @@ interface ReceiveProps {
 
 interface ReceiveState {
     selectedIndex: number;
-    expirationIndex: number | null;
+    expirationIndex: ExpirationPreset | null;
     addressType: string;
     memo: string;
     receiverName: string;
@@ -180,30 +185,6 @@ enum RouteHintMode {
     Automatic = 0,
     Custom = 1
 }
-
-enum ExpirationPreset {
-    TenMinutes = 0,
-    OneHour = 1,
-    OneDay = 2,
-    OneWeek = 3
-}
-
-const expirationIndexFromSeconds = (
-    expirySeconds: string
-): ExpirationPreset | null => {
-    switch (expirySeconds) {
-        case '600':
-            return ExpirationPreset.TenMinutes;
-        case '3600':
-            return ExpirationPreset.OneHour;
-        case '86400':
-            return ExpirationPreset.OneDay;
-        case '604800':
-            return ExpirationPreset.OneWeek;
-        default:
-            return null;
-    }
-};
 
 const LOCKED_EXPIRY = '1';
 const LOCKED_TIME_PERIOD = 'Hours';
@@ -297,7 +278,10 @@ export default class Receive extends React.Component<
 
         const { flowLspNotConfigured } = NodeInfoStore.flowLspNotConfigured();
 
-        const newExpirySeconds = settings?.invoices?.expirySeconds || '3600';
+        const newExpirySeconds =
+            Number(settings?.invoices?.expirySeconds) > 0
+                ? settings!.invoices!.expirySeconds!
+                : '3600';
 
         const expirationIndex = expirationIndexFromSeconds(newExpirySeconds);
 
@@ -2739,14 +2723,19 @@ export default class Receive extends React.Component<
                                                                     onChangeText={(
                                                                         text: string
                                                                     ) => {
+                                                                        const digits =
+                                                                            text.replace(
+                                                                                /[^0-9]/g,
+                                                                                ''
+                                                                            );
                                                                         const expirySeconds =
                                                                             expirySecondsFromInput(
-                                                                                text,
-                                                                                timePeriod
+                                                                                digits,
+                                                                                timePeriod as TimePeriod
                                                                             );
                                                                         this.setState(
                                                                             {
-                                                                                expiry: text,
+                                                                                expiry: digits,
                                                                                 expirySeconds,
                                                                                 expirationIndex:
                                                                                     expirationIndexFromSeconds(
@@ -2777,7 +2766,7 @@ export default class Receive extends React.Component<
                                                                             const expirySeconds =
                                                                                 expirySecondsFromInput(
                                                                                     expiry,
-                                                                                    value
+                                                                                    value as TimePeriod
                                                                                 );
                                                                             this.setState(
                                                                                 {

--- a/views/Settings/InvoicesSettings.tsx
+++ b/views/Settings/InvoicesSettings.tsx
@@ -23,7 +23,7 @@ import SettingsStore, {
 import BackendUtils from '../../utils/BackendUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
-import { expirySecondsFromInput } from '../../utils/ExpiryUtils';
+import { TimePeriod, expirySecondsFromInput } from '../../utils/ExpiryUtils';
 
 import Gear from '../../assets/images/SVG/Gear.svg';
 
@@ -292,23 +292,29 @@ export default class InvoicesSettings extends React.Component<
                                         width: '58%'
                                     }}
                                     onChangeText={async (text: string) => {
+                                        const digits = text.replace(
+                                            /[^0-9]/g,
+                                            ''
+                                        );
                                         const expirySeconds =
                                             expirySecondsFromInput(
-                                                text,
-                                                timePeriod
+                                                digits,
+                                                timePeriod as TimePeriod
                                             );
 
                                         this.setState({
-                                            expiry: text,
+                                            expiry: digits,
                                             expirySeconds
                                         });
-                                        await updateSettings({
-                                            invoices: {
-                                                ...settings.invoices,
-                                                expiry: text,
-                                                expirySeconds
-                                            }
-                                        });
+                                        if (digits && Number(digits) > 0) {
+                                            await updateSettings({
+                                                invoices: {
+                                                    ...settings.invoices,
+                                                    expiry: digits,
+                                                    expirySeconds
+                                                }
+                                            });
+                                        }
                                     }}
                                 />
                                 <Spacer width={4} />
@@ -329,7 +335,7 @@ export default class InvoicesSettings extends React.Component<
                                             const expirySeconds =
                                                 expirySecondsFromInput(
                                                     expiry,
-                                                    value
+                                                    value as TimePeriod
                                                 );
 
                                             this.setState({


### PR DESCRIPTION
# Description

Extracts the expiry-seconds calculation logic from `Receive.tsx` and `InvoicesSettings.tsx` into `utils/ExpiryUtils.ts`.

Additionally "CREATE INVOICE" button on Receive screen is now disabled when expiry input is empty (which would pass `NaN` as the invoice expiry and display an error).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
