### PR TITLE
fix: deep link handling on cold start

### DIFF
--- a/utils/LinkingUtils.ts
+++ b/utils/LinkingUtils.ts
@@ -8,6 +8,17 @@ import { settingsStore } from '../stores/Stores';
 
 class LinkingUtils {
     private shareIntentProcessed = false;
+    private pendingDeepLink: string | null = null;
+
+    processPendingDeepLink = (
+        navigation: NativeStackNavigationProp<any, any>
+    ) => {
+        if (this.pendingDeepLink) {
+            const url = this.pendingDeepLink;
+            this.pendingDeepLink = null;
+            this.handleDeepLink(url, navigation);
+        }
+    };
 
     handleInitialUrl = (navigation: NativeStackNavigationProp<any, any>) =>
         Linking.getInitialURL().then(async (url) => {
@@ -94,6 +105,11 @@ class LinkingUtils {
         url: string,
         navigation: NativeStackNavigationProp<any, any>
     ) => {
+        if (settingsStore.loginRequired()) {
+            this.pendingDeepLink = url;
+            return;
+        }
+
         if (url.startsWith('nostr:')) {
             Linking.openURL(url);
         } else {

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -23,7 +23,6 @@ import ShowHideToggle from '../components/ShowHideToggle';
 import SettingsStore, { PosEnabled } from '../stores/SettingsStore';
 
 import { verifyBiometry } from '../utils/BiometricUtils';
-import LinkingUtils from '../utils/LinkingUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
 
@@ -268,8 +267,6 @@ export default class Lockscreen extends React.Component<
             error: false
         });
 
-        const shareIntentData = route.params?.shareIntentData;
-
         if (
             (passphraseAttempt && passphraseAttempt === passphrase) ||
             (pinAttempt && pinAttempt === pin)
@@ -308,14 +305,6 @@ export default class Lockscreen extends React.Component<
                     navigation.replace('Wallets', { fromStartup: true });
                 }
                 return;
-            } else if (
-                !(
-                    SettingsStore.settings.selectNodeOnStartup &&
-                    SettingsStore.initialStart
-                ) &&
-                !shareIntentData
-            ) {
-                LinkingUtils.handleInitialUrl(navigation);
             }
             if (!SettingsStore.settings.selectNodeOnStartup) {
                 if (

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -354,7 +354,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         } else if (nextAppState === 'active') {
             if (SettingsStore.loginRequired()) {
                 this.props.navigation.navigate('Lockscreen');
-            } else {
+            } else if (this.props.navigation.isFocused()) {
                 if (BackendUtils.supportsNostrWalletConnectService()) {
                     NostrWalletConnectStore.initializeService();
                 }
@@ -455,7 +455,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 if (shareIntentData) {
                     this.setState({ pendingShareIntent: shareIntentData });
                 }
-                await this.fetchData(true, transientRetryCount);
+                await this.fetchData(transientRetryCount);
             } else if (loginRequired) {
                 navigation.navigate('Lockscreen', { shareIntentData });
             } else if (
@@ -487,7 +487,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 if (shareIntentData) {
                     this.setState({ pendingShareIntent: shareIntentData });
                 }
-                await this.fetchData(true, transientRetryCount);
+                await this.fetchData(transientRetryCount);
             } else {
                 // Only navigate to IntroSplash if Wallet screen is focused
                 // to prevent interference when user is on other screens
@@ -509,10 +509,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         }, 100);
     }
 
-    async fetchData(
-        skipHandleInitialUrl: boolean = false,
-        transientRetryCount = 0
-    ) {
+    async fetchData(transientRetryCount = 0) {
         const {
             AlertStore,
             NodeInfoStore,
@@ -1305,13 +1302,15 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             this.setState({
                 initialLoad: false
             });
-            SettingsStore.fetchLock = false;
-            if (!skipHandleInitialUrl) {
+            if (!this.state.pendingShareIntent) {
                 LinkingUtils.handleInitialUrl(this.props.navigation);
             }
         }
 
         SettingsStore.fetchLock = false;
+
+        // Process any deep link that was deferred while login was required
+        LinkingUtils.processPendingDeepLink(this.props.navigation);
 
         // Process pending share intent after wallet is fully loaded and synced
         this.processPendingShareIntent();


### PR DESCRIPTION
# Description

Fixes deep link handling during app startup and warm start. Previously, deep links (lightning:, bitcoin:, LNURL, etc.) could bypass the lock screen on warm start, and the wallet could connect in the background when the user was on the wallet selection screen.

### Problems

1. **Deep links bypass lock screen on warm start**: When the app returns from background with login enabled, `handleOpenURL` calls `handleDeepLink` directly with no auth check. The deep link navigates to the payment screen while `handleAppStateChange` navigates to the lock screen — the deep link wins the race.

2. **Wallet connects in background on wallet selection screen**: `Wallet.handleAppStateChange` calls `getSettingsAndNavigate()` on every foreground event, even when the Wallet screen isn't focused. When the user is on the wallet selection screen (Settings > Display > Select wallet on start-up) and the app foregrounds, the wallet component still triggers `fetchData`, connecting the last-used wallet in the background.

3. **Cold start deep links handled too early or skipped**: Deep links were processed in Lockscreen (before wallet init) or skipped via a `skipHandleInitialUrl` flag, depending on the entry path.

### Changes

**`utils/LinkingUtils.ts`** — Auth gate in `handleDeepLink` itself
- If `loginRequired()`, stores the URL as `pendingDeepLink` instead of navigating. This protects every call site automatically — `handleOpenURL`, `handleAndroidIntents`, `handleInitialUrl`.
- Added `processPendingDeepLink()` to flush the stored URL after auth + wallet connection.

**`views/Wallet/Wallet.tsx`**
- `handleAppStateChange`: Only calls `getSettingsAndNavigate` when the Wallet screen is focused (`navigation.isFocused()`). Prevents background wallet connections when on the wallet selection screen or any other screen.
- `fetchData`: Removed `skipHandleInitialUrl` parameter — `handleInitialUrl` now always runs on initial load. Added `processPendingDeepLink()` call after wallet is fully loaded to flush any deep link deferred during lock screen.

**`views/Lockscreen.tsx`**
- Removed `handleInitialUrl` call from unlock flow. Deep links are no longer processed in Lockscreen — they're handled centrally at the end of `fetchData` in Wallet.tsx after the wallet is fully initialized.

### How it works

| Scenario | Flow |
|---|---|
| Cold start + deep link | Wallet mounts → auth gate if needed → `fetchData` → `handleInitialUrl` processes the URL |
| Warm start + login + deep link | `handleDeepLink` → login required → stored as pending. Lock screen shown. Unlock → `fetchData` → `processPendingDeepLink` |
| Warm start + no login + deep link | `handleDeepLink` → login not required → processes immediately |
| Foreground on wallet selection screen | `handleAppStateChange` → Wallet not focused → skip `getSettingsAndNavigate` → no background connection |

## Test plan

- [ ] Cold start via deep link (lightning:, bitcoin:, LNURL) — should navigate to payment screen after wallet loads
- [ ] Cold start via deep link with PIN/passphrase enabled — should show lock screen first, then navigate to payment screen after unlock and wallet load
- [ ] Warm start via deep link with login enabled (Settings > Security > Login Background) — should show lock screen, not payment screen. After unlock, payment screen should appear
- [ ] Warm start via deep link without login — should navigate to payment screen immediately
- [ ] With "Select wallet on start-up" enabled: background and foreground the app while on wallet selection screen — wallet should NOT connect in the background
- [ ] With "Select wallet on start-up" enabled: background and foreground the app while on the main wallet screen — wallet should reconnect normally
- [ ] Share intent and NFC flows still work as before

## PR Type

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
