### PR TITLE
fix: CDK initialization for remote node Cashu token redemption

### DIFF
--- a/storage/index.ts
+++ b/storage/index.ts
@@ -25,6 +25,13 @@ class Storage {
         const stringValue =
             typeof value === 'string' ? value : JSON.stringify(value);
 
+        if (stringValue == null) {
+            console.error(
+                `Storage.setItem: cannot store null/undefined for key "${key}"`
+            );
+            return false;
+        }
+
         const response = await Keychain.setInternetCredentials(
             prefixedKey,
             prefixedKey,

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -3908,6 +3908,16 @@ export default class CashuStore {
                     value: String(tokenAmt)
                 });
 
+                if (!invoice?.paymentRequest) {
+                    this.loading = false;
+                    return {
+                        success: false,
+                        errorMessage: localeString(
+                            'stores.InvoicesStore.errorCreatingInvoice'
+                        )
+                    };
+                }
+
                 // Create melt quote via CDK
                 const meltQuote = await this.createMeltQuoteCDK(
                     mintUrl,
@@ -3934,6 +3944,16 @@ export default class CashuStore {
                         )}]`,
                         value: receiveAmtSat.toString()
                     });
+
+                    if (!invoice?.paymentRequest) {
+                        this.loading = false;
+                        return {
+                            success: false,
+                            errorMessage: localeString(
+                                'stores.InvoicesStore.errorCreatingInvoice'
+                            )
+                        };
+                    }
                 }
 
                 // Melt via CDK to pay the invoice

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -324,19 +324,28 @@ export default class CashuStore {
                 const derivedSeedPhrase = mnemonic.split(' ');
                 const nodeDir = this.getNodeDir();
 
-                await Storage.setItem(
-                    nodeDir + '-cashu-seed-phrase',
-                    derivedSeedPhrase
-                );
-                await Storage.setItem(
-                    nodeDir + '-cashu-seed-version',
-                    'v2-bip39'
-                );
-
+                // Set in-memory state first so ensureSeed() / deriveCashuPubkey()
+                // work even if Keychain storage throws below
                 runInAction(() => {
                     this.seedPhrase = derivedSeedPhrase;
                     this.seedVersion = 'v2-bip39';
                 });
+
+                try {
+                    await Storage.setItem(
+                        nodeDir + '-cashu-seed-phrase',
+                        derivedSeedPhrase
+                    );
+                    await Storage.setItem(
+                        nodeDir + '-cashu-seed-version',
+                        'v2-bip39'
+                    );
+                } catch (storageErr) {
+                    console.warn(
+                        'CDK: Failed to persist mnemonic to Keychain, will retry on next launch:',
+                        storageErr
+                    );
+                }
 
                 console.log(
                     'CDK: Generated and stored mnemonic for remote node'

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -315,10 +315,32 @@ export default class CashuStore {
 
         try {
             // Get mnemonic from seed derivation
-            const mnemonic = this.getCDKMnemonic();
+            let mnemonic = this.getCDKMnemonic();
             if (!mnemonic) {
-                console.error('CDK: Unable to derive mnemonic');
-                return false;
+                // Remote nodes have no wallet seed to derive from.
+                // Generate and persist a mnemonic so CDK can operate
+                // and recover funds if a flow is interrupted.
+                mnemonic = bip39scure.generateMnemonic(BIP39_WORD_LIST, 128);
+                const derivedSeedPhrase = mnemonic.split(' ');
+                const nodeDir = this.getNodeDir();
+
+                await Storage.setItem(
+                    nodeDir + '-cashu-seed-phrase',
+                    derivedSeedPhrase
+                );
+                await Storage.setItem(
+                    nodeDir + '-cashu-seed-version',
+                    'v2-bip39'
+                );
+
+                runInAction(() => {
+                    this.seedPhrase = derivedSeedPhrase;
+                    this.seedVersion = 'v2-bip39';
+                });
+
+                console.log(
+                    'CDK: Generated and stored mnemonic for remote node'
+                );
             }
 
             await CashuDevKit.initializeWallet(mnemonic, 'sat');

--- a/views/Cashu/CashuToken.tsx
+++ b/views/Cashu/CashuToken.tsx
@@ -542,7 +542,9 @@ export default class CashuTokenView extends React.Component<
                             )}
                             <Button
                                 title={localeString(
-                                    'views.Cashu.CashuToken.meltTokenSelfCustody'
+                                    BackendUtils.supportsChannelManagement()
+                                        ? 'views.Cashu.CashuToken.meltTokenSelfCustody'
+                                        : 'general.receive'
                                 )}
                                 onPress={async () => {
                                     this.setState({
@@ -555,19 +557,27 @@ export default class CashuTokenView extends React.Component<
                                             decoded,
                                             true
                                         );
-                                    if (errorMessage) {
-                                        this.setState({
-                                            errorMessage
-                                        });
-                                    } else if (success) {
+
+                                    if (success) {
                                         this.setState({
                                             success
+                                        });
+                                    } else {
+                                        this.setState({
+                                            errorMessage:
+                                                errorMessage ||
+                                                localeString(
+                                                    'stores.CashuStore.claimError'
+                                                )
                                         });
                                     }
                                 }}
                                 containerStyle={{ marginTop: 15 }}
                                 disabled={
-                                    !hasOpenChannels || !isSupported || loading
+                                    (BackendUtils.supportsChannelManagement() &&
+                                        !hasOpenChannels) ||
+                                    !isSupported ||
+                                    loading
                                 }
                                 secondary
                             />

--- a/views/Cashu/CashuToken.tsx
+++ b/views/Cashu/CashuToken.tsx
@@ -553,7 +553,7 @@ export default class CashuTokenView extends React.Component<
 
                                     const { success, errorMessage } =
                                         await claimToken(
-                                            token!!,
+                                            encodedToken!,
                                             decoded,
                                             true
                                         );


### PR DESCRIPTION
# Description

The CDK migration (#3614) introduced a hard requirement on a BIP-39 mnemonic derived from the wallet seed in order to initialize CDK. Remote node users (CLN REST, LND REST, etc.) don't have a local wallet seed, so `getCDKMnemonic()` returns null, `initializeCDK()` returns false, and all CDK operations fail with a "CDK is not initialized" error. This broke the ability for remote node users to redeem Cashu tokens to self-custody — a flow that receives a token into CDK and immediately melts it to pay a Lightning invoice on the user's own node, never requiring persistent ecash storage.

The fix generates and persists a BIP-39 mnemonic when no wallet seed is available, allowing CDK to initialize and the receive-then-melt flow to work. The mnemonic is stored so that if a melt fails or the app crashes after receiving ecash, the proofs (which use deterministic secret derivation from the mnemonic) can be recovered and spent in a subsequent session. On future launches, `getCDKMnemonic()` picks up the stored seed phrase, so it's only generated once.

## Test plan

- [ ] Connect to a remote LND or CLN node (no local wallet seed)
- [ ] Receive a Cashu token and tap "Redeem to self-custody"
- [ ] Verify the token is received and melted successfully to the node's Lightning wallet
- [ ] Verify no "CDK is not initialized" error appears
- [ ] Verify embedded-lnd and LDK node flows are unaffected

## PR Type

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
