### PR TITLE
fix: InfoModal: only show close button on upgrade prompts, rename onClose to onDismiss

### DIFF
--- a/components/Modals/InfoModal.tsx
+++ b/components/Modals/InfoModal.tsx
@@ -28,7 +28,9 @@ export default class InfoModal extends React.Component<InfoModalProps, {}> {
             infoModalLink,
             infoModalAdditionalButtons,
             infoModalBackgroundColor,
-            infoModalOnClose,
+            infoModalOnDismiss,
+            infoModalShowCloseButton,
+            infoModalShowHelpButton,
             toggleInfoModal
         } = ModalStore;
 
@@ -70,22 +72,26 @@ export default class InfoModal extends React.Component<InfoModalProps, {}> {
                             }
                         }}
                     >
-                        <TouchableOpacity
-                            style={styles.closeIcon}
-                            onPress={() => toggleInfoModal({})}
-                            accessibilityLabel={localeString('general.close')}
-                        >
-                            <Text
-                                style={{
-                                    fontFamily: font('marlideBold'),
-                                    color: themeColor('text'),
-                                    fontSize: 18
-                                }}
+                        {infoModalShowCloseButton && (
+                            <TouchableOpacity
+                                style={styles.closeIcon}
+                                onPress={() => toggleInfoModal({})}
+                                accessibilityLabel={localeString(
+                                    'general.close'
+                                )}
                             >
-                                ✕
-                            </Text>
-                        </TouchableOpacity>
-                        {infoModalLink && (
+                                <Text
+                                    style={{
+                                        fontFamily: font('marlideBold'),
+                                        color: themeColor('text'),
+                                        fontSize: 18
+                                    }}
+                                >
+                                    ✕
+                                </Text>
+                            </TouchableOpacity>
+                        )}
+                        {infoModalShowHelpButton && infoModalLink && (
                             <TouchableOpacity
                                 style={styles.helpIcon}
                                 onPress={() => {
@@ -174,16 +180,17 @@ export default class InfoModal extends React.Component<InfoModalProps, {}> {
                                     </View>
                                 )
                             )}
-                            {infoModalOnClose ? (
+                            {infoModalOnDismiss ? (
                                 <View style={styles.button}>
                                     <Button
                                         title={localeString(
                                             'cashu.upgradePrompt.dontRemind'
                                         )}
                                         onPress={() => {
-                                            const onClose = infoModalOnClose;
+                                            const onDismiss =
+                                                infoModalOnDismiss;
                                             toggleInfoModal({});
-                                            if (onClose) onClose();
+                                            if (onDismiss) onDismiss();
                                         }}
                                         secondary
                                     />

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -1781,7 +1781,9 @@ export default class CashuStore {
                             }
                         }
                     ],
-                    onClose: () => {
+                    showCloseButton: true,
+                    showHelpButton: true,
+                    onDismiss: () => {
                         this.dismissUpgradeThreshold(threshold);
                     }
                 });
@@ -1831,7 +1833,9 @@ export default class CashuStore {
                         });
                     }
                 }
-            ]
+            ],
+            showCloseButton: true,
+            showHelpButton: true
         });
     };
 

--- a/stores/ModalStore.ts
+++ b/stores/ModalStore.ts
@@ -30,7 +30,9 @@ export default class ModalStore {
         callback?: () => void;
     }>;
     @observable public infoModalBackgroundColor?: string;
-    public infoModalOnClose?: () => void;
+    public infoModalOnDismiss?: () => void;
+    @observable public infoModalShowCloseButton?: boolean;
+    @observable public infoModalShowHelpButton?: boolean;
     @observable public alertModalText: string | Array<string> | undefined;
     @observable public alertModalLink: string | undefined;
     @observable public alertModalNav: string | undefined;
@@ -52,14 +54,18 @@ export default class ModalStore {
         link,
         buttons,
         backgroundColor,
-        onClose
+        onDismiss,
+        showCloseButton,
+        showHelpButton
     }: {
         title?: string;
         text?: string | Array<string>;
         link?: string;
         buttons?: Array<{ title: string; callback?: () => void }>;
         backgroundColor?: string;
-        onClose?: () => void;
+        onDismiss?: () => void;
+        showCloseButton?: boolean;
+        showHelpButton?: boolean;
     }) => {
         this.showInfoModal = title || text ? true : false; // Show if title or text exists
         this.infoModalTitle = title;
@@ -67,7 +73,9 @@ export default class ModalStore {
         this.infoModalLink = link;
         this.infoModalAdditionalButtons = buttons;
         this.infoModalBackgroundColor = backgroundColor;
-        this.infoModalOnClose = onClose;
+        this.infoModalOnDismiss = onDismiss;
+        this.infoModalShowCloseButton = showCloseButton;
+        this.infoModalShowHelpButton = showHelpButton;
     };
 
     @action
@@ -194,7 +202,9 @@ export default class ModalStore {
             this.infoModalLink = undefined;
             this.infoModalAdditionalButtons = undefined;
             this.infoModalBackgroundColor = undefined;
-            this.infoModalOnClose = undefined;
+            this.infoModalOnDismiss = undefined;
+            this.infoModalShowCloseButton = undefined;
+            this.infoModalShowHelpButton = undefined;
             return true;
         }
         if (this.showShareModal) {


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-3791**](https://github.com/ZeusLN/zeus/issues/3791)

## Summary
- Fix close (✕) button overlapping text in InfoModal (fixes #3791)
- The ✕ button now only renders on upgrade prompt modals via a new `showCloseButton` prop
- Renamed `onClose`/`infoModalOnClose` to `onDismiss`/`infoModalOnDismiss` for clarity — it controls the "Don't remind me again" behavior, not the close button

## Test plan
- [ ] Open Settings → Privacy, tap ⓘ on any option — verify no ✕ button and no text overlap
- [ ] Trigger a cashu upgrade prompt modal — verify ✕ button, ? help button, and "Don't remind me again" all still work

## PR Type

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
