### PR TITLE
cleanup: remove dead share intent code from LinkingUtils and ShareIntentProcessor

### DIFF
--- a/utils/LinkingUtils.ts
+++ b/utils/LinkingUtils.ts
@@ -3,11 +3,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { localeString } from './LocaleUtils';
 import handleAnything from './handleAnything';
-import {
-    processSharedQRImageFast,
-    getPendingShareIntent,
-    hasPendingShareIntent
-} from './ShareIntentProcessor';
+import { processSharedQRImageFast } from './ShareIntentProcessor';
 import { settingsStore } from '../stores/Stores';
 
 class LinkingUtils {
@@ -116,32 +112,6 @@ class LinkingUtils {
 
     resetShareIntentFlag = () => {
         this.shareIntentProcessed = false;
-    };
-
-    processPendingShareIntent = (
-        navigation: NativeStackNavigationProp<any, any>
-    ): boolean => {
-        try {
-            if (hasPendingShareIntent()) {
-                const pendingData = getPendingShareIntent();
-
-                if (pendingData) {
-                    if (navigation.canGoBack()) {
-                        navigation.popToTop();
-                    }
-                    navigation.push('ShareIntentProcessing', pendingData);
-                    return true;
-                }
-            }
-
-            return false;
-        } catch (error) {
-            console.error(
-                'LinkingUtils: Error processing pending share intent:',
-                error
-            );
-            return false;
-        }
     };
 }
 

--- a/utils/ShareIntentProcessor.ts
+++ b/utils/ShareIntentProcessor.ts
@@ -12,11 +12,6 @@ export interface ShareIntentResult {
     error?: string;
 }
 
-let pendingShareIntentData: {
-    base64Image?: string;
-    qrData?: string;
-} | null = null;
-
 /**
  * Processes a shared QR code image from Android share intent
  * @returns Navigation result with success status, route/params or error message
@@ -94,24 +89,4 @@ export const hasSharedImage = async (): Promise<boolean> => {
         console.error('Error checking for shared image:', error);
         return false;
     }
-};
-
-export const setPendingShareIntent = (data: {
-    base64Image?: string;
-    qrData?: string;
-}) => {
-    pendingShareIntentData = data;
-};
-
-export const getPendingShareIntent = (): {
-    base64Image?: string;
-    qrData?: string;
-} | null => {
-    const data = pendingShareIntentData;
-    pendingShareIntentData = null;
-    return data;
-};
-
-export const hasPendingShareIntent = (): boolean => {
-    return pendingShareIntentData !== null;
 };

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -115,13 +115,7 @@ export default class Lockscreen extends React.Component<
             navigation.replace('Wallets', { fromStartup: true });
         } else {
             SettingsStore.triggerSettingsRefresh = true;
-
-            const shareIntentProcessed =
-                LinkingUtils.processPendingShareIntent(navigation);
-
-            if (!shareIntentProcessed) {
-                navigation.pop();
-            }
+            navigation.pop();
         }
     };
 

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1028,12 +1028,6 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 clearTimeout(this.startupTimeoutId);
                 this.startupTimeoutId = undefined;
             }
-
-            try {
-                LinkingUtils.processPendingShareIntent(this.props.navigation);
-            } catch (error) {
-                console.error('Error processing pending share intent:', error);
-            }
         }
 
         if (BackendUtils.supportsFlowLSP()) {


### PR DESCRIPTION
# Description

## Summary
- Removed unused `setPendingShareIntent`, `getPendingShareIntent`, `hasPendingShareIntent` exports from `ShareIntentProcessor.ts` and the `pendingShareIntentData` module-level variable they operated on
- Removed `processPendingShareIntent` method from `LinkingUtils.ts` and its two call sites in `Wallet.tsx` and `Lockscreen.tsx`

This code was originally part of a working flow (introduced in `578fae9`) where share intent data was stashed in a module-level variable during auth/wallet selection, then picked up after connection. Commit `814e874` replaced that approach with component-state-based handling in `Wallet.tsx`, but didn't clean up the old path — leaving `setPendingShareIntent` never called and `processPendingShareIntent` always returning false.

## Test plan
- [ ] Android: share a QR code image into ZEUS with auth enabled — verify share intent is processed after login
- [ ] Android: share a QR code image with wallet selection enabled — verify it works after selecting wallet
- [ ] iOS: share a QR code image via share extension — verify same flows
- [ ] Cold start and warm start share intents still work on both platforms
- [ ] Normal (non-share-intent) lockscreen login still navigates correctly

## This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
