### PR TITLE
refactor: show Olympus restore option only when SQLite is selected

### DIFF
--- a/components/Modals/RestoreChannelModal.tsx
+++ b/components/Modals/RestoreChannelModal.tsx
@@ -35,7 +35,7 @@ export default class RestoreChannelModal extends React.Component<RestoreChannelM
                 isOpen={showRestoreChannelModal}
                 style={{
                     backgroundColor: 'transparent',
-                    height: 480,
+                    height: onCheckOlympus ? 480 : 420,
                     alignItems: 'center',
                     justifyContent: 'center'
                 }}
@@ -83,16 +83,18 @@ export default class RestoreChannelModal extends React.Component<RestoreChannelM
                         )}`}
                     </Text>
 
-                    <Button
-                        title={localeString(
-                            'views.Tools.migration.import.olympus'
-                        )}
-                        onPress={() => {
-                            if (onCheckOlympus) onCheckOlympus();
-                            toggleRestoreChannelModal({ show: false });
-                        }}
-                        containerStyle={{ marginBottom: 16 }}
-                    />
+                    {onCheckOlympus && (
+                        <Button
+                            title={localeString(
+                                'views.Tools.migration.import.olympus'
+                            )}
+                            onPress={() => {
+                                onCheckOlympus();
+                                toggleRestoreChannelModal({ show: false });
+                            }}
+                            containerStyle={{ marginBottom: 16 }}
+                        />
+                    )}
 
                     <Button
                         title={localeString(

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -300,12 +300,15 @@ export default class SeedRecovery extends React.PureComponent<
     };
 
     askForChannelBackupFirst = (onProceed: () => void) => {
+        const { embeddedLndIsSqlite } = this.state;
         this.props.ModalStore.toggleRestoreChannelModal({
             show: true,
-            onCheckOlympus: async () => {
-                this.handleImportChannelsFromOlympus(onProceed);
-            },
-            onImportFile: async () => {
+            ...(embeddedLndIsSqlite && {
+                onCheckOlympus: () => {
+                    this.handleImportChannelsFromOlympus(onProceed);
+                }
+            }),
+            onImportFile: () => {
                 this.handleImportFile(onProceed);
             },
             onContinueWithoutBackup: () => {


### PR DESCRIPTION
This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [X] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
