### PR TITLE
fix (Swaps): Display correct receive amount for reverse swaps by subtracting claim fee

### DIFF
--- a/android/app/src/main/java/com/zeus/lnc-rn/LncModule.kt
+++ b/android/app/src/main/java/com/zeus/lnc-rn/LncModule.kt
@@ -207,11 +207,11 @@ class LncModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
   }
 
   @ReactMethod
-  fun createReverseClaimTransaction(endpoint: String, swapId: String, claimLeaf: String, refundLeaf: String, privateKey: String, servicePubKey: String, preimageHex: String, transactionHex: String, lockupAddress: String, destinationAddress: String, feeRate: Int, isTestnet: Boolean?, promise: Promise) {
+  fun createReverseClaimTransaction(endpoint: String, swapId: String, claimLeaf: String, refundLeaf: String, privateKey: String, servicePubKey: String, preimageHex: String, transactionHex: String, lockupAddress: String, destinationAddress: String, feeRate: Int, receiveAmount: Double, isTestnet: Boolean?, promise: Promise) {
      Log.d("createReverseClaimTransaction called", "");
 
      try {
-         Lndmobile.createReverseClaimTransaction(endpoint, swapId, claimLeaf, refundLeaf, privateKey, servicePubKey, preimageHex, transactionHex, lockupAddress, destinationAddress, feeRate, isTestnet ?: false)
+         Lndmobile.createReverseClaimTransaction(endpoint, swapId, claimLeaf, refundLeaf, privateKey, servicePubKey, preimageHex, transactionHex, lockupAddress, destinationAddress, feeRate, receiveAmount.toLong(), isTestnet ?: false)
          promise.resolve(null)
      } catch (e: Exception) {
          promise.reject("CREATE_REVERSE_CLAIM_ERROR", e.toString())

--- a/ios/LncMobile/LncModule.mm
+++ b/ios/LncMobile/LncModule.mm
@@ -277,12 +277,13 @@ RCT_EXPORT_METHOD(createReverseClaimTransaction:(NSString *)endpoint
                  lockupAddress:(NSString *)lockupAddress
                  destinationAddress:(NSString *)destinationAddress
                  feeRate:(NSInteger)feeRate
+                 receiveAmount:(double)receiveAmount
                  isTestnet:(BOOL)isTestnet
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
     NSError *error;
-    LndmobileCreateReverseClaimTransaction(endpoint, swapId, claimLeaf, refundLeaf, privateKey, servicePubKey, preimageHex, transactionHex, lockupAddress, destinationAddress, feeRate, isTestnet, &error);
+    LndmobileCreateReverseClaimTransaction(endpoint, swapId, claimLeaf, refundLeaf, privateKey, servicePubKey, preimageHex, transactionHex, lockupAddress, destinationAddress, (int32_t)feeRate, (int64_t)receiveAmount, isTestnet, &error);
     if (error) {
         NSLog(@"createReverseClaimTransaction error   %@",   error);
         reject(@"createReverseClaimTransaction_error", error.localizedDescription, error);

--- a/lndmobile/LndMobile.d.ts
+++ b/lndmobile/LndMobile.d.ts
@@ -81,6 +81,7 @@ export interface ILndMobile {
         lockupAddress: string,
         destinationAddress: string,
         feeRate: number,
+        receiveAmount: number,
         isTestnet?: boolean
     ): Promise<string>;
 

--- a/lndmobile/LndMobileInjection.ts
+++ b/lndmobile/LndMobileInjection.ts
@@ -557,6 +557,7 @@ export interface ILndMobileInjections {
             lockupAddress,
             destinationAddress,
             feeRate,
+            receiveAmount,
             isTestnet
         }: {
             endpoint: string;
@@ -570,6 +571,7 @@ export interface ILndMobileInjections {
             lockupAddress: string;
             destinationAddress: string;
             feeRate: number;
+            receiveAmount: number;
             isTestnet?: boolean;
         }) => Promise<string>;
         createRefundTransaction: ({

--- a/lndmobile/swaps.ts
+++ b/lndmobile/swaps.ts
@@ -77,6 +77,7 @@ export const createReverseClaimTransaction = async ({
     lockupAddress,
     destinationAddress,
     feeRate,
+    receiveAmount,
     isTestnet
 }: {
     endpoint: string;
@@ -90,6 +91,7 @@ export const createReverseClaimTransaction = async ({
     lockupAddress: string;
     destinationAddress: string;
     feeRate: number;
+    receiveAmount: number;
     isTestnet?: boolean;
 }): Promise<string> => {
     try {
@@ -105,6 +107,7 @@ export const createReverseClaimTransaction = async ({
             lockupAddress,
             destinationAddress,
             feeRate,
+            receiveAmount,
             isTestnet
         );
         return error;

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -30,9 +30,34 @@ import Storage from '../storage';
 
 import Swap, { SwapState, SwapType } from '../models/Swap';
 
+interface SubmarineSwapInfo {
+    fees?: {
+        percentage?: number;
+        minerFees?: number;
+    };
+    limits?: {
+        minimal?: number;
+        maximal?: number;
+    };
+}
+
+interface ReverseSwapInfo {
+    fees?: {
+        percentage?: number;
+        minerFees?: {
+            claim?: number;
+            lockup?: number;
+        };
+    };
+    limits?: {
+        minimal?: number;
+        maximal?: number;
+    };
+}
+
 export default class SwapStore {
-    @observable public subInfo = {};
-    @observable public reverseInfo = {};
+    @observable public subInfo: SubmarineSwapInfo = {};
+    @observable public reverseInfo: ReverseSwapInfo = {};
     @observable public loading = true;
     @observable public apiError = '';
     @observable public swaps: any = [];
@@ -54,6 +79,13 @@ export default class SwapStore {
             () => this.getSwapFees()
         );
     }
+
+    getReverseSwapReceiveAmount = (
+        onchainAmount: number | undefined
+    ): number => {
+        const claimFee = this.reverseInfo?.fees?.minerFees?.claim || 0;
+        return (onchainAmount || 0) - claimFee;
+    };
 
     @action
     public clearError = () => {

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -319,7 +319,13 @@ const ActivityListItem = observer(
                             }}
                         >
                             <Amount
-                                sats={item.getAmount}
+                                sats={
+                                    item.isReverseSwap
+                                        ? swapStore?.getReverseSwapReceiveAmount(
+                                              item.getAmount
+                                          )
+                                        : item.getAmount
+                                }
                                 sensitive
                                 color={getRightTitleTheme(item)}
                             />

--- a/views/Swaps/SwapDetails.tsx
+++ b/views/Swaps/SwapDetails.tsx
@@ -648,6 +648,15 @@ export default class SwapDetails extends React.Component<
         }
     };
 
+    reverseSwapReceiveAmount = (): number => {
+        const { SwapStore } = this.props;
+        return (
+            SwapStore?.getReverseSwapReceiveAmount(
+                this.state.swapData?.getAmount
+            ) || 0
+        );
+    };
+
     /**
      * Create and send a claim transaction for a reverse swap
      */
@@ -662,13 +671,22 @@ export default class SwapDetails extends React.Component<
         fee: string
     ): Promise<boolean> => {
         try {
-            const dObject = keys.__D;
+            const dObject = keys?.__D;
 
-            // Extract keys, sort them numerically, and map to byte values
-            const dBytes = Object.keys(dObject)
-                .map((key) => parseInt(key, 10))
-                .sort((a, b) => a - b)
-                .map((key) => dObject[key]);
+            if (!dObject) {
+                console.error('keys.__D is undefined');
+                return false;
+            }
+
+            let dBytes: number[];
+            if (Array.isArray(dObject)) {
+                dBytes = dObject;
+            } else if (dObject?.data && Array.isArray(dObject.data)) {
+                dBytes = dObject.data;
+            } else {
+                console.error('Unexpected key format:', typeof dObject);
+                return false;
+            }
 
             const privateKeyHex = dBytes
                 .map((byte) => byte.toString(16).padStart(2, '0'))
@@ -679,6 +697,15 @@ export default class SwapDetails extends React.Component<
             for (let i = 0; i <= 10; i++) {
                 try {
                     await sleep(1000);
+                    const preimageHex =
+                        typeof preimage === 'string'
+                            ? preimage
+                            : Buffer.isBuffer(preimage)
+                            ? preimage.toString('hex')
+                            : preimage?.data
+                            ? Buffer.from(preimage.data).toString('hex')
+                            : '';
+
                     await createReverseClaimTransaction({
                         endpoint,
                         swapId: createdResponse.id,
@@ -686,11 +713,12 @@ export default class SwapDetails extends React.Component<
                         refundLeaf: createdResponse.swapTree.refundLeaf.output,
                         privateKey: privateKeyHex,
                         servicePubKey: createdResponse.refundPublicKey,
-                        preimageHex: preimage.toString('hex'),
+                        preimageHex,
                         transactionHex,
                         lockupAddress,
                         destinationAddress,
                         feeRate: Number(fee || 2),
+                        receiveAmount: this.reverseSwapReceiveAmount(),
                         isTestnet: this.props.NodeInfoStore!.nodeInfo.isTestNet
                     });
 
@@ -945,7 +973,7 @@ export default class SwapDetails extends React.Component<
                                 )}
                                 value={
                                     <Amount
-                                        sats={swapData?.getAmount}
+                                        sats={this.reverseSwapReceiveAmount()}
                                         sensitive
                                         toggleable
                                     />

--- a/views/Swaps/SwapsPane.tsx
+++ b/views/Swaps/SwapsPane.tsx
@@ -175,7 +175,9 @@ export default class SwapsPane extends React.Component<SwapsPaneProps, {}> {
                                 item?.isSubmarineSwap
                                     ? item.expectedAmount
                                     : item.isReverseSwap
-                                    ? item.getAmount
+                                    ? this.props.SwapStore?.getReverseSwapReceiveAmount(
+                                          item.getAmount
+                                      )
                                     : undefined
                             }
                             sensitive


### PR DESCRIPTION
# Description

- Reverse swap (LN → onchain) was displaying the onchainAmount directly coming from the API, which is the amount locked at the lockup address before the claim TX fee. Hence users saw a higher amount than what they actually received finally on their given `destinationAddress`.
- Added `getReverseSwapReceiveAmount()` in SwapStore that subtracts the claim miner fee from locked onchain amount, and used it across SwapDetails, SwapsPane, and Activity views
- Pass the calculated receive amount to the native bridge (Android / iOS) so the claim transaction is constructed using a fee budget derived from the claim miner fee, ensuring the output matches the displayed amount.
Related backend changes  [47e85b](https://github.com/ZeusLN/lnd/commit/47e85b8ee81c7ebad24fb0d603cc628636805024)  [ba9185](https://github.com/ZeusLN/lnd/pull/5/changes/ba918550f9d1ef45ae423478683d0fd6ee9a3d5a) 

## Test plan
- Create a reverse swap, verify displayed amount on swaps views is consistent across SwapDetails, SwapsPane, and Activity views.
- Verify the claim transaction completes successfully on both Android and iOS
- Confirm the claimed on-chain amount matches what was displayed

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [X] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
