### PR TITLE
fix: skip custom message WebSocket subscription for REST-based backends at startup

### DIFF
--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -78,6 +78,16 @@ export default class LSPStore {
                             channel.remotePubkey === lspPubkey
                     )
                 ) {
+                    // For backends that use custom messages as the LSPS7 fallback
+                    // (e.g. LND REST — supportsLSPS1rest=true so subscription is
+                    // skipped at startup), set up the subscription lazily here,
+                    // just before sending the LSPS7 custom message.
+                    if (
+                        BackendUtils.supportsLSPScustomMessage() &&
+                        !BackendUtils.supportsLSPS7native()
+                    ) {
+                        this.subscribeCustomMessages();
+                    }
                     this.getExtendableChannels();
                 }
             }
@@ -542,6 +552,10 @@ export default class LSPStore {
 
             await index.subscribeCustomMessages();
         } else {
+            // Set sentinel immediately so subsequent calls are blocked by the
+            // guard at the top of this function (analogous to how the
+            // embedded-lnd branch sets customMessagesSubscriber via addListener).
+            this.customMessagesSubscriber = true;
             BackendUtils.subscribeCustomMessages(
                 (response: any) => {
                     const decoded = response.result;
@@ -554,8 +568,12 @@ export default class LSPStore {
                     }
                 },
                 (error: any) => {
+                    runInAction(() => {
+                        this.customMessagesSubscriber = undefined;
+                    });
                     console.error(
-                        'sub custom messages error: ' + error.message
+                        'subscribeCustomMessages WebSocket error:',
+                        error
                     );
                 }
             );

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1253,7 +1253,15 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             ) {
                 await LSPStore.getLSPInfo();
             }
-            if (BackendUtils.supportsLSPScustomMessage()) {
+            if (
+                BackendUtils.supportsLSPScustomMessage() &&
+                !BackendUtils.supportsLSPS1rest()
+            ) {
+                // Only subscribe at startup when the backend uses custom messages
+                // for LSPS1 (e.g. embedded-lnd). Backends that use REST for LSPS1
+                // (LND REST, LNC) do not need this at startup — for them the
+                // subscription is set up lazily from the channels reaction when
+                // LSPS7 channel extension is about to be attempted.
                 LSPStore.subscribeCustomMessages();
             }
             LSPStore.initChannelAcceptor();


### PR DESCRIPTION
# Description

When connecting to an LND REST wallet while an embedded-lnd wallet config also exists, a spurious `subscribeCustomMessages` WebSocket error appeared in the debug output.

For LND REST and LNC, LSPS1 uses the REST API and LSPS7 uses custom messages only as a fallback when channels with the LSP already exist. The WebSocket subscription to /v1/custommessage/subscribe is therefore not needed unconditionally at startup.

Changes:
- `Wallet.tsx`: only call `subscribeCustomMessages` at startup for backends that use custom messages for LSPS1 (`!supportsLSPS1rest()`)
- LSPStore channels reaction: subscribe lazily just before `getExtendableChannels()` for backends using the custom message LSPS7 fallback (LND REST, LNC), and only when a channel with the LSP actually exists
- LSPStore `subscribeCustomMessages`: set `customMessagesSubscriber = true` in the non-embedded-lnd branch so the deduplication guard works correctly; ; reset it to `undefined` on WebSocket error so a subsequent retry is possible; fix error logging (`error` instead of `error.message`)

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
