### PR TITLE
Fix #2132: Restrict numeric input and prevent 0-sat LNURL-pay

### DIFF
--- a/components/AmountInput.tsx
+++ b/components/AmountInput.tsx
@@ -235,7 +235,7 @@ export default class AmountInput extends React.Component<
                                 opacity: locked ? 0.8 : 1
                             }
                         ]}
-                    >
+                >
                         <Text
                             style={[
                                 styles.amountText,
@@ -251,6 +251,48 @@ export default class AmountInput extends React.Component<
                             {formattedAmount}
                         </Text>
                     </TouchableOpacity>
+                    <TextInput
+                        keyboardType="numeric"
+                        placeholder={'0'}
+                        value={
+                            amount !== undefined
+                                ? amount
+                                : sats
+                                ? getAmount(sats)
+                                : undefined
+                        }
+                        onChangeText={(text: string) => {
+                            // remove spaces and non-numeric chars
+                            const formatted = text.replace(/[^\d.,]/g, '');
+                            const satAmount = getSatAmount(
+                                formatted,
+                                forceUnit
+                            );
+                            onAmountChange(formatted, satAmount);
+                            this.setState({ satAmount });
+                        }}
+                        locked={locked}
+                        prefix={
+                            effectiveUnits !== 'sats' &&
+                            (effectiveUnits === 'BTC'
+                                ? '₿'
+                                : !getSymbol().rtl
+                                ? getSymbol().symbol
+                                : null)
+                        }
+                        suffix={
+                            effectiveUnits === 'sats'
+                                ? effectiveUnits
+                                : getSymbol().rtl &&
+                                  effectiveUnits === 'fiat' &&
+                                  getSymbol().symbol
+                        }
+                        style={{
+                            flex: 1,
+                            flexDirection: 'row'
+                        }}
+                        error={error}
+                    />
                     {!hideUnitChangeButton && !locked && (
                         <TouchableOpacity
                             onPress={() => this.onChangeUnits()}

--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -589,7 +589,11 @@ export default class LnurlPay extends React.Component<
                                 buttonStyle={{
                                     backgroundColor: themeColor('secondary')
                                 }}
-                                disabled={loading}
+                                disabled={
+                                    loading ||
+                                    !satAmount ||
+                                    Number(satAmount) <= 0
+                                }
                             />
                         </View>
                     </View>


### PR DESCRIPTION
Closes #2132

Two minimal fixes:

1. components/AmountInput — tighten input filter (shared component) Removes - from the onChangeText character allowlist. The regex was /[^\d.,-]/g; it is now /[^\d.,]/g. The keyboard type is already "numeric" — this closes the gap where a minus sign could slip through the software filter. One character removed from a regex.

2. views/LnurlPay/LnurlPay — disable Confirm on 0 sats The Confirm button had no guard against a zero amount, which caused a bad argument error when sendValues() was called with satAmount = 0. Added !satAmount || Number(satAmount) <= 0 to disabled, following the identical pattern already used in Send.tsx.

No new dependencies, no refactoring, no locale string additions.