### PR TITLE
perf: improve offline wallet startup time

### DIFF
--- a/ldknode/LdkNodeInjection.ts
+++ b/ldknode/LdkNodeInjection.ts
@@ -963,13 +963,14 @@ const initializeNode = async ({
         );
     }
 
-    // Use a longer timeout for restore-from-seed (no local DB yet) since
-    // every read falls through to VSS sequentially. Even existing nodes
-    // may have an incomplete local DB (e.g. after a previous fallback
-    // build), so the default is generous to avoid false alerts.
+    // VSS itself is gated on connectivity upstream (LdkNodeUtils.initNode skips
+    // VSS entirely when offline), so this timeout only kicks in when we're
+    // online but VSS is sluggish. A tight 10s budget for existing nodes is
+    // enough for the typical incremental sync; restore-from-seed needs longer
+    // because every read falls through to VSS sequentially.
     const localDbPath = `${storagePath}/ldk_node_data.sqlite`;
     const hasLocalDb = await RNFS.exists(localDbPath);
-    const vssBuildTimeout = hasLocalDb ? 30 : 60;
+    const vssBuildTimeout = hasLocalDb ? 10 : 60;
     await setVssBuildTimeout(vssBuildTimeout);
     console.log(
         `LDK Node: [${elapsed()}] VSS build timeout set to ${vssBuildTimeout}s (${

--- a/ldknode/LdkNodeInjection.ts
+++ b/ldknode/LdkNodeInjection.ts
@@ -932,7 +932,9 @@ const initializeNode = async ({
         );
     }
 
-    // Configure VSS (Versioned Storage Service) for cloud backup
+    // Configure VSS (Versioned Storage Service) for cloud backup.
+    // Gated on connectivity upstream (LdkNodeUtils.initNode skips VSS entirely
+    // when offline), so everything in here only runs when we're online.
     if (vssConfig && vssConfig.url && vssConfig.storeId) {
         let vssHeaders: Record<string, string> | undefined;
         try {
@@ -961,22 +963,20 @@ const initializeNode = async ({
                 Date.now() - tVssSet
             }ms)`
         );
-    }
 
-    // VSS itself is gated on connectivity upstream (LdkNodeUtils.initNode skips
-    // VSS entirely when offline), so this timeout only kicks in when we're
-    // online but VSS is sluggish. A tight 10s budget for existing nodes is
-    // enough for the typical incremental sync; restore-from-seed needs longer
-    // because every read falls through to VSS sequentially.
-    const localDbPath = `${storagePath}/ldk_node_data.sqlite`;
-    const hasLocalDb = await RNFS.exists(localDbPath);
-    const vssBuildTimeout = hasLocalDb ? 10 : 60;
-    await setVssBuildTimeout(vssBuildTimeout);
-    console.log(
-        `LDK Node: [${elapsed()}] VSS build timeout set to ${vssBuildTimeout}s (${
-            hasLocalDb ? 'existing node' : 'restore / first run'
-        })`
-    );
+        // Tight 10s budget for existing nodes is enough for the typical
+        // incremental sync; restore-from-seed needs longer because every
+        // read falls through to VSS sequentially.
+        const localDbPath = `${storagePath}/ldk_node_data.sqlite`;
+        const hasLocalDb = await RNFS.exists(localDbPath);
+        const vssBuildTimeout = hasLocalDb ? 10 : 60;
+        await setVssBuildTimeout(vssBuildTimeout);
+        console.log(
+            `LDK Node: [${elapsed()}] VSS build timeout set to ${vssBuildTimeout}s (${
+                hasLocalDb ? 'existing node' : 'restore / first run'
+            })`
+        );
+    }
 
     console.log(`LDK Node: [${elapsed()}] Starting buildNode...`);
     const tBuild = Date.now();

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -293,6 +293,7 @@ export default class CashuStore {
     @observable public offlineSpentTokens: Array<CashuToken> = [];
     @observable public showOfflineSpentAlert: boolean = false;
     private isSweeping: boolean = false;
+    private connectivityCallbackRegistered: boolean = false;
 
     settingsStore: SettingsStore;
     invoicesStore: InvoicesStore;
@@ -1727,6 +1728,13 @@ export default class CashuStore {
         // before any wallet implementation init so isOffline is reliable
         // before we hit network-bound code paths. Here we only register the
         // Cashu-specific reconnect handler.
+        //
+        // initializeWallets can run multiple times in a session (handleFocus,
+        // handleAppStateChange) so guard against re-registering the callback;
+        // duplicates would trigger redundant sweeps and pending checks on
+        // every reconnect.
+        if (this.connectivityCallbackRegistered) return;
+        this.connectivityCallbackRegistered = true;
         connectivityStore.onReconnect(() => {
             // delay briefly to let the network stabilize
             if (!this.isSweeping) {

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -1723,7 +1723,10 @@ export default class CashuStore {
     // =========================================================================
 
     public startConnectivityMonitoring = () => {
-        connectivityStore.start();
+        // ConnectivityStore.start() is owned by Wallet.fetchData() — it runs
+        // before any wallet implementation init so isOffline is reliable
+        // before we hit network-bound code paths. Here we only register the
+        // Cashu-specific reconnect handler.
         connectivityStore.onReconnect(() => {
             // delay briefly to let the network stabilize
             if (!this.isSweeping) {
@@ -1733,10 +1736,6 @@ export default class CashuStore {
                 }, 3000);
             }
         });
-    };
-
-    public stopConnectivityMonitoring = () => {
-        connectivityStore.stop();
     };
 
     @action
@@ -1766,7 +1765,6 @@ export default class CashuStore {
         this.offlineSpentTokens = [];
         this.showOfflineSpentAlert = false;
         this.isSweeping = false;
-        this.stopConnectivityMonitoring();
     };
 
     @action

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -3259,8 +3259,10 @@ export default class CashuStore {
                     : [];
 
                 // If no mints in local storage (e.g. fresh recovery),
-                // try to restore mint list from Nostr backup
-                if (localMintUrls.length === 0) {
+                // try to restore mint list from Nostr backup. Skip when
+                // offline — every relay would otherwise time out and add
+                // several seconds to startup.
+                if (localMintUrls.length === 0 && !this.isOffline) {
                     try {
                         const nostrMints = await this.nostrRestoreMints();
                         if (nostrMints && nostrMints.length > 0) {

--- a/stores/ConnectivityStore.ts
+++ b/stores/ConnectivityStore.ts
@@ -86,6 +86,30 @@ export default class ConnectivityStore {
     };
 
     /**
+     * Update isOffline and fire reconnect callbacks if we transitioned
+     * from offline to online. Each callback is wrapped in its own
+     * try/catch so one bad listener can't starve the rest.
+     */
+    private setOnlineState = (online: boolean) => {
+        const wasOffline = this.isOffline;
+        runInAction(() => {
+            this.isOffline = !online;
+        });
+        if (online && wasOffline) {
+            this.reconnectCallbacks.forEach((cb) => {
+                try {
+                    cb();
+                } catch (e) {
+                    console.error(
+                        'ConnectivityStore: reconnect callback failed',
+                        e
+                    );
+                }
+            });
+        }
+    };
+
+    /**
      * Run an immediate probe with a tight budget and update isOffline.
      * Intended to be awaited *before* wallet initialization so that
      * downstream code (LDK Node, CashuStore) sees the correct offline
@@ -98,13 +122,7 @@ export default class ConnectivityStore {
             return true;
         }
         const online = await this.verifyConnectivity(timeoutMs);
-        const wasOffline = this.isOffline;
-        runInAction(() => {
-            this.isOffline = !online;
-        });
-        if (online && wasOffline) {
-            this.reconnectCallbacks.forEach((cb) => cb());
-        }
+        this.setOnlineState(online);
         return online;
     };
 
@@ -117,34 +135,20 @@ export default class ConnectivityStore {
         this.verifyInFlight = true;
         this.verifyConnectivity().then((online) => {
             this.verifyInFlight = false;
-            const wasOffline = this.isOffline;
-            runInAction(() => {
-                this.isOffline = !online;
-            });
-            if (online && wasOffline) {
-                this.reconnectCallbacks.forEach((cb) => cb());
-            }
+            this.setOnlineState(online);
         });
     };
 
     private updateState = (state: NetInfoState) => {
         // isConnected === false is a reliable native signal — mark immediately
         if (state.isConnected === false) {
-            runInAction(() => {
-                this.isOffline = true;
-            });
+            this.setOnlineState(false);
             return;
         }
 
         // isInternetReachable === true is reliable — mark online immediately
         if (state.isInternetReachable === true) {
-            const wasOffline = this.isOffline;
-            runInAction(() => {
-                this.isOffline = false;
-            });
-            if (wasOffline) {
-                this.reconnectCallbacks.forEach((cb) => cb());
-            }
+            this.setOnlineState(true);
             return;
         }
 

--- a/stores/ConnectivityStore.ts
+++ b/stores/ConnectivityStore.ts
@@ -9,6 +9,10 @@ import SettingsStore from './SettingsStore';
 
 const POLL_INTERVAL = 15000; // 15s
 const VERIFY_TIMEOUT_MS = 5000;
+// Tight budget for the pre-startup probe — we'd rather declare ourselves
+// offline and skip 30+s of wallet-init timeouts than block startup waiting
+// for a sluggish reachability host.
+const INITIAL_PROBE_TIMEOUT_MS = 1500;
 const DEFAULT_REACHABILITY_HOST = 'mempool.space';
 const PLATFORM_REACHABILITY_URL =
     Platform.OS === 'ios'
@@ -52,9 +56,12 @@ export default class ConnectivityStore {
         this.reconnectCallbacks.push(callback);
     };
 
-    private probeUrl = async (url: string): Promise<boolean> => {
+    private probeUrl = async (
+        url: string,
+        timeoutMs: number = VERIFY_TIMEOUT_MS
+    ): Promise<boolean> => {
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+        const timeout = setTimeout(() => controller.abort(), timeoutMs);
         try {
             await fetch(url, {
                 method: 'HEAD',
@@ -68,12 +75,37 @@ export default class ConnectivityStore {
         }
     };
 
-    private verifyConnectivity = async (): Promise<boolean> => {
+    private verifyConnectivity = async (
+        timeoutMs: number = VERIFY_TIMEOUT_MS
+    ): Promise<boolean> => {
         const urls = [this.getReachabilityUrl(), ...FALLBACK_REACHABILITY_URLS];
         const results = await Promise.all(
-            urls.map((url) => this.probeUrl(url))
+            urls.map((url) => this.probeUrl(url, timeoutMs))
         );
         return results.some((ok) => ok);
+    };
+
+    /**
+     * Run an immediate probe with a tight budget and update isOffline.
+     * Intended to be awaited *before* wallet initialization so that
+     * downstream code (LDK Node, CashuStore) sees the correct offline
+     * state and can skip network-bound work.
+     */
+    public checkNow = async (
+        timeoutMs: number = INITIAL_PROBE_TIMEOUT_MS
+    ): Promise<boolean> => {
+        if (this.settingsStore.settings?.networking?.disableOfflineCheck) {
+            return true;
+        }
+        const online = await this.verifyConnectivity(timeoutMs);
+        const wasOffline = this.isOffline;
+        runInAction(() => {
+            this.isOffline = !online;
+        });
+        if (online && wasOffline) {
+            this.reconnectCallbacks.forEach((cb) => cb());
+        }
+        return online;
     };
 
     /**

--- a/stores/ConnectivityStore.ts
+++ b/stores/ConnectivityStore.ts
@@ -114,6 +114,9 @@ export default class ConnectivityStore {
      * Intended to be awaited *before* wallet initialization so that
      * downstream code (LDK Node, CashuStore) sees the correct offline
      * state and can skip network-bound work.
+     *
+     * Sets verifyInFlight so a poll- or NetInfo-triggered check() that
+     * lands during startup bails instead of firing a redundant 5s probe.
      */
     public checkNow = async (
         timeoutMs: number = INITIAL_PROBE_TIMEOUT_MS
@@ -121,9 +124,14 @@ export default class ConnectivityStore {
         if (this.settingsStore.settings?.networking?.disableOfflineCheck) {
             return true;
         }
-        const online = await this.verifyConnectivity(timeoutMs);
-        this.setOnlineState(online);
-        return online;
+        this.verifyInFlight = true;
+        try {
+            const online = await this.verifyConnectivity(timeoutMs);
+            this.setOnlineState(online);
+            return online;
+        } finally {
+            this.verifyInFlight = false;
+        }
     };
 
     /**

--- a/utils/LdkNodeUtils.ts
+++ b/utils/LdkNodeUtils.ts
@@ -408,8 +408,14 @@ export async function startLdkNodeWallet({
         }
     }
 
-    // Only sync if the node actually started
-    if (nodeStarted) {
+    // Only sync if the node actually started, and skip entirely when offline.
+    // syncWallets() makes blocking Esplora + RGS requests that would otherwise
+    // wait on the underlying HTTP client timeouts (~30s+). The post-sync RGS
+    // status check would also surface a misleading "empty graph" alert when
+    // we never had a chance to fetch a snapshot.
+    if (nodeStarted && connectivityStore.isOffline) {
+        console.log('LDK Node: Offline — skipping wallet sync');
+    } else if (nodeStarted) {
         onSyncStart?.();
         try {
             await LdkNode.node.syncWallets();

--- a/utils/LdkNodeUtils.ts
+++ b/utils/LdkNodeUtils.ts
@@ -7,6 +7,7 @@
 import RNFS from 'react-native-fs';
 import LdkNode from '../ldknode/LdkNodeInjection';
 import type { Network } from '../ldknode/LdkNode.d';
+import { connectivityStore } from '../stores/Stores';
 
 import { localeString } from './LocaleUtils';
 import { retry } from './SleepUtils';
@@ -210,13 +211,27 @@ async function initNode({
     const networkType = getNetworkType(network);
     const esploraUrl = esploraServerUrl || getDefaultEsploraServer(network);
     const rgsUrl = rgsServerUrl || getDefaultRgsServer(network);
-    const vssUrl = vssServerUrl || DEFAULT_VSS_SERVER;
 
-    // Derive VSS signing keypair using native PBKDF2 (avoids ~3s JS PBKDF2).
-    // The seed is derived once and reused for both storeId and auth headers.
-    const seedHex = await LdkNode.crypto.mnemonicToSeed(mnemonic, passphrase);
-    const vssKey = deriveVssSigningKeyFromSeed(Buffer.from(seedHex, 'hex'));
-    const vssStoreId = Buffer.from(vssKey.publicKey).toString('hex');
+    // Skip VSS entirely when offline. With VSS configured, the native build
+    // blocks for the full 30-60s VSS timeout before falling back to local
+    // SQLite. We'll pick VSS back up on the next launch when we're online.
+    let vssConfig: { url: string; storeId: string } | undefined;
+    let vssKey: { privateKey: Uint8Array; publicKey: Uint8Array } | undefined;
+    if (connectivityStore.isOffline) {
+        console.log('LDK Node: Offline — skipping VSS, using local-only build');
+    } else {
+        // Derive VSS signing keypair using native PBKDF2 (avoids ~3s JS PBKDF2).
+        // The seed is derived once and reused for both storeId and auth headers.
+        const seedHex = await LdkNode.crypto.mnemonicToSeed(
+            mnemonic,
+            passphrase
+        );
+        vssKey = deriveVssSigningKeyFromSeed(Buffer.from(seedHex, 'hex'));
+        vssConfig = {
+            url: vssServerUrl || DEFAULT_VSS_SERVER,
+            storeId: Buffer.from(vssKey.publicKey).toString('hex')
+        };
+    }
 
     return await LdkNode.utils.initializeNode({
         network: networkType,
@@ -229,10 +244,7 @@ async function initNode({
         listeningAddresses,
         lsps1Config,
         trustedPeers0conf,
-        vssConfig: {
-            url: vssUrl,
-            storeId: vssStoreId
-        },
+        vssConfig,
         vssKey
     });
 }

--- a/utils/NostrMintBackup.ts
+++ b/utils/NostrMintBackup.ts
@@ -112,9 +112,18 @@ export async function backupMintsToNostr(
     return timestamp;
 }
 
+// Per-relay budget. Sequential 10s × N relays was the previous model and
+// dominated startup when one relay was slow; with parallel fan-out a
+// tighter budget caps the worst case.
+const RELAY_FETCH_TIMEOUT_MS = 5000;
+
 /**
  * Restores mint URLs from Nostr relays by fetching the kind 30078
  * event and decrypting with NIP-44.
+ *
+ * Queries all relays in parallel and returns as soon as any one of them
+ * yields a backup. Falls back to null if every relay finishes without
+ * finding data.
  */
 export async function restoreMintsFromNostr(
     privateKeyHex: string,
@@ -126,24 +135,37 @@ export async function restoreMintsFromNostr(
         publicKeyHex
     );
 
-    // Try each relay until we get a result
-    for (const relayUrl of relays) {
-        try {
-            const result = await fetchFromRelay(
-                relayUrl,
-                publicKeyHex,
-                conversationKey
-            );
-            if (result) return result;
-        } catch (e) {
-            console.warn(
-                `Nostr mint restore: failed to fetch from ${relayUrl}:`,
-                e
-            );
+    return new Promise((resolve) => {
+        let pending = relays.length;
+        if (pending === 0) {
+            resolve(null);
+            return;
         }
-    }
-
-    return null;
+        let settled = false;
+        relays.forEach(async (relayUrl) => {
+            try {
+                const result = await fetchFromRelay(
+                    relayUrl,
+                    publicKeyHex,
+                    conversationKey
+                );
+                if (result && !settled) {
+                    settled = true;
+                    resolve(result);
+                    return;
+                }
+            } catch (e) {
+                console.warn(
+                    `Nostr mint restore: failed to fetch from ${relayUrl}:`,
+                    e
+                );
+            }
+            if (--pending === 0 && !settled) {
+                settled = true;
+                resolve(null);
+            }
+        });
+    });
 }
 
 function fetchFromRelay(
@@ -157,7 +179,7 @@ function fetchFromRelay(
                 relay.close();
             } catch {}
             resolve(null);
-        }, 10000);
+        }, RELAY_FETCH_TIMEOUT_MS);
 
         const relay = relayInit(relayUrl);
 

--- a/utils/NostrMintBackup.ts
+++ b/utils/NostrMintBackup.ts
@@ -196,18 +196,21 @@ function fetchFromRelay(
                 ]);
 
                 sub.on('event', (event: any) => {
+                    clearTimeout(timeout);
+                    sub.unsub();
+                    relay.close();
                     try {
                         const decrypted = nip44.decrypt(
                             event.content,
                             conversationKey
                         );
                         const data: MintBackupData = JSON.parse(decrypted);
-                        clearTimeout(timeout);
-                        sub.unsub();
-                        relay.close();
                         resolve(data);
                     } catch (e) {
+                        // Malformed/legacy event — don't sit on the timer
+                        // waiting for a second one that won't come.
                         console.warn('Failed to decrypt mint backup event:', e);
+                        resolve(null);
                     }
                 });
 

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -84,6 +84,7 @@ import Storage from '../../storage';
 import AlertStore from '../../stores/AlertStore';
 import BalanceStore from '../../stores/BalanceStore';
 import CashuStore from '../../stores/CashuStore';
+import { connectivityStore } from '../../stores/Stores';
 import ChannelBackupStore from '../../stores/ChannelBackupStore';
 import ChannelsStore from '../../stores/ChannelsStore';
 import TransactionsStore from '../../stores/TransactionsStore';
@@ -593,6 +594,12 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             ContactStore.loadContacts();
             NotesStore.loadNoteKeys();
             CashuStore.reset();
+
+            // Seed isOffline before wallet init so LDK Node / CDK / LND can
+            // skip network-bound work (VSS sync, Esplora, RGS, Nostr restore)
+            // when offline, instead of blocking on internal 30+s timeouts.
+            connectivityStore.start();
+            await connectivityStore.checkNow();
         }
 
         LnurlPayStore.reset();


### PR DESCRIPTION
# Description

When the device is offline, Zeus's LDK Node and Cashu init paths used to block on a series of internal HTTP timeouts — VSS dual-store build (30–60s), `node.syncWallets()` Esplora + RGS fetch (~30s+), and on a fresh recovery, the sequential Nostr relay loop (8 × 10s = up to 80s). End-to-end an offline cold-start could take 60s+ for an existing wallet and several minutes for a fresh recovery.

This PR seeds `connectivityStore.isOffline` *before* any wallet implementation init runs, then short-circuits the network-bound work that would otherwise stall on those internal timeouts. Online cold-start is unchanged apart from a one-time probe capped at ~1.5s.

## Impact

| Path | Before | After |
| --- | --- | --- |
| Initial reachability probe | ~5s probe budget | ~1.5s |
| LDK VSS dual-store build (offline) | ~30s existing / ~60s restore | skipped |
| LDK `syncWallets()` (offline) | ~30s+ Esplora + RGS fetch | skipped |
| Cashu Nostr mint restore (fresh recovery, offline) | up to ~80s sequential | skipped |
| LDK VSS build timeout when online-but-VSS-slow | 30s | 10s |
| **Offline cold-start, existing wallet** | **~60s+** | **~3s** |
| **Offline cold-start, fresh recovery** | **several minutes** | **~3s** |

Online cold-start regresses by at most the new ~1.5s `checkNow()` probe; when online, the same VSS build and sync paths run as before. As a secondary benefit, online Nostr mint restore now fans out across all relays in parallel instead of trying them one-at-a-time.

## Behaviour notes / risks

- **VSS deferral while offline.** A session built offline uses local-only SQLite. VSS resumes on the next launch once we're online; we do not currently rebuild the node mid-session on reconnect, so the same is true if the device comes back online during the session.
- **No alerts when offline.** When VSS / sync / RGS are skipped because we're offline, `vssError` / `esploraError` / `rgsError` stay `undefined`, so `Wallet.tsx` doesn't surface alerts the user already understands. Online failures alert as before.
- **Tighter VSS budget.** Existing-wallet VSS timeout drops from 30s → 10s. Users on slow connections may occasionally see a `vssError` alert where the previous 30s budget would have eventually succeeded. The graceful fallback (local-only build, retry on next launch) is unchanged.
- **Slow-network false positive on the startup probe.** The `checkNow()` budget is 1.5s across three parallel probes (block explorer, ZEUS rates endpoint, Cloudflare trace). On a connection where all three HEAD responses take longer than 1.5s, we'll declare offline and skip VSS / sync for the session. The 15s poll and NetInfo listener will then transition the session to online and fire reconnect callbacks (Cashu sweeps pending tokens, SyncStore resumes embedded-lnd sync), but LDK Node is not rebuilt mid-session — VSS / chain sync resume on the next launch.
- **Connectivity ownership.** `connectivityStore.start()` is now invoked from `Wallet.fetchData()` rather than `CashuStore.initializeWallets()`, which runs early enough for downstream wallet implementations to see a reliable `isOffline`. Cashu still registers its reconnect callback via `startConnectivityMonitoring` (now deduped against re-registration). `stop()` / `reset()` remain wired to the "disable offline check" settings toggle.

## Test plan

- [ ] **Offline cold-start, existing wallet** — disable Wi-Fi/cellular, launch app; confirm UI is interactive within ~3s and no VSS / Esplora / RGS alerts surface.
- [ ] **Online cold-start, existing wallet** — confirm startup time has not regressed beyond the ~1.5s probe.
- [ ] **Online → offline mid-session** — confirm the running session keeps working off local state; on next cold-start, offline path is taken.
- [ ] **Offline → online reconnect** — confirm `connectivityStore.onReconnect` fires and Cashu pending tokens sweep.
- [ ] **Fresh recovery, online** — verify Nostr mint restore still finds the backup with parallel fan-out.
- [ ] **Fresh recovery, offline** — verify we no longer hang on the relay loop and the wallet still loads (no mints, as expected).
- [ ] **VSS reachable but slow** — confirm the new 10s budget falls back to local with a clear `vssError` alert.
- [ ] **Disable offline check toggle** — turning the setting on should stop monitoring and clear `isOffline`; turning it off should resume monitoring.

## PR Type

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
