### PR TITLE
fix: clear stale custom wallet icon references

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -8,6 +8,7 @@ import BackendUtils from '../utils/BackendUtils';
 import { getSupportedBiometryType } from '../utils/BiometricUtils';
 import { localeString } from '../utils/LocaleUtils';
 import MigrationsUtils from '../utils/MigrationUtils';
+import { photoExists } from '../utils/PhotoUtils';
 import { doTorRequest, RequestMethod } from '../utils/TorUtils';
 import {
     DEFAULT_SCORER_URL,
@@ -1939,6 +1940,8 @@ export default class SettingsStore {
                 }
             }
 
+            await this.cleanupMissingNodePhotos();
+
             this.updateNodeProperties(this.settings);
         } catch (error) {
             console.error('Could not load settings', error);
@@ -1948,6 +1951,32 @@ export default class SettingsStore {
         }
 
         return this.settings;
+    };
+
+    // Custom wallet photos are stored as files in DocumentDirectoryPath and
+    // referenced by `rnfs://<filename>`. The file is supposed to be device-local, so a
+    // reference can point to a missing file.
+    // Clear those references so the UI falls back to
+    // the default identicon instead of rendering a broken image.
+    private cleanupMissingNodePhotos = async () => {
+        const nodes = this.settings?.nodes;
+        if (!Array.isArray(nodes) || nodes.length === 0) return;
+
+        let changed = false;
+        for (const node of nodes) {
+            if (!node?.photo?.startsWith('rnfs://')) continue;
+            const exists = await photoExists(node.photo);
+            if (!exists) {
+                runInAction(() => {
+                    node.photo = undefined;
+                });
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            await Storage.setItem(STORAGE_KEY, this.settings);
+        }
     };
 
     public async setSettings(settings: any) {

--- a/utils/PhotoUtils.test.ts
+++ b/utils/PhotoUtils.test.ts
@@ -1,6 +1,8 @@
-import { getPhoto, getPresetName } from './PhotoUtils';
+import { getPhoto, getPresetName, photoExists } from './PhotoUtils';
+const mockExists = jest.fn();
 jest.mock('react-native-fs', () => ({
-    DocumentDirectoryPath: 'docpath'
+    DocumentDirectoryPath: 'docpath',
+    exists: (...args: any[]) => mockExists(...args)
 }));
 jest.mock('react-native', () => ({
     Image: {
@@ -93,6 +95,42 @@ describe('PhotoUtils', () => {
                     ).toEqual(`zeusillustration${i}${suffix}`);
                 }
             }
+        });
+    });
+
+    describe('photoExists', () => {
+        beforeEach(() => {
+            mockExists.mockReset();
+        });
+
+        it('returns false for undefined or empty values', async () => {
+            expect(await photoExists(undefined)).toBe(false);
+            expect(await photoExists('')).toBe(false);
+            expect(mockExists).not.toHaveBeenCalled();
+        });
+
+        it('returns true for non-rnfs values without hitting the filesystem', async () => {
+            expect(await photoExists('preset://lnd')).toBe(true);
+            expect(await photoExists('file://something.jpg')).toBe(true);
+            expect(await photoExists('https://example.com/x.jpg')).toBe(true);
+            expect(mockExists).not.toHaveBeenCalled();
+        });
+
+        it('returns true when the rnfs:// file exists on disk', async () => {
+            mockExists.mockResolvedValueOnce(true);
+            expect(await photoExists('rnfs://photo_123.png')).toBe(true);
+            expect(mockExists).toHaveBeenCalledWith('docpath/photo_123.png');
+        });
+
+        it('returns false when the rnfs:// file is missing', async () => {
+            mockExists.mockResolvedValueOnce(false);
+            expect(await photoExists('rnfs://missing.png')).toBe(false);
+            expect(mockExists).toHaveBeenCalledWith('docpath/missing.png');
+        });
+
+        it('returns false when RNFS.exists throws', async () => {
+            mockExists.mockRejectedValueOnce(new Error('permission denied'));
+            expect(await photoExists('rnfs://err.png')).toBe(false);
         });
     });
 });

--- a/utils/PhotoUtils.ts
+++ b/utils/PhotoUtils.ts
@@ -75,4 +75,15 @@ const getPresetName = (assetUri: string): string => {
         .toLowerCase();
 };
 
-export { getPhoto, getPresetName };
+const photoExists = async (photo: string | undefined): Promise<boolean> => {
+    if (!photo) return false;
+    if (!photo.startsWith('rnfs://')) return true;
+    const fileName = photo.replace('rnfs://', '');
+    try {
+        return await RNFS.exists(`${RNFS.DocumentDirectoryPath}/${fileName}`);
+    } catch {
+        return false;
+    }
+};
+
+export { getPhoto, getPresetName, photoExists };


### PR DESCRIPTION
# Description

Relates to issue: https://github.com/ZeusLN/zeus/issues/4042

Custom wallet photos are stored as device-local files in `DocumentDirectoryPath` and referenced as `rnfs://<filename>` in node settings. These files only exist on the device that originally picked the photo. If an `rnfs://` reference makes its way into another device's settings (e.g. via an iCloud backup restore, or a legacy iCloud Keychain sync from an older Zeus version), the UI tries to load a file that doesn't exist, resulting in a broken/missing wallet icon

### Reproduction note

We were unable to reproduce the original bug on a fresh install of the current build (physical iPhone + iOS Simulator, same Apple ID) because the migration to `cloudSync: false` for keychain storage already prevents new cross-device sync. The bug might be specific to users who upgraded to the latest build from older Zeus versions where settings
were synced via iCloud Keychain.

### What this PR does

- Adds a `photoExists()` helper in `PhotoUtils`  to check whether the file behind an `rnfs://` reference is actually present on disk. 
- Adds `cleanupMissingNodePhotos()` to `SettingsStore.getSettings()`. On every settings load, it scans each node's `photo` field and clears any `rnfs://` reference whose file is missing, so the UI falls back to `NodeIdenticon` instead of rendering a broken image.

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [X] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
