### PR TITLE
fix: refine status card spacing and shrink balance container during active sync

### DIFF
--- a/components/StatusCard.tsx
+++ b/components/StatusCard.tsx
@@ -38,7 +38,8 @@ export default function StatusCard({
                     backgroundColor,
                     borderRadius: 10,
                     padding: 15,
-                    margin: 20
+                    marginHorizontal: 20,
+                    marginVertical: 8
                 }}
             >
                 <Text

--- a/stores/SyncStore.ts
+++ b/stores/SyncStore.ts
@@ -1,4 +1,4 @@
-import { action, observable, when, runInAction } from 'mobx';
+import { action, observable, when, runInAction, computed } from 'mobx';
 import { EmitterSubscription, NativeModules } from 'react-native';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 
@@ -64,6 +64,11 @@ export default class SyncStore {
         this.numBlocksUntilSynced = 1;
         this.stopRescanTracking();
     };
+
+    @computed
+    get isBusy() {
+        return this.isSyncing || this.isRecovering || this.isRescanning;
+    }
 
     public setExpressGraphSyncStatus = (syncing: boolean) =>
         (this.isInExpressGraphSync = syncing);

--- a/views/Wallet/BalancePane.tsx
+++ b/views/Wallet/BalancePane.tsx
@@ -925,7 +925,15 @@ export default class BalancePane extends React.PureComponent<
                                 <LightningBalance />
                             </View>
                         ) : (
-                            <View style={styles.balanceContainer}>
+                            <View
+                                style={[
+                                    styles.balanceContainer,
+                                    SyncStore.isBusy && {
+                                        marginTop: 30,
+                                        marginBottom: 15
+                                    }
+                                ]}
+                            >
                                 <BalanceViewCombined />
                             </View>
                         )}


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

In this PR, we address layout issues with the status cards and the balance container. When multiple sync states are active simultaneously, activity labels could overflow, preventing users from accessing the eCash wallet.
This update dynamically adjusts the balance container margins based on the current sync state and ensures more consistent spacing between status cards, resulting in improved layout stability and usability.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/3095c77c-1857-4019-9518-cba3e337ab33" width="300" />
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/7bace86b-97b2-4611-9d28-34cb5e3de915" width="300" />
    </td>
  </tr>
</table>



This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
