### PR TITLE
feat: add automatic note for channel opening transactions

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -784,6 +784,7 @@
     "views.OpenChannel.peerSuccess": "Successfully connected to peer",
     "views.OpenChannel.channelSuccess": "Successfully opened channel",
     "views.OpenChannel.channelsSuccess": "Successfully opened channels",
+    "views.OpenChannel.openedChannel": "Opened channel",
     "views.OpenChannel.viewStatus": "View status",
     "views.OpenChannel.openChannelToPeer": "Open channel to this peer",
     "views.OpenChannel.channelPendingNote": "The channel will be available once the funding transaction has enough confirmations.",

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -19,6 +19,9 @@ import BackendUtils from '../utils/BackendUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
 
+import Storage from '../storage';
+import { notesStore } from './Stores';
+
 interface ChannelInfoIndex {
     [key: string]: ChannelInfo;
 }
@@ -1220,6 +1223,13 @@ export default class ChannelsStore {
                         this.channelRequest = null;
                         this.channelSuccess = true;
                         this.connectingToPeer = false;
+
+                        if (data?.funding_txid_str) {
+                            const noteKey = `note-${data.funding_txid_str}`;
+                            const note = localeString('views.OpenChannel.openedChannel');
+                            Storage.setItem(noteKey, note);
+                            notesStore.storeNoteKeys(noteKey, note);
+                        }
                     })
                 )
                 .catch((error: Error) => {


### PR DESCRIPTION
## Summary
Adds an automatic note "Opened channel" to activity entries when a new channel is opened.

## Implementation
- Uses `funding_txid_str` from the channel opening response to identify the funding transaction
- Stores the note using existing `Storage` and `notesStore` mechanisms
- Ensures the note is only applied to channel opening transactions

## Result
Channel opening transactions in the Activity list now display a clear note indicating the action.

Relates to issue: #2444g