### PR TITLE
fix: preserve LnurlPay comment when navigating back from AmountKeypad

### DIFF
--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -100,34 +100,33 @@ export default class LnurlPay extends React.Component<
         }
     }
 
-    // ensure the state is reset to show correct units
-    // for when users navs back, while preserving user-entered amounts
-    resetState = () => {
+    // Recalculate the displayed amount in the current unit when the user
+    // navigates back (e.g. from AmountKeypad after switching units).
+    recalculateDisplayAmount = () => {
         const { satAmount } = this.state;
-        const fresh = this.stateFromProps(this.props);
-        // If the user has entered an amount, recalculate display from
-        // their satAmount rather than resetting to route params
         if (satAmount && satAmount != 0) {
             const { amount: displayAmount } = getUnformattedAmount({
                 sats: satAmount
             });
-            this.setState({
-                ...fresh,
-                amount: displayAmount,
-                satAmount
-            });
-        } else {
-            this.setState(fresh);
+            if (displayAmount !== this.state.amount) {
+                this.setState({ amount: displayAmount });
+            }
         }
     };
 
     componentDidMount() {
-        this.props.navigation.addListener('focus', this.resetState);
+        this.props.navigation.addListener(
+            'focus',
+            this.recalculateDisplayAmount
+        );
     }
 
     componentWillUnmount() {
         this.props.navigation.removeListener &&
-            this.props.navigation.removeListener('focus', this.resetState);
+            this.props.navigation.removeListener(
+                'focus',
+                this.recalculateDisplayAmount
+            );
     }
 
     stateFromProps(props: LnurlPayProps) {


### PR DESCRIPTION
# Description

Found a minor issue, where the comment field in the Lightning Address payment screen (`LnurlPay`) was cleared when you tapped the amount field and navigated back.

Root cause: The amount field opens the dedicated `AmountKeypad` screen. When you return from it, React Navigation fires a `focus` event on `LnurlPay`. The registered focus listener called `resetState()`, which did a full state rebuild via `stateFromProps()`, including hardcoding `comment: ''`. Since `comment` is not part of the route params, it was lost.

Fix: the focus listener now only recalculates the displayed amount in the current unit (the one thing that can legitimately change when coming back from the keypad). All other state, including `comment`, is left untouched. Also renamed `resetState` -> `recalculateDisplayAmount` to reflect the narrower scope.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
