### PR TITLE
fix: prevent restore stall when LndmobileStopDaemon never calls back

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1090,6 +1090,7 @@
     "views.Tools.migration.import.downloadingFromOlympus": "Downloading channel backup from Olympus...",
     "views.Tools.migration.status.startingLnd": "Starting LND...",
     "views.Tools.migration.status.initializingWallet": "Initializing wallet...",
+    "views.Tools.migration.status.optimizingPeers": "Optimizing Neutrino peers...",
     "views.Tools.migration.status.importingBackup": "Importing backup...",
     "views.Tools.migration.import.olympusRestoreFailed": "Failed to restore from Olympus: {{error}}",
     "views.Tools.migration.import.restoreComplete": "Restore Complete",

--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -1235,25 +1235,30 @@ export async function createLndWallet({
     const { genSeed, initWallet } = lndMobile.wallet;
 
     if (Platform.OS === 'ios') {
+        log.d('createLndWallet: creating iOS directories');
         await createIOSApplicationSupportAndLndDirectories(lndDir);
         await excludeLndICloudBackup(lndDir);
     }
 
+    log.d('createLndWallet: writing LND config');
     await writeLndConfig({
         lndDir,
         isTestnet,
         isSqlite
     });
+    log.d('createLndWallet: initializing native module');
     await initialize();
 
     if (setStatus)
         setStatus(localeString('views.Tools.migration.status.startingLnd'));
+    log.d('createLndWallet: starting LND');
     await startLnd({
         lndDir,
         walletPassword: '',
         isTorEnabled: false,
         isTestnet: isTestnet || false
     });
+    log.d('createLndWallet: LND started successfully');
 
     let seed: any;
     if (!seedMnemonic) {
@@ -1273,12 +1278,20 @@ export async function createLndWallet({
         setStatus(
             localeString('views.Tools.migration.status.initializingWallet')
         );
+    log.d(
+        `createLndWallet: calling initWallet (recoveryWindow=${
+            isRestore && !hasChannelDb ? 500 : 'none'
+        })`
+    );
     const wallet: any = await initWallet(
         seed.cipher_seed_mnemonic,
         randomBase64,
         isRestore && !hasChannelDb ? 500 : undefined,
         channelBackupsBase64 ? channelBackupsBase64 : undefined,
         walletPassphrase ? walletPassphrase : undefined
+    );
+    log.d(
+        `createLndWallet: initWallet returned (has macaroon: ${!!wallet?.admin_macaroon})`
     );
 
     if (hasChannelDb) {

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -50,12 +50,14 @@ import ModalStore from '../../stores/ModalStore';
 
 import {
     createLndWallet,
+    LndMobileEventEmitter,
     optimizeNeutrinoPeers,
     stopLnd,
     waitForRpcReady,
     STOP_LND_MAX_RETRIES,
     STOP_LND_POLL_DELAY_MS
 } from '../../utils/LndMobileUtils';
+import { sleep } from '../../utils/SleepUtils';
 
 import {
     createLdkNodeWallet,
@@ -789,14 +791,42 @@ export default class SeedRecovery extends React.PureComponent<
                 }
             } else {
                 // Embedded LND restore
-                try {
-                    await stopLnd(
-                        STOP_LND_MAX_RETRIES,
-                        STOP_LND_POLL_DELAY_MS,
-                        true
-                    );
-                } catch (e: any) {}
 
+                // Only stop LND if it's actually running — calling
+                // stopLnd when the daemon isn't up causes
+                // LndmobileStopDaemon to never call back, stalling
+                // the restore flow indefinitely.
+                if (this.props.SettingsStore.embeddedLndStarted) {
+                    this.setState({
+                        successMsg: localeString(
+                            'views.Tools.migration.export.stoppingLnd'
+                        )
+                    });
+                    try {
+                        await stopLnd(
+                            STOP_LND_MAX_RETRIES,
+                            STOP_LND_POLL_DELAY_MS,
+                            true
+                        );
+                    } catch (e: any) {
+                        console.log(
+                            'stopLnd during restore (expected):',
+                            e?.message || e
+                        );
+                    }
+
+                    // Clean up stale event listeners and give the Go
+                    // LND process time to fully shut down before
+                    // starting a new instance.
+                    LndMobileEventEmitter.removeAllListeners('SubscribeState');
+                    await sleep(Platform.OS === 'ios' ? 2000 : 4000);
+                }
+
+                this.setState({
+                    successMsg: localeString(
+                        'views.Tools.migration.status.optimizingPeers'
+                    )
+                });
                 await optimizeNeutrinoPeers(network === 'testnet');
 
                 const recoveryCipherSeed = seedArray.join(' ');
@@ -935,8 +965,32 @@ export default class SeedRecovery extends React.PureComponent<
                             .join(', #')}`}
                     />
                 )}
-                {successMsg && <SuccessMessage message={successMsg} />}
-                {loading && <LoadingIndicator />}
+                {!loading && successMsg && (
+                    <SuccessMessage message={successMsg} />
+                )}
+                {loading && (
+                    <View
+                        style={{
+                            flex: 1,
+                            justifyContent: 'center',
+                            alignItems: 'center'
+                        }}
+                    >
+                        <LoadingIndicator />
+                        {!!successMsg && (
+                            <Text
+                                style={{
+                                    color: themeColor('text'),
+                                    fontFamily: 'PPNeueMontreal-Book',
+                                    fontSize: 15,
+                                    marginTop: 20
+                                }}
+                            >
+                                {successMsg}
+                            </Text>
+                        )}
+                    </View>
+                )}
                 {!loading && (
                     <View style={{ flex: 1, justifyContent: 'center' }}>
                         <View>


### PR DESCRIPTION
## Summary

When restoring an embedded LND wallet via seed recovery, the app would stall indefinitely after tapping "Continue without backup." The root cause is that `LndmobileStopDaemon` on iOS never calls back if the Go daemon is not running, causing `await stopLnd(...)` to hang forever since the outer `try/catch` only catches rejections, not promises that never settle.

The fix checks `SettingsStore.embeddedLndStarted` before calling `stopLnd`, skipping the call entirely when no daemon is running. When LND is running, stale `SubscribeState` listeners are cleaned up and a shutdown delay is added before starting the new instance to avoid race conditions with the Go process still winding down. Status text is now displayed below the loading indicator during restore so users can see which step is in progress, and diagnostic logging has been added to `createLndWallet` for future debugging.

## Test plan
- [ ] Restore an embedded LND wallet via seed recovery, choosing "Continue without backup"
- [ ] Verify the restore completes successfully instead of stalling
- [ ] Verify status messages update during the flow (Stopping LND → Optimizing Neutrino peers → Starting LND → Initializing wallet)
- [ ] Test restore when an existing embedded LND wallet is already running
- [ ] Test restore on a fresh install with no prior LND instance

## PR category 
- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
