### PR TITLE
fix(lightning-address): resolve switch lockup caused by empty Keychain write

### DIFF
--- a/storage/index.ts
+++ b/storage/index.ts
@@ -25,11 +25,11 @@ class Storage {
         const stringValue =
             typeof value === 'string' ? value : JSON.stringify(value);
 
-        if (stringValue == null) {
-            console.error(
-                `Storage.setItem: cannot store null/undefined for key "${key}"`
-            );
-            return false;
+        // Keychain rejects empty/null passwords with EmptyParameterException.
+        // getItem returns `false` for both unset and empty values, so routing
+        // empty writes through removeItem preserves the observable semantics.
+        if (stringValue == null || stringValue === '') {
+            return this.removeItem(key);
         }
 
         const response = await Keychain.setInternetCredentials(

--- a/stores/LightningAddressStore.ts
+++ b/stores/LightningAddressStore.ts
@@ -554,7 +554,8 @@ export default class LightningAddressStore {
                     message: verification,
                     signature,
                     updates,
-                    address_type: this.lightningAddressType
+                    address_type:
+                        updates?.address_type || this.lightningAddressType
                 })
             );
 

--- a/stores/LightningAddressStore.ts
+++ b/stores/LightningAddressStore.ts
@@ -553,9 +553,7 @@ export default class LightningAddressStore {
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                     message: verification,
                     signature,
-                    updates,
-                    address_type:
-                        updates?.address_type || this.lightningAddressType
+                    updates
                 })
             );
 

--- a/views/Cashu/LightningAddress/CreateCashuLightningAddress.tsx
+++ b/views/Cashu/LightningAddress/CreateCashuLightningAddress.tsx
@@ -206,14 +206,18 @@ export default class CreateCashuLightningAddress extends React.Component<
                                                 this.setState({
                                                     loading: true
                                                 });
-                                                await update({
-                                                    mint_url: mintUrl,
-                                                    cashu_pubkey:
-                                                        CashuStore.cashuWallets[
-                                                            mintUrl
-                                                        ].pubkey,
-                                                    address_type: 'cashu'
-                                                }).then(async (response) => {
+                                                try {
+                                                    const response =
+                                                        await update({
+                                                            mint_url: mintUrl,
+                                                            cashu_pubkey:
+                                                                CashuStore
+                                                                    .cashuWallets[
+                                                                    mintUrl
+                                                                ].pubkey,
+                                                            address_type:
+                                                                'cashu'
+                                                        });
                                                     if (response.success) {
                                                         await deleteLocalHashes();
                                                         await updateSettings({
@@ -225,11 +229,13 @@ export default class CreateCashuLightningAddress extends React.Component<
                                                         navigation.popTo(
                                                             'LightningAddress'
                                                         );
-                                                    } else {
-                                                        this.setState({
-                                                            loading: false
-                                                        });
+                                                        return;
                                                     }
+                                                } catch (e) {
+                                                    console.error(e);
+                                                }
+                                                this.setState({
+                                                    loading: false
                                                 });
                                             } else {
                                                 createCashu(mintUrl).then(

--- a/views/LightningAddress/CreateNWCLightningAddress.tsx
+++ b/views/LightningAddress/CreateNWCLightningAddress.tsx
@@ -192,26 +192,26 @@ export default class CreateNWCLightningAddress extends React.Component<
                                                         loading: true
                                                     });
 
-                                                    await update({
-                                                        nwc_string:
-                                                            nwcConnectionString,
-                                                        address_type: 'nwc'
-                                                    }).then(
-                                                        async (response) => {
-                                                            if (
-                                                                response.success
-                                                            ) {
-                                                                navigation.popTo(
-                                                                    'LightningAddress'
-                                                                );
-                                                            } else {
-                                                                this.setState({
-                                                                    loading:
-                                                                        false
-                                                                });
-                                                            }
+                                                    try {
+                                                        const response =
+                                                            await update({
+                                                                nwc_string:
+                                                                    nwcConnectionString,
+                                                                address_type:
+                                                                    'nwc'
+                                                            });
+                                                        if (response.success) {
+                                                            navigation.popTo(
+                                                                'LightningAddress'
+                                                            );
+                                                            return;
                                                         }
-                                                    );
+                                                    } catch (e) {
+                                                        console.error(e);
+                                                    }
+                                                    this.setState({
+                                                        loading: false
+                                                    });
                                                 } else {
                                                     createNWC(
                                                         nwcConnectionString

--- a/views/LightningAddress/CreateZaplockerLightningAddress.tsx
+++ b/views/LightningAddress/CreateZaplockerLightningAddress.tsx
@@ -274,26 +274,32 @@ export default class CreateZaplockerLightningAddress extends React.Component<
                                                     loading: true
                                                 });
 
-                                                const relays_sig = bytesToHex(
-                                                    schnorr.sign(
-                                                        hashjs
-                                                            .sha256()
-                                                            .update(
-                                                                JSON.stringify(
-                                                                    nostrRelays
-                                                                )
+                                                try {
+                                                    const relays_sig =
+                                                        bytesToHex(
+                                                            schnorr.sign(
+                                                                hashjs
+                                                                    .sha256()
+                                                                    .update(
+                                                                        JSON.stringify(
+                                                                            nostrRelays
+                                                                        )
+                                                                    )
+                                                                    .digest(
+                                                                        'hex'
+                                                                    ),
+                                                                nostrPrivateKey
                                                             )
-                                                            .digest('hex'),
-                                                        nostrPrivateKey
-                                                    )
-                                                );
-
-                                                await update({
-                                                    nostr_pk: nostrPublicKey,
-                                                    relays: nostrRelays,
-                                                    relays_sig,
-                                                    address_type: 'zaplocker'
-                                                }).then(async (response) => {
+                                                        );
+                                                    const response =
+                                                        await update({
+                                                            nostr_pk:
+                                                                nostrPublicKey,
+                                                            relays: nostrRelays,
+                                                            relays_sig,
+                                                            address_type:
+                                                                'zaplocker'
+                                                        });
                                                     if (response.success) {
                                                         await updateSettings({
                                                             lightningAddress: {
@@ -305,11 +311,13 @@ export default class CreateZaplockerLightningAddress extends React.Component<
                                                         navigation.popTo(
                                                             'LightningAddress'
                                                         );
-                                                    } else {
-                                                        this.setState({
-                                                            loading: false
-                                                        });
+                                                        return;
                                                     }
+                                                } catch (e) {
+                                                    console.error(e);
+                                                }
+                                                this.setState({
+                                                    loading: false
                                                 });
                                             } else {
                                                 createZaplocker(


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-4025**](https://github.com/ZeusLN/zeus/issues/4025)

Switching the ZEUS Pay LN address between cashu, NWC, and Zaplocker could leave the screen stuck on a spinning loader with no way to recover except force-quitting the app.

## Root cause

`Storage.setItem(key, '')` forwards the empty string as the `password` argument to `Keychain.setInternetCredentials`. On Android, react-native-keychain rejects empty passwords with `com.oblador.keychain.exceptions.EmptyParameterException`. `deleteLocalHashes()`, `deleteAndGenerateNewPreimages()`, and `deleteAddress()` in `LightningAddressStore` all call `Storage.setItem(HASHES_STORAGE_STRING, '')` to clear local preimage hashes — so any flow that runs them throws.

In the cashu switch flow, `await deleteLocalHashes()` runs immediately after a successful `update()`. The `EmptyParameterException` propagated out of the switch handler, which had no `.catch` on the `await update(...).then(...)` chain — `setState({ loading: true })` was never reset, so the Lottie loader spun forever and the existing `<ErrorMessage>` never became visible (it's gated behind `!loading`).

On Zaplocker, the same handler additionally ran the synchronous `schnorr.sign` + `hashjs` computation before the missing catch, so any throw from those would brick the UI the same way.

## PR Type

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
