### PR TITLE
fix(on-chain): update note button text after saving transaction note

### DIFF
--- a/views/SendingOnChain.tsx
+++ b/views/SendingOnChain.tsx
@@ -58,12 +58,12 @@ export default class SendingOnChain extends React.Component<
         );
 
         this.focusListener = navigation.addListener('focus', () => {
-            if (!TransactionsStore.txid) return;
-            Storage.getItem('note-' + TransactionsStore.txid)
+            const { txid: storedTxid } = TransactionsStore;
+            if (!storedTxid) return;
+            const noteKey = `note-${storedTxid}`;
+            Storage.getItem(noteKey)
                 .then((storedNotes) => {
-                    if (storedNotes) {
-                        this.setState({ storedNotes });
-                    }
+                    this.setState({ storedNotes: storedNotes || '' });
                 })
                 .catch((error) => {
                     console.error('Error retrieving notes:', error);
@@ -247,7 +247,7 @@ export default class SendingOnChain extends React.Component<
                                         }
                                         onPress={() =>
                                             navigation.navigate('AddNotes', {
-                                                noteKey: txid
+                                                noteKey: `note-${txid}`
                                             })
                                         }
                                         secondary


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

After an on-chain payment succeeded, the success screen offered Add note, but after saving a note it still showed Add note instead of Update note, unlike other payment flows.

### Root cause
Notes are stored under the key note-${txid} (same as Transaction.getNoteKey and AddNotes). The success screen looked up note-${txid} for the button label but navigated to AddNotes with noteKey: txid, so the note was written under the wrong key and the UI never saw it.

### Changes
views/SendingOnChain.tsx: Pass noteKey: \note-${txid}`** when opening **AddNotes`.
Focus handler: Load notes with that same key and always sync local state (including empty string when the note is cleared) so the label stays correct when returning from AddNotes.
### Test plan

- [ ] Send an on-chain payment until the success screen shows with a txid.
- [ ] Tap Add note, enter text, save → return to success screen → button label should "Update note".
- [ ] Tap Update note, clear the note, save → button should read Add note again.
- [ ] Open the same tx from wallet / transaction detail → note should appear and match what you saved on the success screen.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [x] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
