### PR TITLE
fix: derive node identicon from stable connection fields instead of nickname

### DIFF
--- a/components/NodeIdenticon.tsx
+++ b/components/NodeIdenticon.tsx
@@ -8,8 +8,6 @@ import PrivacyUtils from './../utils/PrivacyUtils';
 
 const hash = require('object-hash');
 
-const IDENTICON_TITLE_MAX_LENGTH = 24;
-
 export const NodeTitle = (selectedNode: any, overrideSensitivity = false) => {
     const displayName =
         selectedNode && selectedNode.nickname
@@ -38,23 +36,32 @@ export default function NodeIdenticon({
     width?: number;
     rounded?: boolean;
 }) {
-    const fullTitle = NodeTitle(selectedNode, true);
-    const title =
-        fullTitle.length > IDENTICON_TITLE_MAX_LENGTH
-            ? fullTitle.substring(0, IDENTICON_TITLE_MAX_LENGTH - 3) + '...'
-            : fullTitle;
+    // Build hash from stable connection identity fields so the identicon
+    // doesn't change when the user edits the nickname.
+    const stableIdentity = (() => {
+        if (!selectedNode) {
+            return 'unknown';
+        }
+        switch (selectedNode.implementation) {
+            case 'lndhub':
+                return `lndhub-${selectedNode.lndhubUrl || ''}-${
+                    selectedNode.username || ''
+                }`;
+            case 'nostr-wallet-connect':
+                return `nwc-${selectedNode.nostrWalletConnectUrl || ''}`;
+            case 'embedded-lnd':
+                return `embedded-lnd-${selectedNode.lndDir || 'lnd'}`;
+            default:
+                return selectedNode.url
+                    ? `${selectedNode.implementation || ''}-${selectedNode.url}`
+                    : `${selectedNode.implementation || ''}-${
+                          selectedNode.host || ''
+                      }:${selectedNode.port || ''}`;
+        }
+    })();
 
     const data = new Identicon(
-        hash.sha1(
-            selectedNode && selectedNode.implementation === 'lndhub'
-                ? `${title}-${selectedNode.username}`
-                : selectedNode &&
-                  selectedNode.implementation === 'nostr-wallet-connect'
-                ? `${title}-${selectedNode.nostrWalletConnectUrl}`
-                : selectedNode && selectedNode.implementation === 'embedded-lnd'
-                ? `${title}-${selectedNode.lndDir || 'lnd'}`
-                : title
-        ),
+        hash.sha1(stableIdentity),
         // @ts-ignore:next-line
         {
             background: [255, 255, 255, 255],


### PR DESCRIPTION
# Description

This tweak ensures that the node title, or more specifically, the nickname don't alter the identicon generated for a wallet.

Now the hash is built from stable connection identity fields per implementation type:

|Implementation|Hash input|
|-|-|
|lndhub|lndhub-{lndhubUrl}-{username}|
| nostr-wallet-connect|nwc-{nostrWalletConnectUrl}|
| embedded-lnd|embedded-lnd-{lndDir || 'lnd'}|
|Others (lnd, cln-rest, lightning-node-connect)|{implementation}-{url} or {implementation}-{host}:{port}|
  

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
