### PR TITLE
fix: CLN routing event fee display

### DIFF
--- a/views/Routing/RoutingEvent.tsx
+++ b/views/Routing/RoutingEvent.tsx
@@ -176,6 +176,7 @@ export default class RoutingEvent extends React.Component<
 
         const {
             fee,
+            feeSat,
             getTime,
             inChannelId,
             outChannelId,
@@ -325,11 +326,7 @@ export default class RoutingEvent extends React.Component<
                         <>
                             <View style={styles.amount}>
                                 <Amount
-                                    sats={
-                                        fee ||
-                                        (parseInt(inAmt) - parseInt(outAmt)) /
-                                            1000
-                                    }
+                                    sats={feeSat}
                                     jumboText
                                     toggleable
                                     credit


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-3885**](https://github.com/ZeusLN/zeus/issues/3885)

## Problem

When viewing a specific forward event on CLN (via CLNRest), the earned fee was shown ~1000x too small. The aggregate views (by day, week, etc.) displayed correctly.

## Root Cause

In `RoutingEvent.tsx`, the fee was computed as:

```jsx
sats={fee || (parseInt(inAmt) - parseInt(outAmt)) / 1000}
```

Two issues compound here:

1. `fee` is an LND-specific raw field. For CLN, it's `undefined`, so the fallback always runs.
2. `inAmt` and `outAmt` are computed properties on `ForwardEvent` that already convert from millisats to sats (`Number(this.in_msat) / 1000`). Dividing by 1000 again produces a value 1000x too small.

The list view didn't have this bug because it used `item.feeSat` — the model's computed property that correctly converts `fee_msat` to sats.

## Fix

Use the `feeSat` computed property in the detail view, matching the list view's approach. This is a one-line behavioral change — `feeSat` correctly handles both LND (`fee_msat` from API) and CLN (`fee_msat` from API) by dividing once by 1000.

## This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

- [ ] Embedded LND
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
