### PR TITLE
fix: avoid redundant getNodeInfo() call on app start

### DIFF
--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -83,6 +83,7 @@ export default class LSPStore {
                     )
                 ) {
                     this.getExtendableChannels();
+                    this.nodeInfoStore.getNodeInfo();
                 }
             }
         );

--- a/stores/NodeInfoStore.ts
+++ b/stores/NodeInfoStore.ts
@@ -1,4 +1,4 @@
-import { action, observable, reaction, runInAction } from 'mobx';
+import { action, observable, runInAction } from 'mobx';
 import NetworkInfo from '../models/NetworkInfo';
 import NodeInfo from '../models/NodeInfo';
 import ChannelsStore from './ChannelsStore';
@@ -23,15 +23,6 @@ export default class NodeInfoStore {
     constructor(channelsStore: ChannelsStore, settingsStore: SettingsStore) {
         this.channelsStore = channelsStore;
         this.settingsStore = settingsStore;
-
-        reaction(
-            () => this.channelsStore.channels,
-            () => {
-                if (this.channelsStore.channels.length !== 0) {
-                    this.getNodeInfo();
-                }
-            }
-        );
     }
 
     @action


### PR DESCRIPTION
# Description

`NodeInfoStore` had a MobX reaction that called `getNodeInfo()` whenever `ChannelsStore.channels` was written. During startup, `fetchData()` already calls `getNodeInfo()` sequentially before `getChannels()` runs, so when `getChannels()` resolves and writes to `this.channels`, the reaction fired a second redundant `getNodeInfo()`.

The reaction was introduced in #2720 (commit https://github.com/ZeusLN/zeus/commit/9d8b330176ee622539c4d282335e93684b7ff3c4), probably to keep `nodeInfo.currentBlockHeight` fresh for the LSPS7 lease expiry display in `Channel.tsx`.

Fix: remove the broad reaction from `NodeInfoStore` and move the targeted `getNodeInfo()` call into `LSPStore`'s existing `channels` reaction, which is already gated on `supportsLSPScustomMessage() && lspPubkey && channel belongs to LSP`. Both reactions watch the same observable, so the LSP reaction fires in every scenario where the original one did, but only for users who actually have an LSP channel configured, and never unconditionally on startup.

No LSPS7 behaviour is lost: `currentBlockHeight` is read at navigation time, which is after node data has been fetched on startup - and for live channel changes, the LSPStore reaction now refreshes it.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
