### PR TITLE
feat(channels): add automatic note when opening channel (fix #2444)

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -784,7 +784,7 @@
     "views.OpenChannel.peerSuccess": "Successfully connected to peer",
     "views.OpenChannel.channelSuccess": "Successfully opened channel",
     "views.OpenChannel.channelsSuccess": "Successfully opened channels",
-    "views.OpenChannel.openedChannel": "Opened channel",
+    "views.OpenChannel.openedChannelNote": "Opened channel",
     "views.OpenChannel.viewStatus": "View status",
     "views.OpenChannel.openChannelToPeer": "Open channel to this peer",
     "views.OpenChannel.channelPendingNote": "The channel will be available once the funding transaction has enough confirmations.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -784,6 +784,7 @@
     "views.OpenChannel.peerSuccess": "Successfully connected to peer",
     "views.OpenChannel.channelSuccess": "Successfully opened channel",
     "views.OpenChannel.channelsSuccess": "Successfully opened channels",
+    "views.OpenChannel.openedChannel": "Opened channel",
     "views.OpenChannel.viewStatus": "View status",
     "views.OpenChannel.openChannelToPeer": "Open channel to this peer",
     "views.OpenChannel.channelPendingNote": "The channel will be available once the funding transaction has enough confirmations.",

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -19,6 +19,9 @@ import BackendUtils from '../utils/BackendUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
 
+import Storage from '../storage';
+import { notesStore } from './Stores';
+
 interface ChannelInfoIndex {
     [key: string]: ChannelInfo;
 }
@@ -1220,6 +1223,13 @@ export default class ChannelsStore {
                         this.channelRequest = null;
                         this.channelSuccess = true;
                         this.connectingToPeer = false;
+
+                        if (data?.funding_txid_str) {
+                            const noteKey = `note-${data.funding_txid_str}`;
+                            const note = localeString('views.OpenChannel.openedChannel');
+                            Storage.setItem(noteKey, note);
+                            notesStore.storeNoteKeys(noteKey, note);
+                        }
                     })
                 )
                 .catch((error: Error) => {

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -1226,7 +1226,7 @@ export default class ChannelsStore {
 
                         if (data?.funding_txid_str) {
                             const noteKey = `note-${data.funding_txid_str}`;
-                            const note = localeString('views.OpenChannel.openedChannel');
+                            const note = localeString('views.OpenChannel.openedChannelNote');
                             Storage.setItem(noteKey, note);
                             notesStore.storeNoteKeys(noteKey, note);
                         }


### PR DESCRIPTION
## Description

Adds automatic note creation for the funding transaction when opening a Lightning channel.

Previously, when a channel was opened, the corresponding transaction in the Activity list did not include any note. This change ensures that a note ("Opened channel") is automatically added for better tracking.

## Changes Made

* Added localized string `views.OpenChannel.openedChannelNote`
* Updated `ChannelsStore` to create a note after successful channel opening
* Linked the note to the funding transaction using `funding_txid_str`
* Used existing `NotesStore.storeNoteKeys` method to persist the note

## Type of Change

* [x] Enhancement

## How to Test

1. Open a new Lightning channel
2. Go to Activity list
3. Verify that the funding transaction includes the note "Opened channel"

## Checklist

* [x] Changes are minimal and scoped
* [x] Follows project conventions
* [x] No unrelated files modified
* [x] Builds and runs without errors

Fixes #2444
