### PR TITLE
fix(nfc): add NDEF_DISCOVERED intent filters for lightning URI scheme

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -146,10 +146,6 @@
             <action android:name="android.nfc.action.NDEF_DISCOVERED" />
             <category android:name="android.intent.category.DEFAULT" />
             <data android:scheme="lightning" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-            <category android:name="android.intent.category.DEFAULT" />
             <data android:scheme="LIGHTNING" />
         </intent-filter>
         <intent-filter>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -143,6 +143,16 @@
             <data android:mimeType="text/plain" />
         </intent-filter>
         <intent-filter>
+            <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <data android:scheme="lightning" />
+        </intent-filter>
+        <intent-filter>
+            <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <data android:scheme="LIGHTNING" />
+        </intent-filter>
+        <intent-filter>
             <action android:name="android.intent.action.SEND" />
             <category android:name="android.intent.category.DEFAULT" />
             <data android:mimeType="image/*" />


### PR DESCRIPTION
## Problem

When Android scans an NFC tag that contains a Lightning URI (e.g. `lightning:lnurl1...`) stored as a **URI-type NDEF record**, the OS dispatches an `NDEF_DISCOVERED` intent using the URI scheme (`lightning:`). Zeus does not register an intent filter for this case and therefore does **not appear in Android's app chooser** — even though it can handle the `lightning:` scheme perfectly well once launched.

Zeus currently only registers `NDEF_DISCOVERED` for `mimeType="text/plain"`, which covers tags written by NFC apps that store the Lightning URI as a plain text record. URI-type NDEF records — the standard format used by devices like NFC payment cards and tools such as ZapBox — are not caught by this filter.

> Note: The existing `ACTION_VIEW` + `BROWSABLE` intent filters for `lightning:` handle deep links from browsers and QR code scanners, but **not** the NFC tag dispatch system.

## Fix

Add `NDEF_DISCOVERED` intent filters for the `lightning` and `LIGHTNING` schemes to `AndroidManifest.xml`.

## Scope

This PR intentionally covers only the `lightning` / `LIGHTNING` prefix to keep the change focused and reviewable. The same issue applies to other schemes already registered for `ACTION_VIEW` (e.g. `lnurl`, `lnurlp`, `lnurlw`, `lnurlc`, `bitcoin`, `BITCOIN`, `cashu`, `lndconnect`) but those are left for a follow-up PR.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other
