### PR TITLE
ui: Add reserve balance display to Lightning and On-chain wallet rows

### DIFF
--- a/components/LayerBalances/PaymentMethodList.tsx
+++ b/components/LayerBalances/PaymentMethodList.tsx
@@ -11,6 +11,7 @@ import LightningSwipeableRow from './LightningSwipeableRow';
 import EcashSwipeableRow from './EcashSwipeableRow';
 import Amount from '../Amount';
 
+import Channel from '../../models/Channel';
 import BackendUtils from '../../utils/BackendUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
@@ -19,7 +20,13 @@ import OnChainSvg from '../../assets/images/SVG/DynamicSVG/OnChainSvg';
 import LightningSvg from '../../assets/images/SVG/DynamicSVG/LightningSvg';
 import EcashSvg from '../../assets/images/SVG/DynamicSVG/EcashSvg';
 
-import { nodeInfoStore, settingsStore } from '../../stores/Stores';
+import BigNumber from 'bignumber.js';
+
+import {
+    channelsStore,
+    nodeInfoStore,
+    settingsStore
+} from '../../stores/Stores';
 
 interface PaymentMethodListProps {
     navigation: StackNavigationProp<any, any>;
@@ -33,6 +40,7 @@ interface PaymentMethodListProps {
     lnurlParams?: LNURLWithdrawParams | undefined;
     lightningBalance?: number | string;
     onchainBalance?: number | string;
+    onchainReserve?: number;
     ecashBalance?: number | string;
     accounts?: Array<{
         name: string;
@@ -51,6 +59,7 @@ type DataRow = {
     subtitle?: string;
     disabled?: boolean;
     balance?: number | string;
+    reserve?: number;
     account?: string;
     hidden?: boolean;
     satAmount?: number;
@@ -81,13 +90,19 @@ const LayerIcon = ({ layer }: { layer: string }) => {
 
 const hasInsufficientBalance = (
     balance: number | string | undefined,
-    satAmount: number | undefined
-) =>
-    Number(balance) === 0 ||
-    (satAmount !== undefined && satAmount > Number(balance));
+    satAmount: number | undefined,
+    reserve: number = 0
+) => {
+    const spendable = Number(balance ?? 0) - reserve;
+    return spendable <= 0 || (satAmount !== undefined && satAmount > spendable);
+};
 
 const Row = ({ item }: { item: DataRow }) => {
-    const insufficient = hasInsufficientBalance(item.balance, item.satAmount);
+    const insufficient = hasInsufficientBalance(
+        item.balance,
+        item.satAmount,
+        item.reserve
+    );
     const layerLabel = LAYER_LOCALE_MAP[item.layer]
         ? localeString(LAYER_LOCALE_MAP[item.layer])
         : item.layer;
@@ -142,7 +157,13 @@ const Row = ({ item }: { item: DataRow }) => {
                 {item.balance !== undefined && (
                     <View style={styles.balanceContainer}>
                         <Amount
-                            sats={item.balance}
+                            sats={
+                                item.reserve && item.reserve > 0
+                                    ? new BigNumber(item.balance)
+                                          .minus(item.reserve)
+                                          .toNumber()
+                                    : item.balance
+                            }
                             sensitive
                             colorOverride={
                                 insufficient
@@ -150,6 +171,32 @@ const Row = ({ item }: { item: DataRow }) => {
                                     : themeColor('buttonText')
                             }
                         />
+                        {item.reserve != null && item.reserve > 0 && (
+                            <View
+                                style={{
+                                    flexDirection: 'row',
+                                    alignItems: 'center',
+                                    justifyContent: 'flex-end'
+                                }}
+                            >
+                                <Text
+                                    style={{
+                                        color: themeColor('buttonText'),
+                                        fontSize: 10,
+                                        fontFamily: 'PPNeueMontreal-Book',
+                                        marginRight: 2
+                                    }}
+                                >
+                                    {`${localeString('general.reserve')}:`}
+                                </Text>
+                                <Amount
+                                    sats={item.reserve}
+                                    sensitive
+                                    colorOverride={themeColor('buttonText')}
+                                    fontSize={10}
+                                />
+                            </View>
+                        )}
                     </View>
                 )}
             </LinearGradient>
@@ -179,7 +226,11 @@ const SwipeableRow = ({
     offer?: string;
     lnurlParams?: LNURLWithdrawParams | undefined;
 }) => {
-    const insufficient = hasInsufficientBalance(item.balance, item.satAmount);
+    const insufficient = hasInsufficientBalance(
+        item.balance,
+        item.satAmount,
+        item.reserve
+    );
     const rowDisabled = item.disabled || insufficient;
     if (item.layer === 'Lightning') {
         return (
@@ -266,16 +317,24 @@ export default class PaymentMethodList extends Component<
             lnurlParams,
             lightningBalance,
             onchainBalance,
+            onchainReserve,
             ecashBalance,
             accounts
         } = this.props;
         let DATA: DataRow[] = [];
+
+        const lightningChannelReserve = channelsStore.channels.reduce(
+            (sum: number, channel: Channel) =>
+                sum + Number(channel.localReserveBalance || 0),
+            0
+        );
 
         if (lightning || lnurlParams) {
             DATA.push({
                 layer: 'Lightning',
                 subtitle: lightning ?? lnurlParams?.tag,
                 balance: lightningBalance,
+                reserve: lightningChannelReserve,
                 disabled: false,
                 satAmount
             });
@@ -299,6 +358,7 @@ export default class PaymentMethodList extends Component<
                 layer: 'Lightning address',
                 subtitle: lightningAddress,
                 balance: lightningBalance,
+                reserve: lightningChannelReserve,
                 disabled: false,
                 satAmount
             });
@@ -310,6 +370,7 @@ export default class PaymentMethodList extends Component<
                 subtitle: offer,
                 disabled: !nodeInfoStore.supportsOffers,
                 balance: lightningBalance,
+                reserve: lightningChannelReserve,
                 satAmount
             });
         }
@@ -321,6 +382,7 @@ export default class PaymentMethodList extends Component<
                 subtitle: value,
                 disabled: !BackendUtils.supportsOnchainSends(),
                 balance: onchainBalance,
+                reserve: onchainReserve,
                 account: 'default',
                 satAmount
             });

--- a/components/LayerBalances/index.tsx
+++ b/components/LayerBalances/index.tsx
@@ -21,7 +21,7 @@ import EcashSwipeableRow from './EcashSwipeableRow';
 import { Row as LayoutRow } from '../layout/Row';
 import Pill from '../Pill';
 
-import { cashuStore, utxosStore } from '../../stores/Stores';
+import { cashuStore, channelsStore, utxosStore } from '../../stores/Stores';
 
 import BalanceStore from '../../stores/BalanceStore';
 import CashuStore from '../../stores/CashuStore';
@@ -29,6 +29,7 @@ import UnitsStore from '../../stores/UnitsStore';
 import UTXOsStore from '../../stores/UTXOsStore';
 import SettingsStore from '../../stores/SettingsStore';
 
+import Channel from '../../models/Channel';
 import BackendUtils from '../../utils/BackendUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { blendHexColors, themeColor } from '../../utils/ThemeUtils';
@@ -73,6 +74,7 @@ type DataRow = {
     layer: string;
     subtitle?: string;
     balance: string | number;
+    reserve?: number;
     // TODO check if exists
     count?: number;
     watchOnly?: boolean;
@@ -275,10 +277,41 @@ const Row = ({ item }: { item: DataRow }) => {
                     {!item.needsConfig && (
                         <View style={styles.rightContent}>
                             <Amount
-                                sats={item.balance}
+                                sats={
+                                    item.reserve && item.reserve > 0
+                                        ? new BigNumber(item.balance)
+                                              .minus(item.reserve)
+                                              .toNumber()
+                                        : item.balance
+                                }
                                 sensitive
                                 colorOverride={themeColor('buttonText')}
                             />
+                            {item.reserve != null && item.reserve > 0 && (
+                                <View
+                                    style={{
+                                        flexDirection: 'row',
+                                        alignItems: 'center'
+                                    }}
+                                >
+                                    <Text
+                                        style={{
+                                            color: themeColor('buttonText'),
+                                            fontSize: 10,
+                                            fontFamily: 'PPNeueMontreal-Book',
+                                            marginRight: 2
+                                        }}
+                                    >
+                                        {`${localeString('general.reserve')}:`}
+                                    </Text>
+                                    <Amount
+                                        sats={item.reserve}
+                                        sensitive
+                                        colorOverride={themeColor('buttonText')}
+                                        fontSize={10}
+                                    />
+                                </View>
+                            )}
                             {/* Show custodial pill below balance for Ecash */}
                             {isEcash && item.custodial && (
                                 <View style={styles.pillRight}>
@@ -439,8 +472,19 @@ export default class LayerBalances extends Component<LayerBalancesProps, {}> {
         } = this.props;
 
         const { settings } = SettingsStore!;
-        const { totalBlockchainBalance, lightningBalance } = BalanceStore!;
+        const {
+            totalBlockchainBalance,
+            lightningBalance,
+            reservedBalanceAnchorChan
+        } = BalanceStore!;
         const { totalBalanceSats, mintUrls, mintInfos } = CashuStore!;
+
+        // Sum local channel reserves across all active channels
+        const lightningChannelReserve = channelsStore.channels.reduce(
+            (sum: number, channel: Channel) =>
+                sum + Number(channel.localReserveBalance || 0),
+            0
+        );
 
         const otherAccounts = editMode
             ? this.props.UTXOsStore?.accounts
@@ -452,13 +496,15 @@ export default class LayerBalances extends Component<LayerBalancesProps, {}> {
 
         DATA.push({
             layer: 'Lightning',
-            balance: Number(lightningBalance).toFixed(3)
+            balance: Number(lightningBalance).toFixed(3),
+            reserve: lightningChannelReserve
         });
 
         if (BackendUtils.supportsOnchainReceiving()) {
             DATA.push({
                 layer: 'On-chain',
-                balance: Number(totalBlockchainBalance).toFixed(3)
+                balance: Number(totalBlockchainBalance).toFixed(3),
+                reserve: reservedBalanceAnchorChan
             });
         }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,5 +1,6 @@
 {
     "general.send": "Send",
+    "general.reserve": "Reserve",
     "general.tor": "Tor",
     "general.torEnabled": "Tor enabled",
     "general.receive": "Receive",

--- a/stores/BalanceStore.ts
+++ b/stores/BalanceStore.ts
@@ -15,6 +15,7 @@ export default class BalanceStore {
     @observable public error = false;
     @observable public pendingOpenBalance: number | string | any;
     @observable public lightningBalance: number | string;
+    @observable public reservedBalanceAnchorChan: number = 0;
     @observable public otherAccounts: any = {};
     settingsStore: SettingsStore;
 
@@ -44,6 +45,7 @@ export default class BalanceStore {
         this.unconfirmedBlockchainBalance = 0;
         this.confirmedBlockchainBalance = 0;
         this.totalBlockchainBalance = 0;
+        this.reservedBalanceAnchorChan = 0;
         this.otherAccounts = {};
         this.loadingBlockchainBalance = false;
     };
@@ -92,6 +94,10 @@ export default class BalanceStore {
                 data.total_balance || 0
             );
 
+            const reservedBalanceAnchorChan = Number(
+                data.reserved_balance_anchor_chan || 0
+            );
+
             runInAction(() => {
                 if (set) {
                     if (accounts && accounts.default && data.confirmed_balance)
@@ -105,6 +111,7 @@ export default class BalanceStore {
                     this.totalBlockchainBalance = totalBlockchainBalance;
                     this.totalBlockchainBalanceAccounts =
                         totalBlockchainBalanceAccounts;
+                    this.reservedBalanceAnchorChan = reservedBalanceAnchorChan;
                 }
                 this.loadingBlockchainBalance = false;
             });
@@ -112,6 +119,7 @@ export default class BalanceStore {
                 unconfirmedBlockchainBalance,
                 confirmedBlockchainBalance,
                 totalBlockchainBalance,
+                reservedBalanceAnchorChan,
                 accounts
             };
         } catch {
@@ -166,6 +174,8 @@ export default class BalanceStore {
             this.confirmedBlockchainBalance =
                 onChain?.confirmedBlockchainBalance || 0;
             this.totalBlockchainBalance = onChain?.totalBlockchainBalance || 0;
+            this.reservedBalanceAnchorChan =
+                onChain?.reservedBalanceAnchorChan || 0;
         });
 
         return {

--- a/views/ChoosePaymentMethod.tsx
+++ b/views/ChoosePaymentMethod.tsx
@@ -225,7 +225,11 @@ export default class ChoosePaymentMethod extends React.Component<
         } = this.state;
 
         const { accounts } = UTXOsStore!;
-        const { totalBlockchainBalance, lightningBalance } = BalanceStore!;
+        const {
+            totalBlockchainBalance,
+            lightningBalance,
+            reservedBalanceAnchorChan
+        } = BalanceStore!;
         const { totalBalanceSats } = CashuStore!;
 
         const hasInsufficientFunds = this.hasInsufficientFunds();
@@ -303,6 +307,7 @@ export default class ChoosePaymentMethod extends React.Component<
                     // balance data
                     lightningBalance={lightningBalance}
                     onchainBalance={totalBlockchainBalance}
+                    onchainReserve={reservedBalanceAnchorChan}
                     ecashBalance={totalBalanceSats}
                     accounts={accounts}
                 />


### PR DESCRIPTION
# Description

Related issue: [ZEUS-3092](https://github.com/ZeusLN/zeus/issues/3092)

Shows channel and anchor reserves on the wallet balance rows and payment method selection screen, giving users a clearer picture of their actual spendable balance. WIP, still working on how this is displayed.

|Before|After|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-05 at 23 52 25" src="https://github.com/user-attachments/assets/7f217b48-2265-46f5-bc0d-cdee3222a999" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-06 at 00 00 47" src="https://github.com/user-attachments/assets/80809d37-0cff-4de3-be9d-d4403bccb248" />|

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-06 at 00 06 35" src="https://github.com/user-attachments/assets/547bd670-b7df-45a5-a939-7d3ca539cb22" />

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
