### PR TITLE
Clarify hold invoice cancellation errors

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1759,7 +1759,7 @@
     "error.failureReasonTimeout": "There are more routes to try, but the payment timeout was exceeded.",
     "error.failureReasonNoRoute": "No route found",
     "error.failureReasonError": "A non-recoverable error has occured",
-    "error.failureReasonIncorrectPaymentDetails": "Payment failed: Payment details incorrect (unknown payment hash, invalid amount or invalid final CLTV delta).",
+    "error.failureReasonIncorrectPaymentDetails": "Payment failed because the invoice was rejected, canceled, or is no longer valid. For a canceled hold invoice, the held payment is released and your funds are not sent. Check Activity for the final payment state.",
     "error.failureReasonIncorrectPaymentDetailsKeysend": "The receiving node might not accept keysend payments.",
     "error.failureReasonInsufficientBalance": "Insufficient local balance",
     "error.ldk.recipientRejected": "Payment rejected by recipient",

--- a/utils/ErrorUtils.test.ts
+++ b/utils/ErrorUtils.test.ts
@@ -124,7 +124,19 @@ describe('ErrorUtils', () => {
                     ['UnhandledContext']
                 )
             ).toEqual(
-                'Payment failed: Payment details incorrect (unknown payment hash, invalid amount or invalid final CLTV delta).'
+                'Payment failed because the invoice was rejected, canceled, or is no longer valid. For a canceled hold invoice, the held payment is released and your funds are not sent. Check Activity for the final payment state.'
+            );
+        });
+
+        it('Handles raw LND payment details errors', () => {
+            expect(
+                errorToUserFriendly(
+                    new Error(
+                        'Payment details incorrect (unknown hash, invalid amt or invalid final cltv delta)'
+                    )
+                )
+            ).toEqual(
+                'Payment failed because the invoice was rejected, canceled, or is no longer valid. For a canceled hold invoice, the held payment is released and your funds are not sent. Check Activity for the final payment state.'
             );
         });
 
@@ -138,7 +150,20 @@ describe('ErrorUtils', () => {
                     ['Keysend']
                 )
             ).toEqual(
-                'Payment failed: Payment details incorrect (unknown payment hash, invalid amount or invalid final CLTV delta). The receiving node might not accept keysend payments.'
+                'Payment failed because the invoice was rejected, canceled, or is no longer valid. For a canceled hold invoice, the held payment is released and your funds are not sent. Check Activity for the final payment state. The receiving node might not accept keysend payments.'
+            );
+        });
+
+        it('Handles raw LND payment details errors with Keysend errorContext', () => {
+            expect(
+                errorToUserFriendly(
+                    new Error(
+                        'Payment details incorrect (unknown hash, invalid amt or invalid final cltv delta)'
+                    ),
+                    ['Keysend']
+                )
+            ).toEqual(
+                'Payment failed because the invoice was rejected, canceled, or is no longer valid. For a canceled hold invoice, the held payment is released and your funds are not sent. Check Activity for the final payment state. The receiving node might not accept keysend payments.'
             );
         });
 

--- a/utils/ErrorUtils.ts
+++ b/utils/ErrorUtils.ts
@@ -16,6 +16,7 @@ const userFriendlyErrors: any = {
     FAILURE_REASON_ERROR: 'error.failureReasonError',
     FAILURE_REASON_INCORRECT_PAYMENT_DETAILS:
         'error.failureReasonIncorrectPaymentDetails',
+    'Payment details incorrect': 'error.failureReasonIncorrectPaymentDetails',
     FAILURE_REASON_INSUFFICIENT_BALANCE:
         'error.failureReasonInsufficientBalance',
     // LDK Node payment failure reasons
@@ -99,7 +100,7 @@ const errorToUserFriendly = (error: Error, errorContext?: string[]) => {
 
     if (
         errorContext?.includes('Keysend') &&
-        errorMsg === 'FAILURE_REASON_INCORRECT_PAYMENT_DETAILS'
+        localeKey === 'error.failureReasonIncorrectPaymentDetails'
     ) {
         baseError +=
             ' ' +


### PR DESCRIPTION
# Description

Relates to issue: **#2001**

This PR makes the LND "Payment details incorrect" response clearer for users, especially when a hold invoice has been canceled. It maps the raw LND REST error text to the existing incorrect-payment-details locale key, updates the English copy to explain that the invoice may have been rejected, canceled, or expired, and keeps the Keysend-specific hint appended through the locale-key path.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

Validation run for this focused patch:

- `./node_modules/.bin/prettier --check utils/ErrorUtils.ts utils/ErrorUtils.test.ts locales/en.json`
- `./node_modules/.bin/eslint utils/ErrorUtils.ts utils/ErrorUtils.test.ts`
- `./node_modules/.bin/jest utils/ErrorUtils.test.ts --runInBand`
- `./node_modules/.bin/tsc --noEmit --pretty false`

Current GitHub PR checks are passing on the PR:

- lint: passed
- prettier: passed
- test: passed
- tsc: passed

Maintainer-requested first-time-contributor media is still not attached. This patch changes utility error mapping and locale text, with behavior covered by `utils/ErrorUtils.test.ts`; no synthetic screenshot or recording has been attached.

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Not device-tested. This is a utility/error-message mapping change covered by `utils/ErrorUtils.test.ts`.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

The new test covers the raw LND REST text: `Payment details incorrect (unknown hash, invalid amt or invalid final cltv delta)`.

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

Fixes #2001