### PR TITLE
fix: skip LND restart on initial wallet creation to prevent cfheaders sync interruption

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1549,6 +1549,7 @@ export default class SettingsStore {
     @observable public isSqlite?: boolean;
     @observable public initialStart: boolean = true;
     @observable public embeddedLndStarted: boolean = false;
+    @observable public walletJustCreated: boolean = false;
     @observable public lndFolderMissing: boolean = false;
     // NWC
     @observable public nostrWalletConnectUrl: string;

--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -1126,6 +1126,12 @@ export async function createLndWallet({
         channelBackupsBase64 ? channelBackupsBase64 : undefined,
         walletPassphrase ? walletPassphrase : undefined
     );
+
+    // Mark that LND is already running from wallet creation,
+    // so Wallet.tsx skips the stop→init→start cycle
+    settingsStore.embeddedLndStarted = true;
+    settingsStore.walletJustCreated = true;
+
     return { wallet, seed, randomBase64 };
 }
 

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -536,139 +536,164 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                     );
                 };
 
-                try {
-                    AlertStore.checkNeutrinoPeers();
+                // If LND is already running (e.g. just created via Quick Start),
+                // skip the stop→init→start cycle entirely
+                if (!SettingsStore.walletJustCreated) {
+                    try {
+                        AlertStore.checkNeutrinoPeers();
 
-                    // Skip stopLnd when wallet is already closed (e.g. after delete)
-                    if (!recovery && SettingsStore.embeddedLndStarted) {
-                        await stopLnd();
+                        // Skip stopLnd when wallet is already closed (e.g. after delete)
+                        if (!recovery && SettingsStore.embeddedLndStarted) {
+                            await stopLnd();
+                        }
+
+                        if (settings?.ecash?.enableCashu)
+                            await CashuStore.initializeWallets();
+
+                        console.log('lndDir', lndDir);
+
+                        try {
+                            await initializeLnd({
+                                lndDir: lndDir || 'lnd',
+                                isTestnet: embeddedLndNetwork === 'Testnet',
+                                rescan,
+                                compactDb,
+                                isSqlite
+                            });
+                        } catch (initError: any) {
+                            // During recovery, initializeLnd may fail because createLndWallet
+                            // already set up the directories and config - that's OK, continue
+                            if (recovery) {
+                                console.log(
+                                    'initializeLnd failed during recovery (expected):',
+                                    initError?.message
+                                );
+                            } else {
+                                throw initError;
+                            }
+                        }
+                    } catch (error: any) {
+                        console.log(
+                            'embedded-lnd startup error:',
+                            error?.message,
+                            error
+                        );
+                        if (
+                            !recovery &&
+                            matchesLndErrorCode(
+                                error?.message || String(error),
+                                LndErrorCode.LND_FOLDER_MISSING
+                            )
+                        ) {
+                            showFolderMissingAlert();
+                            return;
+                        }
+                        throw error;
                     }
 
-                    if (settings?.ecash?.enableCashu)
-                        await CashuStore.initializeWallets();
+                    // on initial load, do not run EGS
+                    if (initialLoad) {
+                        await updateSettings({
+                            initialLoad: false
+                        });
+                    } else {
+                        if (expressGraphSyncEnabled) {
+                            const expressGraphSyncStart = new Date().getTime();
+                            console.log(
+                                '[Performance] Express Graph Sync starting...'
+                            );
 
-                    console.log('lndDir', lndDir);
+                            await expressGraphSync();
+
+                            const expressGraphSyncDuration =
+                                new Date().getTime() - expressGraphSyncStart;
+                            console.log(
+                                `[Performance] Express Graph Sync completed in ${expressGraphSyncDuration}ms`
+                            );
+
+                            if (settings.resetExpressGraphSyncOnStartup) {
+                                await updateSettings({
+                                    resetExpressGraphSyncOnStartup: false
+                                });
+                            }
+                        } else {
+                            console.log(
+                                '[Performance] Express Graph Sync skipped (disabled) - faster startup'
+                            );
+                        }
+                    }
 
                     try {
-                        await initializeLnd({
+                        await startLnd({
                             lndDir: lndDir || 'lnd',
+                            walletPassword: walletPassword || '',
+                            isTorEnabled: embeddedTor,
                             isTestnet: embeddedLndNetwork === 'Testnet',
-                            rescan,
-                            compactDb,
-                            isSqlite
+                            isRecovery: recovery
                         });
-                    } catch (initError: any) {
-                        // During recovery, initializeLnd may fail because createLndWallet
-                        // already set up the directories and config - that's OK, continue
-                        if (recovery) {
-                            console.log(
-                                'initializeLnd failed during recovery (expected):',
-                                initError?.message
+                    } catch (error: any) {
+                        const errorMessage = error?.message ?? '';
+                        console.log('startLnd error:', errorMessage);
+
+                        // Handle folder missing error
+                        if (
+                            matchesLndErrorCode(
+                                errorMessage,
+                                LndErrorCode.LND_FOLDER_MISSING
+                            )
+                        ) {
+                            showFolderMissingAlert();
+                            return;
+                        }
+
+                        // Handle LND start failed after max retries - restart app
+                        if (isLndError(error, LndErrorCode.LND_START_FAILED)) {
+                            restartNeeded(true);
+                            return;
+                        }
+
+                        // Handle transient errors - attempt restart with exponential backoff
+                        if (isTransientRpcError(errorMessage)) {
+                            await retryOnTransientError(
+                                error,
+                                errorMessage,
+                                'startLnd error',
+                                transientRetryCount,
+                                setConnectingStatus,
+                                () =>
+                                    this.getSettingsAndNavigate(
+                                        transientRetryCount + 1
+                                    )
                             );
-                        } else {
-                            throw initError;
+                            return;
                         }
-                    }
-                } catch (error: any) {
-                    console.log(
-                        'embedded-lnd startup error:',
-                        error?.message,
-                        error
-                    );
-                    if (
-                        !recovery &&
-                        matchesLndErrorCode(
-                            error?.message || String(error),
-                            LndErrorCode.LND_FOLDER_MISSING
-                        )
-                    ) {
-                        showFolderMissingAlert();
-                        return;
-                    }
-                    throw error;
-                }
 
-                // on initial load, do not run EGS
-                if (initialLoad) {
-                    await updateSettings({
-                        initialLoad: false
-                    });
+                        // Fatal error - throw to outer handler
+                        console.error('Fatal startLnd error:', error);
+                        setConnectingStatus(false);
+                        throw error;
+                    }
                 } else {
-                    if (expressGraphSyncEnabled) {
-                        const expressGraphSyncStart = new Date().getTime();
-                        console.log(
-                            '[Performance] Express Graph Sync starting...'
-                        );
+                    try {
+                        // LND was just created and is already running — skip stop→init→start
+                        AlertStore.checkNeutrinoPeers();
+                        SettingsStore.walletJustCreated = false;
 
-                        await expressGraphSync();
+                        if (settings?.ecash?.enableCashu)
+                            await CashuStore.initializeWallets();
 
-                        const expressGraphSyncDuration =
-                            new Date().getTime() - expressGraphSyncStart;
-                        console.log(
-                            `[Performance] Express Graph Sync completed in ${expressGraphSyncDuration}ms`
-                        );
-
-                        if (settings.resetExpressGraphSyncOnStartup) {
-                            await updateSettings({
-                                resetExpressGraphSyncOnStartup: false
-                            });
+                        await waitForRpcReady();
+                        if (!SyncStore.isSyncing) {
+                            SyncStore.startSyncing();
                         }
-                    } else {
-                        console.log(
-                            '[Performance] Express Graph Sync skipped (disabled) - faster startup'
+                    } catch (error: any) {
+                        console.error(
+                            'Fatal error during post-wallet creation setup:',
+                            error
                         );
+                        setConnectingStatus(false);
+                        throw error;
                     }
-                }
-
-                try {
-                    await startLnd({
-                        lndDir: lndDir || 'lnd',
-                        walletPassword: walletPassword || '',
-                        isTorEnabled: embeddedTor,
-                        isTestnet: embeddedLndNetwork === 'Testnet',
-                        isRecovery: recovery
-                    });
-                } catch (error: any) {
-                    const errorMessage = error?.message ?? '';
-                    console.log('startLnd error:', errorMessage);
-
-                    // Handle folder missing error
-                    if (
-                        matchesLndErrorCode(
-                            errorMessage,
-                            LndErrorCode.LND_FOLDER_MISSING
-                        )
-                    ) {
-                        showFolderMissingAlert();
-                        return;
-                    }
-
-                    // Handle LND start failed after max retries - restart app
-                    if (isLndError(error, LndErrorCode.LND_START_FAILED)) {
-                        restartNeeded(true);
-                        return;
-                    }
-
-                    // Handle transient errors - attempt restart with exponential backoff
-                    if (isTransientRpcError(errorMessage)) {
-                        await retryOnTransientError(
-                            error,
-                            errorMessage,
-                            'startLnd error',
-                            transientRetryCount,
-                            setConnectingStatus,
-                            () =>
-                                this.getSettingsAndNavigate(
-                                    transientRetryCount + 1
-                                )
-                        );
-                        return;
-                    }
-
-                    // Fatal error - throw to outer handler
-                    console.error('Fatal startLnd error:', error);
-                    setConnectingStatus(false);
-                    throw error;
                 }
 
                 try {


### PR DESCRIPTION
# Description

- When Quick Start creates a new wallet, LND is already running and syncing cfheaders — but navigating to the Wallet view would stop and restart it, killing the in-progress sync. This would result in the user getting stuck on the 'Starting your wallet' screen on wallet creation.
- Added `walletJustCreated` flag to skip the stop→init→start cycle in `fetchData()` when LND is already running from wallet creation
- Start syncing in the wallet-just-created path only after `waitForRpcReady()` confirms the server is accepting calls

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
