### PR TITLE
fix: stale payment success state persisting across invoice creations

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -505,26 +505,28 @@ export default class Receive extends React.Component<
         }
     }
 
-    clearListeners = () => {
-        if (this.listener && this.listener.stop) this.listener.stop();
-        if (this.listenerSecondary && this.listenerSecondary.stop)
-            this.listenerSecondary.stop();
-    };
+    componentWillUnmount() {
+        this.cleanup();
+    }
 
     clearIntervals = () => {
         if (this.lnInterval) clearInterval(this.lnInterval);
         if (this.onChainInterval) clearInterval(this.onChainInterval);
     };
 
-    onBack = () => {
-        const { InvoicesStore } = this.props;
-        const { reset } = InvoicesStore;
-        // kill all listeners and pollers before navigating back
-        this.clearListeners();
+    cleanup = () => {
+        // kill all listeners and pollers
+        if (this.listener && this.listener.stop) this.listener.stop();
+        if (this.listenerSecondary && this.listenerSecondary.stop)
+            this.listenerSecondary.stop();
         this.clearIntervals();
 
         // clear invoice
-        reset();
+        this.props.InvoicesStore.reset();
+    };
+
+    onBack = () => {
+        this.cleanup();
     };
 
     autoGenerateInvoice = (
@@ -1399,7 +1401,7 @@ export default class Receive extends React.Component<
                         });
                     }
 
-                    InvoicesStore.clearUnified();
+                    this.cleanup();
                 }}
                 color={themeColor('text')}
                 underlayColor="transparent"


### PR DESCRIPTION
# Description

## Summary

When creating an invoice in the Receive view, navigating away, and then having that invoice paid externally, returning to create a new invoice could incorrectly show the success message from the old payment. The same issue occurred when using the X button to clear an invoice and create a new one. This was caused by the `watchedInvoicePaid` state and invoice subscription listeners not being cleaned up on unmount or clear. This fix adds `componentWillUnmount` and consolidates all cleanup (listeners, polling intervals, and store reset) into a single `cleanup()` method shared by the back button, X button, and unmount lifecycle.

## Test plan
- [ ] Create a Lightning invoice, leave the Receive view, pay it externally, then return and create a new invoice — should show a fresh form, not the old success message
- [ ] Create a Lightning invoice, press the X button, create a new invoice, pay the old one — should not show success on the new invoice
- [ ] Create and pay an invoice normally — success screen should still display correctly
- [ ] Verify POS mode invoice flow still works as expected

## This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
