### PR TITLE
fix(ldk): read r_hash from lookupInvoice request object

### DIFF
--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -1225,9 +1225,11 @@ export default class LdkNode {
     /**
      * Lookup invoice by payment hash
      */
-    lookupInvoice = async (rHash: string): Promise<any> => {
+    lookupInvoice = async (data: { r_hash: string }): Promise<any> => {
         const payments = await LdkNodeInjection.payments.listPayments();
-        const payment = payments.find((p) => p.kind.hash === rHash);
+        const payment = data?.r_hash
+            ? payments.find((p) => p.kind.hash === data.r_hash)
+            : undefined;
 
         if (payment) {
             return this.formatPaymentAsInvoice(payment);


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This PR fixes an issue in LdkNode.lookupInvoice where an incorrect r_hash value was used during comparison with p.kind.hash. Previously, lookupInvoice expected rHash as a string and compared it directly with p.kind.hash. However, in practice, callers (via BackendUtils.lookupInvoice) pass data in the shape { r_hash }. As a result, the comparison effectively became:

``` p.kind.hash === { r_hash: ... } ```

which always evaluates to false, causing invoice lookups to consistently fail.

This change updates LdkNode.lookupInvoice to accept the correct input shape and extract data.r_hash for comparison. This ensures the lookup logic works correctly and aligns with how other backends handle the same input format.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
