### PR TITLE
fix: token import: add mint not working when enabling Cashu for first time

### DIFF
--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -1946,7 +1946,10 @@ export default class CashuStore {
             await this.syncCDKBalances();
 
             // Update local mintUrls from CDK (source of truth)
-            this.mintUrls = await CashuDevKit.getMintUrls();
+            const updatedMintUrls = await CashuDevKit.getMintUrls();
+            runInAction(() => {
+                this.mintUrls = updatedMintUrls;
+            });
 
             // Backup to local storage for migration on restart
             await Storage.setItem(
@@ -1995,7 +1998,10 @@ export default class CashuStore {
         }
 
         delete this.cashuWallets[mintUrl];
-        this.mintUrls = await CashuDevKit.getMintUrls();
+        const updatedMintUrls = await CashuDevKit.getMintUrls();
+        runInAction(() => {
+            this.mintUrls = updatedMintUrls;
+        });
 
         await Storage.setItem(
             `${this.getNodeDir()}-cashu-mintUrls`,
@@ -2625,7 +2631,10 @@ export default class CashuStore {
                 }
 
                 // Get mint URLs from CDK (source of truth) and populate cache
-                this.mintUrls = await CashuDevKit.getMintUrls();
+                const cdkMints = await CashuDevKit.getMintUrls();
+                runInAction(() => {
+                    this.mintUrls = cdkMints;
+                });
                 this.mintUrls.forEach((url) =>
                     this.addedMintsCache.add(this.normalizeMintUrl(url))
                 );
@@ -2771,9 +2780,12 @@ export default class CashuStore {
             } catch (e) {
                 console.warn('CDK initialization failed:', e);
                 // Fallback: use local storage mint URLs if CDK fails
-                this.mintUrls = storedMintUrls
+                const fallbackMints = storedMintUrls
                     ? JSON.parse(storedMintUrls)
                     : [];
+                runInAction(() => {
+                    this.mintUrls = fallbackMints;
+                });
                 await Promise.all(
                     this.mintUrls.map((mintUrl) =>
                         this.initializeWallet(mintUrl)
@@ -2783,7 +2795,12 @@ export default class CashuStore {
         } else {
             // CDK not available - use local storage (should not happen in production)
             console.warn('CDK not available, using local storage');
-            this.mintUrls = storedMintUrls ? JSON.parse(storedMintUrls) : [];
+            const fallbackMints = storedMintUrls
+                ? JSON.parse(storedMintUrls)
+                : [];
+            runInAction(() => {
+                this.mintUrls = fallbackMints;
+            });
             await Promise.all(
                 this.mintUrls.map((mintUrl) => this.initializeWallet(mintUrl))
             );

--- a/views/Cashu/CashuToken.tsx
+++ b/views/Cashu/CashuToken.tsx
@@ -459,22 +459,39 @@ export default class CashuTokenView extends React.Component<
                                                     : 'views.Cashu.AddMint.enableAndAdd'
                                             )}
                                             onPress={async () => {
-                                                if (!enableCashu) {
-                                                    await settingsStore.updateSettings(
-                                                        {
-                                                            ecash: {
-                                                                ...(settingsStore
-                                                                    .settings
-                                                                    .ecash ||
-                                                                    {}),
-                                                                enableCashu:
-                                                                    true
+                                                CashuStore.setLoading(true);
+                                                try {
+                                                    if (!enableCashu) {
+                                                        await settingsStore.updateSettings(
+                                                            {
+                                                                ecash: {
+                                                                    ...(settingsStore
+                                                                        .settings
+                                                                        .ecash ||
+                                                                        {}),
+                                                                    enableCashu:
+                                                                        true
+                                                                }
                                                             }
-                                                        }
+                                                        );
+                                                        await CashuStore.initializeWallets();
+                                                    }
+                                                    await addMint(mint);
+                                                } catch (e) {
+                                                    console.error(
+                                                        'Error enabling Cashu / adding mint:',
+                                                        e
                                                     );
-                                                    await CashuStore.initializeWallets();
+                                                    this.setState({
+                                                        errorMessage:
+                                                            localeString(
+                                                                'stores.CashuStore.errorAddingMint'
+                                                            )
+                                                    });
+                                                    CashuStore.setLoading(
+                                                        false
+                                                    );
                                                 }
-                                                await addMint(mint);
                                             }}
                                             containerStyle={{ marginTop: 15 }}
                                             disabled={!isSupported || loading}


### PR DESCRIPTION
# Decription

When importing a Cashu token for the first time with Cashu disabled, pressing the "Enable Cashu and add mint" button would only enable Cashu — the button text would change to "Add mint" but the mint was never actually added, requiring the user to press the button a second time. This was caused by two issues: `this.mintUrls` assignments after `await` calls in `@action`-decorated async methods were not wrapped in `runInAction()`, which could cause MobX to miss the state update and not re-render the component; and the button handler had no loading state during `initializeWallets()`, leaving the button enabled with no spinner — making it appear the operation completed prematurely — and no error handling, so if `initializeWallets()` threw, `addMint` would silently never execute.

## Changes

- **`stores/CashuStore.ts`**: Wrap all `this.mintUrls` assignments after `await` in `runInAction()` in `addMint`, `removeMint`, and `initializeWallets` (both success and fallback paths)
- **`views/Cashu/CashuToken.tsx`**: Set `CashuStore.setLoading(true)` at the start of the "Enable Cashu and add mint" button handler so the button disables immediately and the loading indicator shows during the entire operation; add `try/catch` to prevent silent failures

## Test plan

- [ ] With Cashu disabled, scan/import a Cashu token
- [ ] Press "Enable Cashu and add mint" — verify loading indicator appears immediately, button is disabled, and mint is added in a single press
- [ ] Verify the "Receive" button becomes enabled after the mint is added
- [ ] With Cashu already enabled, import a token from a new mint — verify "Add mint" still works correctly
- [ ] Remove a mint and verify mint list updates properly

## PR Type

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
