### PR TITLE
fix: Onboarding: prevent swipe-back from clobbering an existing wallet

### DIFF
--- a/utils/WalletCreationUtils.ts
+++ b/utils/WalletCreationUtils.ts
@@ -39,6 +39,18 @@ export async function createOnboardingWallet(params: WalletCreationParams) {
 
     const { setConnectingStatus, updateSettings, settings } = settingsStore;
 
+    // Refuse to create a new wallet if one already exists. Overwriting the
+    // `nodes` array would orphan the existing node directory and any funds it
+    // holds. Treat this as a successful no-op so callers route the user back
+    // to the Wallet view rather than into an error state.
+    if (settings?.nodes?.length) {
+        console.warn(
+            'createOnboardingWallet: existing node detected, skipping creation'
+        );
+        onSuccess();
+        return;
+    }
+
     const commonSettings = {
         privacy: {
             ...settings.privacy,

--- a/views/Onboarding/RecommendedSettings.tsx
+++ b/views/Onboarding/RecommendedSettings.tsx
@@ -185,7 +185,11 @@ export default class RecommendedSettings extends React.Component<
                     choosingPeers: false,
                     creatingWallet: false
                 }),
-            onSuccess: () => navigation.navigate('Wallet')
+            onSuccess: () =>
+                navigation.reset({
+                    index: 0,
+                    routes: [{ name: 'Wallet' }]
+                })
         });
     };
 

--- a/views/Onboarding/WalletSettings.tsx
+++ b/views/Onboarding/WalletSettings.tsx
@@ -119,7 +119,11 @@ export default class WalletSettings extends React.Component<
                     choosingPeers: false,
                     creatingWallet: false
                 }),
-            onSuccess: () => navigation.navigate('Wallet')
+            onSuccess: () =>
+                navigation.reset({
+                    index: 0,
+                    routes: [{ name: 'Wallet' }]
+                })
         });
     };
 


### PR DESCRIPTION
# Description

- Replaces `navigation.navigate('Wallet')` with `navigation.reset` in `WalletSettings` and `RecommendedSettings` so the onboarding screens are removed from the stack after wallet creation. Without this, Android's system swipe-back gesture on the Wallet view returned the user into the wallet-creation flow.
- Adds a defense-in-depth guard in `createOnboardingWallet` that bails out (logs a warning, calls `onSuccess`) when `settings.nodes` already has entries, so the onboarding path can never overwrite an existing node directory and mnemonic.

## Bug report
A user on v0.13.0 (Android, embedded LDK + Minibits ecash) created a wallet, received funds via their Lightning address, then swiped right intending to close the app. They landed back inside the wallet-creation flow with no way to cancel; on completion their balance read as zero. The original LDK node directory still existed on disk, but `settings.nodes` had been overwritten with a fresh empty node, making the funds unreachable through the UI.

## Scope
`createOnboardingWallet` is only called from the two onboarding screens. The "add another wallet" flow (`views/Settings/WalletConfiguration.tsx`) and seed recovery (`views/Settings/SeedRecovery.tsx`) call `createLndWallet` / `createLdkNodeWallet` directly and append to the `nodes` array, so they are unaffected by the guard.

## Test plan
- [ ] Fresh install → complete onboarding → verify swipe-back from Wallet does not return to onboarding

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
