### PR TITLE
fix: add optional chaining and error display for swap fee fetching

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2176,6 +2176,7 @@
     "views.Swaps.rescueKey.incorrectHost": "Could not connect to the specified host. Please check the host and try again",
     "views.Swaps.rescueKey.delete": "Delete rescue key",
     "views.Swaps.intro.description": "Using the Swap service, you can move funds from on-chain to Lightning, and vice versa, without having to open or close a channel.",
+    "views.Swaps.fetchFeesFailed": "Failed to fetch swap fees. Please check your connection and try again.",
     "views.Swaps.intro.continue": "Continue",
     "views.Swaps.rescueKey.deleteConfirmation": "Are you sure you want to delete the rescue key? All swaps will also be deleted from your swap history. Please back up your keys before proceeding, as you can use them later to recover those swaps.",
     "views.SwapDetails.title": "Swap Details",

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -151,6 +151,7 @@ export default class SwapStore {
     @action
     public getSwapFees = async () => {
         this.loading = true;
+        this.apiError = '';
         console.log(`Fetching fees from: ${this.getHost}`);
         try {
             const response = await ReactNativeBlobUtil.fetch(
@@ -160,15 +161,28 @@ export default class SwapStore {
             );
             const status = response.info().status;
             if (status == 200) {
-                this.subInfo = response.json().BTC.BTC;
-                console.log('submarine swap fees', this.subInfo);
+                const data = response.json();
+                const subInfo = data?.BTC?.BTC;
+                if (subInfo) {
+                    this.subInfo = subInfo;
+                    console.log('Submarine rates', this.subInfo);
+                } else {
+                    console.warn(
+                        'Unexpected submarine swap fee response:',
+                        JSON.stringify(data)
+                    );
+                    this.apiError = localeString('views.Swaps.fetchFeesFailed');
+                }
             } else if (status == 403) {
                 const data = response.json();
                 this.apiError = data?.error || data?.message;
                 this.loading = false;
                 return;
             }
-        } catch {}
+        } catch (e) {
+            console.error('Error fetching submarine swap fees:', e);
+            this.apiError = localeString('views.Swaps.fetchFeesFailed');
+        }
 
         try {
             const response = await ReactNativeBlobUtil.fetch(
@@ -178,15 +192,28 @@ export default class SwapStore {
             );
             const status = response.info().status;
             if (status == 200) {
-                this.reverseInfo = response.json().BTC.BTC;
-                console.log('reverse swap fees', this.reverseInfo);
+                const data = response.json();
+                const reverseInfo = data?.BTC?.BTC;
+                if (reverseInfo) {
+                    this.reverseInfo = reverseInfo;
+                    console.log('Reverse rates', this.reverseInfo);
+                } else {
+                    console.warn(
+                        'Unexpected reverse swap fee response:',
+                        JSON.stringify(data)
+                    );
+                    this.apiError = localeString('views.Swaps.fetchFeesFailed');
+                }
             } else if (status == 403) {
                 const data = response.json();
                 this.apiError = data?.error || data?.message;
                 this.loading = false;
                 return;
             }
-        } catch {}
+        } catch (e) {
+            console.error('Error fetching reverse swap fees:', e);
+            this.apiError = localeString('views.Swaps.fetchFeesFailed');
+        }
         this.loading = false;
     };
 


### PR DESCRIPTION
# Description

Fixes a crash caused by unguarded `response.json().BTC.BTC` access in `getSwapFees` — if the API returns an unexpected structure, this null dereference triggers a Hermes SIGSEGV on the JS thread. This change adds null-safe optional chaining, displays an error message on the Swaps view when fee fetching fails (network error, unexpected response, etc.), and replaces silent empty `catch {}` blocks with error logging.

## Test plan
- [ ] Open Swaps view on testnet — verify fees load and no crash
- [ ] Disable network / kill tor and open Swaps view — verify error message appears instead of crash
- [ ] Re-enable network and re-open Swaps view — verify error clears and fees load

## This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
