### PR TITLE
utils: use app locale for number separators

### DIFF
--- a/components/Amount.tsx
+++ b/components/Amount.tsx
@@ -13,11 +13,7 @@ import LoadingIndicator from './LoadingIndicator';
 
 import { localeString, formatInlineNoun } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
-import {
-    formatBitcoinWithSpaces,
-    numberWithCommas,
-    numberWithDecimals
-} from '../utils/UnitsUtils';
+import { formatBitcoinWithSpaces, numberWithCommas } from '../utils/UnitsUtils';
 import type { Units } from '../utils/UnitsUtils';
 import PrivacyUtils from '../utils/PrivacyUtils';
 import { processSatsAmount, getUnformattedAmount } from '../utils/AmountUtils';
@@ -49,7 +45,6 @@ interface AmountDisplayProps {
     accessible?: boolean;
     accessibilityLabel?: string;
     roundAmount?: boolean;
-    separatorSwap?: boolean;
     onPendingPress?: () => void;
 }
 
@@ -76,7 +71,6 @@ function AmountDisplay({
     accessible,
     accessibilityLabel,
     roundAmount = false,
-    separatorSwap = false,
     onPendingPress
 }: AmountDisplayProps) {
     if (unit === 'fiat' && !symbol) {
@@ -254,11 +248,7 @@ function AmountDisplay({
                 ) : unit === 'BTC' ? (
                     formatBitcoinWithSpaces(amount)
                 ) : unit === 'fiat' ? (
-                    separatorSwap ? (
-                        numberWithDecimals(amount)
-                    ) : (
-                        numberWithCommas(amount)
-                    )
+                    numberWithCommas(amount)
                 ) : (
                     amount.toString()
                 )}
@@ -370,6 +360,48 @@ interface AmountProps {
 @inject('FiatStore', 'UnitsStore', 'SettingsStore')
 @observer
 export default class Amount extends React.Component<AmountProps, {}> {
+    componentDidMount() {
+        this.ensureFiatRatesAvailable();
+    }
+
+    componentDidUpdate(prevProps: Readonly<AmountProps>) {
+        if (
+            prevProps.fixedUnits !== this.props.fixedUnits ||
+            prevProps.sats !== this.props.sats ||
+            prevProps.FiatStore?.fiatRates !==
+                this.props.FiatStore?.fiatRates ||
+            prevProps.SettingsStore?.settings.fiat !==
+                this.props.SettingsStore?.settings.fiat
+        ) {
+            this.ensureFiatRatesAvailable();
+        }
+    }
+
+    ensureFiatRatesAvailable = () => {
+        const FiatStore = this.props.FiatStore!;
+        const UnitsStore = this.props.UnitsStore!;
+        const SettingsStore = this.props.SettingsStore!;
+        const units = this.props.fixedUnits || UnitsStore.units;
+        const selectedFiat = SettingsStore.settings?.fiat;
+
+        if (
+            units !== 'fiat' ||
+            !SettingsStore.settings?.fiatEnabled ||
+            !selectedFiat ||
+            FiatStore.loading
+        ) {
+            return;
+        }
+
+        const hasSelectedFiatRate = FiatStore.fiatRates?.some(
+            (entry: any) => entry.code === selectedFiat
+        );
+
+        if (!hasSelectedFiatRate) {
+            FiatStore.getFiatRates();
+        }
+    };
+
     render() {
         const {
             sats: value,

--- a/components/AmountInput.tsx
+++ b/components/AmountInput.tsx
@@ -11,6 +11,7 @@ import { getSatAmount } from '../utils/AmountUtils';
 import {
     SATS_PER_BTC,
     formatBitcoinWithSpaces,
+    normalizeNumberString,
     numberWithCommas
 } from '../utils/UnitsUtils';
 
@@ -50,8 +51,8 @@ const getAmount = (sats: string | number, forceUnit?: string) => {
     const { fiat } = settings;
     const units = forceUnit || unitsStore.units;
 
-    // replace , with . for unit separator
-    const value = sats ? sats.toString().replace(/,/g, '.') : '';
+    // Normalize any locale-specific separators to the app's canonical format.
+    const value = sats ? normalizeNumberString(sats) : '';
 
     const fiatEntry =
         fiat && fiatRates
@@ -72,7 +73,7 @@ const getAmount = (sats: string | number, forceUnit?: string) => {
             const { decimalPlaces } = fiatStore.getSymbol();
             const decimals = decimalPlaces !== undefined ? decimalPlaces : 2;
             amount = rate
-                ? new BigNumber(value.toString().replace(/,/g, '.'))
+                ? new BigNumber(normalizeNumberString(value))
                       .times(rate)
                       .div(SATS_PER_BTC)
                       .toNumber()

--- a/components/Conversion.tsx
+++ b/components/Conversion.tsx
@@ -12,6 +12,7 @@ import UnitsStore from '../stores/UnitsStore';
 import SettingsStore from '../stores/SettingsStore';
 
 import { themeColor } from '../utils/ThemeUtils';
+import { normalizeNumberString } from '../utils/UnitsUtils';
 
 import ClockIcon from '../assets/images/SVG/Clock.svg';
 
@@ -70,9 +71,10 @@ export default class Conversion extends React.Component<
         if (sats) {
             satAmount = sats;
         } else {
-            satAmount = Number.isNaN(Number(amount))
+            const normalizedAmount = normalizeNumberString(amount ?? 0);
+            satAmount = Number.isNaN(Number(normalizedAmount))
                 ? 0
-                : getSatAmount(amount ?? 0, forceUnit);
+                : getSatAmount(normalizedAmount, forceUnit);
         }
 
         if (!fiatEnabled || (!amount && !sats)) return;

--- a/components/CurrencyConverterContent.tsx
+++ b/components/CurrencyConverterContent.tsx
@@ -23,7 +23,7 @@ import { Row } from './layout/Row';
 
 import { themeColor } from '../utils/ThemeUtils';
 import { localeString } from '../utils/LocaleUtils';
-import { numberWithCommas } from '../utils/UnitsUtils';
+import { normalizeNumberString, numberWithCommas } from '../utils/UnitsUtils';
 
 import Storage from '../storage';
 
@@ -173,22 +173,18 @@ export default class CurrencyConverterContent extends React.Component<
     };
 
     handleInputChange = (value: string, currency: string) => {
-        const sanitizedValue = value.replace(/,/g, '').replace(/[^\d.]/g, '');
+        const sanitizedValue = value ? normalizeNumberString(value) : '';
 
         const { inputValues } = this.state;
         const FiatStore = this.props.FiatStore!;
         const fiatRates = FiatStore?.fiatRates || [];
 
-        const formatNumber = (value: string, currency: string) => {
-            if (currency === 'BTC') {
-                if (parseFloat(value) > 1) {
-                    return numberWithCommas(value);
-                } else {
-                    return value;
-                }
-            } else {
-                return numberWithCommas(value);
+        const formatNumber = (value: string) => {
+            if (value === '') {
+                return '';
             }
+
+            return numberWithCommas(value);
         };
 
         const convertedValues: { [key: string]: string } = { ...inputValues };
@@ -205,7 +201,7 @@ export default class CurrencyConverterContent extends React.Component<
             return;
         }
 
-        const formattedValue = formatNumber(sanitizedValue, currency);
+        const formattedValue = formatNumber(sanitizedValue);
         convertedValues[currency] = formattedValue;
 
         Object.keys(convertedValues).forEach((key) => {
@@ -275,7 +271,7 @@ export default class CurrencyConverterContent extends React.Component<
                     }
                 }
 
-                convertedValues[key] = formatNumber(convertedValue, key);
+                convertedValues[key] = formatNumber(convertedValue);
             }
         });
 

--- a/components/CurrencyList.tsx
+++ b/components/CurrencyList.tsx
@@ -13,7 +13,7 @@ import FiatStore from '../stores/FiatStore';
 
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
-import { numberWithCommas, numberWithDecimals } from '../utils/UnitsUtils';
+import { SATS_PER_BTC, numberWithCommas } from '../utils/UnitsUtils';
 
 import BitcoinIcon from '../assets/images/SVG/bitcoin-icon.svg';
 import Star from '../assets/images/SVG/Star.svg';
@@ -128,7 +128,9 @@ export default class CurrencyList extends React.Component<
                                             fontSize: 12
                                         }}
                                     >
-                                        100,000,000 sats = 1 BTC
+                                        {`${numberWithCommas(
+                                            SATS_PER_BTC
+                                        )} sats = 1 BTC`}
                                     </ListItem.Subtitle>
                                 )}
                             </ListItem.Content>
@@ -198,11 +200,10 @@ export default class CurrencyList extends React.Component<
                             (r) => r.code === item.value
                         );
                         if (!rateEntry) return null;
-                        const { symbol, space, rtl, separatorSwap } =
-                            FiatStore!.symbolLookup(item.value);
-                        const formattedRate = separatorSwap
-                            ? numberWithDecimals(rateEntry.rate)
-                            : numberWithCommas(rateEntry.rate);
+                        const { symbol, space, rtl } = FiatStore!.symbolLookup(
+                            item.value
+                        );
+                        const formattedRate = numberWithCommas(rateEntry.rate);
                         const rateDisplay = rtl
                             ? `${formattedRate}${
                                   space ? ' ' : ''

--- a/components/KeypadAmountDisplay.tsx
+++ b/components/KeypadAmountDisplay.tsx
@@ -11,8 +11,7 @@ import { themeColor } from '../utils/ThemeUtils';
 import {
     getDecimalPlaceholder,
     formatBitcoinWithSpaces,
-    numberWithCommas,
-    numberWithDecimals
+    numberWithCommas
 } from '../utils/UnitsUtils';
 
 interface KeypadAmountDisplayProps {
@@ -51,14 +50,13 @@ export default class KeypadAmountDisplay extends React.Component<KeypadAmountDis
             children
         } = this.props;
         const units = forceUnit || UnitsStore!.units;
-        const { symbol, space, rtl, separatorSwap } =
+        const { symbol, space, rtl } =
             units === 'fiat'
                 ? FiatStore!.getSymbol()
                 : {
                       symbol: '',
                       space: false,
-                      rtl: false,
-                      separatorSwap: false
+                      rtl: false
                   };
 
         const color = textAnimation.interpolate({
@@ -71,8 +69,6 @@ export default class KeypadAmountDisplay extends React.Component<KeypadAmountDis
         const formattedNumber =
             units === 'BTC'
                 ? formatBitcoinWithSpaces(amount)
-                : separatorSwap
-                ? numberWithDecimals(amount)
                 : numberWithCommas(amount);
 
         const isSingularSat = units === 'sats' && parseFloat(amount) === 1;

--- a/components/PinPad.tsx
+++ b/components/PinPad.tsx
@@ -12,8 +12,9 @@ import { themeColor } from '../utils/ThemeUtils';
 import { Row } from './layout/Row';
 import Success from '../assets/images/SVG/Success.svg';
 import Touchable from './Touchable';
-import { fiatStore, settingsStore, unitsStore } from '../stores/Stores';
+import { settingsStore } from '../stores/Stores';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
+import { getDecimalSeparator } from '../utils/UnitsUtils';
 
 import DeleteKey from '../assets/images/SVG/DeleteKey.svg';
 
@@ -171,10 +172,7 @@ export default function PinPad({
                                     : DEFAULT_SIZE
                             }}
                         >
-                            {unitsStore.units === 'fiat' &&
-                            fiatStore.getSymbol().separatorSwap
-                                ? ','
-                                : '.'}
+                            {getDecimalSeparator()}
                         </Text>
                     </Touchable>
                 ) : (

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -63,6 +63,7 @@ import { localeString } from '../utils/LocaleUtils';
 import MigrationsUtils from '../utils/MigrationUtils';
 import { themeColor, getUpgradeBackgroundColor } from '../utils/ThemeUtils';
 import { RATING_MODAL_TRIGGER_DELAY } from '../utils/RatingUtils';
+import { numberWithCommas } from '../utils/UnitsUtils';
 
 import NavigationService from '../NavigationService';
 
@@ -2152,7 +2153,7 @@ export default class CashuStore {
         // modal's close animation finishes (onClosed callback)
         setTimeout(() => {
             if (nextThreshold) {
-                const nextThresholdFormatted = nextThreshold.toLocaleString();
+                const nextThresholdFormatted = numberWithCommas(nextThreshold);
                 this.modalStore.toggleInfoModal({
                     title: localeString('cashu.upgradePrompt.dismissedTitle'),
                     text: localeString('cashu.upgradePrompt.dismissed').replace(

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -59,6 +59,7 @@ import { localeString } from '../utils/LocaleUtils';
 import MigrationsUtils from '../utils/MigrationUtils';
 import { themeColor, getUpgradeBackgroundColor } from '../utils/ThemeUtils';
 import { RATING_MODAL_TRIGGER_DELAY } from '../utils/RatingUtils';
+import { numberWithCommas } from '../utils/UnitsUtils';
 
 import NavigationService from '../NavigationService';
 
@@ -2190,7 +2191,7 @@ export default class CashuStore {
         // modal's close animation finishes (onClosed callback)
         setTimeout(() => {
             if (nextThreshold) {
-                const nextThresholdFormatted = nextThreshold.toLocaleString();
+                const nextThresholdFormatted = numberWithCommas(nextThreshold);
                 this.modalStore.toggleInfoModal({
                     title: localeString('cashu.upgradePrompt.dismissedTitle'),
                     text: localeString('cashu.upgradePrompt.dismissed').replace(

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -3,11 +3,7 @@ import ReactNativeBlobUtil from 'react-native-blob-util';
 import BigNumber from 'bignumber.js';
 
 import SettingsStore from './SettingsStore';
-import {
-    SATS_PER_BTC,
-    numberWithCommas,
-    numberWithDecimals
-} from '../utils/UnitsUtils';
+import { SATS_PER_BTC, numberWithCommas } from '../utils/UnitsUtils';
 
 interface CurrencyDisplayRules {
     symbol: string;
@@ -644,7 +640,7 @@ export default class FiatStore {
                 (entry) => entry.code === fiat
             )[0];
             const rate = (fiatEntry && fiatEntry.rate) || 0;
-            const { symbol, space, rtl, separatorSwap } = this.symbolLookup(
+            const { symbol, space, rtl } = this.symbolLookup(
                 fiatEntry && fiatEntry.code
             );
 
@@ -653,13 +649,9 @@ export default class FiatStore {
                 .multipliedBy(SATS_PER_BTC)
                 .toFixed(0);
 
-            const formattedRate = separatorSwap
-                ? numberWithDecimals(rate)
-                : numberWithCommas(rate);
+            const formattedRate = numberWithCommas(rate);
 
-            const formattedMoscow = separatorSwap
-                ? numberWithDecimals(moscowTime)
-                : numberWithCommas(moscowTime);
+            const formattedMoscow = numberWithCommas(moscowTime);
 
             if (sats) {
                 return `${formattedMoscow} sats = 1 ${fiat}`;
@@ -726,10 +718,8 @@ export default class FiatStore {
     };
 
     public formatAmountForDisplay = (input: string | number) => {
-        const { symbol, space, rtl, separatorSwap } = this.getSymbol();
-        const amount = separatorSwap
-            ? numberWithDecimals(input)
-            : numberWithCommas(input);
+        const { symbol, space, rtl } = this.getSymbol();
+        const amount = numberWithCommas(input);
 
         if (rtl) return `${amount}${space ? ' ' : ''}${symbol}`;
         return `${symbol}${space ? ' ' : ''}${amount}`;

--- a/utils/AmountUtils.test.ts
+++ b/utils/AmountUtils.test.ts
@@ -27,6 +27,7 @@ jest.mock('../stores/Stores', () => {
     const mockUnitsStore = { units: 'sats' };
     const mockSettingsStore = {
         settings: {
+            locale: 'en',
             display: {
                 showMillisatoshiAmounts: true,
                 removeDecimalSpaces: false,
@@ -36,7 +37,10 @@ jest.mock('../stores/Stores', () => {
         }
     };
     const mockFiatStore = {
-        symbolLookup: () => ({
+        symbolLookup: (code: string) => ({
+            symbol: code === 'EUR' ? '€' : '$',
+            space: code === 'EUR',
+            rtl: false,
             decimalPlaces: 2
         }),
         fiatRates: [
@@ -57,7 +61,6 @@ jest.mock('../stores/Stores', () => {
             symbol: '$',
             space: false,
             rtl: false,
-            separatorSwap: false,
             decimalPlaces: 2
         })
     };
@@ -72,6 +75,7 @@ describe('AmountUtils', () => {
     beforeEach(() => {
         // Reset to default state before each test
         (settingsStore as any).settings = {
+            locale: 'en',
             display: {
                 showMillisatoshiAmounts: true
             }
@@ -232,6 +236,7 @@ describe('AmountUtils', () => {
             // Reset mocks before each test
             (unitsStore as any).units = 'sats';
             (settingsStore as any).settings = {
+                locale: 'en',
                 fiat: 'USD',
                 display: {
                     removeDecimalSpaces: false,
@@ -256,7 +261,6 @@ describe('AmountUtils', () => {
                 symbol: '$',
                 space: false,
                 rtl: false,
-                separatorSwap: false,
                 decimalPlaces: 2
             });
         });
@@ -403,7 +407,6 @@ describe('AmountUtils', () => {
                     symbol: '€',
                     space: true,
                     rtl: false,
-                    separatorSwap: false,
                     decimalPlaces: 2
                 });
                 const result = getUnformattedAmount({
@@ -420,7 +423,6 @@ describe('AmountUtils', () => {
                     symbol: '¥',
                     space: false,
                     rtl: false,
-                    separatorSwap: false,
                     decimalPlaces: 0
                 });
                 const result = getUnformattedAmount({
@@ -553,7 +555,6 @@ describe('AmountUtils', () => {
                 symbol: code === 'EUR' ? '€' : '$',
                 space: code === 'EUR',
                 rtl: false,
-                separatorSwap: false,
                 decimalPlaces: 2
             });
         });
@@ -574,7 +575,7 @@ describe('AmountUtils', () => {
             it('handles small amounts correctly', () => {
                 (unitsStore as any).units = 'BTC';
                 const result = getAmountFromSats(1000);
-                expect(result).toBe('₿0.00001');
+                expect(result).toBe('₿0.00 001');
             });
 
             it('handles negative values', () => {
@@ -664,6 +665,7 @@ describe('AmountUtils', () => {
             // Reset mocks before each test
             (unitsStore as any).units = 'sats';
             (settingsStore as any).settings = {
+                locale: 'en',
                 fiat: 'USD',
                 display: {
                     removeDecimalSpaces: false,
@@ -688,7 +690,6 @@ describe('AmountUtils', () => {
                 symbol: code === 'EUR' ? '€' : '$',
                 space: code === 'EUR',
                 rtl: false,
-                separatorSwap: false,
                 decimalPlaces: 2
             });
         });
@@ -755,8 +756,7 @@ describe('AmountUtils', () => {
             it('handles amounts with commas (treats commas as decimal separators)', () => {
                 (unitsStore as any).units = 'fiat';
                 const result = getFormattedAmount('50,000');
-                // The code replaces commas with dots, so "50,000" becomes "50.000" = 50.00
-                expect(result).toBe('$50.00');
+                expect(result).toBe('$50,000.00');
             });
 
             it('handles amounts with decimals and commas', () => {
@@ -772,7 +772,7 @@ describe('AmountUtils', () => {
                 expect(result).toBe('€ 45,000.00');
             });
 
-            it('handles separatorSwap currencies correctly', () => {
+            it('formats fiat using the app locale instead of the fiat currency', () => {
                 (unitsStore as any).units = 'fiat';
                 (settingsStore as any).settings.fiat = 'ARS';
                 (fiatStore as any).fiatRates = [
@@ -787,20 +787,16 @@ describe('AmountUtils', () => {
                     symbol: code === 'ARS' ? '$' : '$',
                     space: code === 'ARS',
                     rtl: false,
-                    separatorSwap: true,
                     decimalPlaces: 2
                 });
                 const result = getFormattedAmount(50000);
-                // separatorSwap swaps commas and dots: 50000.00 becomes 50.000,00
-                expect(result).toBe('$ 50.000,00');
+                expect(result).toBe('$ 50,000.00');
             });
 
-            it('handles amounts with both commas and decimals (results in NaN)', () => {
+            it('handles amounts with both commas and decimals', () => {
                 (unitsStore as any).units = 'fiat';
                 const result = getFormattedAmount('1,234.56');
-                // Commas are replaced with dots, so "1,234.56" becomes "1.234.56" which has two dots
-                // Number("1.234.56") = NaN, so toFixed(2) = "NaN"
-                expect(result).toBe('$NaN');
+                expect(result).toBe('$1,234.56');
             });
 
             it('returns N/A when fiat rates are not available', () => {
@@ -825,6 +821,30 @@ describe('AmountUtils', () => {
                 expect(result).toBe('₿1');
             });
         });
+
+        describe('locale-driven separators', () => {
+            beforeEach(() => {
+                (settingsStore as any).settings.locale = 'de';
+            });
+
+            it('formats sats using the app locale', () => {
+                (unitsStore as any).units = 'sats';
+                const result = getFormattedAmount(1000);
+                expect(result).toBe('1.000 sats');
+            });
+
+            it('formats fiat using the app locale', () => {
+                (unitsStore as any).units = 'fiat';
+                const result = getFormattedAmount(50000);
+                expect(result).toBe('$50.000,00');
+            });
+
+            it('formats BTC using the app locale', () => {
+                (unitsStore as any).units = 'BTC';
+                const result = getFormattedAmount(12345.6789);
+                expect(result).toBe('₿12.345,67 89');
+            });
+        });
     });
 
     describe('getSatAmount', () => {
@@ -832,6 +852,7 @@ describe('AmountUtils', () => {
             // Reset mocks before each test
             (unitsStore as any).units = 'sats';
             (settingsStore as any).settings = {
+                locale: 'en',
                 fiat: 'USD',
                 display: {
                     removeDecimalSpaces: false,
@@ -867,10 +888,10 @@ describe('AmountUtils', () => {
                 expect(result).toBe(1000);
             });
 
-            it('handles comma-separated input by converting to dots', () => {
+            it('handles locale grouping separators in English-style locales', () => {
                 (unitsStore as any).units = 'sats';
                 const result = getSatAmount('1,001');
-                expect(result).toBe(1.001);
+                expect(result).toBe(1001);
             });
         });
 
@@ -973,6 +994,24 @@ describe('AmountUtils', () => {
                 (unitsStore as any).units = 'sats';
                 const result = getSatAmount('50000', 'fiat');
                 expect(result).toBe(100000000);
+            });
+        });
+
+        describe('locale-driven parsing', () => {
+            beforeEach(() => {
+                (settingsStore as any).settings.locale = 'de';
+            });
+
+            it('treats dot as a grouping separator in European-style locales', () => {
+                (unitsStore as any).units = 'fiat';
+                const result = getSatAmount('50.000');
+                expect(result).toBe(100000000);
+            });
+
+            it('accepts the locale decimal separator in European-style locales', () => {
+                (unitsStore as any).units = 'fiat';
+                const result = getSatAmount('0,5');
+                expect(result).toBe(1000);
             });
         });
 

--- a/utils/AmountUtils.ts
+++ b/utils/AmountUtils.ts
@@ -3,7 +3,8 @@ import BigNumber from 'bignumber.js';
 import { settingsStore, fiatStore, unitsStore } from '../stores/Stores';
 import {
     numberWithCommas,
-    numberWithDecimals,
+    normalizeNumberString,
+    formatBitcoinWithSpaces,
     SATS_PER_BTC
 } from './UnitsUtils';
 import type { Units } from './UnitsUtils';
@@ -24,7 +25,6 @@ export interface ValueDisplayProps {
     rtl?: boolean;
     space?: boolean;
     error?: string;
-    separatorSwap?: boolean;
 }
 
 /**
@@ -44,8 +44,7 @@ export function processSatsAmount(
     const amountStr = amount.toString();
     const hideMsats = forceMsats ? false : shouldHideMillisatoshiAmounts();
 
-    // Remove commas from the amount string for processing
-    const cleanAmountStr = amountStr.replace(/,/g, '');
+    const cleanAmountStr = normalizeNumberString(amountStr);
 
     // Always check for decimals when hideMsats is enabled
     const [, decimalPart] = cleanAmountStr.split('.');
@@ -164,8 +163,7 @@ export function getUnformattedAmount({
             }
 
             const rate = (fiatEntry && fiatEntry.rate) || 0;
-            const { symbol, space, rtl, decimalPlaces, separatorSwap } =
-                fiatStore.getSymbol();
+            const { symbol, space, rtl, decimalPlaces } = fiatStore.getSymbol();
 
             const decimals = decimalPlaces !== undefined ? decimalPlaces : 2;
 
@@ -180,8 +178,7 @@ export function getUnformattedAmount({
                 negative,
                 plural: false,
                 rtl,
-                space,
-                separatorSwap
+                space
             };
         } else {
             return {
@@ -213,12 +210,14 @@ export function getAmountFromSats(
         const valueToProcess = (wholeSats && wholeSats.toString()) || '0';
         if (valueToProcess.includes('-')) {
             const processedValue = valueToProcess.split('-')[1];
-            return `-₿${FeeUtils.toFixed(
-                Number(processedValue) / SATS_PER_BTC
+            return `-₿${formatBitcoinWithSpaces(
+                FeeUtils.toFixed(Number(processedValue) / SATS_PER_BTC)
             )}`;
         }
 
-        return `₿${FeeUtils.toFixed(Number(wholeSats || 0) / SATS_PER_BTC)}`;
+        return `₿${formatBitcoinWithSpaces(
+            FeeUtils.toFixed(Number(wholeSats || 0) / SATS_PER_BTC)
+        )}`;
     } else if (units === 'sats') {
         const sats = `${numberWithCommas(wholeSats || value) || 0} ${
             Number(value) === 1 || Number(value) === -1 ? 'sat' : 'sats'
@@ -232,16 +231,16 @@ export function getAmountFromSats(
             }
             const { code } = fiatEntry;
             const rate = (fiatEntry && fiatEntry.rate) || 0;
-            const { symbol, space, rtl, separatorSwap } =
+            const { symbol, space, rtl, decimalPlaces } =
                 fiatStore.symbolLookup(code);
+
+            const decimals = decimalPlaces !== undefined ? decimalPlaces : 2;
 
             const amount = (
                 FeeUtils.toFixed(Number(wholeSats || 0) / SATS_PER_BTC) * rate
-            ).toFixed(2);
+            ).toFixed(decimals);
 
-            const formattedAmount = separatorSwap
-                ? numberWithDecimals(amount)
-                : numberWithCommas(amount);
+            const formattedAmount = numberWithCommas(amount);
 
             if (rtl) {
                 return `${formattedAmount}${space ? ' ' : ''}${symbol}`;
@@ -273,10 +272,14 @@ export function getFormattedAmount(
         const valueToProcess = value.toString() || '0';
         if (valueToProcess.includes('-')) {
             const processedValue = valueToProcess.split('-')[1];
-            return `-₿${FeeUtils.toFixed(Number(processedValue))}`;
+            return `-₿${formatBitcoinWithSpaces(
+                FeeUtils.toFixed(Number(processedValue))
+            )}`;
         }
 
-        return `₿${FeeUtils.toFixed(Number(value || 0))}`;
+        return `₿${formatBitcoinWithSpaces(
+            FeeUtils.toFixed(Number(value || 0))
+        )}`;
     } else if (units === 'sats') {
         const [wholeSats] = value.toString().split('.');
         const sats = `${numberWithCommas(wholeSats || value) || 0} ${
@@ -290,17 +293,15 @@ export function getFormattedAmount(
                 return localeString('general.notAvailable');
             }
             const { code } = fiatEntry;
-            const { symbol, space, rtl, separatorSwap } =
+            const { symbol, space, rtl, decimalPlaces } =
                 fiatStore.symbolLookup(code);
+            const decimals = decimalPlaces !== undefined ? decimalPlaces : 2;
 
-            // handle amounts passed in with commas
-            const amount = Number(value.toString().replace(/,/g, '.')).toFixed(
-                2
+            const amount = Number(normalizeNumberString(value)).toFixed(
+                decimals
             );
 
-            const formattedAmount = separatorSwap
-                ? numberWithDecimals(amount)
-                : numberWithCommas(amount);
+            const formattedAmount = numberWithCommas(amount);
 
             if (rtl) {
                 return `${formattedAmount}${space ? ' ' : ''}${symbol}`;
@@ -368,7 +369,7 @@ export function getSatAmount(
     const { units } = unitsStore;
     const effectiveUnits = forceUnit || units;
 
-    const value = amount ? amount.toString().replace(/,/g, '.') : 0;
+    const value = amount ? normalizeNumberString(amount) : '0';
 
     const fiatEntry =
         fiat && fiatRates

--- a/utils/UnitsUtils.test.ts
+++ b/utils/UnitsUtils.test.ts
@@ -1,8 +1,16 @@
-import { getDecimalPlaceholder } from './UnitsUtils';
+import {
+    formatBitcoinWithSpaces,
+    getDecimalPlaceholder,
+    getDecimalSeparator,
+    normalizeNumberString,
+    numberWithCommas
+} from './UnitsUtils';
+import { settingsStore } from '../stores/Stores';
 
 jest.mock('../stores/Stores', () => ({
     settingsStore: {
         settings: {
+            locale: 'en',
             fiat: 'USD',
             display: {
                 removeDecimalSpaces: false
@@ -17,6 +25,11 @@ jest.mock('../stores/Stores', () => ({
 }));
 
 describe('UnitsUtils', () => {
+    beforeEach(() => {
+        (settingsStore as any).settings.locale = 'en';
+        (settingsStore as any).settings.display.removeDecimalSpaces = false;
+    });
+
     describe('getDecimalPlaceholder', () => {
         it('Returns string and count properly', () => {
             expect(getDecimalPlaceholder('1231.2', 'BTC')).toEqual({
@@ -45,6 +58,40 @@ describe('UnitsUtils', () => {
                 string: '000',
                 count: 3
             });
+        });
+    });
+
+    describe('locale-aware formatting', () => {
+        it('uses English-style separators by default', () => {
+            expect(numberWithCommas('1234567.89')).toBe('1,234,567.89');
+            expect(getDecimalSeparator()).toBe('.');
+        });
+
+        it('uses European-style separators for supported app locales', () => {
+            (settingsStore as any).settings.locale = 'de';
+            expect(numberWithCommas('1234567.89')).toBe('1.234.567,89');
+            expect(getDecimalSeparator()).toBe(',');
+        });
+
+        it('formats BTC decimals with locale-aware separators', () => {
+            (settingsStore as any).settings.locale = 'de';
+            expect(formatBitcoinWithSpaces('12345.6789')).toBe('12.345,67 89');
+        });
+    });
+
+    describe('locale-aware normalization', () => {
+        it('keeps English formatted input canonical', () => {
+            expect(normalizeNumberString('1,234.56')).toBe('1234.56');
+        });
+
+        it('normalizes European formatted input using the app locale', () => {
+            (settingsStore as any).settings.locale = 'de';
+            expect(normalizeNumberString('1.234,56')).toBe('1234.56');
+        });
+
+        it('treats fallback decimal input as a decimal when needed', () => {
+            (settingsStore as any).settings.locale = 'de';
+            expect(normalizeNumberString('0.5')).toBe('0.5');
         });
     });
 });

--- a/utils/UnitsUtils.ts
+++ b/utils/UnitsUtils.ts
@@ -3,6 +3,279 @@ import { settingsStore, fiatStore } from '../stores/Stores';
 // 100_000_000
 const SATS_PER_BTC = 100000000;
 
+const EUROPEAN_STYLE_LOCALES = new Set([
+    'bg',
+    'cs',
+    'de',
+    'el',
+    'es',
+    'fi',
+    'fr',
+    'hr',
+    'hu',
+    'id',
+    'it',
+    'nb',
+    'nl',
+    'pl',
+    'pt',
+    'ro',
+    'ru',
+    'sk',
+    'sl',
+    'sv',
+    'tr',
+    'uk',
+    'vi'
+]);
+
+const NUMBER_FORMAT_LOCALE_OVERRIDES: { [key: string]: string } = {
+    en: 'en-US',
+    hi_IN: 'hi-IN',
+    jp: 'ja-JP',
+    pt: 'pt-BR',
+    zh: 'zh-CN',
+    zh_TW: 'zh-TW'
+};
+
+const normalizeLocaleForNumberFormat = (locale?: string) => {
+    const normalizedLocale = locale || settingsStore?.settings?.locale || 'en';
+    return (
+        NUMBER_FORMAT_LOCALE_OVERRIDES[normalizedLocale] ||
+        normalizedLocale.replace(/_/g, '-')
+    );
+};
+
+const usesEuropeanNumberFormat = (locale?: string) => {
+    const normalizedLocale = normalizeLocaleForNumberFormat(locale);
+
+    try {
+        const parts = new Intl.NumberFormat(normalizedLocale).formatToParts(
+            1000.1
+        );
+        const decimalSeparator = parts.find(
+            (part) => part.type === 'decimal'
+        )?.value;
+
+        if (decimalSeparator) {
+            return decimalSeparator === ',';
+        }
+    } catch {
+        // Fall back to a curated locale list if Intl data is unavailable.
+    }
+
+    const baseLocale = normalizedLocale.split('-')[0];
+    return (
+        EUROPEAN_STYLE_LOCALES.has(normalizedLocale) ||
+        EUROPEAN_STYLE_LOCALES.has(baseLocale)
+    );
+};
+
+const getNumberFormatSettings = (locale?: string) => {
+    const europeanStyle = usesEuropeanNumberFormat(locale);
+
+    return {
+        decimalSeparator: europeanStyle ? ',' : '.',
+        groupSeparator: europeanStyle ? '.' : ','
+    };
+};
+
+const getDecimalSeparator = (locale?: string) =>
+    getNumberFormatSettings(locale).decimalSeparator;
+
+const splitNumericValue = (value: string | number, locale?: string) => {
+    const { decimalSeparator, groupSeparator } =
+        getNumberFormatSettings(locale);
+    const input = `${value ?? 0}`.trim().replace(/\s/g, '');
+
+    if (!input) {
+        return {
+            sign: '',
+            integerPart: '0',
+            decimalPart: undefined,
+            hasExplicitDecimal: false
+        };
+    }
+
+    const sign = input.startsWith('-') ? '-' : '';
+    const unsignedInput = sign ? input.slice(1) : input;
+    const fallbackSeparator = decimalSeparator === '.' ? ',' : '.';
+
+    const normalizeGroupedValue = (integerValue: string) =>
+        integerValue.replace(/[.,]/g, '') || '0';
+
+    const splitOnSeparator = (separator: string) => {
+        const parts = unsignedInput.split(separator);
+
+        if (parts.length === 1) {
+            return undefined;
+        }
+
+        if (parts.length > 2) {
+            const decimalPart = parts.pop() || '';
+            return {
+                sign,
+                integerPart: normalizeGroupedValue(parts.join(separator)),
+                decimalPart: decimalPart.replace(/[.,]/g, ''),
+                hasExplicitDecimal: true
+            };
+        }
+
+        const [integerPart, decimalPart = ''] = parts;
+        return {
+            sign,
+            integerPart: normalizeGroupedValue(integerPart),
+            decimalPart: decimalPart.replace(/[.,]/g, ''),
+            hasExplicitDecimal: true
+        };
+    };
+
+    if (/[.,]/.test(unsignedInput)) {
+        const lastDecimalIndex = unsignedInput.lastIndexOf(decimalSeparator);
+        const lastFallbackIndex = unsignedInput.lastIndexOf(fallbackSeparator);
+
+        if (lastDecimalIndex >= 0 && lastFallbackIndex >= 0) {
+            const decimalIndex = Math.max(lastDecimalIndex, lastFallbackIndex);
+            return {
+                sign,
+                integerPart: normalizeGroupedValue(
+                    unsignedInput.slice(0, decimalIndex)
+                ),
+                decimalPart: unsignedInput
+                    .slice(decimalIndex + 1)
+                    .replace(/[.,]/g, ''),
+                hasExplicitDecimal: true
+            };
+        }
+
+        if (unsignedInput.endsWith(decimalSeparator)) {
+            return {
+                sign,
+                integerPart: normalizeGroupedValue(unsignedInput.slice(0, -1)),
+                decimalPart: '',
+                hasExplicitDecimal: true
+            };
+        }
+
+        if (unsignedInput.includes(decimalSeparator)) {
+            return splitOnSeparator(decimalSeparator)!;
+        }
+
+        if (unsignedInput.includes(groupSeparator)) {
+            const parts = unsignedInput.split(groupSeparator);
+            const [integerPart, decimalPart = ''] = parts;
+            const isDecimalFallback =
+                parts.length === 2 &&
+                (integerPart === '0' || decimalPart.length !== 3);
+
+            if (isDecimalFallback) {
+                return {
+                    sign,
+                    integerPart: normalizeGroupedValue(integerPart),
+                    decimalPart: decimalPart.replace(/[.,]/g, ''),
+                    hasExplicitDecimal: true
+                };
+            }
+
+            return {
+                sign,
+                integerPart: normalizeGroupedValue(parts.join(groupSeparator)),
+                decimalPart: undefined,
+                hasExplicitDecimal: false
+            };
+        }
+
+        if (unsignedInput.endsWith(fallbackSeparator)) {
+            return {
+                sign,
+                integerPart: normalizeGroupedValue(unsignedInput.slice(0, -1)),
+                decimalPart: '',
+                hasExplicitDecimal: true
+            };
+        }
+
+        if (unsignedInput.includes(fallbackSeparator)) {
+            const parts = unsignedInput.split(fallbackSeparator);
+            const [integerPart, decimalPart = ''] = parts;
+            const isGroupedFallback =
+                parts.length > 2 ||
+                (parts.length === 2 &&
+                    decimalPart.length === 3 &&
+                    integerPart.length > 0 &&
+                    integerPart !== '0');
+
+            if (isGroupedFallback) {
+                return {
+                    sign,
+                    integerPart: normalizeGroupedValue(
+                        parts.join(fallbackSeparator)
+                    ),
+                    decimalPart: undefined,
+                    hasExplicitDecimal: false
+                };
+            }
+
+            return {
+                sign,
+                integerPart: normalizeGroupedValue(integerPart),
+                decimalPart: decimalPart.replace(/[.,]/g, ''),
+                hasExplicitDecimal: true
+            };
+        }
+    }
+
+    return {
+        sign,
+        integerPart: unsignedInput.replace(/[.,]/g, '') || '0',
+        decimalPart: undefined,
+        hasExplicitDecimal: false
+    };
+};
+
+const normalizeNumberString = (value: string | number, locale?: string) => {
+    const { sign, integerPart, decimalPart, hasExplicitDecimal } =
+        splitNumericValue(value, locale);
+
+    if (!hasExplicitDecimal) {
+        return `${sign}${integerPart}`;
+    }
+
+    return `${sign}${integerPart}.${decimalPart || ''}`;
+};
+
+const splitCanonicalNumericValue = (value: string | number) => {
+    const input = `${value ?? 0}`.trim();
+
+    if (!input) {
+        return {
+            sign: '',
+            integerPart: '0',
+            decimalPart: undefined,
+            hasExplicitDecimal: false
+        };
+    }
+
+    const sign = input.startsWith('-') ? '-' : '';
+    const unsignedInput = sign ? input.slice(1) : input;
+    const [integerPartRaw, decimalPart] = unsignedInput.split('.');
+
+    return {
+        sign,
+        integerPart: integerPartRaw || '0',
+        decimalPart,
+        hasExplicitDecimal: unsignedInput.includes('.')
+    };
+};
+
+const formatGroupedInteger = (
+    integerPart: string,
+    groupSeparator: string
+): string => {
+    const sanitizedInteger = integerPart || '0';
+
+    return sanitizedInteger.replace(/\B(?=(\d{3})+(?!\d))/g, groupSeparator);
+};
+
 const getDecimalPlaceholder = (amount: string, units: string) => {
     const [_, decimalPart] = amount.split('.');
     const occupiedPlaces: number = (decimalPart && decimalPart.length) || 0;
@@ -40,46 +313,53 @@ const getDecimalPlaceholder = (amount: string, units: string) => {
     };
 };
 
-const numberWithCommas = (x: string | number) =>
-    x?.toString()?.replace(/\B(?=(\d{3})+(?!\d))/g, ',') || '0';
+const numberWithCommas = (x: string | number) => {
+    const { decimalSeparator, groupSeparator } = getNumberFormatSettings();
+    const { sign, integerPart, decimalPart, hasExplicitDecimal } =
+        splitCanonicalNumericValue(x);
+    const integerFormatted = formatGroupedInteger(integerPart, groupSeparator);
 
-const numberWithDecimals = (x: string | number) =>
-    numberWithCommas(x).replace(/[,.]/g, (y: string) =>
-        y === ',' ? '.' : ','
-    );
+    if (hasExplicitDecimal) {
+        return `${sign}${integerFormatted}${decimalSeparator}${
+            decimalPart || ''
+        }`;
+    }
+
+    return `${sign}${integerFormatted}`;
+};
 
 const formatBitcoinWithSpaces = (x: string | number) => {
-    // Convert to string to handle decimal parts
-    const [integerPart, decimalPart] = x.toString().split('.');
+    const { decimalSeparator, groupSeparator } = getNumberFormatSettings();
+    const { sign, integerPart, decimalPart, hasExplicitDecimal } =
+        splitCanonicalNumericValue(x);
+    const integerFormatted = formatGroupedInteger(integerPart, groupSeparator);
 
-    const integerFormatted = numberWithCommas(integerPart);
-
-    // // If no decimal part, return the integer part as is
-    if (x.toString().includes('.') && !decimalPart) {
-        return `${integerFormatted}.`;
-    } else if (!decimalPart) {
-        return integerFormatted;
+    if (hasExplicitDecimal && decimalPart === '') {
+        return `${sign}${integerFormatted}${decimalSeparator}`;
+    } else if (decimalPart === undefined) {
+        return `${sign}${integerFormatted}`;
     }
 
     if (settingsStore?.settings?.display?.removeDecimalSpaces) {
-        return `${integerFormatted}.${decimalPart}`;
+        return `${sign}${integerFormatted}${decimalSeparator}${decimalPart}`;
     }
 
-    // Handle the first two characters, then group the rest in threes
     const firstTwo = decimalPart.slice(0, 2);
     const rest = decimalPart.slice(2).replace(/(\d{3})(?=\d)/g, '$1 ');
+    const spacedDecimal = [firstTwo, rest].filter(Boolean).join(' ');
 
-    // Combine integer part, first two characters, and formatted rest
-    return `${integerFormatted}.${firstTwo} ${rest}`.trim();
+    return `${sign}${integerFormatted}${decimalSeparator}${spacedDecimal}`;
 };
 
 type Units = 'sats' | 'BTC' | 'fiat';
 
 export {
     SATS_PER_BTC,
+    getNumberFormatSettings,
+    getDecimalSeparator,
+    normalizeNumberString,
     getDecimalPlaceholder,
     numberWithCommas,
-    numberWithDecimals,
     formatBitcoinWithSpaces
 };
 export type { Units };

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -26,11 +26,7 @@ import ActivityToCsv from './ActivityToCsv';
 import { localeString } from '../../utils/LocaleUtils';
 import BackendUtils from '../../utils/BackendUtils';
 import { themeColor } from '../../utils/ThemeUtils';
-import {
-    SATS_PER_BTC,
-    numberWithCommas,
-    numberWithDecimals
-} from '../../utils/UnitsUtils';
+import { SATS_PER_BTC, numberWithCommas } from '../../utils/UnitsUtils';
 import PrivacyUtils from '../../utils/PrivacyUtils';
 
 import ActivityStore, { DEFAULT_FILTERS } from '../../stores/ActivityStore';
@@ -723,18 +719,15 @@ export default class Activity extends React.PureComponent<
                             (entry: any) => entry.code === fiat
                         )[0];
 
-                    const { symbol, space, rtl, separatorSwap } = fiatEntry
+                    const { symbol, space, rtl } = fiatEntry
                         ? FiatStore.symbolLookup(fiatEntry.code)
                         : {
                               symbol: 'N/A',
                               space: true,
-                              rtl: false,
-                              separatorSwap: false
+                              rtl: false
                           };
 
-                    const formattedRate = separatorSwap
-                        ? numberWithDecimals(rate)
-                        : numberWithCommas(rate);
+                    const formattedRate = numberWithCommas(rate);
 
                     const exchangeRate = rtl
                         ? `${formattedRate}${

--- a/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
@@ -25,6 +25,7 @@ import DateTimeUtils from '../../../utils/DateTimeUtils';
 import NostrConnectUtils from '../../../utils/NostrConnectUtils';
 import { themeColor } from '../../../utils/ThemeUtils';
 import { localeString } from '../../../utils/LocaleUtils';
+import { numberWithCommas } from '../../../utils/UnitsUtils';
 
 import NostrWalletConnectStore from '../../../stores/NostrWalletConnectStore';
 
@@ -420,9 +421,9 @@ export default class NWCConnectionDetails extends React.Component<
                                             keyValue={localeString(
                                                 'views.Settings.NostrWalletConnect.budget'
                                             )}
-                                            value={`${connection.maxAmountSats.toLocaleString()} ${localeString(
-                                                'general.sats'
-                                            )}${
+                                            value={`${numberWithCommas(
+                                                connection.maxAmountSats
+                                            )} ${localeString('general.sats')}${
                                                 connection.budgetRenewal !==
                                                 'never'
                                                     ? ` (${connection.budgetRenewal})`
@@ -437,7 +438,9 @@ export default class NWCConnectionDetails extends React.Component<
                                                 keyValue={localeString(
                                                     'views.Settings.NostrWalletConnect.totalSpent'
                                                 )}
-                                                value={`${connection.totalSpendSats.toLocaleString()} ${localeString(
+                                                value={`${numberWithCommas(
+                                                    connection.totalSpendSats
+                                                )} ${localeString(
                                                     'general.sats'
                                                 )}`}
                                             />
@@ -446,7 +449,9 @@ export default class NWCConnectionDetails extends React.Component<
                                                 keyValue={localeString(
                                                     'views.Settings.NostrWalletConnect.remainingBudget'
                                                 )}
-                                                value={`${connection.remainingBudget.toLocaleString()} ${localeString(
+                                                value={`${numberWithCommas(
+                                                    connection.remainingBudget
+                                                )} ${localeString(
                                                     'general.sats'
                                                 )}`}
                                             />

--- a/views/Settings/NostrWalletConnect/NWCConnectionsList.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionsList.tsx
@@ -24,6 +24,7 @@ import NostrWalletConnectStore from '../../../stores/NostrWalletConnectStore';
 import { themeColor } from '../../../utils/ThemeUtils';
 import { localeString } from '../../../utils/LocaleUtils';
 import DateTimeUtils from '../../../utils/DateTimeUtils';
+import { numberWithCommas } from '../../../utils/UnitsUtils';
 
 import NWCConnection, {
     ConnectionWarningType
@@ -270,9 +271,9 @@ export default class NWCConnectionsList extends React.Component<
                                         { color: themeColor('text') }
                                     ]}
                                 >
-                                    {`${connection.remainingBudget.toLocaleString()} ${localeString(
-                                        'general.sats'
-                                    )}`}
+                                    {`${numberWithCommas(
+                                        connection.remainingBudget
+                                    )} ${localeString('general.sats')}`}
                                 </Text>
                                 <Text
                                     style={[
@@ -337,9 +338,11 @@ export default class NWCConnectionsList extends React.Component<
                                         { color: themeColor('secondaryText') }
                                     ]}
                                 >
-                                    {`${connection.totalSpendSats.toLocaleString()} / ${connection.maxAmountSats.toLocaleString()} ${localeString(
-                                        'general.sats'
-                                    )}`}
+                                    {`${numberWithCommas(
+                                        connection.totalSpendSats
+                                    )} / ${numberWithCommas(
+                                        connection.maxAmountSats
+                                    )} ${localeString('general.sats')}`}
                                     {connection.budgetRenewal !== 'never'
                                         ? ` (${connection.budgetRenewal})`
                                         : ''}


### PR DESCRIPTION
# Description

Relates to issue: #3833

This PR makes number separators follow the app language across the app.
<img width="424" height="790" alt="Screenshot 2026-03-31 at 2 03 53 AM" src="https://github.com/user-attachments/assets/7a6deb10-4491-408e-ac47-703ea3dcccaf" />
<img width="424" height="790" alt="Screenshot 2026-03-31 at 2 04 58 AM" src="https://github.com/user-attachments/assets/4dc85cd0-5fb3-4a84-9a40-87852483d44a" />

Before this change, Bitcoin and sats were always shown in English-style formatting, while fiat formatting depended on the selected currency. That could show mixed separator styles on the same screen.

With this change, the selected app language is used as the single source of truth for number separators for:
- sats
- BTC
- fiat
- exchange rates
- keypad decimal display
- related amount input and conversion flows

This keeps formatting consistent when switching between languages like English and German.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] Embedded LND
- [ ] LDK Node

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding