### PR TITLE
fix: show delete button for offline spent cashu tokens

### DIFF
--- a/views/Cashu/CashuToken.tsx
+++ b/views/Cashu/CashuToken.tsx
@@ -573,53 +573,56 @@ export default class CashuTokenView extends React.Component<
                             />
                         </View>
                     )}
-                {infoIndex === 0 && pendingClaim && (
-                    <View style={{ bottom: 15 }}>
-                        <Button
-                            title={localeString('general.delete')}
-                            onPress={() => {
-                                Alert.alert(
-                                    localeString('cashu.deleteToken.title'),
-                                    localeString('cashu.deleteToken.message'),
-                                    [
-                                        {
-                                            text: localeString(
-                                                'general.cancel'
-                                            ),
-                                            style: 'cancel'
-                                        },
-                                        {
-                                            text: localeString(
-                                                'general.delete'
-                                            ),
-                                            style: 'destructive',
-                                            onPress: async () => {
-                                                const isSpentToken =
-                                                    CashuStore.offlineSpentTokens.some(
-                                                        (t) =>
-                                                            t.encodedToken ===
-                                                            encodedToken
-                                                    );
-                                                if (isSpentToken) {
-                                                    await CashuStore.removeOfflineSpentToken(
-                                                        encodedToken!
-                                                    );
-                                                } else {
-                                                    await CashuStore.removeOfflinePendingToken(
-                                                        encodedToken!
-                                                    );
+                {infoIndex === 0 &&
+                    (pendingClaim || route.params?.offlineSpent) && (
+                        <View style={{ bottom: 15 }}>
+                            <Button
+                                title={localeString('general.delete')}
+                                onPress={() => {
+                                    Alert.alert(
+                                        localeString('cashu.deleteToken.title'),
+                                        localeString(
+                                            'cashu.deleteToken.message'
+                                        ),
+                                        [
+                                            {
+                                                text: localeString(
+                                                    'general.cancel'
+                                                ),
+                                                style: 'cancel'
+                                            },
+                                            {
+                                                text: localeString(
+                                                    'general.delete'
+                                                ),
+                                                style: 'destructive',
+                                                onPress: async () => {
+                                                    const isSpentToken =
+                                                        CashuStore.offlineSpentTokens.some(
+                                                            (t) =>
+                                                                t.encodedToken ===
+                                                                encodedToken
+                                                        );
+                                                    if (isSpentToken) {
+                                                        await CashuStore.removeOfflineSpentToken(
+                                                            encodedToken!
+                                                        );
+                                                    } else {
+                                                        await CashuStore.removeOfflinePendingToken(
+                                                            encodedToken!
+                                                        );
+                                                    }
+                                                    navigation.goBack();
                                                 }
-                                                navigation.goBack();
                                             }
-                                        }
-                                    ]
-                                );
-                            }}
-                            containerStyle={{ marginTop: 15 }}
-                            warning
-                        />
-                    </View>
-                )}
+                                        ]
+                                    );
+                                }}
+                                containerStyle={{ marginTop: 15 }}
+                                warning
+                            />
+                        </View>
+                    )}
             </Screen>
         );
     }


### PR DESCRIPTION
# Description

The delete button on the CashuToken view was only showing for tokens with `pendingClaim` set, meaning users with offline spent tokens had no way to delete them. This fix expands the visibility condition to also check for the `offlineSpent` route param. The delete handler already correctly distinguishes between offline spent and offline pending tokens, so no other changes were needed.

## Test plan
- [ ] Navigate to an offline spent cashu token
- [ ] Verify the delete button is visible
- [ ] Confirm deleting the token removes it and navigates back
- [ ] Verify delete button still works for pending claim tokens
- [ ] Verify no delete button appears for normal spent tokens

## PR Type

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
