### PR TITLE
Allow overpaying fixed lightning invoices

### DIFF
--- a/components/AmountInput.tsx
+++ b/components/AmountInput.tsx
@@ -27,7 +27,7 @@ import NavigationService from '../NavigationService';
 interface AmountInputProps {
     onAmountChange: (amount: string, satAmount: string | number) => void;
     amount?: string;
-    sats?: string;
+    sats?: string | number;
     locked?: boolean;
     title?: string;
     hideConversion?: boolean;
@@ -93,25 +93,39 @@ export default class AmountInput extends React.Component<
     constructor(props: any) {
         super(props);
 
-        const { amount, onAmountChange } = props;
+        const { amount, sats, forceUnit, onAmountChange } = props;
         let satAmount = '0';
-        if (amount)
-            satAmount = getSatAmount(amount, props.forceUnit).toString();
+        let displayAmount = amount || '';
+        if (amount !== undefined) {
+            satAmount = getSatAmount(amount, forceUnit).toString();
+        } else if (sats !== undefined) {
+            satAmount = sats.toString();
+            displayAmount = getAmount(sats, forceUnit);
+        }
 
-        onAmountChange(amount, satAmount);
+        onAmountChange(displayAmount, satAmount);
         this.state = {
             satAmount
         };
     }
 
     componentDidUpdate(prevProps: Readonly<AmountInputProps>): void {
-        const { amount, forceUnit, onAmountChange } = this.props;
-        if (amount !== prevProps.amount || forceUnit !== prevProps.forceUnit) {
+        const { amount, sats, forceUnit, onAmountChange } = this.props;
+        if (
+            amount !== prevProps.amount ||
+            sats !== prevProps.sats ||
+            forceUnit !== prevProps.forceUnit
+        ) {
             if (forceUnit === 'sats' && forceUnit !== prevProps.forceUnit) {
                 const currentSatAmount = getSatAmount(amount || '', forceUnit);
                 this.setState({ satAmount: currentSatAmount });
 
                 onAmountChange(currentSatAmount.toString(), currentSatAmount);
+            } else if (amount === undefined && sats !== undefined) {
+                const satAmount = sats.toString();
+                if (satAmount !== this.state.satAmount.toString()) {
+                    this.setState({ satAmount });
+                }
             } else {
                 const satAmount = getSatAmount(amount || '', forceUnit);
                 if (satAmount !== this.state.satAmount) {
@@ -123,9 +137,10 @@ export default class AmountInput extends React.Component<
 
     onChangeUnits = () => {
         const { amount, onAmountChange, UnitsStore }: any = this.props;
+        const satAmount = this.state.satAmount || getSatAmount(amount || 0);
         UnitsStore.changeUnits();
-        const satAmount = getSatAmount(amount, this.props.forceUnit);
-        onAmountChange(amount, satAmount);
+        const displayAmount = getAmount(satAmount, this.props.forceUnit);
+        onAmountChange(displayAmount, satAmount);
         this.setState({ satAmount });
     };
 
@@ -300,7 +315,7 @@ export default class AmountInput extends React.Component<
     }
 }
 
-export { getSatAmount };
+export { getAmount, getSatAmount };
 
 const styles = StyleSheet.create({
     amountDisplay: {

--- a/locales/en.json
+++ b/locales/en.json
@@ -816,6 +816,7 @@
     "views.PaymentRequest.payCustom": "Pay custom amount",
     "views.PaymentRequest.feeEstimate": "Fee Estimate",
     "views.PaymentRequest.feeEstimateExceedsLimit": "The estimated fee for this payment is higher than the limit set below. Consider raising the fee limit to avoid payment failures.",
+    "views.PaymentRequest.amountBelowMinimum": "Payment amount cannot be less than the invoice amount.",
     "views.PaymentRequest.successProbability": "Success Probability",
     "views.PaymentRequest.description": "Description",
     "views.PaymentRequest.timestamp": "Timestamp",

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -18,7 +18,6 @@ import Amount from '../components/Amount';
 import AmountInput from '../components/AmountInput';
 import Button from '../components/Button';
 import SwipeButton from '../components/SwipeButton';
-import Conversion from '../components/Conversion';
 import FeeLimit from '../components/FeeLimit';
 import Header from '../components/Header';
 import HopPicker from '../components/HopPicker';
@@ -82,7 +81,7 @@ interface InvoiceProps {
 }
 
 interface InvoiceState {
-    customAmount: string;
+    customAmount?: string;
     satAmount: string | number;
     enableMultiPathPayment: boolean;
     enableAtomicMultiPathPayment: boolean;
@@ -190,6 +189,8 @@ export default class PaymentRequest extends React.Component<
         );
 
         this.setState({
+            customAmount: requestAmount ? undefined : '',
+            satAmount: requestAmount || '',
             feeOption,
             feeLimitSat: settings?.payments?.defaultFeeFixed || '100',
             maxFeePercent: settings?.payments?.defaultFeePercentage || '5.0',
@@ -219,7 +220,7 @@ export default class PaymentRequest extends React.Component<
         });
     }
 
-    isAmountValidToSwap(): boolean {
+    isAmountValidToSwap(amount?: string | number): boolean {
         const { SwapStore, InvoicesStore } = this.props;
 
         const subInfo: any = SwapStore.subInfo;
@@ -239,10 +240,41 @@ export default class PaymentRequest extends React.Component<
         const minBN = new BigNumber(min);
         const maxBN = new BigNumber(max);
 
-        const input = this.calculateLimit(requestAmount || 0);
+        const input = this.calculateLimit(Number(amount || requestAmount || 0));
 
         return input.gte(minBN) && input.lte(maxBN);
     }
+
+    getSelectedPaymentAmount = (
+        satAmount: string | number,
+        requestAmount?: string | number | null
+    ): number => {
+        const hasSelectedAmount =
+            satAmount !== '' && satAmount !== undefined && satAmount !== null;
+        return Number(hasSelectedAmount ? satAmount : requestAmount || 0);
+    };
+
+    getPaymentAmountOverride = (
+        satAmount: string | number,
+        requestAmount?: string | number | null
+    ): string | undefined => {
+        const selectedPaymentAmount = this.getSelectedPaymentAmount(
+            satAmount,
+            requestAmount
+        );
+        if (!selectedPaymentAmount) return undefined;
+        if (!requestAmount) return selectedPaymentAmount.toString();
+        return selectedPaymentAmount > Number(requestAmount)
+            ? selectedPaymentAmount.toString()
+            : undefined;
+    };
+
+    isSelectedPaymentAmountValid = (
+        selectedPaymentAmount: number,
+        requestAmount?: string | number | null
+    ): boolean =>
+        selectedPaymentAmount > 0 &&
+        (!requestAmount || selectedPaymentAmount >= Number(requestAmount));
 
     bigCeil = (big: BigNumber): BigNumber => {
         return big.integerValue(BigNumber.ROUND_CEIL);
@@ -432,6 +464,20 @@ export default class PaymentRequest extends React.Component<
 
         const { paymentRequest, pay_req } = InvoicesStore;
         const { implementation } = SettingsStore;
+        const requestAmount = pay_req && pay_req.getRequestAmount;
+        const selectedPaymentAmount = this.getSelectedPaymentAmount(
+            satAmount,
+            requestAmount
+        );
+
+        if (
+            !this.isSelectedPaymentAmountValid(
+                selectedPaymentAmount,
+                requestAmount
+            )
+        ) {
+            return;
+        }
 
         const isCLightning: boolean = implementation === 'cln-rest';
 
@@ -460,7 +506,7 @@ export default class PaymentRequest extends React.Component<
         // Call sendPayment with the freshest values
         this.sendPayment({
             payment_request: paymentRequest,
-            amount: satAmount ? satAmount.toString() : undefined,
+            amount: this.getPaymentAmountOverride(satAmount, requestAmount),
             max_parts: enableMultiPathPayment ? maxParts : '16',
             max_shard_amt: enableMultiPathPayment ? maxShardAmt : '',
             fee_limit_sat: feeLimitSat,
@@ -489,6 +535,7 @@ export default class PaymentRequest extends React.Component<
             maxShardAmt,
             feeOption,
             customAmount,
+            satAmount,
             zaplockerToggle,
             settingsToggle,
             timeoutSeconds,
@@ -614,6 +661,17 @@ export default class PaymentRequest extends React.Component<
         const isLdkNode: boolean = implementation === 'ldk-node';
 
         const isNoAmountInvoice: boolean = !requestAmount;
+        const selectedPaymentAmount = this.getSelectedPaymentAmount(
+            satAmount,
+            requestAmount
+        );
+        const isPaymentAmountBelowInvoiceAmount =
+            !isNoAmountInvoice &&
+            selectedPaymentAmount < Number(requestAmount || 0);
+        const isPaymentAmountValid = this.isSelectedPaymentAmountValid(
+            selectedPaymentAmount,
+            requestAmount
+        );
 
         const noBalance = this.props.BalanceStore.lightningBalance === 0;
 
@@ -647,7 +705,7 @@ export default class PaymentRequest extends React.Component<
                     onPress={() => {
                         const amountToSwap = isNoAmountInvoice
                             ? this.state.satAmount
-                            : requestAmount;
+                            : selectedPaymentAmount;
                         if (paymentRequest && amountToSwap) {
                             navigation.navigate('Swaps', {
                                 initialInvoice: paymentRequest,
@@ -764,35 +822,61 @@ export default class PaymentRequest extends React.Component<
                                                 />
                                             </View>
                                         )}
-                                    {isNoAmountInvoice ? (
-                                        <AmountInput
-                                            amount={customAmount}
-                                            title={localeString(
-                                                'views.PaymentRequest.customAmt'
-                                            )}
-                                            onAmountChange={(
-                                                amount: string,
-                                                satAmount: string | number
-                                            ) => {
-                                                this.setState({
-                                                    customAmount: amount,
-                                                    satAmount
-                                                });
-                                            }}
-                                        />
-                                    ) : (
-                                        <View style={styles.center}>
-                                            <Amount
-                                                sats={requestAmount}
-                                                jumboText
-                                                toggleable
+                                    <AmountInput
+                                        amount={customAmount}
+                                        sats={
+                                            isNoAmountInvoice
+                                                ? undefined
+                                                : requestAmount
+                                        }
+                                        title={localeString(
+                                            'views.PaymentRequest.customAmt'
+                                        )}
+                                        onAmountChange={(
+                                            amount: string,
+                                            satAmount: string | number
+                                        ) => {
+                                            this.setState({
+                                                customAmount: amount,
+                                                satAmount,
+                                                validAmountToSwap:
+                                                    this.isAmountValidToSwap(
+                                                        satAmount
+                                                    )
+                                            });
+                                        }}
+                                        error={
+                                            isPaymentAmountBelowInvoiceAmount
+                                        }
+                                    />
+                                    {!isNoAmountInvoice && (
+                                        <>
+                                            <KeyValue
+                                                keyValue={localeString(
+                                                    'views.Settings.LightningAddressInfo.minimumAmount'
+                                                )}
+                                                value={
+                                                    <Amount
+                                                        sats={requestAmount}
+                                                        toggleable
+                                                    />
+                                                }
                                             />
-                                            <View style={{ top: 10 }}>
-                                                <Conversion
-                                                    sats={requestAmount}
-                                                />
-                                            </View>
-                                        </View>
+                                            {isPaymentAmountBelowInvoiceAmount && (
+                                                <View
+                                                    style={{
+                                                        paddingTop: 10,
+                                                        paddingBottom: 10
+                                                    }}
+                                                >
+                                                    <WarningMessage
+                                                        message={localeString(
+                                                            'views.PaymentRequest.amountBelowMinimum'
+                                                        )}
+                                                    />
+                                                </View>
+                                            )}
+                                        </>
                                     )}
                                 </>
 
@@ -1061,9 +1145,7 @@ export default class PaymentRequest extends React.Component<
 
                                 <FeeLimit
                                     satAmount={
-                                        isNoAmountInvoice
-                                            ? customAmount
-                                            : requestAmount || 0
+                                        selectedPaymentAmount || customAmount
                                     }
                                     onFeeLimitSatChange={(value: string) =>
                                         this.setState({
@@ -1577,8 +1659,9 @@ export default class PaymentRequest extends React.Component<
                                     <LoadingIndicator size={30} />
                                 </>
                             )}
-                            {requestAmount &&
-                            requestAmount >= slideToPayThreshold ? (
+                            {lightningReadyToSend &&
+                            isPaymentAmountValid &&
+                            selectedPaymentAmount >= slideToPayThreshold ? (
                                 <SwipeButton
                                     key={this.state.swipeButtonKey}
                                     onSwipeSuccess={this.triggerPayment}
@@ -1608,7 +1691,10 @@ export default class PaymentRequest extends React.Component<
                                                 : undefined
                                         }
                                         onPress={this.triggerPayment}
-                                        disabled={!lightningReadyToSend}
+                                        disabled={
+                                            !lightningReadyToSend ||
+                                            !isPaymentAmountValid
+                                        }
                                     />
                                 </View>
                             )}


### PR DESCRIPTION
# Description

Relates to issue: **#2009**

This PR allows fixed-amount BOLT11 invoices to be paid with a larger amount than the invoice amount. It initializes the editable amount from the invoice amount, treats the invoice amount as the minimum, and only passes an explicit amount override when the selected amount is greater than the invoice amount.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I've run `yarn run test` and made sure all of the tests pass

Validation run for this focused patch:

- `./node_modules/.bin/prettier --check views/PaymentRequest.tsx locales/en.json`
- `./node_modules/.bin/eslint views/PaymentRequest.tsx`
- `./node_modules/.bin/tsc --noEmit --pretty false`

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Not device-tested. The patch was validated with focused static checks only.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Not node-tested. The change is limited to amount input state, minimum validation, and payment amount override selection before the existing payment call.

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

Fixes #2009
