### PR TITLE
feat: skip Choose Payment Method view if not other option

### DIFF
--- a/components/LayerBalances/EcashSwipeableRow.tsx
+++ b/components/LayerBalances/EcashSwipeableRow.tsx
@@ -1,14 +1,14 @@
 import React, { Component } from 'react';
 import {
-    Alert,
     Animated,
     StyleSheet,
     Text,
     View,
     I18nManager,
-    TouchableOpacity
+    TouchableOpacity,
+    Alert
 } from 'react-native';
-import { getParams as getlnurlParams, LNURLWithdrawParams } from 'js-lnurl';
+import { LNURLWithdrawParams } from 'js-lnurl';
 import { RectButton, Swipeable } from 'react-native-gesture-handler';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { inject, observer } from 'mobx-react';
@@ -16,8 +16,8 @@ import { inject, observer } from 'mobx-react';
 import BackendUtils from '../../utils/BackendUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
+import { navigateForSelectedPaymentRow } from '../../utils/ChoosePaymentMethodUtils';
 
-import { cashuStore } from '../../stores/Stores';
 import SyncStore from '../../stores/SyncStore';
 
 import MintToken from '../../assets/images/SVG/MintToken.svg';
@@ -180,62 +180,16 @@ export default class EcashSwipeableRow extends Component<
         if (this.swipeableRow) this.swipeableRow.openLeft();
     };
 
-    private handleLnurlRequest = async (
-        lightning?: string,
-        lnurlParams?: any,
-        navigation?: any
-    ): Promise<void> => {
-        const params = lnurlParams || (await getlnurlParams(lightning ?? ''));
-        if (
-            params &&
-            params.status === 'ERROR' &&
-            params.domain?.endsWith('.onion')
-        ) {
-            // TODO handle fetching of params with internal Tor
-            throw new Error(`${params.domain} says: ${params.reason}`);
-        }
-
-        switch (params.tag) {
-            case 'payRequest':
-                params.lnurlText = lightning;
-                navigation.navigate('LnurlPay', {
-                    lnurlParams: params,
-                    ecash: true
-                });
-                break;
-            case 'withdrawRequest':
-                navigation.navigate('ReceiveEcash', {
-                    lnurlParams: params
-                });
-                break;
-            default:
-                Alert.alert(
-                    localeString('general.error'),
-                    params.status === 'ERROR'
-                        ? `${params.domain} says: ${params.reason}`
-                        : `${localeString(
-                              'utils.handleAnything.unsupportedLnurlType'
-                          )}: ${params.tag}`,
-                    [
-                        {
-                            text: localeString('general.ok'),
-                            onPress: () => void 0
-                        }
-                    ],
-                    { cancelable: false }
-                );
-        }
-    };
-
     private fetchLnInvoice = () => {
         const { lightning, lnurlParams, navigation } = this.props;
-        if (lightning?.toLowerCase().startsWith('lnurl') || lnurlParams) {
-            this.handleLnurlRequest(lightning, lnurlParams, navigation);
-            return;
-        } else {
-            cashuStore.getPayReq(lightning ?? '');
-            this.props.navigation.navigate('CashuPaymentRequest', {});
-        }
+        navigateForSelectedPaymentRow(
+            navigation,
+            { layer: 'Lightning via ecash' },
+            { lightning, lnurlParams },
+            { replace: false }
+        ).catch((error) => {
+            Alert.alert(localeString('general.error'), error.message);
+        });
     };
 
     render() {

--- a/components/LayerBalances/EcashSwipeableRow.tsx
+++ b/components/LayerBalances/EcashSwipeableRow.tsx
@@ -16,7 +16,10 @@ import { inject, observer } from 'mobx-react';
 import BackendUtils from '../../utils/BackendUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
-import { navigateForSelectedPaymentRow } from '../../utils/ChoosePaymentMethodUtils';
+import {
+    navigateForSelectedPaymentRow,
+    PaymentMethodLayer
+} from '../../utils/ChoosePaymentMethodUtils';
 
 import SyncStore from '../../stores/SyncStore';
 
@@ -184,7 +187,7 @@ export default class EcashSwipeableRow extends Component<
         const { lightning, lnurlParams, navigation } = this.props;
         navigateForSelectedPaymentRow(
             navigation,
-            { layer: 'Lightning via ecash' },
+            { layer: PaymentMethodLayer.LightningViaEcash },
             { lightning, lnurlParams },
             { replace: false }
         ).catch((error) => {

--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -8,24 +8,18 @@ import {
     I18nManager,
     TouchableOpacity
 } from 'react-native';
-import { getParams as getlnurlParams, LNURLWithdrawParams } from 'js-lnurl';
+import { LNURLWithdrawParams } from 'js-lnurl';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { inject, observer } from 'mobx-react';
 
-import ReactNativeBlobUtil from 'react-native-blob-util';
 import { RectButton, Swipeable } from 'react-native-gesture-handler';
 
-import { doTorRequest, RequestMethod } from '../../utils/TorUtils';
 import BackendUtils from './../../utils/BackendUtils';
 import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
+import { navigateForSelectedPaymentRow } from '../../utils/ChoosePaymentMethodUtils';
 
-import {
-    modalStore,
-    invoicesStore,
-    nodeInfoStore,
-    settingsStore
-} from './../../stores/Stores';
+import { modalStore, nodeInfoStore } from './../../stores/Stores';
 import SyncStore from '../../stores/SyncStore';
 
 import Receive from './../../assets/images/SVG/Receive.svg';
@@ -212,109 +206,6 @@ export default class LightningSwipeableRow extends Component<
         }
     };
 
-    private handleLnurlRequest = async (
-        lightning?: string,
-        lnurlParams?: any,
-        navigation?: any,
-        settings?: any
-    ): Promise<void> => {
-        const params = lnurlParams || (await getlnurlParams(lightning ?? ''));
-        if (
-            params &&
-            params.status === 'ERROR' &&
-            params.domain?.endsWith('.onion')
-        ) {
-            // TODO handle fetching of params with internal Tor
-            throw new Error(`${params.domain} says: ${params.reason}`);
-        }
-        switch (params.tag) {
-            case 'payRequest':
-                params.lnurlText = lightning;
-                navigation.navigate('LnurlPay', {
-                    lnurlParams: params,
-                    ecash:
-                        BackendUtils.supportsCashuWallet() &&
-                        settings?.ecash?.enableCashu
-                });
-                break;
-            case 'withdrawRequest':
-                navigation.navigate('Receive', {
-                    lnurlParams: params
-                });
-                break;
-            default:
-                Alert.alert(
-                    localeString('general.error'),
-                    params.status === 'ERROR'
-                        ? `${params.domain} says: ${params.reason}`
-                        : `${localeString(
-                              'utils.handleAnything.unsupportedLnurlType'
-                          )}: ${params.tag}`,
-                    [
-                        {
-                            text: localeString('general.ok'),
-                            onPress: () => void 0
-                        }
-                    ],
-                    { cancelable: false }
-                );
-        }
-    };
-    private handleLightningAddress = async (
-        lightningAddress: string,
-        navigation: any,
-        settings: any
-    ): Promise<void> => {
-        const [username, bolt11Domain] = lightningAddress.split('@');
-        const url = bolt11Domain.includes('.onion')
-            ? `http://${bolt11Domain}/.well-known/lnurlp/${username.toLowerCase()}`
-            : `https://${bolt11Domain}/.well-known/lnurlp/${username.toLowerCase()}`;
-
-        const error = localeString(
-            'utils.handleAnything.lightningAddressError'
-        );
-
-        if (settingsStore.enableTor && bolt11Domain.includes('.onion')) {
-            await doTorRequest(url, RequestMethod.GET)
-                .then((response: any) => {
-                    if (!response.callback) {
-                        throw new Error(error);
-                    }
-                    navigation.navigate('LnurlPay', {
-                        lnurlParams: response,
-                        ecash:
-                            BackendUtils.supportsCashuWallet() &&
-                            settings?.ecash?.enableCashu,
-                        lightningAddress
-                    });
-                })
-                .catch((error: any) => {
-                    throw new Error(error);
-                });
-        } else {
-            await ReactNativeBlobUtil.fetch('get', url).then(
-                (response: any) => {
-                    const status = response.info().status;
-                    if (status === 200) {
-                        const data = response.json();
-                        if (!data.callback) {
-                            throw new Error(error);
-                        }
-                        navigation.navigate('LnurlPay', {
-                            lnurlParams: data,
-                            ecash:
-                                BackendUtils.supportsCashuWallet() &&
-                                settings?.ecash?.enableCashu,
-                            lightningAddress
-                        });
-                    } else {
-                        throw new Error(error);
-                    }
-                }
-            );
-        }
-    };
-
     private fetchLnInvoice = async () => {
         const {
             lightning,
@@ -324,34 +215,23 @@ export default class LightningSwipeableRow extends Component<
             navigation,
             lnurlParams
         } = this.props;
-        const { settings } = settingsStore;
-        if (clinkNoffer) {
-            this.props.navigation.navigate('ClinkPay', {
-                noffer: clinkNoffer
-            });
-        } else if (offer) {
-            this.props.navigation.navigate('Send', {
-                destination: offer,
-                bolt12: offer,
-                transactionType: 'BOLT 12',
-                isValid: true
-            });
-        } else if (lightningAddress) {
-            this.handleLightningAddress(lightningAddress, navigation, settings);
-        } else if (
-            lightning?.toLowerCase().startsWith('lnurl') ||
-            lnurlParams
-        ) {
-            this.handleLnurlRequest(
-                lightning,
-                lnurlParams,
-                navigation,
-                settings
-            );
-        } else {
-            invoicesStore.getPayReq(lightning ?? '');
-            navigation.navigate('PaymentRequest', {});
-        }
+
+        const row = clinkNoffer
+            ? { layer: 'CLINK' as const }
+            : offer
+            ? { layer: 'Offer' as const }
+            : lightningAddress
+            ? { layer: 'Lightning address' as const }
+            : { layer: 'Lightning' as const };
+
+        await navigateForSelectedPaymentRow(
+            navigation,
+            row,
+            { lightning, lightningAddress, offer, clinkNoffer, lnurlParams },
+            { replace: false }
+        ).catch((error) => {
+            Alert.alert(localeString('general.error'), error.message);
+        });
     };
 
     render() {

--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -17,7 +17,10 @@ import { RectButton, Swipeable } from 'react-native-gesture-handler';
 import BackendUtils from './../../utils/BackendUtils';
 import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
-import { navigateForSelectedPaymentRow } from '../../utils/ChoosePaymentMethodUtils';
+import {
+    navigateForSelectedPaymentRow,
+    PaymentMethodLayer
+} from '../../utils/ChoosePaymentMethodUtils';
 
 import { modalStore, nodeInfoStore } from './../../stores/Stores';
 import SyncStore from '../../stores/SyncStore';
@@ -217,12 +220,12 @@ export default class LightningSwipeableRow extends Component<
         } = this.props;
 
         const row = clinkNoffer
-            ? { layer: 'CLINK' as const }
+            ? { layer: PaymentMethodLayer.Clink }
             : offer
-            ? { layer: 'Offer' as const }
+            ? { layer: PaymentMethodLayer.Offer }
             : lightningAddress
-            ? { layer: 'Lightning address' as const }
-            : { layer: 'Lightning' as const };
+            ? { layer: PaymentMethodLayer.LightningAddress }
+            : { layer: PaymentMethodLayer.Lightning };
 
         await navigateForSelectedPaymentRow(
             navigation,

--- a/components/LayerBalances/OnchainSwipeableRow.tsx
+++ b/components/LayerBalances/OnchainSwipeableRow.tsx
@@ -5,7 +5,8 @@ import {
     Text,
     View,
     I18nManager,
-    TouchableOpacity
+    TouchableOpacity,
+    Alert
 } from 'react-native';
 import { RectButton, Swipeable } from 'react-native-gesture-handler';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -14,6 +15,7 @@ import { inject, observer } from 'mobx-react';
 import BackendUtils from './../../utils/BackendUtils';
 import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
+import { navigateForSelectedPaymentRow } from '../../utils/ChoosePaymentMethodUtils';
 
 import { modalStore } from './../../stores/Stores';
 import SyncStore from '../../stores/SyncStore';
@@ -169,12 +171,18 @@ export default class OnchainSwipeableRow extends Component<
     };
 
     private sendToAddress = () => {
-        const { navigation, value, satAmount, feeRate } = this.props;
-        navigation.navigate('Send', {
-            destination: value,
-            satAmount,
-            fee: feeRate,
-            transactionType: 'On-chain'
+        const { navigation, value, satAmount, feeRate, account } = this.props;
+        const acct = account ?? 'default';
+        navigateForSelectedPaymentRow(
+            navigation,
+            {
+                layer: acct === 'default' ? 'On-chain' : acct,
+                account: acct
+            },
+            { value, satAmount, feeRate },
+            { replace: false }
+        ).catch((error) => {
+            Alert.alert(localeString('general.error'), error.message);
         });
     };
 

--- a/components/LayerBalances/OnchainSwipeableRow.tsx
+++ b/components/LayerBalances/OnchainSwipeableRow.tsx
@@ -15,7 +15,10 @@ import { inject, observer } from 'mobx-react';
 import BackendUtils from './../../utils/BackendUtils';
 import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
-import { navigateForSelectedPaymentRow } from '../../utils/ChoosePaymentMethodUtils';
+import {
+    navigateForSelectedPaymentRow,
+    PaymentMethodLayer
+} from '../../utils/ChoosePaymentMethodUtils';
 
 import { modalStore } from './../../stores/Stores';
 import SyncStore from '../../stores/SyncStore';
@@ -62,7 +65,10 @@ export default class OnchainSwipeableRow extends Component<
 
             if (text === localeString('general.receive')) {
                 navigation.navigate('Receive', {
-                    account: account === 'On-chain' ? 'default' : account,
+                    account:
+                        account === PaymentMethodLayer.OnChain
+                            ? 'default'
+                            : account,
                     autoGenerateOnChain: true,
                     forceOnChain: true
                 });
@@ -176,7 +182,7 @@ export default class OnchainSwipeableRow extends Component<
         navigateForSelectedPaymentRow(
             navigation,
             {
-                layer: acct === 'default' ? 'On-chain' : acct,
+                layer: acct === 'default' ? PaymentMethodLayer.OnChain : acct,
                 account: acct
             },
             { value, satAmount, feeRate },

--- a/components/LayerBalances/PaymentMethodList.tsx
+++ b/components/LayerBalances/PaymentMethodList.tsx
@@ -19,7 +19,8 @@ import type {
 } from '../../utils/ChoosePaymentMethodUtils';
 import {
     buildPaymentMethodListRows,
-    hasInsufficientBalance
+    hasInsufficientBalance,
+    PaymentMethodLayer
 } from '../../utils/ChoosePaymentMethodUtils';
 
 import OnChainSvg from '../../components/SVG/OnChainSvg';
@@ -47,12 +48,13 @@ interface PaymentMethodListProps {
 I18nManager.allowRTL(false);
 
 const LAYER_LOCALE_MAP: Record<string, string> = {
-    Lightning: 'general.lightning',
-    'Lightning via ecash': 'components.LayerBalances.lightningViaEcash',
-    'Lightning address': 'general.lightningAddress',
-    Offer: 'views.Settings.Bolt12Offer',
-    CLINK: 'views.Settings.Noffer',
-    'On-chain': 'general.onchain'
+    [PaymentMethodLayer.Lightning]: 'general.lightning',
+    [PaymentMethodLayer.LightningViaEcash]:
+        'components.LayerBalances.lightningViaEcash',
+    [PaymentMethodLayer.LightningAddress]: 'general.lightningAddress',
+    [PaymentMethodLayer.Offer]: 'views.Settings.Bolt12Offer',
+    [PaymentMethodLayer.Clink]: 'views.Settings.Noffer',
+    [PaymentMethodLayer.OnChain]: 'general.onchain'
 };
 
 const getGradientColors = (): [string, string] => {
@@ -63,9 +65,14 @@ const getGradientColors = (): [string, string] => {
 };
 
 const LayerIcon = ({ layer }: { layer: string }) => {
-    if (layer === 'Lightning via ecash') return <EcashSvg />;
-    if (layer === 'On-chain') return <OnChainSvg />;
-    if (['Lightning', 'Lightning address', 'Offer', 'CLINK'].includes(layer))
+    if (layer === PaymentMethodLayer.LightningViaEcash) return <EcashSvg />;
+    if (layer === PaymentMethodLayer.OnChain) return <OnChainSvg />;
+    if (
+        layer === PaymentMethodLayer.Lightning ||
+        layer === PaymentMethodLayer.LightningAddress ||
+        layer === PaymentMethodLayer.Offer ||
+        layer === PaymentMethodLayer.Clink
+    )
         return <LightningSvg />;
     return <OnChainSvg />;
 };
@@ -167,7 +174,7 @@ const SwipeableRow = ({
 }) => {
     const insufficient = hasInsufficientBalance(item.balance, item.satAmount);
     const rowDisabled = item.disabled || insufficient;
-    if (item.layer === 'Lightning') {
+    if (item.layer === PaymentMethodLayer.Lightning) {
         return (
             <LightningSwipeableRow
                 navigation={navigation}
@@ -181,7 +188,7 @@ const SwipeableRow = ({
         );
     }
 
-    if (item.layer === 'Lightning address') {
+    if (item.layer === PaymentMethodLayer.LightningAddress) {
         return (
             <LightningSwipeableRow
                 navigation={navigation}
@@ -194,7 +201,7 @@ const SwipeableRow = ({
         );
     }
 
-    if (item.layer === 'Lightning via ecash') {
+    if (item.layer === PaymentMethodLayer.LightningViaEcash) {
         return (
             <EcashSwipeableRow
                 navigation={navigation}
@@ -208,7 +215,7 @@ const SwipeableRow = ({
         );
     }
 
-    if (item.layer === 'Offer') {
+    if (item.layer === PaymentMethodLayer.Offer) {
         return (
             <LightningSwipeableRow
                 navigation={navigation}
@@ -221,7 +228,7 @@ const SwipeableRow = ({
         );
     }
 
-    if (item.layer === 'CLINK') {
+    if (item.layer === PaymentMethodLayer.Clink) {
         // The row's balance/satAmount (when populated for Fixed noffers)
         // already reflects the larger of lightning and ecash, so the
         // standard insufficient-balance check is correct here. For
@@ -239,7 +246,7 @@ const SwipeableRow = ({
         );
     }
 
-    if (item.layer === 'On-chain' || item.account) {
+    if (item.layer === PaymentMethodLayer.OnChain || item.account) {
         return (
             <OnchainSwipeableRow
                 navigation={navigation}

--- a/components/LayerBalances/PaymentMethodList.tsx
+++ b/components/LayerBalances/PaymentMethodList.tsx
@@ -11,16 +11,20 @@ import LightningSwipeableRow from './LightningSwipeableRow';
 import EcashSwipeableRow from './EcashSwipeableRow';
 import Amount from '../Amount';
 
-import BackendUtils from '../../utils/BackendUtils';
-import { decodeNoffer, NofferPriceType } from '../../utils/ClinkUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
+import type {
+    PaymentMethodListAccount,
+    PaymentMethodListRow
+} from '../../utils/ChoosePaymentMethodUtils';
+import {
+    buildPaymentMethodListRows,
+    hasInsufficientBalance
+} from '../../utils/ChoosePaymentMethodUtils';
 
 import OnChainSvg from '../../components/SVG/OnChainSvg';
 import LightningSvg from '../../components/SVG/LightningSvg';
 import EcashSvg from '../../components/SVG/EcashSvg';
-
-import { nodeInfoStore, settingsStore } from '../../stores/Stores';
 
 interface PaymentMethodListProps {
     navigation: NativeStackNavigationProp<any, any>;
@@ -36,27 +40,11 @@ interface PaymentMethodListProps {
     lightningBalance?: number | string;
     onchainBalance?: number | string;
     ecashBalance?: number | string;
-    accounts?: Array<{
-        name: string;
-        balance: number;
-        XFP?: string;
-        watch_only?: boolean;
-        hidden?: boolean;
-    }>;
+    accounts?: PaymentMethodListAccount[];
 }
 
 //  To toggle LTR/RTL change to `true`
 I18nManager.allowRTL(false);
-
-type DataRow = {
-    layer: string;
-    subtitle?: string;
-    disabled?: boolean;
-    balance?: number | string;
-    account?: string;
-    hidden?: boolean;
-    satAmount?: number;
-};
 
 const LAYER_LOCALE_MAP: Record<string, string> = {
     Lightning: 'general.lightning',
@@ -82,14 +70,7 @@ const LayerIcon = ({ layer }: { layer: string }) => {
     return <OnChainSvg />;
 };
 
-const hasInsufficientBalance = (
-    balance: number | string | undefined,
-    satAmount: number | undefined
-) =>
-    Number(balance) === 0 ||
-    (satAmount !== undefined && satAmount > Number(balance));
-
-const Row = ({ item }: { item: DataRow }) => {
+const Row = ({ item }: { item: PaymentMethodListRow }) => {
     const insufficient = hasInsufficientBalance(item.balance, item.satAmount);
     const layerLabel = LAYER_LOCALE_MAP[item.layer]
         ? localeString(LAYER_LOCALE_MAP[item.layer])
@@ -172,7 +153,7 @@ const SwipeableRow = ({
     clinkNoffer,
     lnurlParams
 }: {
-    item: DataRow;
+    item: PaymentMethodListRow;
     index: number;
     navigation: NativeStackNavigationProp<any, any>;
     value?: string;
@@ -280,142 +261,6 @@ export default class PaymentMethodList extends Component<
     PaymentMethodListProps,
     {}
 > {
-    private buildData = (satAmount: number | undefined): DataRow[] => {
-        const {
-            value,
-            lightning,
-            lightningAddress,
-            offer,
-            clinkNoffer,
-            lnurlParams,
-            lightningBalance,
-            onchainBalance,
-            ecashBalance,
-            accounts
-        } = this.props;
-        let DATA: DataRow[] = [];
-
-        if (lightning || lnurlParams) {
-            DATA.push({
-                layer: 'Lightning',
-                subtitle: lightning ?? lnurlParams?.tag,
-                balance: lightningBalance,
-                disabled: false,
-                satAmount
-            });
-
-            if (
-                BackendUtils.supportsCashuWallet() &&
-                settingsStore?.settings?.ecash?.enableCashu
-            ) {
-                DATA.push({
-                    layer: 'Lightning via ecash',
-                    subtitle: lightning ?? lnurlParams?.tag,
-                    balance: ecashBalance,
-                    disabled: false,
-                    satAmount
-                });
-            }
-        }
-
-        if (lightningAddress) {
-            DATA.push({
-                layer: 'Lightning address',
-                subtitle: lightningAddress,
-                balance: lightningBalance,
-                disabled: false,
-                satAmount
-            });
-        }
-
-        if (offer) {
-            DATA.push({
-                layer: 'Offer',
-                subtitle: offer,
-                disabled: !nodeInfoStore.supportsOffers,
-                balance: lightningBalance,
-                satAmount
-            });
-        }
-
-        // Only show on-chain balance for non-Lnbank accounts
-        if (value && BackendUtils.supportsOnchainReceiving()) {
-            DATA.push({
-                layer: 'On-chain',
-                subtitle: value,
-                disabled: !BackendUtils.supportsOnchainSends(),
-                balance: onchainBalance,
-                account: 'default',
-                satAmount
-            });
-
-            if (accounts && accounts.length > 0) {
-                accounts.forEach((account) => {
-                    if (!account.hidden && !account.watch_only) {
-                        DATA.push({
-                            layer: account.name,
-                            subtitle: value ?? account.XFP,
-                            disabled: false,
-                            balance: account.balance,
-                            account: account.name,
-                            hidden: account.hidden,
-                            satAmount
-                        });
-                    }
-                });
-            }
-        }
-
-        // Rendered after the balance-backed rows so the UI groups
-        // "buckets you can spend from" together up top, with the noffer
-        // (which spans lightning + ecash and may have no known amount)
-        // sitting beneath them.
-        if (clinkNoffer) {
-            // Only Fixed-price noffers carry the amount in the bech32 itself.
-            // Variable and Spontaneous noffers have no amount until the
-            // service returns a bolt11, so a balance comparison here would
-            // be meaningless.
-            let embeddedAmount: number | undefined;
-            try {
-                const decoded = decodeNoffer(clinkNoffer);
-                if (
-                    decoded.priceType === NofferPriceType.Fixed &&
-                    typeof decoded.price === 'number' &&
-                    decoded.price > 0
-                ) {
-                    embeddedAmount = decoded.price;
-                }
-            } catch {}
-            // ClinkPay can settle the returned bolt11 via either the
-            // lightning balance or ecash, so the row's balance is the
-            // larger of the two (ecash only counts when cashu is enabled).
-            // Using the max means the row is enabled iff at least one
-            // bucket alone can cover the amount.
-            const ecashAvailable =
-                BackendUtils.supportsCashuWallet() &&
-                settingsStore?.settings?.ecash?.enableCashu;
-            const clinkBalance = Math.max(
-                Number(lightningBalance ?? 0),
-                ecashAvailable ? Number(ecashBalance ?? 0) : 0
-            );
-            DATA.push({
-                layer: 'CLINK',
-                subtitle: clinkNoffer,
-                // No funds in either bucket means no path to pay,
-                // regardless of the noffer's pricing type.
-                disabled: clinkBalance === 0,
-                ...(embeddedAmount !== undefined && {
-                    balance: clinkBalance,
-                    // Compare against the noffer's embedded price (the
-                    // amount that will actually be paid) rather than any
-                    // BIP21 `amount=` that may have come in separately.
-                    satAmount: embeddedAmount
-                })
-            });
-        }
-        return DATA;
-    };
-
     render() {
         const {
             navigation,
@@ -426,13 +271,28 @@ export default class PaymentMethodList extends Component<
             lightningAddress,
             offer,
             clinkNoffer,
-            lnurlParams
+            lnurlParams,
+            accounts
         } = this.props;
         const satAmountNum =
             satAmount !== undefined && !isNaN(Number(satAmount))
                 ? Number(satAmount)
                 : undefined;
-        const DATA = this.buildData(satAmountNum);
+        const DATA = buildPaymentMethodListRows(
+            {
+                value,
+                lightning,
+                lightningAddress,
+                offer,
+                clinkNoffer,
+                lnurlParams,
+                lightningBalance: this.props.lightningBalance,
+                onchainBalance: this.props.onchainBalance,
+                ecashBalance: this.props.ecashBalance,
+                accounts
+            },
+            satAmountNum
+        );
         return (
             <View style={{ flex: 1 }}>
                 <FlatList

--- a/components/LayerBalances/index.tsx
+++ b/components/LayerBalances/index.tsx
@@ -30,6 +30,7 @@ import UTXOsStore from '../../stores/UTXOsStore';
 import SettingsStore from '../../stores/SettingsStore';
 
 import BackendUtils from '../../utils/BackendUtils';
+import { PaymentMethodLayer } from '../../utils/ChoosePaymentMethodUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { blendHexColors, themeColor } from '../../utils/ThemeUtils';
 
@@ -198,9 +199,9 @@ const Row = ({ item }: { item: DataRow }) => {
                     <MatiSvg />
                 ) : isEcash ? (
                     <EcashSvg />
-                ) : item.layer === 'On-chain' ? (
+                ) : item.layer === PaymentMethodLayer.OnChain ? (
                     <OnChainSvg />
-                ) : item.layer === 'Lightning' ? (
+                ) : item.layer === PaymentMethodLayer.Lightning ? (
                     <LightningSvg />
                 ) : moreAccounts ? null : (
                     <OnChainSvg />
@@ -220,9 +221,9 @@ const Row = ({ item }: { item: DataRow }) => {
                                 themeColor('buttonText') || themeColor('text')
                         }}
                     >
-                        {item.layer === 'Lightning'
+                        {item.layer === PaymentMethodLayer.Lightning
                             ? localeString('general.lightning')
-                            : item.layer === 'On-chain'
+                            : item.layer === PaymentMethodLayer.OnChain
                             ? localeString('general.onchain')
                             : item.layer}
                     </Text>
@@ -342,7 +343,7 @@ const SwipeableRow = ({
         );
     }
 
-    if (item.layer === 'Lightning') {
+    if (item.layer === PaymentMethodLayer.Lightning) {
         return (
             <LightningSwipeableRow
                 navigation={navigation}
@@ -355,7 +356,7 @@ const SwipeableRow = ({
         );
     }
 
-    if (item.layer === 'On-chain') {
+    if (item.layer === PaymentMethodLayer.OnChain) {
         return (
             <OnchainSwipeableRow
                 navigation={navigation}
@@ -452,13 +453,13 @@ export default class LayerBalances extends Component<LayerBalancesProps, {}> {
         let DATA: DataRow[] = [];
 
         DATA.push({
-            layer: 'Lightning',
+            layer: PaymentMethodLayer.Lightning,
             balance: Number(lightningBalance).toFixed(3)
         });
 
         if (BackendUtils.supportsOnchainReceiving()) {
             DATA.push({
-                layer: 'On-chain',
+                layer: PaymentMethodLayer.OnChain,
                 balance: Number(totalBlockchainBalance).toFixed(3)
             });
         }

--- a/utils/ChoosePaymentMethodUtils.ts
+++ b/utils/ChoosePaymentMethodUtils.ts
@@ -1,0 +1,399 @@
+/**
+ * Shared helpers for ChoosePaymentMethod, PaymentMethodList, and swipeable rows:
+ * building payment-method rows, selectability checks, and navigation for a chosen row.
+ */
+import { Alert } from 'react-native';
+import { getParams as getlnurlParams, LNURLWithdrawParams } from 'js-lnurl';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import ReactNativeBlobUtil from 'react-native-blob-util';
+
+import BackendUtils from './BackendUtils';
+import { decodeNoffer, NofferPriceType } from './ClinkUtils';
+import { localeString } from './LocaleUtils';
+import { doTorRequest, RequestMethod } from './TorUtils';
+
+import {
+    cashuStore,
+    invoicesStore,
+    nodeInfoStore,
+    settingsStore
+} from '../stores/Stores';
+
+export type PaymentMethodListAccount = {
+    name: string;
+    balance: number;
+    XFP?: string;
+    watch_only?: boolean;
+    hidden?: boolean;
+};
+
+/** Props needed to build list rows (no navigation / feeRate). */
+export type PaymentMethodListRowsInput = {
+    value?: string;
+    lightning?: string;
+    lightningAddress?: string;
+    offer?: string;
+    clinkNoffer?: string;
+    lnurlParams?: LNURLWithdrawParams | undefined;
+    lightningBalance?: number | string;
+    onchainBalance?: number | string;
+    ecashBalance?: number | string;
+    accounts?: PaymentMethodListAccount[];
+};
+
+export type PaymentMethodListRow = {
+    layer: string;
+    subtitle?: string;
+    disabled?: boolean;
+    balance?: number | string;
+    account?: string;
+    hidden?: boolean;
+    satAmount?: number;
+};
+
+export type LockedPaymentMethodNavigationContext = {
+    lightning?: string;
+    lightningAddress?: string;
+    offer?: string;
+    clinkNoffer?: string;
+    lnurlParams?: LNURLWithdrawParams;
+    value?: string;
+    satAmount?: number;
+    feeRate?: string;
+};
+
+type StackNav = NativeStackNavigationProp<any, any>;
+
+export function hasInsufficientBalance(
+    balance: number | string | undefined,
+    satAmount: number | undefined
+): boolean {
+    return (
+        Number(balance) === 0 ||
+        (satAmount !== undefined && satAmount > Number(balance))
+    );
+}
+
+export function buildPaymentMethodListRows(
+    props: PaymentMethodListRowsInput,
+    satAmount: number | undefined
+): PaymentMethodListRow[] {
+    const {
+        value,
+        lightning,
+        lightningAddress,
+        offer,
+        clinkNoffer,
+        lnurlParams,
+        lightningBalance,
+        onchainBalance,
+        ecashBalance,
+        accounts
+    } = props;
+    const rows: PaymentMethodListRow[] = [];
+
+    if (lightning || lnurlParams) {
+        rows.push({
+            layer: 'Lightning',
+            subtitle: lightning ?? lnurlParams?.tag,
+            balance: lightningBalance,
+            disabled: false,
+            satAmount
+        });
+
+        if (
+            BackendUtils.supportsCashuWallet() &&
+            settingsStore?.settings?.ecash?.enableCashu
+        ) {
+            rows.push({
+                layer: 'Lightning via ecash',
+                subtitle: lightning ?? lnurlParams?.tag,
+                balance: ecashBalance,
+                disabled: false,
+                satAmount
+            });
+        }
+    }
+
+    if (lightningAddress) {
+        rows.push({
+            layer: 'Lightning address',
+            subtitle: lightningAddress,
+            balance: lightningBalance,
+            disabled: false,
+            satAmount
+        });
+    }
+
+    if (offer) {
+        rows.push({
+            layer: 'Offer',
+            subtitle: offer,
+            disabled: !nodeInfoStore.supportsOffers,
+            balance: lightningBalance,
+            satAmount
+        });
+    }
+
+    if (value && BackendUtils.supportsOnchainReceiving()) {
+        rows.push({
+            layer: 'On-chain',
+            subtitle: value,
+            disabled: !BackendUtils.supportsOnchainSends(),
+            balance: onchainBalance,
+            account: 'default',
+            satAmount
+        });
+
+        if (accounts && accounts.length > 0) {
+            accounts.forEach((account) => {
+                if (!account.hidden && !account.watch_only) {
+                    rows.push({
+                        layer: account.name,
+                        subtitle: value ?? account.XFP,
+                        disabled: false,
+                        balance: account.balance,
+                        account: account.name,
+                        hidden: account.hidden,
+                        satAmount
+                    });
+                }
+            });
+        }
+    }
+
+    if (clinkNoffer) {
+        let embeddedAmount: number | undefined;
+        try {
+            const decoded = decodeNoffer(clinkNoffer);
+            if (
+                decoded.priceType === NofferPriceType.Fixed &&
+                typeof decoded.price === 'number' &&
+                decoded.price > 0
+            ) {
+                embeddedAmount = decoded.price;
+            }
+        } catch {}
+        const ecashAvailable =
+            BackendUtils.supportsCashuWallet() &&
+            settingsStore?.settings?.ecash?.enableCashu;
+        const clinkBalance = Math.max(
+            Number(lightningBalance ?? 0),
+            ecashAvailable ? Number(ecashBalance ?? 0) : 0
+        );
+        rows.push({
+            layer: 'CLINK',
+            subtitle: clinkNoffer,
+            disabled: clinkBalance === 0,
+            ...(embeddedAmount !== undefined && {
+                balance: clinkBalance,
+                satAmount: embeddedAmount
+            })
+        });
+    }
+    return rows;
+}
+
+export function isPaymentMethodListRowSelectable(
+    row: PaymentMethodListRow
+): boolean {
+    return !row.disabled && !hasInsufficientBalance(row.balance, row.satAmount);
+}
+
+// ─── Navigation (single implementation for list rows and auto-skip) ─────────
+
+function go(
+    navigation: StackNav,
+    useReplace: boolean,
+    name: string,
+    params?: object
+): void {
+    if (useReplace) {
+        navigation.replace(name, params);
+    } else {
+        navigation.navigate(name, params);
+    }
+}
+
+async function handleLnurlRequest(
+    lightning: string | undefined,
+    lnurlParams: LNURLWithdrawParams | undefined,
+    navigation: StackNav,
+    useReplace: boolean,
+    variant: 'lightning' | 'ecash'
+): Promise<void> {
+    const params: any = lnurlParams || (await getlnurlParams(lightning ?? ''));
+    if (params?.status === 'ERROR' && params.domain?.endsWith('.onion')) {
+        throw new Error(`${params.domain} says: ${params.reason}`);
+    }
+    switch (params.tag) {
+        case 'payRequest':
+            params.lnurlText = lightning;
+            go(navigation, useReplace, 'LnurlPay', {
+                lnurlParams: params,
+                ecash:
+                    variant === 'ecash'
+                        ? true
+                        : BackendUtils.supportsCashuWallet() &&
+                          settingsStore.settings?.ecash?.enableCashu
+            });
+            break;
+        case 'withdrawRequest':
+            go(
+                navigation,
+                useReplace,
+                variant === 'ecash' ? 'ReceiveEcash' : 'Receive',
+                { lnurlParams: params }
+            );
+            break;
+        default:
+            Alert.alert(
+                localeString('general.error'),
+                params.status === 'ERROR'
+                    ? `${params.domain} says: ${params.reason}`
+                    : `${localeString(
+                          'utils.handleAnything.unsupportedLnurlType'
+                      )}: ${params.tag}`,
+                [
+                    {
+                        text: localeString('general.ok'),
+                        onPress: () => void 0
+                    }
+                ],
+                { cancelable: false }
+            );
+    }
+}
+
+async function lightningLnAddress(
+    lightningAddress: string,
+    navigation: StackNav,
+    useReplace: boolean
+): Promise<void> {
+    const [username, bolt11Domain] = lightningAddress.split('@');
+    const url = bolt11Domain.includes('.onion')
+        ? `http://${bolt11Domain}/.well-known/lnurlp/${username.toLowerCase()}`
+        : `https://${bolt11Domain}/.well-known/lnurlp/${username.toLowerCase()}`;
+
+    const error = localeString('utils.handleAnything.lightningAddressError');
+    const ecash =
+        BackendUtils.supportsCashuWallet() &&
+        settingsStore.settings?.ecash?.enableCashu;
+
+    const onLnurlp = (data: { callback?: string }) => {
+        if (!data.callback) {
+            throw new Error(error);
+        }
+        go(navigation, useReplace, 'LnurlPay', {
+            lnurlParams: data,
+            ecash,
+            lightningAddress
+        });
+    };
+
+    if (settingsStore.enableTor && bolt11Domain.includes('.onion')) {
+        const response = await doTorRequest(url, RequestMethod.GET);
+        if (!response.callback) {
+            throw new Error(error);
+        }
+        onLnurlp(response);
+    } else {
+        const response = await ReactNativeBlobUtil.fetch('get', url);
+        if (response.info().status !== 200) {
+            throw new Error(error);
+        }
+        onLnurlp(response.json());
+    }
+}
+
+function navigateLightningRoute(
+    ctx: LockedPaymentMethodNavigationContext,
+    navigation: StackNav,
+    useReplace: boolean
+): Promise<void> {
+    const { lightning, lightningAddress, offer, lnurlParams } = ctx;
+
+    if (offer) {
+        go(navigation, useReplace, 'Send', {
+            destination: offer,
+            bolt12: offer,
+            transactionType: 'BOLT 12',
+            isValid: true
+        });
+        return Promise.resolve();
+    }
+    if (lightningAddress) {
+        return lightningLnAddress(lightningAddress, navigation, useReplace);
+    }
+    if (lightning?.toLowerCase().startsWith('lnurl') || lnurlParams) {
+        return handleLnurlRequest(
+            lightning,
+            lnurlParams,
+            navigation,
+            useReplace,
+            'lightning'
+        );
+    }
+    invoicesStore.getPayReq(lightning ?? '');
+    go(navigation, useReplace, 'PaymentRequest', {});
+    return Promise.resolve();
+}
+
+function navigateEcashRoute(
+    ctx: LockedPaymentMethodNavigationContext,
+    navigation: StackNav,
+    useReplace: boolean
+): Promise<void> {
+    const { lightning, lnurlParams } = ctx;
+    if (lightning?.toLowerCase().startsWith('lnurl') || lnurlParams) {
+        return handleLnurlRequest(
+            lightning,
+            lnurlParams,
+            navigation,
+            useReplace,
+            'ecash'
+        );
+    }
+    cashuStore.getPayReq(lightning ?? '');
+    go(navigation, useReplace, 'CashuPaymentRequest', {});
+    return Promise.resolve();
+}
+
+/**
+ * Navigates to the payment flow screen for an already-selected payment list row.
+ */
+export async function navigateForSelectedPaymentRow(
+    navigation: StackNav,
+    row: PaymentMethodListRow,
+    ctx: LockedPaymentMethodNavigationContext,
+    options: { replace: boolean }
+): Promise<void> {
+    const { replace } = options;
+
+    if (row.layer === 'Lightning' || row.layer === 'Offer') {
+        await navigateLightningRoute(ctx, navigation, replace);
+        return;
+    }
+    if (row.layer === 'Lightning address') {
+        if (!ctx.lightningAddress) return;
+        await lightningLnAddress(ctx.lightningAddress, navigation, replace);
+        return;
+    }
+    if (row.layer === 'Lightning via ecash') {
+        await navigateEcashRoute(ctx, navigation, replace);
+        return;
+    }
+    if (row.layer === 'CLINK') {
+        if (!ctx.clinkNoffer) return;
+        go(navigation, replace, 'ClinkPay', { noffer: ctx.clinkNoffer });
+        return;
+    }
+    if (row.layer === 'On-chain' || row.account) {
+        go(navigation, replace, 'Send', {
+            destination: ctx.value,
+            satAmount: ctx.satAmount,
+            fee: ctx.feeRate,
+            transactionType: 'On-chain'
+        });
+    }
+}

--- a/utils/ChoosePaymentMethodUtils.ts
+++ b/utils/ChoosePaymentMethodUtils.ts
@@ -19,6 +19,15 @@ import {
     settingsStore
 } from '../stores/Stores';
 
+export enum PaymentMethodLayer {
+    Lightning = 'Lightning',
+    LightningViaEcash = 'Lightning via ecash',
+    LightningAddress = 'Lightning address',
+    Offer = 'Offer',
+    Clink = 'CLINK',
+    OnChain = 'On-chain'
+}
+
 export type PaymentMethodListAccount = {
     name: string;
     balance: number;
@@ -51,7 +60,7 @@ export type PaymentMethodListRow = {
     satAmount?: number;
 };
 
-export type LockedPaymentMethodNavigationContext = {
+export type PaymentMethodNavigationContext = {
     lightning?: string;
     lightningAddress?: string;
     offer?: string;
@@ -94,7 +103,7 @@ export function buildPaymentMethodListRows(
 
     if (lightning || lnurlParams) {
         rows.push({
-            layer: 'Lightning',
+            layer: PaymentMethodLayer.Lightning,
             subtitle: lightning ?? lnurlParams?.tag,
             balance: lightningBalance,
             disabled: false,
@@ -106,7 +115,7 @@ export function buildPaymentMethodListRows(
             settingsStore?.settings?.ecash?.enableCashu
         ) {
             rows.push({
-                layer: 'Lightning via ecash',
+                layer: PaymentMethodLayer.LightningViaEcash,
                 subtitle: lightning ?? lnurlParams?.tag,
                 balance: ecashBalance,
                 disabled: false,
@@ -117,7 +126,7 @@ export function buildPaymentMethodListRows(
 
     if (lightningAddress) {
         rows.push({
-            layer: 'Lightning address',
+            layer: PaymentMethodLayer.LightningAddress,
             subtitle: lightningAddress,
             balance: lightningBalance,
             disabled: false,
@@ -127,7 +136,7 @@ export function buildPaymentMethodListRows(
 
     if (offer) {
         rows.push({
-            layer: 'Offer',
+            layer: PaymentMethodLayer.Offer,
             subtitle: offer,
             disabled: !nodeInfoStore.supportsOffers,
             balance: lightningBalance,
@@ -137,7 +146,7 @@ export function buildPaymentMethodListRows(
 
     if (value && BackendUtils.supportsOnchainReceiving()) {
         rows.push({
-            layer: 'On-chain',
+            layer: PaymentMethodLayer.OnChain,
             subtitle: value,
             disabled: !BackendUtils.supportsOnchainSends(),
             balance: onchainBalance,
@@ -182,7 +191,7 @@ export function buildPaymentMethodListRows(
             ecashAvailable ? Number(ecashBalance ?? 0) : 0
         );
         rows.push({
-            layer: 'CLINK',
+            layer: PaymentMethodLayer.Clink,
             subtitle: clinkNoffer,
             disabled: clinkBalance === 0,
             ...(embeddedAmount !== undefined && {
@@ -307,7 +316,7 @@ async function lightningLnAddress(
 }
 
 function navigateLightningRoute(
-    ctx: LockedPaymentMethodNavigationContext,
+    ctx: PaymentMethodNavigationContext,
     navigation: StackNav,
     useReplace: boolean
 ): Promise<void> {
@@ -340,7 +349,7 @@ function navigateLightningRoute(
 }
 
 function navigateEcashRoute(
-    ctx: LockedPaymentMethodNavigationContext,
+    ctx: PaymentMethodNavigationContext,
     navigation: StackNav,
     useReplace: boolean
 ): Promise<void> {
@@ -365,35 +374,38 @@ function navigateEcashRoute(
 export async function navigateForSelectedPaymentRow(
     navigation: StackNav,
     row: PaymentMethodListRow,
-    ctx: LockedPaymentMethodNavigationContext,
+    ctx: PaymentMethodNavigationContext,
     options: { replace: boolean }
 ): Promise<void> {
     const { replace } = options;
 
-    if (row.layer === 'Lightning' || row.layer === 'Offer') {
+    if (
+        row.layer === PaymentMethodLayer.Lightning ||
+        row.layer === PaymentMethodLayer.Offer
+    ) {
         await navigateLightningRoute(ctx, navigation, replace);
         return;
     }
-    if (row.layer === 'Lightning address') {
+    if (row.layer === PaymentMethodLayer.LightningAddress) {
         if (!ctx.lightningAddress) return;
         await lightningLnAddress(ctx.lightningAddress, navigation, replace);
         return;
     }
-    if (row.layer === 'Lightning via ecash') {
+    if (row.layer === PaymentMethodLayer.LightningViaEcash) {
         await navigateEcashRoute(ctx, navigation, replace);
         return;
     }
-    if (row.layer === 'CLINK') {
+    if (row.layer === PaymentMethodLayer.Clink) {
         if (!ctx.clinkNoffer) return;
         go(navigation, replace, 'ClinkPay', { noffer: ctx.clinkNoffer });
         return;
     }
-    if (row.layer === 'On-chain' || row.account) {
+    if (row.layer === PaymentMethodLayer.OnChain || row.account) {
         go(navigation, replace, 'Send', {
             destination: ctx.value,
             satAmount: ctx.satAmount,
             fee: ctx.feeRate,
-            transactionType: 'On-chain'
+            transactionType: PaymentMethodLayer.OnChain
         });
     }
 }

--- a/views/ChoosePaymentMethod.tsx
+++ b/views/ChoosePaymentMethod.tsx
@@ -8,6 +8,11 @@ import Bolt11Utils from '../utils/Bolt11Utils';
 
 import Header from '../components/Header';
 import PaymentMethodList from '../components/LayerBalances/PaymentMethodList';
+import {
+    buildPaymentMethodListRows,
+    isPaymentMethodListRowSelectable,
+    navigateForSelectedPaymentRow
+} from '../utils/ChoosePaymentMethodUtils';
 import Screen from '../components/Screen';
 import Amount from '../components/Amount';
 import { ErrorMessage } from '../components/SuccessErrorMessage';
@@ -21,7 +26,7 @@ import CashuStore from '../stores/CashuStore';
 import UTXOsStore from '../stores/UTXOsStore';
 import InvoicesStore from '../stores/InvoicesStore';
 
-import { feeStore, settingsStore } from '../stores/Stores';
+import { feeStore, settingsStore, syncStore } from '../stores/Stores';
 
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
@@ -67,6 +72,8 @@ export default class ChoosePaymentMethod extends React.Component<
     private focusUnsubscribe?: () => void;
     private blurUnsubscribe?: () => void;
     private hasNavigatedAway = false;
+    private didReplaceWithSoleMethod = false;
+    private soleMethodReplaceBusy = false;
 
     state = {
         value: '',
@@ -97,6 +104,83 @@ export default class ChoosePaymentMethod extends React.Component<
             this.fetchOnchainFees(value);
         });
     }
+
+    componentDidUpdate() {
+        void this.replacePaymentMethodScreenIfSingleChoice();
+    }
+
+    private replacePaymentMethodScreenIfSingleChoice = async () => {
+        if (
+            this.didReplaceWithSoleMethod ||
+            this.soleMethodReplaceBusy ||
+            syncStore.isSyncing
+        ) {
+            return;
+        }
+
+        const { navigation, BalanceStore, CashuStore, UTXOsStore } = this.props;
+        const {
+            value,
+            satAmount,
+            lightning,
+            lightningAddress,
+            offer,
+            clinkNoffer,
+            lnurlParams,
+            feeRate
+        } = this.state;
+
+        const satAmountNum =
+            satAmount !== '' && !isNaN(Number(satAmount))
+                ? Number(satAmount)
+                : undefined;
+
+        const rows = buildPaymentMethodListRows(
+            {
+                value,
+                lightning,
+                lightningAddress,
+                offer,
+                clinkNoffer,
+                lnurlParams,
+                lightningBalance: BalanceStore!.lightningBalance,
+                onchainBalance: BalanceStore!.totalBlockchainBalance,
+                ecashBalance: CashuStore!.totalBalanceSats,
+                accounts: UTXOsStore!.accounts
+            },
+            satAmountNum
+        );
+
+        const selectableRows = rows.filter(isPaymentMethodListRowSelectable);
+
+        if (selectableRows.length !== 1) {
+            return;
+        }
+
+        this.soleMethodReplaceBusy = true;
+        this.didReplaceWithSoleMethod = true;
+
+        try {
+            await navigateForSelectedPaymentRow(
+                navigation,
+                selectableRows[0],
+                {
+                    lightning,
+                    lightningAddress,
+                    offer,
+                    clinkNoffer,
+                    lnurlParams,
+                    value,
+                    satAmount: satAmountNum,
+                    feeRate
+                },
+                { replace: true }
+            );
+        } catch {
+            this.didReplaceWithSoleMethod = false;
+            this.soleMethodReplaceBusy = false;
+        }
+    };
 
     componentWillUnmount() {
         this.focusUnsubscribe?.();

--- a/views/UTXOs/CoinControl.tsx
+++ b/views/UTXOs/CoinControl.tsx
@@ -11,6 +11,7 @@ import Header from '../../components/Header';
 import LoadingIndicator from './../../components/LoadingIndicator';
 import Screen from './../../components/Screen';
 
+import { PaymentMethodLayer } from './../../utils/ChoosePaymentMethodUtils';
 import { localeString } from './../../utils/LocaleUtils';
 import BackendUtils from './../../utils/BackendUtils';
 import { themeColor } from './../../utils/ThemeUtils';
@@ -44,7 +45,7 @@ export default class CoinControl extends React.Component<
 
         const accountParam = props.route.params.account;
         const account =
-            accountParam && accountParam === 'On-chain'
+            accountParam && accountParam === PaymentMethodLayer.OnChain
                 ? 'default'
                 : accountParam;
 


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This PR removes duplicate Lightning / LNURL / lightning-address / ecash payment routing from the swipeable row components, moves list building and navigation into utils/ChoosePaymentMethodUtils.ts, and replaces the Choose Payment Method screen when exactly one payment method row is selectable (so users are not shown a pointless picker)

### Test Plan 

- [ ]  Open **Choose Payment Method** for a payment where only **one** method is available with balance (e.g single-path invoice or only on-chain). Confirm the screen **skips** to the Choose payment method flow.
- [ ] Open the same screen for a payment with **two+** available methods with balance (e.g. Lightning + e-cash). Confirm the **list** appears and each option still opens the expected screen.
- [ ]  On the list, **swipe Send** on Lightning and (if shown) ecash / on-chain rows; confirm navigation matches inten 
- [ ]  start while **wallet is syncing**—if skip does not run until sync ends, that matches current `syncStore.isSyncing` guard.
- [ ]  **Back** after auto-skip: stack should return to a sensible previous screen.


This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding