### PR TITLE
fix: send all funds displaying wrong fiat and BTC conversion amounts

### DIFF
--- a/components/AmountInput.tsx
+++ b/components/AmountInput.tsx
@@ -108,10 +108,7 @@ export default class AmountInput extends React.Component<
         const { amount, forceUnit, onAmountChange } = this.props;
         if (amount !== prevProps.amount || forceUnit !== prevProps.forceUnit) {
             if (forceUnit === 'sats' && forceUnit !== prevProps.forceUnit) {
-                const currentSatAmount = getSatAmount(
-                    amount || '',
-                    prevProps.forceUnit
-                );
+                const currentSatAmount = getSatAmount(amount || '', forceUnit);
                 this.setState({ satAmount: currentSatAmount });
 
                 onAmountChange(currentSatAmount.toString(), currentSatAmount);


### PR DESCRIPTION
# Description

**Summary of the bug**: In `AmountInput.tsx:113`, when the "Use all possible funds" toggle activates and `forceUnit` changes to 'sats', the code called `getSatAmount(amount, prevProps.forceUnit)` — interpreting the already-in-sats balance using the user's current display unit (e.g. fiat). So 7,000,000 sats was treated as £7,000,000 or 7,000,000 Bitcoin, producing a massively wrong `satAmount` that propagated to all conversion displays and the confirmation screen.

|Before|After|
|-|-|
|<img width="1280" height="2856" alt="Screenshot_1773799127" src="https://github.com/user-attachments/assets/066b9c54-3ed3-4ab5-9246-983bde65c556" />|<img width="1280" height="2856" alt="Screenshot_1773799882" src="https://github.com/user-attachments/assets/8d1e5327-f080-4188-aa6c-eae426e26906" />|

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
