### PR TITLE
fix: verify reachability with fallback URLs before marking offline

### DIFF
--- a/stores/ConnectivityStore.ts
+++ b/stores/ConnectivityStore.ts
@@ -8,7 +8,14 @@ import SettingsStore from './SettingsStore';
 
 const REACHABILITY_POLL_INTERVAL = 15000; // 15s
 const OFFLINE_DEBOUNCE_MS = 10000; // 10s
+const VERIFY_TIMEOUT_MS = 5000;
 const DEFAULT_REACHABILITY_HOST = 'mempool.space';
+// Fallback URLs tried when the primary reachability host is unreachable.
+// If ANY of these succeed, the device is online.
+const FALLBACK_REACHABILITY_URLS = [
+    'https://pay.zeusln.app/api/rates?storeId=Fjt7gLnGpg4UeBMFccLquy3GTTEz4cHU4PZMU63zqMBo',
+    'https://cloudflare.com/cdn-cgi/trace'
+];
 
 export default class ConnectivityStore {
     @observable public isOffline: boolean = false;
@@ -16,6 +23,7 @@ export default class ConnectivityStore {
     private netInfoUnsubscribe: NetInfoSubscription | null = null;
     private reachabilityInterval: ReturnType<typeof setInterval> | null = null;
     private offlineDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+    private verifyInFlight: boolean = false;
     private reconnectCallbacks: Array<() => void> = [];
     private settingsStore: SettingsStore;
 
@@ -51,6 +59,37 @@ export default class ConnectivityStore {
         }
     };
 
+    private probeUrl = async (url: string): Promise<boolean> => {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+        try {
+            // Any HTTP response — even 4xx/5xx — proves connectivity;
+            // only network-level failures (caught below) mean unreachable
+            await fetch(url, {
+                method: 'HEAD',
+                signal: controller.signal
+            });
+            return true;
+        } catch {
+            return false;
+        } finally {
+            clearTimeout(timeout);
+        }
+    };
+
+    /**
+     * Confirm we're truly offline before trusting NetInfo's
+     * isInternetReachable=false. Probe the configured reachability host
+     * and fallback URLs in parallel. If ANY respond the device is online.
+     */
+    private verifyOffline = async (): Promise<boolean> => {
+        const urls = [this.getReachabilityUrl(), ...FALLBACK_REACHABILITY_URLS];
+        const results = await Promise.all(
+            urls.map((url) => this.probeUrl(url))
+        );
+        return !results.some((ok) => ok);
+    };
+
     private updateState = (state: NetInfoState) => {
         // isConnected === false is a reliable native signal (airplane mode, no
         // network interface) — surface immediately without debouncing
@@ -62,16 +101,41 @@ export default class ConnectivityStore {
             return;
         }
 
-        // isInternetReachable === false can be a false positive on Android when
-        // the JS reachability fetch fails transiently; debounce before surfacing
+        // isInternetReachable === false can be a false positive when the
+        // reachability fetch fails transiently; debounce and then verify
+        // with our own fetch before marking offline.
+        // When already offline, skip the debounce and verify immediately
+        // so recovery isn't delayed.
         if (state.isInternetReachable === false) {
-            if (!this.offlineDebounceTimer) {
-                this.offlineDebounceTimer = setTimeout(() => {
-                    this.offlineDebounceTimer = null;
-                    runInAction(() => {
-                        this.isOffline = true;
+            if (this.isOffline) {
+                if (!this.verifyInFlight) {
+                    this.verifyInFlight = true;
+                    this.verifyOffline().then((trulyOffline) => {
+                        this.verifyInFlight = false;
+                        if (!trulyOffline && this.isOffline) {
+                            runInAction(() => {
+                                this.isOffline = false;
+                            });
+                            this.reconnectCallbacks.forEach((cb) => cb());
+                        }
                     });
+                }
+            } else if (!this.offlineDebounceTimer) {
+                const timer = setTimeout(async () => {
+                    const trulyOffline = await this.verifyOffline();
+                    // Only apply if this timer is still the active one —
+                    // an online event during verifyOffline will have
+                    // cleared it via clearDebounce()
+                    if (this.offlineDebounceTimer === timer) {
+                        if (trulyOffline) {
+                            runInAction(() => {
+                                this.isOffline = true;
+                            });
+                        }
+                        this.offlineDebounceTimer = null;
+                    }
                 }, OFFLINE_DEBOUNCE_MS);
+                this.offlineDebounceTimer = timer;
             }
             return;
         }

--- a/stores/ConnectivityStore.ts
+++ b/stores/ConnectivityStore.ts
@@ -6,12 +6,9 @@ import NetInfo, {
 
 import SettingsStore from './SettingsStore';
 
-const REACHABILITY_POLL_INTERVAL = 15000; // 15s
-const OFFLINE_DEBOUNCE_MS = 10000; // 10s
+const POLL_INTERVAL = 15000; // 15s
 const VERIFY_TIMEOUT_MS = 5000;
 const DEFAULT_REACHABILITY_HOST = 'mempool.space';
-// Fallback URLs tried when the primary reachability host is unreachable.
-// If ANY of these succeed, the device is online.
 const FALLBACK_REACHABILITY_URLS = [
     'https://pay.zeusln.app/api/rates?storeId=Fjt7gLnGpg4UeBMFccLquy3GTTEz4cHU4PZMU63zqMBo',
     'https://cloudflare.com/cdn-cgi/trace'
@@ -21,8 +18,7 @@ export default class ConnectivityStore {
     @observable public isOffline: boolean = false;
 
     private netInfoUnsubscribe: NetInfoSubscription | null = null;
-    private reachabilityInterval: ReturnType<typeof setInterval> | null = null;
-    private offlineDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+    private pollInterval: ReturnType<typeof setInterval> | null = null;
     private verifyInFlight: boolean = false;
     private reconnectCallbacks: Array<() => void> = [];
     private settingsStore: SettingsStore;
@@ -39,7 +35,6 @@ export default class ConnectivityStore {
                 ? privacy.customBlockExplorer
                 : privacy?.defaultBlockExplorer || DEFAULT_REACHABILITY_HOST;
 
-        // Custom host may include scheme (e.g. http://mynode:3006#mempool.space)
         if (custom && host.indexOf('://') !== -1) {
             const hostUrl = host.split('#')[0];
             return `${hostUrl}/api/blocks/tip/height`;
@@ -52,19 +47,10 @@ export default class ConnectivityStore {
         this.reconnectCallbacks.push(callback);
     };
 
-    private clearDebounce = () => {
-        if (this.offlineDebounceTimer) {
-            clearTimeout(this.offlineDebounceTimer);
-            this.offlineDebounceTimer = null;
-        }
-    };
-
     private probeUrl = async (url: string): Promise<boolean> => {
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
         try {
-            // Any HTTP response — even 4xx/5xx — proves connectivity;
-            // only network-level failures (caught below) mean unreachable
             await fetch(url, {
                 method: 'HEAD',
                 signal: controller.signal
@@ -77,79 +63,56 @@ export default class ConnectivityStore {
         }
     };
 
-    /**
-     * Confirm we're truly offline before trusting NetInfo's
-     * isInternetReachable=false. Probe the configured reachability host
-     * and fallback URLs in parallel. If ANY respond the device is online.
-     */
-    private verifyOffline = async (): Promise<boolean> => {
+    private verifyConnectivity = async (): Promise<boolean> => {
         const urls = [this.getReachabilityUrl(), ...FALLBACK_REACHABILITY_URLS];
         const results = await Promise.all(
             urls.map((url) => this.probeUrl(url))
         );
-        return !results.some((ok) => ok);
+        return results.some((ok) => ok);
+    };
+
+    /**
+     * Core logic: probe fallback URLs and update isOffline accordingly.
+     * Called by the poll interval and on NetInfo state changes.
+     */
+    private check = () => {
+        if (this.verifyInFlight) return;
+        this.verifyInFlight = true;
+        this.verifyConnectivity().then((online) => {
+            this.verifyInFlight = false;
+            const wasOffline = this.isOffline;
+            runInAction(() => {
+                this.isOffline = !online;
+            });
+            if (online && wasOffline) {
+                this.reconnectCallbacks.forEach((cb) => cb());
+            }
+        });
     };
 
     private updateState = (state: NetInfoState) => {
-        // isConnected === false is a reliable native signal (airplane mode, no
-        // network interface) — surface immediately without debouncing
+        // isConnected === false is a reliable native signal — mark immediately
         if (state.isConnected === false) {
-            this.clearDebounce();
             runInAction(() => {
                 this.isOffline = true;
             });
             return;
         }
 
-        // isInternetReachable === false can be a false positive when the
-        // reachability fetch fails transiently; debounce and then verify
-        // with our own fetch before marking offline.
-        // When already offline, skip the debounce and verify immediately
-        // so recovery isn't delayed.
-        if (state.isInternetReachable === false) {
-            if (this.isOffline) {
-                if (!this.verifyInFlight) {
-                    this.verifyInFlight = true;
-                    this.verifyOffline().then((trulyOffline) => {
-                        this.verifyInFlight = false;
-                        if (!trulyOffline && this.isOffline) {
-                            runInAction(() => {
-                                this.isOffline = false;
-                            });
-                            this.reconnectCallbacks.forEach((cb) => cb());
-                        }
-                    });
-                }
-            } else if (!this.offlineDebounceTimer) {
-                const timer = setTimeout(async () => {
-                    const trulyOffline = await this.verifyOffline();
-                    // Only apply if this timer is still the active one —
-                    // an online event during verifyOffline will have
-                    // cleared it via clearDebounce()
-                    if (this.offlineDebounceTimer === timer) {
-                        if (trulyOffline) {
-                            runInAction(() => {
-                                this.isOffline = true;
-                            });
-                        }
-                        this.offlineDebounceTimer = null;
-                    }
-                }, OFFLINE_DEBOUNCE_MS);
-                this.offlineDebounceTimer = timer;
+        // isInternetReachable === true is reliable — mark online immediately
+        if (state.isInternetReachable === true) {
+            const wasOffline = this.isOffline;
+            runInAction(() => {
+                this.isOffline = false;
+            });
+            if (wasOffline) {
+                this.reconnectCallbacks.forEach((cb) => cb());
             }
             return;
         }
 
-        // Online — isConnected is not false and isInternetReachable is true or
-        // null (null = unknown, treat as online to avoid false positives)
-        this.clearDebounce();
-        const wasOffline = this.isOffline;
-        runInAction(() => {
-            this.isOffline = false;
-        });
-        if (wasOffline) {
-            this.reconnectCallbacks.forEach((cb) => cb());
-        }
+        // null or false — verify ourselves with fallback probes
+        this.check();
     };
 
     @action
@@ -165,11 +128,9 @@ export default class ConnectivityStore {
         });
 
         this.netInfoUnsubscribe = NetInfo.addEventListener(this.updateState);
-        // Poll every 15s so isInternetReachable gets re-evaluated
-        // after reconnect (the listener alone can leave it stale)
-        this.reachabilityInterval = setInterval(() => {
+        this.pollInterval = setInterval(() => {
             NetInfo.fetch().then(this.updateState);
-        }, REACHABILITY_POLL_INTERVAL);
+        }, POLL_INTERVAL);
     };
 
     @action
@@ -178,11 +139,10 @@ export default class ConnectivityStore {
             this.netInfoUnsubscribe();
             this.netInfoUnsubscribe = null;
         }
-        if (this.reachabilityInterval) {
-            clearInterval(this.reachabilityInterval);
-            this.reachabilityInterval = null;
+        if (this.pollInterval) {
+            clearInterval(this.pollInterval);
+            this.pollInterval = null;
         }
-        this.clearDebounce();
     };
 
     @action

--- a/views/Settings/Networking.tsx
+++ b/views/Settings/Networking.tsx
@@ -3,7 +3,6 @@ import { View, ScrollView } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import Button from '../../components/Button';
 import Header from '../../components/Header';
 import Screen from '../../components/Screen';
 import Switch from '../../components/Switch';
@@ -146,23 +145,6 @@ export default class Networking extends React.Component<
                                 : localeString('general.online')}
                         </Text>
                     </View>
-
-                    {ConnectivityStore.isOffline && (
-                        <View style={{ marginTop: 15, marginBottom: 20 }}>
-                            <Button
-                                title={localeString(
-                                    'views.Settings.Networking.resetOfflineDetection'
-                                )}
-                                onPress={() => {
-                                    ConnectivityStore.reset();
-                                    if (!disableOfflineCheck) {
-                                        ConnectivityStore.start();
-                                    }
-                                }}
-                                secondary
-                            />
-                        </View>
-                    )}
                 </ScrollView>
             </Screen>
         );


### PR DESCRIPTION
# Description

Fixes false positive offline detection when the configured reachability host (e.g. mempool.space) is unreachable but the device is otherwise online. After the debounce timer fires, a new `verifyOffline` step probes fallback URLs (pay.zeusln.app, cloudflare.com) before committing to offline state. If any probe succeeds, the device is considered online and `isOffline` remains false.

## Test plan
- [ ] Confirm device stays online when mempool.space is blocked but internet is available
- [ ] Confirm device correctly marks offline when truly disconnected (airplane mode)
- [ ] Confirm reconnect callbacks fire after recovering from a true offline state

## PR Type

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [x] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
