### PR TITLE
enhancement: LDK: wait for node readiness before fetching startup data

### DIFF
--- a/utils/LdkNodeUtils.ts
+++ b/utils/LdkNodeUtils.ts
@@ -64,6 +64,13 @@ export const RGS_SERVERS_TESTNET: EsploraServer[] = [
 // Default pathfinding scores server
 export const DEFAULT_SCORER_URL = 'https://scores.zeusln.com/latest.bin';
 
+// Native-module error string emitted while `buildNode` is still rebuilding
+// the node reference on its background queue
+const LDK_NODE_NOT_INITIALIZED = 'Node not initialized';
+
+// Local sentinel for the gap between the node existing and reporting running
+const LDK_NODE_NOT_RUNNING_YET = 'LDK Node not running yet';
+
 /**
  * Get the storage directory path for LDK Node data
  */
@@ -365,7 +372,7 @@ export async function startLdkNodeWallet({
             delayMs: 500,
             shouldRetry: (e: any) => {
                 const errMsg = e?.message || e?.toString?.() || String(e);
-                return errMsg.includes('Node not initialized');
+                return errMsg.includes(LDK_NODE_NOT_INITIALIZED);
             }
         });
         nodeStarted = true;
@@ -431,8 +438,6 @@ export async function startLdkNodeWallet({
     return { vssError, esploraError, rgsError };
 }
 
-const LDK_NODE_NOT_RUNNING_YET = 'LDK Node not running yet';
-
 /**
  * Wait for the LDK Node native module to report a running node.
  *
@@ -455,7 +460,7 @@ export async function waitForLdkNodeReady(
         shouldRetry: (e: any) => {
             const errMsg = e?.message || e?.toString?.() || String(e);
             return (
-                errMsg.includes('Node not initialized') ||
+                errMsg.includes(LDK_NODE_NOT_INITIALIZED) ||
                 errMsg.includes(LDK_NODE_NOT_RUNNING_YET)
             );
         }

--- a/utils/LdkNodeUtils.ts
+++ b/utils/LdkNodeUtils.ts
@@ -431,6 +431,8 @@ export async function startLdkNodeWallet({
     return { vssError, esploraError, rgsError };
 }
 
+const LDK_NODE_NOT_RUNNING_YET = 'LDK Node not running yet';
+
 /**
  * Wait for the LDK Node native module to report a running node.
  *
@@ -440,8 +442,6 @@ export async function startLdkNodeWallet({
  * both that error and a transient `!isRunning` as retryable) so callers
  * can tolerate that race instead of surfacing it as a fatal startup error.
  */
-const LDK_NODE_NOT_RUNNING_YET = 'LDK Node not running yet';
-
 export async function waitForLdkNodeReady(
     timeoutMs: number = 60000
 ): Promise<void> {

--- a/utils/LdkNodeUtils.ts
+++ b/utils/LdkNodeUtils.ts
@@ -9,6 +9,7 @@ import LdkNode from '../ldknode/LdkNodeInjection';
 import type { Network } from '../ldknode/LdkNode.d';
 
 import { localeString } from './LocaleUtils';
+import { retry } from './SleepUtils';
 import { deriveVssSigningKeyFromSeed } from './VssAuthUtils';
 
 export type SupportedNetwork =
@@ -358,7 +359,15 @@ export async function startLdkNodeWallet({
     let nodeStarted = false;
 
     try {
-        await LdkNode.node.start();
+        await retry({
+            fn: () => LdkNode.node.start(),
+            maxRetries: 5,
+            delayMs: 500,
+            shouldRetry: (e: any) => {
+                const errMsg = e?.message || e?.toString?.() || String(e);
+                return errMsg.includes('Node not initialized');
+            }
+        });
         nodeStarted = true;
         console.log('LDK Node: Started successfully');
     } catch (e: any) {
@@ -372,6 +381,11 @@ export async function startLdkNodeWallet({
             // Node may still be running despite fee estimation failure —
             // attempt sync to detect RGS errors too
             nodeStarted = true;
+        } else {
+            // Surface non-fee-rate failures to the caller instead of
+            // returning silently — a phantom-success makes the downstream
+            // waitForLdkNodeReady timeout in 60s with a misleading error.
+            throw e;
         }
     }
 
@@ -418,6 +432,37 @@ export async function startLdkNodeWallet({
 }
 
 /**
+ * Wait for the LDK Node native module to report a running node.
+ *
+ * `buildNode` clears the native node reference up-front and rebuilds it on
+ * a background queue, so any call into the module during that window
+ * rejects with "Node not initialized". Retries `status()` calls (treating
+ * both that error and a transient `!isRunning` as retryable) so callers
+ * can tolerate that race instead of surfacing it as a fatal startup error.
+ */
+const LDK_NODE_NOT_RUNNING_YET = 'LDK Node not running yet';
+
+export async function waitForLdkNodeReady(
+    timeoutMs: number = 60000
+): Promise<void> {
+    await retry({
+        fn: async () => {
+            const status = await LdkNode.node.status();
+            if (!status.isRunning) throw new Error(LDK_NODE_NOT_RUNNING_YET);
+        },
+        maxRetries: Math.floor(timeoutMs / 500),
+        delayMs: 500,
+        shouldRetry: (e: any) => {
+            const errMsg = e?.message || e?.toString?.() || String(e);
+            return (
+                errMsg.includes('Node not initialized') ||
+                errMsg.includes(LDK_NODE_NOT_RUNNING_YET)
+            );
+        }
+    });
+}
+
+/**
  * Stop a running LDK Node
  */
 export async function stopLdkNode(): Promise<void> {
@@ -450,6 +495,7 @@ export default {
     generateMnemonic,
     createLdkNodeWallet,
     startLdkNodeWallet,
+    waitForLdkNodeReady,
     stopLdkNode,
     deleteLdkNodeWallet,
     ESPLORA_SERVERS_MAINNET,

--- a/utils/WalletCreationUtils.ts
+++ b/utils/WalletCreationUtils.ts
@@ -95,6 +95,9 @@ export async function createOnboardingWallet(params: WalletCreationParams) {
                     ...commonSettings
                 });
 
+                // Node is already built — tell Wallet.tsx to skip re-init
+                settingsStore.walletJustCreated = true;
+
                 setConnectingStatus(true);
                 onSuccess();
             } else {

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -60,6 +60,7 @@ import {
 import {
     startLdkNodeWallet,
     stopLdkNode,
+    waitForLdkNodeReady,
     DEFAULT_VSS_SERVER,
     DEFAULT_SCORER_URL
 } from '../../utils/LdkNodeUtils';
@@ -1152,6 +1153,8 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             }
         } else if (implementation === 'ldk-node') {
             try {
+                console.log('[LDK startup] waiting for node to be ready');
+                await waitForLdkNodeReady();
                 console.log('[LDK startup] fetching node info');
                 await NodeInfoStore.getNodeInfo();
                 console.log('[LDK startup] fetching balance');


### PR DESCRIPTION
# Description

- Wraps `LdkNode.node.start()` in `startLdkNodeWallet` with a small `retry` shell that retries on `"Node not initialized"`, and rethrows non-fee-rate `start()` failures instead of silently swallowing them.
- Adds `waitForLdkNodeReady()` helper that retries `status()` until `isRunning` is true, treating both `"Node not initialized"` and a transient `!isRunning` as retryable. Called from `Wallet.tsx` at the top of the LDK Node startup block, before `NodeInfoStore.getNodeInfo()` and the other data fetches.
- Sets `SettingsStore.walletJustCreated = true` after `createLdkNodeWallet` in `createOnboardingWallet`, matching the pattern already used by `SeedRecovery.tsx` and `WalletConfiguration.tsx`. Onboarding no longer tears down and rebuilds the freshly built node.

## Why

Users were sometimes seeing `"Node not initialized"` during LDK Node wallet startup. The native `buildNode` (iOS `LdkNodeModule.swift`, Android `LdkNodeModule.kt`) synchronously nulls the existing node reference and rebuilds on a background queue, so the field is `nil`/`null` for the entire build window (up to ~60s on a restore-from-seed with VSS). Any call into the module during that window — `nodeId`, `status`, `listChannels` — rejects with `"Node not initialized"` and surfaces as a fatal startup error in the dashboard.

Two contributing factors made this much more likely:

1. `createOnboardingWallet` was the only LDK creation path that didn't set `walletJustCreated = true`, so `Wallet.tsx` took the `!justCreated` branch on every fresh wallet — stopping and rebuilding the node it had just built and widening the race window.
2. `startLdkNodeWallet` silently swallowed any non-fee-rate `start()` failure, returning success. The downstream `getNodeInfo` call would then hit the still-unset node and produce the misleading `"Node not initialized"` error instead of the real cause.

The readiness gate mirrors what we already do for embedded LND via `waitForRpcReady` in `utils/LndMobileUtils.ts`.

## Behavior

- `start()` is retried up to 5 times at 500ms intervals on `"Node not initialized"`. Non-fee-rate failures now propagate to the caller, where `Wallet.tsx`'s LDK `catch (connectionError)` clears `connectingStatus` and calls `NodeInfoStore.handleGetNodeInfoError()`.
- `waitForLdkNodeReady()` runs `status()` via `retry` (120 attempts × 500ms = 60s ceiling). It retries on `"Node not initialized"` and on a distinct `"LDK Node not running yet"` sentinel emitted when the node exists but hasn't transitioned to running.
- The fee-rate carve-out in `startLdkNodeWallet` is preserved — those errors continue to set `esploraError` and let sync proceed.

## Out of scope (follow-ups)

- Native `buildNode` could be made atomic (build into a local, only commit to `self.node` once ready) to close the race window inside the module itself. This PR is purely consumer-side defense.

## Test plan

- [ ] Fresh wallet creation (onboarding) — verify dashboard loads without `"Node not initialized"` and that `walletJustCreated` skips the redundant stop+rebuild cycle.
- [ ] Restore-from-seed with VSS configured — verify the longer build window (up to 60s) is tolerated and the dashboard eventually loads.
- [ ] Restore-from-seed with VSS unreachable — verify fallback to local SQLite still surfaces the dashboard.
- [ ] Switch between two LDK Node wallets — verify the rebuild path between `stopLdkNode()` and `start()` doesn't leak the error.
- [ ] Force a genuine startup failure (e.g., bad Esplora URL) — verify the rethrow path produces a clean error via `handleGetNodeInfoError()` instead of a 60s phantom readiness timeout.

## PR Type

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
