### PR TITLE
fix: submit button for SCB backup screen

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -78,6 +78,8 @@
     "general.pay": "Pay",
     "general.payLater": "Pay Later",
     "general.open": "Open",
+    "general.set": "Set",
+    "general.notSet": "Not set",
     "general.settled": "Settled",
     "general.new": "New",
     "general.loading": "Loading",

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -961,7 +961,9 @@ export default class SeedRecovery extends React.PureComponent<
                                         width: '90%',
                                         alignSelf: 'center',
                                         ...(selectedInputType === 'scb' && {
-                                            maxHeight: 200
+                                            maxHeight: 200,
+                                            padding: 10,
+                                            paddingRight: 20
                                         })
                                     }}
                                     multiline={selectedInputType === 'scb'}

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -616,7 +616,12 @@ export default class SeedRecovery extends React.PureComponent<
                         style={{
                             flex: 1,
                             fontFamily: 'PPNeueMontreal-Medium',
-                            color: themeColor('text'),
+                            color:
+                                !showSuggestions && type === 'scb'
+                                    ? text
+                                        ? themeColor('highlight')
+                                        : themeColor('secondaryText')
+                                    : themeColor('text'),
                             fontSize: 18,
                             alignSelf:
                                 type === 'mnemonicWord'
@@ -634,6 +639,10 @@ export default class SeedRecovery extends React.PureComponent<
                             selectedWordIndex === index
                         )
                             ? '********'
+                            : !showSuggestions && type === 'scb'
+                            ? text
+                                ? localeString('general.set')
+                                : localeString('general.notSet')
                             : text}
                     </Text>
                 </TouchableOpacity>

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -542,7 +542,16 @@ export default class SeedRecovery extends React.PureComponent<
                             }
                         }
 
-                        this.setState({ showSuggestions: false });
+                        if (type === 'scb') {
+                            this.setState({
+                                showSuggestions: false,
+                                selectedWordIndex: null
+                            });
+                        } else {
+                            this.setState({
+                                showSuggestions: false
+                            });
+                        }
 
                         // set focus
                         if (!Keyboard.isVisible()) {
@@ -913,7 +922,10 @@ export default class SeedRecovery extends React.PureComponent<
                                 <TextInput
                                     ref={this.textInput}
                                     onFocus={() => {
-                                        if (selectedText?.length === 0) {
+                                        if (
+                                            selectedText?.length === 0 &&
+                                            selectedInputType !== 'scb'
+                                        ) {
                                             this.setState({
                                                 showSuggestions: true
                                             });
@@ -938,8 +950,12 @@ export default class SeedRecovery extends React.PureComponent<
                                         marginLeft: 10,
                                         marginRight: 10,
                                         width: '90%',
-                                        alignSelf: 'center'
+                                        alignSelf: 'center',
+                                        ...(selectedInputType === 'scb' && {
+                                            maxHeight: 200
+                                        })
                                     }}
+                                    multiline={selectedInputType === 'scb'}
                                     autoCapitalize="none"
                                     autoCorrect={false}
                                     autoFocus
@@ -955,6 +971,12 @@ export default class SeedRecovery extends React.PureComponent<
                                                     text.length > 0
                                                         ? true
                                                         : false
+                                            });
+                                        } else if (
+                                            selectedInputType === 'scb'
+                                        ) {
+                                            this.setState({
+                                                showSuggestions: false
                                             });
                                         }
 
@@ -1014,137 +1036,171 @@ export default class SeedRecovery extends React.PureComponent<
                         </View>
                         {!showSuggestions && (
                             <>
-                                <ScrollView
-                                    contentContainerStyle={{
-                                        flexGrow: 1,
-                                        flexDirection: 'row'
-                                    }}
-                                    keyboardShouldPersistTaps="handled"
-                                >
-                                    {restoreSwaps ||
-                                    restoreRescueKey ||
-                                    implementation === 'ldk-node' ? (
-                                        <>
-                                            <View
-                                                style={{
-                                                    ...styles.column,
-                                                    alignSelf:
-                                                        !selectedInputType
-                                                            ? 'center'
-                                                            : undefined
-                                                }}
-                                            >
-                                                {[0, 1, 2, 3, 4, 5].map((i) => (
-                                                    <RecoveryLabel
-                                                        key={i}
-                                                        type="mnemonicWord"
-                                                        index={i}
-                                                        text={
-                                                            this.state
-                                                                .seedArray[i]
-                                                        }
-                                                    />
-                                                ))}
-                                            </View>
-                                            <View
-                                                style={{
-                                                    ...styles.column,
-                                                    alignSelf:
-                                                        !selectedInputType
-                                                            ? 'center'
-                                                            : undefined
-                                                }}
-                                            >
-                                                {[6, 7, 8, 9, 10, 11].map(
-                                                    (i) => (
-                                                        <RecoveryLabel
-                                                            key={i}
-                                                            type="mnemonicWord"
-                                                            index={i}
-                                                            text={
-                                                                this.state
-                                                                    .seedArray[
-                                                                    i
-                                                                ]
-                                                            }
-                                                        />
-                                                    )
-                                                )}
-                                            </View>
-                                        </>
-                                    ) : (
-                                        <>
-                                            <View
-                                                style={{
-                                                    ...styles.column,
-                                                    alignSelf:
-                                                        !selectedInputType
-                                                            ? 'center'
-                                                            : undefined
-                                                }}
-                                            >
-                                                {[
-                                                    0, 1, 2, 3, 4, 5, 6, 7, 8,
-                                                    9, 10, 11
-                                                ].map((index: number) => {
-                                                    return (
-                                                        <RecoveryLabel
-                                                            key={index}
-                                                            type="mnemonicWord"
-                                                            index={index}
-                                                            text={
-                                                                seedArray[index]
-                                                            }
-                                                        />
-                                                    );
-                                                })}
-                                            </View>
-                                            <View
-                                                style={{
-                                                    ...styles.column,
-                                                    alignSelf:
-                                                        !selectedInputType
-                                                            ? 'center'
-                                                            : undefined
-                                                }}
-                                            >
-                                                {[
-                                                    12, 13, 14, 15, 16, 17, 18,
-                                                    19, 20, 21, 22, 23
-                                                ].map((index: number) => {
-                                                    return (
-                                                        <RecoveryLabel
-                                                            key={index}
-                                                            type="mnemonicWord"
-                                                            index={index}
-                                                            text={
-                                                                seedArray[index]
-                                                            }
-                                                        />
-                                                    );
-                                                })}
-                                            </View>
-                                        </>
-                                    )}
-                                </ScrollView>
+                                {selectedInputType !== 'scb' && (
+                                    <ScrollView
+                                        contentContainerStyle={{
+                                            flexGrow: 1,
+                                            flexDirection: 'row'
+                                        }}
+                                        keyboardShouldPersistTaps="handled"
+                                    >
+                                        {restoreSwaps ||
+                                        restoreRescueKey ||
+                                        implementation === 'ldk-node' ? (
+                                            <>
+                                                <View
+                                                    style={{
+                                                        ...styles.column,
+                                                        alignSelf:
+                                                            !selectedInputType
+                                                                ? 'center'
+                                                                : undefined
+                                                    }}
+                                                >
+                                                    {[0, 1, 2, 3, 4, 5].map(
+                                                        (i) => (
+                                                            <RecoveryLabel
+                                                                key={i}
+                                                                type="mnemonicWord"
+                                                                index={i}
+                                                                text={
+                                                                    this.state
+                                                                        .seedArray[
+                                                                        i
+                                                                    ]
+                                                                }
+                                                            />
+                                                        )
+                                                    )}
+                                                </View>
+                                                <View
+                                                    style={{
+                                                        ...styles.column,
+                                                        alignSelf:
+                                                            !selectedInputType
+                                                                ? 'center'
+                                                                : undefined
+                                                    }}
+                                                >
+                                                    {[6, 7, 8, 9, 10, 11].map(
+                                                        (i) => (
+                                                            <RecoveryLabel
+                                                                key={i}
+                                                                type="mnemonicWord"
+                                                                index={i}
+                                                                text={
+                                                                    this.state
+                                                                        .seedArray[
+                                                                        i
+                                                                    ]
+                                                                }
+                                                            />
+                                                        )
+                                                    )}
+                                                </View>
+                                            </>
+                                        ) : (
+                                            <>
+                                                <View
+                                                    style={{
+                                                        ...styles.column,
+                                                        alignSelf:
+                                                            !selectedInputType
+                                                                ? 'center'
+                                                                : undefined
+                                                    }}
+                                                >
+                                                    {[
+                                                        0, 1, 2, 3, 4, 5, 6, 7,
+                                                        8, 9, 10, 11
+                                                    ].map((index: number) => {
+                                                        return (
+                                                            <RecoveryLabel
+                                                                key={index}
+                                                                type="mnemonicWord"
+                                                                index={index}
+                                                                text={
+                                                                    seedArray[
+                                                                        index
+                                                                    ]
+                                                                }
+                                                            />
+                                                        );
+                                                    })}
+                                                </View>
+                                                <View
+                                                    style={{
+                                                        ...styles.column,
+                                                        alignSelf:
+                                                            !selectedInputType
+                                                                ? 'center'
+                                                                : undefined
+                                                    }}
+                                                >
+                                                    {[
+                                                        12, 13, 14, 15, 16, 17,
+                                                        18, 19, 20, 21, 22, 23
+                                                    ].map((index: number) => {
+                                                        return (
+                                                            <RecoveryLabel
+                                                                key={index}
+                                                                type="mnemonicWord"
+                                                                index={index}
+                                                                text={
+                                                                    seedArray[
+                                                                        index
+                                                                    ]
+                                                                }
+                                                            />
+                                                        );
+                                                    })}
+                                                </View>
+                                            </>
+                                        )}
+                                    </ScrollView>
+                                )}
 
                                 {!(
                                     restoreSwaps ||
                                     restoreRescueKey ||
                                     implementation === 'ldk-node'
-                                ) && (
+                                ) &&
+                                    selectedInputType !== 'scb' && (
+                                        <View
+                                            style={{
+                                                flexGrow: 1,
+                                                flexDirection: 'row'
+                                            }}
+                                        >
+                                            <View style={styles.scb}>
+                                                <RecoveryLabel
+                                                    type="scb"
+                                                    text={channelBackupsBase64}
+                                                />
+                                            </View>
+                                        </View>
+                                    )}
+                                {selectedInputType === 'scb' && (
                                     <View
                                         style={{
-                                            flexGrow: 1,
-                                            flexDirection: 'row'
+                                            marginTop: 10,
+                                            width: '100%',
+                                            paddingHorizontal: 6
                                         }}
                                     >
-                                        <View style={styles.scb}>
-                                            <RecoveryLabel
-                                                type="scb"
-                                                text={channelBackupsBase64}
-                                            />
-                                        </View>
+                                        <Button
+                                            title={localeString(
+                                                'general.confirm'
+                                            )}
+                                            onPress={() => {
+                                                Keyboard.dismiss();
+                                                this.setState({
+                                                    selectedInputType: null,
+                                                    selectedText: ''
+                                                });
+                                            }}
+                                            secondary
+                                        />
                                     </View>
                                 )}
                             </>
@@ -1321,7 +1377,7 @@ export default class SeedRecovery extends React.PureComponent<
                                 )}
                             </>
                         )}
-                        {!showSuggestions && (
+                        {!showSuggestions && selectedInputType !== 'scb' && (
                             <View
                                 style={{
                                     alignSelf: 'center',


### PR DESCRIPTION
# Description

Relates to issue: [ZEUS-3878](https://github.com/ZeusLN/zeus/issues/3878)

- Fix SCB (Static Channel Backup) input on the wallet recovery view — previously there was no way to progress after selecting the SCB field
- Hide seed word suggestions (BIP39 word list) when SCB input is selected, as they are irrelevant
- Make the SCB text input multiline so users can paste large base64 backup data
- Hide seed word fields (1-24) and the SCB label when actively editing the SCB, showing only the input and a confirm button
- Hide the restore wallet button during SCB input to avoid confusion — the confirm button dismisses SCB input mode, then the restore button becomes visible again

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
