### PR TITLE
fix: stealth mode deactivation: sync native state w/ JS settings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -374,7 +374,7 @@ export default class App extends React.PureComponent {
             }
         }
 
-        // Apply stealth mode when app goes to background
+        // Sync stealth mode when app goes to background
         if (nextAppState === 'background') {
             try {
                 const settings = await settingsStore.getSettings();
@@ -382,6 +382,15 @@ export default class App extends React.PureComponent {
                     const stealthApp =
                         settings.privacy.stealthApp || 'calculator';
                     await StealthModeUtils.enableStealthMode(stealthApp);
+                } else {
+                    // If stealth was toggled off but native state wasn't
+                    // synced (e.g. user pressed Home instead of Back),
+                    // disable it now
+                    const nativeActive =
+                        await StealthModeUtils.isStealthModeActive();
+                    if (nativeActive) {
+                        await StealthModeUtils.disableStealthMode();
+                    }
                 }
             } catch (error) {
                 console.error(

--- a/components/StealthModeWrapper.tsx
+++ b/components/StealthModeWrapper.tsx
@@ -49,23 +49,30 @@ const StealthModeWrapper: React.FC<StealthModeWrapperProps> = ({
             // Check native stealth status first (most reliable)
             const nativeActive = await StealthModeUtils.isStealthModeActive();
 
+            // Get JS settings to cross-reference
+            const settingsStr = await Storage.getItem(STORAGE_KEY);
+            const settings = settingsStr ? JSON.parse(settingsStr) : {};
+            const jsStealthEnabled = settings?.privacy?.stealthMode || false;
+
+            if (nativeActive && !jsStealthEnabled) {
+                // JS says stealth is off but native is still active —
+                // sync native to match JS (e.g. user toggled off but
+                // the app was killed before the native change applied)
+                await StealthModeUtils.disableStealthMode();
+                return;
+            }
+
             if (nativeActive) {
-                // Get the selected stealth app and config from settings
-                const settingsStr = await Storage.getItem(STORAGE_KEY);
-                if (settingsStr) {
-                    const settings = JSON.parse(settingsStr);
-                    const selectedApp =
-                        settings?.privacy?.stealthApp || 'calculator';
-                    setStealthApp(selectedApp);
-                    setStealthConfig({
-                        pinLength: settings?.privacy?.stealthPinLength || 5,
-                        vpnCountry:
-                            settings?.privacy?.stealthVpnCountry ||
-                            'Switzerland',
-                        vpnServer:
-                            settings?.privacy?.stealthVpnServer || 'Geneva'
-                    });
-                }
+                // Both agree stealth is on — show decoy
+                const selectedApp =
+                    settings?.privacy?.stealthApp || 'calculator';
+                setStealthApp(selectedApp);
+                setStealthConfig({
+                    pinLength: settings?.privacy?.stealthPinLength || 5,
+                    vpnCountry:
+                        settings?.privacy?.stealthVpnCountry || 'Switzerland',
+                    vpnServer: settings?.privacy?.stealthVpnServer || 'Geneva'
+                });
                 setIsStealthActive(true);
             }
         } catch (error) {


### PR DESCRIPTION
# Description

Relates to issue: [ZEUS-4030](https://github.com/ZeusLN/zeus/issues/4030)

Fixes a bug where stealth mode (calculator disguise) could not be deactivated after toggling it off in settings (#4030). The root cause was that the native Android component state (activity aliases controlling the launcher icon) was only updated on a React Navigation `blur` event, which doesn't fire when the user presses Home or kills the app instead of navigating back. This left the native state out of sync with the JS setting, so on next launch the app would still show the calculator decoy. The fix adds two sync points: a startup check in `StealthModeWrapper` that detects and resolves any JS/native mismatch, and a background handler in `App.tsx` that disables native stealth when the setting is off.

## Test plan
- [ ] Enable stealth mode with calculator disguise
- [ ] Toggle stealth mode OFF in settings, then press Home (don't press Back)
- [ ] Reopen app — should show Zeus, not the calculator
- [ ] Enable stealth mode again, toggle OFF, then force-kill the app
- [ ] Reopen app — should show Zeus, not the calculator
- [ ] Verify enabling stealth mode still works correctly
- [ ] Verify unlocking the decoy app (e.g. 5 taps on `=`) still works correctly

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
