### PR TITLE
fix: prevent embedded LND crash on app restart with Bolt default

### DIFF
--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -1214,7 +1214,8 @@ export async function createLndWallet({
     channelBackupsBase64,
     channelDbUri,
     channelDbFileName,
-    setStatus
+    setStatus,
+    isSqlite = false
 }: {
     lndDir: string;
     seedMnemonic?: string;
@@ -1224,6 +1225,7 @@ export async function createLndWallet({
     channelDbUri?: string;
     channelDbFileName?: string;
     setStatus?: (message: string | null) => void;
+    isSqlite?: boolean;
 }) {
     const {
         initialize,
@@ -1240,7 +1242,7 @@ export async function createLndWallet({
     await writeLndConfig({
         lndDir,
         isTestnet,
-        isSqlite: true
+        isSqlite
     });
     await initialize();
 

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -97,6 +97,7 @@ interface SeedRecoveryProps {
             restoreRescueKey?: boolean;
             nickname?: string;
             photo?: string;
+            isSqlite?: boolean;
         }
     >;
 }
@@ -137,6 +138,7 @@ interface SeedRecoveryState {
     channelDbUri?: string;
     channelDbFileName?: string;
     olympusRestorePending: boolean;
+    embeddedLndIsSqlite: boolean;
 }
 
 @inject('NodeInfoStore', 'SettingsStore', 'SwapStore', 'ModalStore')
@@ -186,7 +188,8 @@ export default class SeedRecovery extends React.PureComponent<
             ldkPassphrase: '',
             ldkNodeDir: '',
             embeddedLdkNetwork: 'mainnet',
-            olympusRestorePending: false
+            olympusRestorePending: false,
+            embeddedLndIsSqlite: false
         };
     }
 
@@ -233,7 +236,9 @@ export default class SeedRecovery extends React.PureComponent<
             props.route.params?.implementation ?? 'embedded-lnd';
         const restoreSwaps = props.route.params?.restoreSwaps ?? false;
         const restoreRescueKey = props.route.params?.restoreRescueKey ?? false;
+        const isSqlite = props.route.params?.isSqlite ?? false;
         this.setState({
+            embeddedLndIsSqlite: isSqlite,
             network,
             implementation,
             restoreSwaps,
@@ -361,7 +366,8 @@ export default class SeedRecovery extends React.PureComponent<
             adminMacaroon,
             embeddedLndNetwork,
             seedPhrase,
-            lndDir
+            lndDir,
+            embeddedLndIsSqlite
         } = this.state;
         const { updateSettings, settings } = SettingsStore;
 
@@ -377,7 +383,7 @@ export default class SeedRecovery extends React.PureComponent<
             embeddedLndNetwork,
             implementation: 'embedded-lnd',
             lndDir,
-            isSqlite: true
+            isSqlite: embeddedLndIsSqlite
         };
 
         let nodes: any;
@@ -794,7 +800,8 @@ export default class SeedRecovery extends React.PureComponent<
 
                 const lndDir = uuidv4();
 
-                const { channelDbUri, channelDbFileName } = this.state;
+                const { channelDbUri, channelDbFileName, embeddedLndIsSqlite } =
+                    this.state;
 
                 try {
                     const response = await createLndWallet({
@@ -804,6 +811,7 @@ export default class SeedRecovery extends React.PureComponent<
                         channelBackupsBase64,
                         channelDbUri,
                         channelDbFileName,
+                        isSqlite: embeddedLndIsSqlite,
                         setStatus: (msg) =>
                             this.setState({
                                 successMsg: msg || ''

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -949,7 +949,8 @@ export default class WalletConfiguration extends React.Component<
     };
 
     createNewWallet = async (network: string = 'Mainnet') => {
-        const { recoveryCipherSeed, channelBackupsBase64 } = this.state;
+        const { recoveryCipherSeed, channelBackupsBase64, isSqlite } =
+            this.state;
         const { SettingsStore, SyncStore } = this.props;
         const { embeddedLndStarted } = SettingsStore;
 
@@ -989,7 +990,8 @@ export default class WalletConfiguration extends React.Component<
                 lndDir,
                 seedMnemonic: recoveryCipherSeed,
                 isTestnet: network === 'Testnet',
-                channelBackupsBase64
+                channelBackupsBase64,
+                isSqlite: isSqlite ?? false
             });
         } catch (error) {
             console.log('Error creating wallet:', error);
@@ -2973,7 +2975,10 @@ export default class WalletConfiguration extends React.Component<
                                                             network:
                                                                 embeddedLndNetwork,
                                                             nickname,
-                                                            photo
+                                                            photo,
+                                                            isSqlite:
+                                                                isSqlite ??
+                                                                false
                                                         }
                                                     )
                                                 }


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

Fixes a crash affecting embedded LND wallets on app restart when using the default BoltDB backend.

### Summary
Previously, wallets created with BoltDB could crash on restart because the app wrote an SQLite config during creation. On the next launch, LND attempted to open the data directory using BoltDB, causing a mismatch and crash.

### Root Cause
- `createLndWallet` always wrote an SQLite config  
- New nodes were saved with `isSqlite: false` (Bolt)  
- On restart, the app rewrote the config to Bolt, which didn’t match the existing database files  

### What Changed
- `createLndWallet` now accepts an optional `isSqlite` flag  
- Defaults to `false` (BoltDB) unless explicitly set  
- Onboarding uses the default (BoltDB), keeping config consistent  
- Wallet configuration respects the user’s selected database (SQLite or BoltDB)  

### Testing
- [ ] Create a wallet with default settings (BoltDB), restart the app → no crash  
- [ ] Create a wallet with SQLite, restart the app → works as expected  

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
