### PR TITLE
fix: CashuStore: don't auto-delete Lightning address when wiping Cashu data

### DIFF
--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -45,11 +45,7 @@ import CashuToken from '../models/CashuToken';
 
 import Storage from '../storage';
 
-import {
-    activityStore,
-    connectivityStore,
-    lightningAddressStore
-} from './Stores';
+import { activityStore, connectivityStore } from './Stores';
 import InvoicesStore from './InvoicesStore';
 import ChannelsStore from './ChannelsStore';
 import SettingsStore, { DEFAULT_NOSTR_RELAYS } from './SettingsStore';
@@ -4375,10 +4371,6 @@ export default class CashuStore {
             await Storage.removeItem(`${lndDir}-cashu-seed-phrase`);
             await Storage.removeItem(`${lndDir}-cashu-seed`);
             await Storage.removeItem(`${lndDir}-cashu-randomizeMintSelection`);
-
-            if (lightningAddressStore.lightningAddressType === 'cashu') {
-                lightningAddressStore.deleteAddress();
-            }
 
             // Reset store state
             this.reset();


### PR DESCRIPTION
# Description

Originally set up to handle legacy format Cashu wallets for Embedded LND, but now it creates an issue for ZEUS Pay+ subscribers on Embedded LND trying to troubleshoot their Cashu wallets.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
