### PR TITLE
fix: display loading state and enable scrolling in RaxTxHex

### DIFF
--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -815,6 +815,9 @@ export default class TransactionsStore {
 
     public broadcastRawTxToMempoolSpace = (raw_tx_hex: string) => {
         this.resetBroadcast();
+        runInAction(() => {
+            this.loading = true;
+        });
         const headers = {
             'Access-Control-Allow-Origin': '*',
             'Content-Type': 'text/plain'

--- a/views/RawTxHex.tsx
+++ b/views/RawTxHex.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { Route } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -68,7 +68,6 @@ export default class RawTxHex extends React.PureComponent<
             broadcast_err,
             loading
         } = TransactionsStore;
-
         return (
             <Screen>
                 <Header
@@ -85,12 +84,9 @@ export default class RawTxHex extends React.PureComponent<
                     }}
                     navigation={navigation}
                 />
-                <View
-                    style={{
-                        top: 5,
-                        padding: 15,
-                        alignItems: 'center'
-                    }}
+                <ScrollView
+                    style={{ padding: 15 }}
+                    contentContainerStyle={{ alignItems: 'center' }}
                 >
                     <CollapsedQR
                         value={value}
@@ -104,7 +100,11 @@ export default class RawTxHex extends React.PureComponent<
                         )}
                         onPress={() => broadcastRawTxToMempoolSpace(value)}
                     />
-                    {loading && <LoadingIndicator />}
+                    {loading && (
+                        <View style={{ marginTop: 20 }}>
+                            <LoadingIndicator />
+                        </View>
+                    )}
                     {broadcast_txid && (
                         <SuccessMessage
                             message={broadcast_txid}
@@ -117,7 +117,7 @@ export default class RawTxHex extends React.PureComponent<
                         />
                     )}
                     {broadcast_err && <ErrorMessage message={broadcast_err} />}
-                </View>
+                </ScrollView>
             </Screen>
         );
     }


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This PR improves the RaxTxHex view by addressing issues with scrolling and content visibility. Previously, when the QR code was displayed, users were unable to scroll, which made it difficult to view error messages from broadcastRawTxToMempoolSpace. The screen is now wrapped in a ScrollView, ensuring all content remains accessible.

Additionally, a loading state has been introduced when calling broadcastRawTxToMempoolSpace, providing better user feedback during the process. These changes enhance overall usability by enabling smooth scrolling and clearly indicating ongoing actions.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
