### PR TITLE
fix: Show share icon on all QR tabs in CollapsedQR

### DIFF
--- a/components/AnimatedQRDisplay.tsx
+++ b/components/AnimatedQRDisplay.tsx
@@ -78,10 +78,6 @@ const AnimatedQRDisplay: React.FC<AnimatedQRDisplayProps> = ({
                     value={getDisplayValue()}
                     copyValue={getCopyValue()}
                     iconOnly
-                    showShare={
-                        isSingleFrameSelected ||
-                        (isBbqrSelected && !isMultiFrame)
-                    }
                     showSpeed={
                         isBcurSelected || (isBbqrSelected && isMultiFrame)
                     }

--- a/components/CollapsedQR.tsx
+++ b/components/CollapsedQR.tsx
@@ -118,7 +118,6 @@ interface CollapsedQRProps {
     copyText?: string;
     copyValue?: string;
     iconContainerStyle?: any;
-    showShare?: boolean;
     showSpeed?: boolean;
     iconOnly?: boolean;
     hideText?: boolean;
@@ -179,7 +178,6 @@ export default class CollapsedQR extends React.Component<
             copyValue,
             collapseText,
             iconContainerStyle,
-            showShare,
             iconOnly,
             hideText,
             expanded,
@@ -428,73 +426,54 @@ export default class CollapsedQR extends React.Component<
                         onPress={() => this.toggleCollapse()}
                     />
                 )}
-                {showShare ? (
-                    <View
-                        style={{
-                            flexDirection: 'row',
-                            justifyContent: 'center',
-                            gap: 40
-                        }}
-                    >
-                        <CopyButton
-                            iconContainerStyle={iconContainerStyle}
-                            copyValue={copyValue || value}
-                            title={copyText}
+                <View
+                    style={{
+                        flexDirection: 'row',
+                        justifyContent: 'center',
+                        gap: showSpeed ? 8 : 40
+                    }}
+                >
+                    {showSpeed && (
+                        <QRSpeedMeterButton
+                            showOptions={showSpeedOptions}
+                            onPress={() =>
+                                this.setState({
+                                    showSpeedOptions: !showSpeedOptions
+                                })
+                            }
                             iconOnly={iconOnly}
                         />
-                        <ShareButton
-                            iconContainerStyle={
-                                supportsNFC ? iconContainerStyle : undefined
-                            }
+                    )}
+                    <CopyButton
+                        iconContainerStyle={
+                            !showSpeed ? iconContainerStyle : undefined
+                        }
+                        copyValue={copyValue || value}
+                        title={copyText}
+                        iconOnly={iconOnly}
+                    />
+                    <ShareButton
+                        iconContainerStyle={
+                            supportsNFC && !showSpeed
+                                ? iconContainerStyle
+                                : undefined
+                        }
+                        value={copyValue || value}
+                        qrRef={tempQRRef}
+                        iconOnly={iconOnly}
+                        onPress={handleShare}
+                        onShareComplete={() =>
+                            this.setState({ tempQRRef: null })
+                        }
+                        onShareGiftLink={onShareGiftLink}
+                    />
+                    {supportsNFC && (
+                        <NFCButton
                             value={copyValue || value}
-                            qrRef={tempQRRef}
-                            iconOnly={iconOnly}
-                            onPress={handleShare}
-                            onShareComplete={() =>
-                                this.setState({ tempQRRef: null })
-                            }
-                            onShareGiftLink={onShareGiftLink}
-                        />
-                        {supportsNFC && (
-                            <NFCButton
-                                value={copyValue || value}
-                                iconOnly={iconOnly}
-                            />
-                        )}
-                    </View>
-                ) : (
-                    <View
-                        style={{
-                            flexDirection: 'row',
-                            justifyContent: 'center',
-                            gap: 8
-                        }}
-                    >
-                        {showSpeed && (
-                            <QRSpeedMeterButton
-                                showOptions={showSpeedOptions}
-                                onPress={() =>
-                                    this.setState({
-                                        showSpeedOptions: !showSpeedOptions
-                                    })
-                                }
-                                iconOnly={iconOnly}
-                            />
-                        )}
-                        <CopyButton
-                            copyValue={copyValue || value}
-                            title={copyText}
                             iconOnly={iconOnly}
                         />
-
-                        {supportsNFC && (
-                            <NFCButton
-                                value={copyValue || value}
-                                iconOnly={iconOnly}
-                            />
-                        )}
-                    </View>
-                )}
+                    )}
+                </View>
                 {showSpeedOptions && onQRAnimationSpeedChange && showSpeed && (
                     <View style={styles.speedOptions}>
                         <ButtonGroup

--- a/views/Cashu/ReceiveEcash.tsx
+++ b/views/Cashu/ReceiveEcash.tsx
@@ -736,7 +736,6 @@ export default class ReceiveEcash extends React.Component<
                                                             lightningAddress
                                                         }
                                                         iconOnly={true}
-                                                        showShare={true}
                                                         expanded
                                                         textBottom
                                                         hideText
@@ -773,7 +772,6 @@ export default class ReceiveEcash extends React.Component<
                                                             lnInvoiceCopyValue
                                                         }
                                                         iconOnly={true}
-                                                        showShare={true}
                                                         expanded
                                                         textBottom
                                                         truncateLongValue

--- a/views/MultiQR.tsx
+++ b/views/MultiQR.tsx
@@ -89,7 +89,6 @@ const MultiQR: React.FC<MultiQRProps> = (props: MultiQRProps) => {
 
     const renderItem = ({ item, index }: { item: any; index: number }) => (
         <CollapsedQR
-            showShare={true}
             value={item}
             expanded
             hideText={route.params?.fromContactDetailsView && index === 0}

--- a/views/PayCode.tsx
+++ b/views/PayCode.tsx
@@ -208,7 +208,6 @@ export default class PayCodeView extends React.Component<
                                 value={qrValue}
                                 copyValue={qrValue}
                                 expanded
-                                showShare
                                 iconOnly
                                 textBottom
                                 truncateLongValue

--- a/views/QR.tsx
+++ b/views/QR.tsx
@@ -114,7 +114,6 @@ export default class QR extends React.PureComponent<QRProps, QRState> {
                         satAmount={satAmount}
                         displayAmount
                         labelBottom={labelBottom ? label || value : undefined}
-                        showShare={true}
                         iconOnly={true}
                         nfcSupported={nfcSupported}
                     />

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -2081,7 +2081,6 @@ export default class Receive extends React.Component<
                                                 <CollapsedQR
                                                     value={unifiedInvoice || ''}
                                                     iconOnly={true}
-                                                    showShare={true}
                                                     expanded
                                                     textBottom
                                                     truncateLongValue
@@ -2107,7 +2106,6 @@ export default class Receive extends React.Component<
                                                         lnInvoiceCopyValue
                                                     }
                                                     iconOnly={true}
-                                                    showShare={true}
                                                     expanded
                                                     textBottom
                                                     truncateLongValue
@@ -2133,7 +2131,6 @@ export default class Receive extends React.Component<
                                                         btcAddressCopyValue
                                                     }
                                                     iconOnly={true}
-                                                    showShare={true}
                                                     expanded
                                                     textBottom
                                                     truncateLongValue
@@ -2184,7 +2181,6 @@ export default class Receive extends React.Component<
                                                     value={`lightning:${lightningAddress}`}
                                                     copyValue={lightningAddress}
                                                     iconOnly={true}
-                                                    showShare={true}
                                                     expanded
                                                     textBottom
                                                     hideText
@@ -2220,7 +2216,6 @@ export default class Receive extends React.Component<
                                                         lnInvoiceCopyValue
                                                     }
                                                     iconOnly={true}
-                                                    showShare={true}
                                                     expanded
                                                     textBottom
                                                     truncateLongValue

--- a/views/Settings/NostrWalletConnect/NWCConnectionQR.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionQR.tsx
@@ -164,7 +164,6 @@ export default class NWCConnectionQR extends React.Component<
                 >
                     <CollapsedQR
                         value={nostrUrl}
-                        showShare={true}
                         hideText={true}
                         expanded
                         iconOnly={true}

--- a/views/Tools/CreateWithdrawalRequest.tsx
+++ b/views/Tools/CreateWithdrawalRequest.tsx
@@ -216,7 +216,6 @@ export default class CreateWithdrawalRequest extends Component<
                         <CollapsedQR
                             value={this.state.bolt12 || ''}
                             iconOnly={true}
-                            showShare={true}
                             expanded
                             textBottom
                             truncateLongValue


### PR DESCRIPTION
# Description

Previously, the Share button in `CollapsedQR` only appeared on the single-frame QR tab. This meant that when a Cashu token was too long (>1000 chars) and the single-frame tab was hidden, users had no way to share the token in text form. 

This change removes the `showShare` prop and consolidates the two icon row branches into one, so the Share button now always appears on all QR format tabs (single frame, BCUr, BBQr). This also benefits PSBT and TXHex views, which now show the share icon on animated QR tabs as well. The speed control continues to appear on multi-frame animated tabs as before.

## Test plan
- [ ] Open a Cashu token with a long token string (>1000 chars) where the single QR tab is hidden
- [ ] Verify the share icon appears on the BCUr and BBQr tabs
- [ ] Verify the speed control still appears on animated (multi-frame) tabs
- [ ] Verify sharing works correctly (Image, Text, Gift Link options)
- [ ] Open a PSBT or TXHex view and confirm share icon shows on all tabs
- [ ] Open Receive view, PayCode, NWC connection QR - confirm share still works as before

## PR Type

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
