### PR TITLE
ui: Hide ≈ symbol while fiat rate is loading

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -200,6 +200,8 @@ function AmountDisplay({
     };
 
     const renderCurrencyAmount = () => {
+        const isFiatRateLoading = amount === 'N/A' && fiatRatesLoading;
+
         const feeSection = fee && (
             <>
                 <Spacer width={2} />
@@ -228,7 +230,7 @@ function AmountDisplay({
                 accessible={accessible}
             >
                 {negative ? '-' : ''}
-                {amount === 'N/A' && fiatRatesLoading ? (
+                {isFiatRateLoading ? (
                     <LoadingIndicator size={20} />
                 ) : unit === 'BTC' ? (
                     formatBitcoinWithSpaces(amount)
@@ -247,7 +249,9 @@ function AmountDisplay({
         const indicators = (
             <>
                 {unit === 'BTC' && roundAmount && <RoundingIndicator />}
-                {unit === 'fiat' && <ApproximateSymbol accessible />}
+                {unit === 'fiat' && !isFiatRateLoading && (
+                    <ApproximateSymbol accessible />
+                )}
             </>
         );
 


### PR DESCRIPTION
# Description

Before, while fiat rates were fetched the approximate symbol was still visible next to the loading spinner. I think that looks a bit weird.

|Before|After|
|-|-|
|<img width="406" height="439" alt="grafik" src="https://github.com/user-attachments/assets/c556f84b-c244-4575-9188-b42b46fdeaa3" />|<img width="406" height="431" alt="grafik" src="https://github.com/user-attachments/assets/20c5c2ce-2837-4070-b02a-9b27612443be" />|

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
