### PR TITLE
fix: defer ZEUS Pay push credential registration until device token is available

### DIFF
--- a/stores/LightningAddressStore.ts
+++ b/stores/LightningAddressStore.ts
@@ -93,6 +93,7 @@ export default class LightningAddressStore {
     // Push
     @observable public currentDeviceToken: string;
     @observable public serviceDeviceToken: string;
+    private pendingPushUpdate: boolean = false;
     @observable public readyToAutomaticallyAccept: boolean = false;
     @observable public prepareToAutomaticallyAcceptStart: boolean = false;
     // Auth
@@ -1072,15 +1073,28 @@ export default class LightningAddressStore {
         return attestation;
     };
 
-    public setDeviceToken = (token: string) =>
-        (this.currentDeviceToken = token);
+    @action
+    public setDeviceToken = (token: string) => {
+        this.currentDeviceToken = token;
+        if (this.pendingPushUpdate) {
+            this.pendingPushUpdate = false;
+            this.updatePushCredentials().catch((e) =>
+                console.log('Failed to update push credentials', e)
+            );
+        }
+    };
 
     public updatePushCredentials = async () => {
+        if (!this.currentDeviceToken) {
+            // Device token hasn't arrived yet — defer until
+            // setDeviceToken is called by the push notification callback
+            this.pendingPushUpdate = true;
+            return;
+        }
         // only push update if the device token has changed
         if (
-            this.currentDeviceToken &&
-            (!this.serviceDeviceToken ||
-                this.currentDeviceToken !== this.serviceDeviceToken)
+            !this.serviceDeviceToken ||
+            this.currentDeviceToken !== this.serviceDeviceToken
         ) {
             await this.update({
                 device_token: this.currentDeviceToken,


### PR DESCRIPTION
# Description

ZEUS Pay push notifications were failing to register for newly created wallets due to a race condition between native device token registration and wallet creation. When a user creates a new wallet, `updatePushCredentials()` is called immediately, but the native push token may not have arrived yet from the OS. Previously, this caused the function to silently return without registering, with no retry mechanism.

This fix adds a `pendingPushUpdate` flag so that if `updatePushCredentials()` is called before the device token is available, the registration is deferred and automatically triggered once `setDeviceToken()` fires from the native callback.

This also covers the edge case of existing wallets that connect before the device token callback completes, without causing redundant server calls for wallets that are already registered.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
