### PR TITLE
fix: handle LSP non-JSON responses and clear stale error state on invoice creation

### DIFF
--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -393,9 +393,11 @@ export default class InvoicesStore {
                 );
             } catch (e) {}
 
-            await this.lspStore.getZeroConfFee(
-                Number(new BigNumber(value).times(1000))
-            );
+            try {
+                await this.lspStore.getZeroConfFee(
+                    Number(new BigNumber(value).times(1000))
+                );
+            } catch (e) {}
 
             if (new BigNumber(value).gt(this.lspStore.zeroConfFee || 0)) {
                 req.value = new BigNumber(value).minus(
@@ -449,11 +451,20 @@ export default class InvoicesStore {
                     value !== '0' &&
                     !noLsp
                 ) {
-                    await this.lspStore
-                        .getZeroConfInvoice(invoice.getPaymentRequest)
-                        .then((response: any) => {
-                            jit_bolt11 = response;
+                    try {
+                        const response = await this.lspStore.getZeroConfInvoice(
+                            invoice.getPaymentRequest
+                        );
+                        jit_bolt11 = response as string;
+                    } catch (e: any) {
+                        // Clear error state so the unwrapped invoice
+                        // can be displayed without a stale error banner
+                        runInAction(() => {
+                            this.lspStore.flow_error = false;
+                            this.lspStore.flow_error_msg = '';
+                            this.lspStore.showLspSettings = false;
                         });
+                    }
                 }
 
                 if (lnurl) {

--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -89,7 +89,6 @@ export default class LSPStore {
         if (!errorsOnly) {
             this.info = {};
             this.resetFee();
-            this.showLspSettings = false;
             this.channelAcceptor = undefined;
             this.customMessagesSubscriber = undefined;
         }
@@ -97,10 +96,17 @@ export default class LSPStore {
         this.error_msg = '';
         this.flow_error = false;
         this.flow_error_msg = '';
+        this.showLspSettings = false;
     };
 
     @action
-    public resetFee = () => (this.zeroConfFee = undefined);
+    public resetFee = () => {
+        this.zeroConfFee = undefined;
+        this.feeId = undefined;
+        this.flow_error = false;
+        this.flow_error_msg = '';
+        this.showLspSettings = false;
+    };
 
     @action
     public resetLSPS1Data = () => {
@@ -247,7 +253,19 @@ export default class LSPStore {
             )
                 .then((response: any) => {
                     const status = response.info().status;
-                    const data = response.json();
+                    let data: any;
+                    try {
+                        data = response.json();
+                    } catch (jsonErr) {
+                        runInAction(() => {
+                            this.flow_error = true;
+                            this.flow_error_msg = `${localeString(
+                                'stores.LSPStore.error'
+                            )}: HTTP ${status}`;
+                        });
+                        reject();
+                        return;
+                    }
                     if (status == 200) {
                         runInAction(() => {
                             this.zeroConfFee =
@@ -264,12 +282,23 @@ export default class LSPStore {
                         });
                         resolve(this.zeroConfFee);
                     } else {
-                        this.flow_error = true;
+                        runInAction(() => {
+                            this.flow_error = true;
+                            this.flow_error_msg = data?.message
+                                ? `${localeString('stores.LSPStore.error')}: ${
+                                      data.message
+                                  }`
+                                : `${localeString(
+                                      'stores.LSPStore.error'
+                                  )}: HTTP ${status}`;
+                        });
                         reject();
                     }
                 })
                 .catch(() => {
-                    this.flow_error = true;
+                    runInAction(() => {
+                        this.flow_error = true;
+                    });
                     reject();
                 });
         });
@@ -371,7 +400,19 @@ export default class LSPStore {
             )
                 .then(async (response: any) => {
                     const status = response.info().status;
-                    const data = response.json();
+                    let data: any;
+                    try {
+                        data = response.json();
+                    } catch (jsonErr) {
+                        runInAction(() => {
+                            this.flow_error = true;
+                            this.flow_error_msg = `${localeString(
+                                'stores.LSPStore.error'
+                            )}: HTTP ${status}`;
+                        });
+                        reject();
+                        return;
+                    }
                     if (status == 200 || status == 201) {
                         resolve(data.jit_bolt11);
                     } else {
@@ -391,7 +432,9 @@ export default class LSPStore {
                     }
                 })
                 .catch(() => {
-                    this.flow_error = true;
+                    runInAction(() => {
+                        this.flow_error = true;
+                    });
                     reject();
                 });
         });

--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -89,7 +89,6 @@ export default class LSPStore {
         if (!errorsOnly) {
             this.info = {};
             this.resetFee();
-            this.showLspSettings = false;
             this.channelAcceptor = undefined;
             this.customMessagesSubscriber = undefined;
         }
@@ -97,10 +96,17 @@ export default class LSPStore {
         this.error_msg = '';
         this.flow_error = false;
         this.flow_error_msg = '';
+        this.showLspSettings = false;
     };
 
     @action
-    public resetFee = () => (this.zeroConfFee = undefined);
+    public resetFee = () => {
+        this.zeroConfFee = undefined;
+        this.feeId = undefined;
+        this.flow_error = false;
+        this.flow_error_msg = '';
+        this.showLspSettings = false;
+    };
 
     @action
     public resetLSPS1Data = () => {
@@ -175,7 +181,19 @@ export default class LSPStore {
             )
                 .then(async (response: any) => {
                     const status = response.info().status;
-                    const data = response.json();
+                    let data: any;
+                    try {
+                        data = response.json();
+                    } catch (jsonErr) {
+                        runInAction(() => {
+                            this.flow_error = true;
+                            this.flow_error_msg = `${localeString(
+                                'stores.LSPStore.error'
+                            )}: HTTP ${status}`;
+                        });
+                        reject();
+                        return;
+                    }
                     if (status == 200) {
                         this.info = data;
                         resolve(this.info);
@@ -247,7 +265,19 @@ export default class LSPStore {
             )
                 .then((response: any) => {
                     const status = response.info().status;
-                    const data = response.json();
+                    let data: any;
+                    try {
+                        data = response.json();
+                    } catch (jsonErr) {
+                        runInAction(() => {
+                            this.flow_error = true;
+                            this.flow_error_msg = `${localeString(
+                                'stores.LSPStore.error'
+                            )}: HTTP ${status}`;
+                        });
+                        reject();
+                        return;
+                    }
                     if (status == 200) {
                         runInAction(() => {
                             this.zeroConfFee =
@@ -264,12 +294,23 @@ export default class LSPStore {
                         });
                         resolve(this.zeroConfFee);
                     } else {
-                        this.flow_error = true;
+                        runInAction(() => {
+                            this.flow_error = true;
+                            this.flow_error_msg = data?.message
+                                ? `${localeString('stores.LSPStore.error')}: ${
+                                      data.message
+                                  }`
+                                : `${localeString(
+                                      'stores.LSPStore.error'
+                                  )}: HTTP ${status}`;
+                        });
                         reject();
                     }
                 })
                 .catch(() => {
-                    this.flow_error = true;
+                    runInAction(() => {
+                        this.flow_error = true;
+                    });
                     reject();
                 });
         });
@@ -371,17 +412,33 @@ export default class LSPStore {
             )
                 .then(async (response: any) => {
                     const status = response.info().status;
-                    const data = response.json();
+                    let data: any;
+                    try {
+                        data = response.json();
+                    } catch (jsonErr) {
+                        runInAction(() => {
+                            this.flow_error = true;
+                            this.flow_error_msg = `${localeString(
+                                'stores.LSPStore.error'
+                            )}: HTTP ${status}`;
+                        });
+                        reject();
+                        return;
+                    }
                     if (status == 200 || status == 201) {
                         resolve(data.jit_bolt11);
                     } else {
                         runInAction(() => {
                             this.flow_error = true;
-                            this.flow_error_msg = `${localeString(
-                                'stores.LSPStore.error'
-                            )}: ${data.message}`;
+                            this.flow_error_msg = data?.message
+                                ? `${localeString('stores.LSPStore.error')}: ${
+                                      data.message
+                                  }`
+                                : `${localeString(
+                                      'stores.LSPStore.error'
+                                  )}: HTTP ${status}`;
                             if (
-                                data.message &&
+                                data?.message &&
                                 data.message.includes('access key')
                             ) {
                                 this.showLspSettings = true;
@@ -391,7 +448,9 @@ export default class LSPStore {
                     }
                 })
                 .catch(() => {
-                    this.flow_error = true;
+                    runInAction(() => {
+                        this.flow_error = true;
+                    });
                     reject();
                 });
         });


### PR DESCRIPTION
# Description

When the LSP server returns non-JSON responses (such as a 503 HTML page from nginx during rate limiting or downtime), `response.json()` would throw a `SyntaxError` before the HTTP status could be checked, crashing the invoice creation flow. Both the `/fee` and `/proposal` endpoint handlers now wrap the JSON parse in a try/catch and set a meaningful `flow_error_msg` with the HTTP status.

The `getZeroConfFee` await was also missing a try/catch, so a rejected promise would propagate as an uncaught exception, skipping the `flow_error` check entirely and leaving `createInvoice` in a broken state. Additionally, `resetFee()` only cleared `zeroConfFee` but not `feeId`, `flow_error`, `flow_error_msg`, or `showLspSettings`, so errors from a previous invoice attempt would persist into the next one even on success. `showLspSettings` was also gated behind the `!errorsOnly` branch in `LSPStore.reset()`, meaning it was never cleared when the create invoice button called `reset(true)`.

Finally, when `/proposal` fails but the backend invoice was successfully created, the error state is now cleared so the unwrapped invoice can be displayed without a stale error banner alongside it.

## Test plan

- [ ] Create an invoice when LSP is healthy — should get wrapped invoice as before
- [ ] Create an invoice when LSP returns 503 on `/proposal` — should fall back to unwrapped invoice without error banner
- [ ] Create an invoice when LSP returns 503 on `/fee` — should abort with error, then retry successfully after LSP recovers with no stale errors
- [ ] Rapid successive invoice creations — verify no stale error state carries over between attempts

## PR Type

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
