### PR TITLE
refactor: extract handlePaymentReceived helper in subscribeInvoice

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -771,20 +771,48 @@ export default class Receive extends React.Component<
             .catch();
     };
 
-    subscribeInvoice = async (rHash?: string, onChainAddress?: string) => {
-        const {
-            InvoicesStore,
-            PosStore,
-            SettingsStore,
-            NodeInfoStore,
-            BalanceStore,
-            ChannelsStore
-        } = this.props;
-        const { orderId, orderTotal, orderTip, exchangeRate, rate, value } =
+    handlePaymentReceived = (
+        amount: number,
+        posPayment?: {
+            type: 'ln' | 'onchain';
+            tx: string;
+            preimage?: string;
+        }
+    ) => {
+        const { InvoicesStore, PosStore, BalanceStore, ChannelsStore } =
+            this.props;
+        const { orderId, orderTotal, orderTip, exchangeRate, rate } =
             this.state;
+
+        InvoicesStore.setWatchedInvoicePaid(amount);
+        BalanceStore.getCombinedBalance();
+
+        if (
+            posPayment?.type === 'ln' &&
+            BackendUtils.supportsChannelManagement()
+        ) {
+            ChannelsStore.getChannels();
+        }
+
+        if (orderId && posPayment) {
+            PosStore.recordPayment({
+                orderId,
+                orderTotal,
+                orderTip,
+                exchangeRate,
+                rate,
+                ...posPayment
+            });
+            // Clear stored invoice after successful payment
+            PosStore.clearOrderInvoice(orderId);
+        }
+    };
+
+    subscribeInvoice = async (rHash?: string, onChainAddress?: string) => {
+        const { SettingsStore, NodeInfoStore } = this.props;
+        const { value } = this.state;
         const { implementation, settings } = SettingsStore;
         const { nodeInfo } = NodeInfoStore;
-        const { setWatchedInvoicePaid } = InvoicesStore;
 
         const numConfPreference =
             settings.pos && settings.pos.confirmationPreference === '1conf'
@@ -821,29 +849,17 @@ export default class Receive extends React.Component<
                                 // @ts-ignore:next-line
                                 Base64Utils.bytesToHex(invoice.r_hash) === rHash
                             ) {
-                                setWatchedInvoicePaid(
-                                    Number(invoice.amt_paid_sat)
-                                );
-                                BalanceStore.getCombinedBalance();
-                                ChannelsStore.getChannels();
-
-                                if (orderId) {
-                                    PosStore.recordPayment({
-                                        orderId,
-                                        orderTotal,
-                                        orderTip,
-                                        exchangeRate,
-                                        rate,
+                                this.handlePaymentReceived(
+                                    Number(invoice.amt_paid_sat),
+                                    {
                                         type: 'ln',
                                         tx: invoice.payment_request,
                                         preimage: Base64Utils.bytesToHex(
                                             // @ts-ignore:next-line
                                             invoice.r_preimage
                                         )
-                                    });
-                                    // Clear stored invoice after successful payment
-                                    PosStore.clearOrderInvoice(orderId);
-                                }
+                                    }
+                                );
                                 this.listener?.remove();
                             }
                         } catch (error) {
@@ -886,24 +902,13 @@ export default class Receive extends React.Component<
                                     numConfPreference &&
                                 Number(transaction.amount) >= Number(value)
                             ) {
-                                setWatchedInvoicePaid(
-                                    Number(transaction.amount)
-                                );
-                                BalanceStore.getCombinedBalance();
-
-                                if (orderId) {
-                                    PosStore.recordPayment({
-                                        orderId,
-                                        orderTotal,
-                                        orderTip,
-                                        exchangeRate,
-                                        rate,
+                                this.handlePaymentReceived(
+                                    Number(transaction.amount),
+                                    {
                                         type: 'onchain',
                                         tx: transaction.tx_hash
-                                    });
-                                    // Clear stored invoice after successful payment
-                                    PosStore.clearOrderInvoice(orderId);
-                                }
+                                    }
+                                );
                                 this.listenerSecondary?.remove();
                             }
                         } catch (error) {
@@ -943,24 +948,14 @@ export default class Receive extends React.Component<
                                     return;
                                 }
                                 if (result.settled) {
-                                    setWatchedInvoicePaid(result.amt_paid_sat);
-                                    BalanceStore.getCombinedBalance();
-                                    ChannelsStore.getChannels();
-
-                                    if (orderId) {
-                                        PosStore.recordPayment({
-                                            orderId,
-                                            orderTotal,
-                                            orderTip,
-                                            exchangeRate,
-                                            rate,
+                                    this.handlePaymentReceived(
+                                        result.amt_paid_sat,
+                                        {
                                             type: 'ln',
                                             tx: result.payment_request,
                                             preimage: result.r_preimage
-                                        });
-                                        // Clear stored invoice after successful payment
-                                        PosStore.clearOrderInvoice(orderId);
-                                    }
+                                        }
+                                    );
                                     this.listener?.remove();
                                 }
                             } catch (error) {
@@ -1002,22 +997,10 @@ export default class Receive extends React.Component<
                                         numConfPreference &&
                                     Number(result.amount) >= Number(value)
                                 ) {
-                                    setWatchedInvoicePaid(result.amount);
-                                    BalanceStore.getCombinedBalance();
-
-                                    if (orderId) {
-                                        PosStore.recordPayment({
-                                            orderId,
-                                            orderTotal,
-                                            orderTip,
-                                            exchangeRate,
-                                            rate,
-                                            type: 'onchain',
-                                            tx: result.tx_hash
-                                        });
-                                        // Clear stored invoice after successful payment
-                                        PosStore.clearOrderInvoice(orderId);
-                                    }
+                                    this.handlePaymentReceived(result.amount, {
+                                        type: 'onchain',
+                                        tx: result.tx_hash
+                                    });
                                     this.listenerSecondary?.remove();
                                 }
                             } catch (error) {
@@ -1047,23 +1030,13 @@ export default class Receive extends React.Component<
                                         Number(value) &&
                                     Number(result.amt_paid_sat) !== 0
                                 ) {
-                                    setWatchedInvoicePaid(result.amt_paid_sat);
-                                    BalanceStore.getCombinedBalance();
-                                    ChannelsStore.getChannels();
-
-                                    if (orderId) {
-                                        PosStore.recordPayment({
-                                            orderId,
-                                            orderTotal,
-                                            orderTip,
-                                            exchangeRate,
-                                            rate,
+                                    this.handlePaymentReceived(
+                                        result.amt_paid_sat,
+                                        {
                                             type: 'ln',
                                             tx: result.payment_request
-                                        });
-                                        // Clear stored invoice after successful payment
-                                        PosStore.clearOrderInvoice(orderId);
-                                    }
+                                        }
+                                    );
                                     this.clearIntervals();
                                     break;
                                 }
@@ -1106,22 +1079,13 @@ export default class Receive extends React.Component<
                                             Number(value) &&
                                         output.address === onChainAddress
                                     ) {
-                                        setWatchedInvoicePaid(output.amount);
-                                        BalanceStore.getCombinedBalance();
-
-                                        if (orderId) {
-                                            PosStore.recordPayment({
-                                                orderId,
-                                                orderTotal,
-                                                orderTip,
-                                                exchangeRate,
-                                                rate,
+                                        this.handlePaymentReceived(
+                                            output.amount,
+                                            {
                                                 type: 'onchain',
                                                 tx: result.tx_hash
-                                            });
-                                            // Clear stored invoice after successful payment
-                                            PosStore.clearOrderInvoice(orderId);
-                                        }
+                                            }
+                                        );
                                         this.clearIntervals();
                                         // break parent loop
                                         i = txs.length;
@@ -1153,24 +1117,13 @@ export default class Receive extends React.Component<
                                     ) >= Number(value) &&
                                     Number(result.amount_received_msat) !== 0
                                 ) {
-                                    setWatchedInvoicePaid(
-                                        result.amount_received_msat / 1000
-                                    );
-                                    BalanceStore.getCombinedBalance();
-                                    ChannelsStore.getChannels();
-                                    if (orderId) {
-                                        PosStore.recordPayment({
-                                            orderId,
-                                            orderTotal,
-                                            orderTip,
-                                            exchangeRate,
-                                            rate,
+                                    this.handlePaymentReceived(
+                                        result.amount_received_msat / 1000,
+                                        {
                                             type: 'ln',
                                             tx: result.bolt11
-                                        });
-                                        // Clear stored invoice after successful payment
-                                        PosStore.clearOrderInvoice(orderId);
-                                    }
+                                        }
+                                    );
                                     this.clearIntervals();
                                     break;
                                 }
@@ -1194,21 +1147,11 @@ export default class Receive extends React.Component<
                                 Number(result.amt) >= Number(value) &&
                                 Number(result.amt) !== 0
                             ) {
-                                setWatchedInvoicePaid(result.amt);
-                                if (orderId) {
-                                    PosStore.recordPayment({
-                                        orderId,
-                                        orderTotal,
-                                        orderTip,
-                                        exchangeRate,
-                                        rate,
-                                        type: 'ln',
-                                        tx: result.payment_request,
-                                        preimage: result.r_preimage
-                                    });
-                                    // Clear stored invoice after successful payment
-                                    PosStore.clearOrderInvoice(orderId);
-                                }
+                                this.handlePaymentReceived(Number(result.amt), {
+                                    type: 'ln',
+                                    tx: result.payment_request,
+                                    preimage: result.r_preimage
+                                });
                                 this.clearIntervals();
                                 break;
                             }


### PR DESCRIPTION
# Description

Based on https://github.com/ZeusLN/zeus/pull/3793.

Extracts a `handlePaymentReceived` helper that centralizes the post-payment actions shared across all 5 backend implementations in `subscribeInvoice` (`setWatchedInvoicePaid`, `getCombinedBalance`, `getChannels`, POS recording).

Bug fix:
- `lndhub` was not calling `getCombinedBalance` after receiving a payment, so the displayed balance never refreshed.
- `getChannels` was being called after on-chain payments, but channels are unaffected by received on-chain payments, so it now only refreshes after LN payments.

Question:
I noticed `embedded-lnd` uses `>` while `lightning-node-connect` and `lnd` use `>=` to check on-chain confirmations:
embedded-lnd: `transaction.num_confirmations > numConfPreference`
lightning-node-connect: `result.num_confirmations >= numConfPreference`
lnd: `result.num_confirmations >= numConfPreference`

With `numConfPreference` being `0` (0 conf) or `1` (1 conf), the `>` in `embedded-lnd` would mean 0 conf mode still requires at least 1 confirmation, and 1 conf mode requires 2. Is this intentional, or should it be `>=` to match the other implementations?

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
