### PR TITLE
fix: disable autocorrect, show seed words in cleartext, and use 1-based indices for invalid word errors

### DIFF
--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -383,6 +383,22 @@ export default class SeedRecovery extends React.PureComponent<
         );
 
         const restore = async () => {
+            // Validate all seed words against BIP39 wordlist before attempting restore
+            const invalidWords: number[] = [];
+            seedArray.forEach((word: string, i: number) => {
+                if (!BIP39_WORD_LIST.includes(word?.toLowerCase()?.trim())) {
+                    invalidWords.push(i + 1); // 1-based index to match UI
+                }
+            });
+            if (invalidWords.length > 0) {
+                this.setState({
+                    errorMsg: `${localeString(
+                        'views.Settings.NodeConfiguration.invalidSeedWord'
+                    )}: #${invalidWords.join(', #')}`
+                });
+                return;
+            }
+
             this.setState({ loading: true });
 
             await stopLnd();
@@ -490,6 +506,7 @@ export default class SeedRecovery extends React.PureComponent<
                                         alignSelf: 'center'
                                     }}
                                     autoCapitalize="none"
+                                    autoCorrect={false}
                                     autoFocus
                                     onChangeText={(text: string) => {
                                         this.setState({


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-3828**](https://github.com/ZeusLN/zeus/issues/3828)

1. Disabled autocorrect (line 500): Added `autoCorrect={false}` to the seed word `TextInput`. This prevents the keyboard from auto-correcting BIP39 words (which aren't regular dictionary words in any language).
2. Show words in cleartext (line 365): Removed the '********' redaction logic. Previously, entered seed words were masked unless actively selected, making it impossible to notice autocorrect changes. Now all entered words are visible so users can verify them.
3. Pre-validate with 1-based word indices (lines 378-392): Added validation before calling restore() that checks every seed word against the BIP39 wordlist. If any words are invalid, it shows an error like "Invalid seed word: # 3, # 7" using 1-based indices matching the UI labels, instead of letting LND return a confusing 0-based error.

Question: is #2 necessary now that autocorrect is removed? I'm leaning towards leaving it as is with the other changes carrying the weight of it.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x]  I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [x] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
