### PR TITLE
deps: replace elliptic with @noble/secp256k1

### DIFF
--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -1,4 +1,5 @@
 import bolt11 from 'bolt11';
+import { signSync } from '@noble/secp256k1';
 
 import { settingsStore } from '../stores/Stores';
 
@@ -6,8 +7,7 @@ import LND from './LND';
 import LoginRequest from './../models/LoginRequest';
 import Base64Utils from './../utils/Base64Utils';
 import { Hash as sha256Hash } from 'fast-sha256';
-const EC = require('elliptic').ec;
-const ec = new EC('secp256k1');
+import '../zeus_modules/noble_ecc'; // ensures hmacSha256Sync is configured for signSync
 
 export default class LndHub extends LND {
     getHeaders = (accessToken: string) => {
@@ -83,7 +83,7 @@ export default class LndHub extends LND {
             .update(Base64Utils.stringToUint8Array(message))
             .digest();
 
-        let signed, signature, key, linkingKeyPair;
+        let signed, signature, key;
         switch (settingsStore.settings.lndHubLnAuthMode || 'Alby') {
             case 'Alby':
                 key = new sha256Hash()
@@ -93,10 +93,9 @@ export default class LndHub extends LND {
                         )
                     )
                     .digest();
-                linkingKeyPair = ec.keyFromPrivate(key, true);
-                signed = linkingKeyPair
-                    .sign(messageHash, { canonical: true })
-                    .toDER('hex');
+                signed = Buffer.from(signSync(messageHash, key)).toString(
+                    'hex'
+                );
                 signature = new sha256Hash()
                     .update(Base64Utils.stringToUint8Array(signed))
                     .digest();

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "crypto-js": "4.2.0",
     "dateformat": "5.0.3",
     "ecpair": "3.0.1",
-    "elliptic": "6.6.1",
     "events": "1.1.1",
     "fast-crc32c": "2.0.0",
     "fast-sha256": "1.3.0",

--- a/views/LnurlAuth.tsx
+++ b/views/LnurlAuth.tsx
@@ -5,6 +5,7 @@ import { inject, observer } from 'mobx-react';
 import { Alert, StyleSheet, Text, View } from 'react-native';
 import querystring from 'querystring-es3';
 import { HMAC as sha256HMAC } from 'fast-sha256';
+import { getPublicKey, signSync } from '@noble/secp256k1';
 import { Route } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
@@ -23,9 +24,7 @@ import BackendUtils from '../utils/BackendUtils';
 import Base64Utils from '../utils/Base64Utils';
 import DropdownSetting from '../components/DropdownSetting';
 import SettingsStore, { LNDHUB_AUTH_MODES } from '../stores/SettingsStore';
-
-const EC = require('elliptic').ec;
-const ec = new EC('secp256k1');
+import '../zeus_modules/noble_ecc'; // ensures hmacSha256Sync is configured for signSync
 
 const LNURLAUTH_CANONICAL_PHRASE =
     'DO NOT EVER SIGN THIS TEXT WITH YOUR PRIVATE KEYS! IT IS ONLY USED FOR DERIVATION OF LNURL-AUTH HASHING-KEY, DISCLOSING ITS SIGNATURE WILL COMPROMISE YOUR LNURL-AUTH IDENTITY AND MAY LEAD TO LOSS OF FUNDS!';
@@ -125,19 +124,16 @@ export default class LnurlAuth extends React.Component<
                     .update(Base64Utils.stringToUint8Array(this.state.domain))
                     .digest();
 
-                const linkingKeyPair = ec.keyFromPrivate(linkingKeyPriv, true);
-                const pubPoint = linkingKeyPair.getPublic();
-                // Need to compress the key
-                const linkingKeyPub = pubPoint.encodeCompressed('hex');
+                const linkingKeyPub = Buffer.from(
+                    getPublicKey(linkingKeyPriv, true)
+                ).toString('hex');
 
-                const signedMessage = ec.sign(
+                const signedMessageDER = signSync(
                     Base64Utils.hexToBytes(this.state.k1),
-                    linkingKeyPriv,
-                    { canonical: true }
+                    linkingKeyPriv
                 );
-                const signedMessageDER = signedMessage.toDER();
                 const signedMessageDERHex =
-                    Base64Utils.bytesToHex(signedMessageDER);
+                    Buffer.from(signedMessageDER).toString('hex');
 
                 this.setState({
                     linkingKeyPub,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4882,7 +4882,7 @@ electron-to-chromium@^1.5.73:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.139.tgz#56ae7d42439e2967a54badbadaeb12f748987f37"
   integrity sha512-GGnRYOTdN5LYpwbIr0rwP/ZHOQSvAF6TG0LSzp28uCBb9JiXHJGmaaKw29qjNJc5bGnnp6kXJqRnGMQoELwi5w==
 
-elliptic@6.6.1, elliptic@^6.5.3, elliptic@^6.5.5, elliptic@^6.5.7:
+elliptic@^6.5.3, elliptic@^6.5.5, elliptic@^6.5.7:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
   integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==


### PR DESCRIPTION
# Description

`elliptic` has CVE-2025-14505 (unpatched) -> replaced with `@noble/secp256k1`, which is already a direct dependency.

Testing:
- I ran a script comparing DER signature output and compressed pubkey of both libraries for identical fixed inputs -> byte-for-byte match confirmed.
- I connected a LNBits LNDHub account (demo.lnbits.com) and authenticated on lightninglogin.live via LNURL-auth. Same linking pubkey on both master and this branch.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [x] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [x] Contributors will need to run `yarn` after this PR is merged in
- [x] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
