### PR TITLE
enhancement: clipboard: re-read on foreground return, always show paste action

### DIFF
--- a/components/WalletHeader.tsx
+++ b/components/WalletHeader.tsx
@@ -376,20 +376,16 @@ export default class WalletHeader extends React.Component<
     readClipboard = async () => {
         const { SettingsStore } = this.props;
         const { settings } = SettingsStore!;
+        let clipboard = '';
 
-        if (settings.privacy && settings.privacy.clipboard) {
-            const clipboard = await Clipboard.getString();
-
-            if (!!clipboard && (await isClipboardValue(clipboard))) {
-                this.setState({
-                    clipboard
-                });
-            } else {
-                this.setState({ clipboard: '' });
+        if (settings.privacy?.clipboard) {
+            const value = await Clipboard.getString();
+            if (value && (await isClipboardValue(value))) {
+                clipboard = value;
             }
-        } else {
-            this.setState({ clipboard: '' });
         }
+
+        this.setState({ clipboard });
     };
 
     render() {

--- a/components/WalletHeader.tsx
+++ b/components/WalletHeader.tsx
@@ -198,11 +198,14 @@ const ClipboardBadge = ({
     clipboard
 }: {
     navigation: NativeStackNavigationProp<any, any>;
-    clipboard: string;
+    clipboard?: string;
 }) => (
     <TouchableOpacity
         onPress={async () => {
-            const response = await handleAnything(clipboard);
+            const value = clipboard || (await Clipboard.getString());
+            if (!value) return;
+            if (!clipboard && !(await isClipboardValue(value))) return;
+            const response = await handleAnything(value);
             const [route, props] = response;
             navigation.navigate(route, props);
         }}
@@ -732,14 +735,18 @@ export default class WalletHeader extends React.Component<
                                     </View>
                                 )}
 
-                                {!connecting && !!clipboard && (
-                                    <View style={{ marginRight: 15 }}>
-                                        <ClipboardBadge
-                                            navigation={navigation}
-                                            clipboard={clipboard}
-                                        />
-                                    </View>
-                                )}
+                                {!connecting &&
+                                    (!!clipboard ||
+                                        !settings.privacy?.clipboard) && (
+                                        <View style={{ marginRight: 15 }}>
+                                            <ClipboardBadge
+                                                navigation={navigation}
+                                                clipboard={
+                                                    clipboard || undefined
+                                                }
+                                            />
+                                        </View>
+                                    )}
                                 {!connecting && unredeemedTokens?.length > 0 && (
                                     <View style={{ marginRight: 15 }}>
                                         <UnredeemedTokensBadge

--- a/components/WalletHeader.tsx
+++ b/components/WalletHeader.tsx
@@ -10,9 +10,11 @@ const insets = initialWindowMetrics?.insets ?? {
 };
 import {
     Animated,
+    AppState,
     Dimensions,
     Easing,
     Image,
+    NativeEventSubscription,
     StyleSheet,
     Text,
     TouchableOpacity,
@@ -341,6 +343,7 @@ export default class WalletHeader extends React.Component<
     };
 
     focusListener: any = null;
+    appStateListener: NativeEventSubscription | null = null;
 
     componentDidMount() {
         this.readClipboard();
@@ -349,12 +352,22 @@ export default class WalletHeader extends React.Component<
             'focus',
             this.readClipboard
         );
+
+        this.appStateListener = AppState.addEventListener(
+            'change',
+            (nextAppState) => {
+                if (nextAppState === 'active') {
+                    this.readClipboard();
+                }
+            }
+        );
     }
 
     componentWillUnmount(): void {
         if (this.focusListener) {
             this.focusListener();
         }
+        this.appStateListener?.remove();
     }
 
     readClipboard = async () => {
@@ -368,6 +381,8 @@ export default class WalletHeader extends React.Component<
                 this.setState({
                     clipboard
                 });
+            } else {
+                this.setState({ clipboard: '' });
             }
         } else {
             this.setState({ clipboard: '' });

--- a/components/WalletHeader.tsx
+++ b/components/WalletHeader.tsx
@@ -198,14 +198,11 @@ const ClipboardBadge = ({
     clipboard
 }: {
     navigation: NativeStackNavigationProp<any, any>;
-    clipboard?: string;
+    clipboard: string;
 }) => (
     <TouchableOpacity
         onPress={async () => {
-            const value = clipboard || (await Clipboard.getString());
-            if (!value) return;
-            if (!clipboard && !(await isClipboardValue(value))) return;
-            const response = await handleAnything(value);
+            const response = await handleAnything(clipboard);
             const [route, props] = response;
             navigation.navigate(route, props);
         }}
@@ -731,18 +728,14 @@ export default class WalletHeader extends React.Component<
                                     </View>
                                 )}
 
-                                {!connecting &&
-                                    (!!clipboard ||
-                                        !settings.privacy?.clipboard) && (
-                                        <View style={{ marginRight: 15 }}>
-                                            <ClipboardBadge
-                                                navigation={navigation}
-                                                clipboard={
-                                                    clipboard || undefined
-                                                }
-                                            />
-                                        </View>
-                                    )}
+                                {!connecting && !!clipboard && (
+                                    <View style={{ marginRight: 15 }}>
+                                        <ClipboardBadge
+                                            navigation={navigation}
+                                            clipboard={clipboard}
+                                        />
+                                    </View>
+                                )}
                                 {!connecting && unredeemedTokens?.length > 0 && (
                                     <View style={{ marginRight: 15 }}>
                                         <UnredeemedTokensBadge

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -1632,15 +1632,26 @@ export default class Send extends React.Component<SendProps, SendState> {
                         </View>
                     )}
 
-                    {!!clipboard && !destination && (
-                        <View style={styles.button}>
-                            <Button
-                                title={localeString('general.paste')}
-                                onPress={() => this.validateAddress(clipboard)}
-                                secondary
-                            />
-                        </View>
-                    )}
+                    {(!!clipboard ||
+                        !SettingsStore.settings.privacy?.clipboard) &&
+                        !destination && (
+                            <View style={styles.button}>
+                                <Button
+                                    title={localeString('general.paste')}
+                                    onPress={async () => {
+                                        if (clipboard) {
+                                            this.validateAddress(clipboard);
+                                        } else {
+                                            const value =
+                                                await Clipboard.getString();
+                                            if (value)
+                                                this.validateAddress(value);
+                                        }
+                                    }}
+                                    secondary
+                                />
+                            </View>
+                        )}
 
                     {destination && !transactionType && (
                         <View style={styles.button}>

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -348,17 +348,16 @@ export default class Send extends React.Component<SendProps, SendState> {
     readClipboard = async () => {
         const { SettingsStore } = this.props;
         const settings = SettingsStore.settings;
+        let clipboard = '';
 
-        if (settings.privacy && settings.privacy.clipboard) {
-            const clipboard = await Clipboard.getString();
-            if (!!clipboard && (await isClipboardValue(clipboard))) {
-                this.setState({ clipboard });
-            } else {
-                this.setState({ clipboard: '' });
+        if (settings.privacy?.clipboard) {
+            const value = await Clipboard.getString();
+            if (value && (await isClipboardValue(value))) {
+                clipboard = value;
             }
-        } else {
-            this.setState({ clipboard: '' });
         }
+
+        this.setState({ clipboard });
     };
 
     subscribePayment = (streamingCall: string) => {

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+    AppState,
     FlatList,
     Image,
     NativeModules,
@@ -134,6 +135,7 @@ interface SendState {
 export default class Send extends React.Component<SendProps, SendState> {
     listener: any;
     private backPressSubscription: NativeEventSubscription;
+    private appStateSubscription: NativeEventSubscription | null = null;
     private previousAmount: string = '';
     private previousSatAmount: string | number = '0';
 
@@ -302,7 +304,7 @@ export default class Send extends React.Component<SendProps, SendState> {
     async componentDidMount() {
         const { SettingsStore, route } = this.props;
         const { getSettings } = SettingsStore;
-        const settings = await getSettings();
+        await getSettings();
 
         if (route.params?.fromGraphSync) {
             clearPendingPaymentData().catch((error) => {
@@ -313,14 +315,7 @@ export default class Send extends React.Component<SendProps, SendState> {
             });
         }
 
-        if (settings.privacy && settings.privacy.clipboard) {
-            const clipboard = await Clipboard.getString();
-            if (await isClipboardValue(clipboard)) {
-                this.setState({
-                    clipboard
-                });
-            }
-        }
+        await this.readClipboard();
 
         if (this.state.destination) {
             this.validateAddress(this.state.destination);
@@ -331,14 +326,40 @@ export default class Send extends React.Component<SendProps, SendState> {
             this.backPressed.bind(this)
         );
 
+        this.appStateSubscription = AppState.addEventListener(
+            'change',
+            (nextAppState) => {
+                if (nextAppState === 'active') {
+                    this.readClipboard();
+                }
+            }
+        );
+
         const nfcSupported = await NfcManager.isSupported();
         this.setState({ nfcSupported });
     }
 
     componentWillUnmount(): void {
         this.backPressSubscription?.remove();
+        this.appStateSubscription?.remove();
         if (this.listener && this.listener.stop) this.listener.stop();
     }
+
+    readClipboard = async () => {
+        const { SettingsStore } = this.props;
+        const settings = SettingsStore.settings;
+
+        if (settings.privacy && settings.privacy.clipboard) {
+            const clipboard = await Clipboard.getString();
+            if (!!clipboard && (await isClipboardValue(clipboard))) {
+                this.setState({ clipboard });
+            } else {
+                this.setState({ clipboard: '' });
+            }
+        } else {
+            this.setState({ clipboard: '' });
+        }
+    };
 
     subscribePayment = (streamingCall: string) => {
         const { handlePayment, handlePaymentError } =


### PR DESCRIPTION
# Description

Previously, clipboard reading only triggered on `componentDidMount` (and on navigation `focus` in `WalletHeader`), so users who copied an invoice or address while Zeus was backgrounded wouldn't see the clipboard banner until they navigated away and back.

This PR adds `AppState` listeners to both `WalletHeader` and `Send` so the clipboard is re-read whenever the app returns to the foreground. Also fixes a pre-existing issue where the clipboard banner would persist after the clipboard content changed to something invalid.

Additionally, when automatic clipboard reading is disabled in privacy settings, the clipboard icon and paste button are now always shown. Tapping them reads the clipboard on demand, so privacy-conscious users still get a one-tap paste shortcut without any background clipboard access.

## Test plan
- [ ] Copy a Lightning invoice, background Zeus, return — clipboard banner should appear
- [ ] Copy a Lightning invoice, see banner, background Zeus, copy random text, return — banner should disappear
- [ ] Disable clipboard in privacy settings — clipboard icon should still appear on wallet screen and paste button on Send screen
- [ ] With clipboard disabled, copy an invoice, tap the clipboard icon / paste button — should navigate correctly
- [ ] With clipboard disabled, copy random text, tap the clipboard icon / paste button — should do nothing
- [ ] With login on background enabled, confirm lockscreen still appears correctly on foreground return

## PR Type

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x]  I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
