### PR TITLE
feat(cashu): detect cashu tokens wrapped in any https URL

### DIFF
--- a/utils/CashuUtils.test.ts
+++ b/utils/CashuUtils.test.ts
@@ -118,13 +118,23 @@ describe('CashuUtils', () => {
             expect(CashuUtils.isValidCashuToken('notavalidtoken')).toBe(false);
         });
 
-        it('accepts tokens with a sufficient base64url-shaped payload', () => {
+        it('accepts tokens with a sufficient base64-shaped payload', () => {
             expect(CashuUtils.isValidCashuToken('cashuAinvalidpayload')).toBe(
                 true
             );
             expect(CashuUtils.isValidCashuToken('cashuBinvalidpayload')).toBe(
                 true
             );
+        });
+
+        it('accepts standard-base64 tokens with +, /, and = padding', () => {
+            // v3 wallets that use btoa() emit standard base64 with padding
+            expect(CashuUtils.isValidCashuToken('cashuAeyJ0b2tlbi8rIn0=')).toBe(
+                true
+            );
+            expect(
+                CashuUtils.isValidCashuToken('cashuAa+b/c=d+e/f=g+h/i==')
+            ).toBe(true);
         });
 
         it('rejects tokens whose payload is too short after the prefix', () => {
@@ -134,7 +144,7 @@ describe('CashuUtils', () => {
             expect(CashuUtils.isValidCashuToken('cashuBshort')).toBe(false);
         });
 
-        it('rejects tokens with non-base64url characters after the prefix', () => {
+        it('rejects tokens with non-base64 characters after the prefix', () => {
             expect(CashuUtils.isValidCashuToken('cashuA!!!!!!!!!!')).toBe(
                 false
             );
@@ -142,6 +152,18 @@ describe('CashuUtils', () => {
                 CashuUtils.isValidCashuToken('cashuB?invalid=value&more')
             ).toBe(false);
             expect(CashuUtils.isValidCashuToken('cashuAfrica')).toBe(false);
+        });
+
+        it('extracts and validates token even with trailing URL noise', () => {
+            // Web wrappers sometimes append &memo=... after the token; the
+            // extractor must trim that off so the shape check still passes.
+            const valid =
+                'cashuAeyJ0b2tlbiI6IFt7InByb29mcyI6IFtdLCAibWludCI6ICJodHRwczovL21pbnQuZXhhbXBsZS5jb20ifV19';
+            expect(
+                CashuUtils.isValidCashuToken(
+                    `https://wallet.cashu.me/?token=${valid}&memo=hello`
+                )
+            ).toBe(true);
         });
 
         it('rejects null/undefined', () => {

--- a/utils/CashuUtils.test.ts
+++ b/utils/CashuUtils.test.ts
@@ -118,13 +118,30 @@ describe('CashuUtils', () => {
             expect(CashuUtils.isValidCashuToken('notavalidtoken')).toBe(false);
         });
 
-        it('accepts any token with cashuA/cashuB prefix (prefix check only)', () => {
+        it('accepts tokens with a sufficient base64url-shaped payload', () => {
             expect(CashuUtils.isValidCashuToken('cashuAinvalidpayload')).toBe(
                 true
             );
             expect(CashuUtils.isValidCashuToken('cashuBinvalidpayload')).toBe(
                 true
             );
+        });
+
+        it('rejects tokens whose payload is too short after the prefix', () => {
+            expect(CashuUtils.isValidCashuToken('cashuA')).toBe(false);
+            expect(CashuUtils.isValidCashuToken('cashuB')).toBe(false);
+            expect(CashuUtils.isValidCashuToken('cashuAshort')).toBe(false);
+            expect(CashuUtils.isValidCashuToken('cashuBshort')).toBe(false);
+        });
+
+        it('rejects tokens with non-base64url characters after the prefix', () => {
+            expect(CashuUtils.isValidCashuToken('cashuA!!!!!!!!!!')).toBe(
+                false
+            );
+            expect(
+                CashuUtils.isValidCashuToken('cashuB?invalid=value&more')
+            ).toBe(false);
+            expect(CashuUtils.isValidCashuToken('cashuAfrica')).toBe(false);
         });
 
         it('rejects null/undefined', () => {

--- a/utils/CashuUtils.ts
+++ b/utils/CashuUtils.ts
@@ -83,9 +83,9 @@ class CashuUtils {
             return false;
         }
 
-        return (
-            cleanToken.startsWith('cashuA') || cleanToken.startsWith('cashuB')
-        );
+        // Structural shape check: cashuA/cashuB prefix + base64url body.
+        // Cryptographic validation lives in isValidCashuTokenAsync (CDK).
+        return /^cashu[AB][0-9A-Za-z_-]{10,}$/.test(cleanToken);
     };
 
     isValidCashuTokenAsync = async (token: string): Promise<boolean> => {

--- a/utils/CashuUtils.ts
+++ b/utils/CashuUtils.ts
@@ -45,6 +45,8 @@ class CashuUtils {
     /**
      * Extract raw token string from various URL formats.
      * Supports both cashuA (v3 JSON) and cashuB (v4 CBOR) token prefixes.
+     * Accepts both base64url (`-`/`_`) and standard-base64 (`+`/`/`/`=`)
+     * alphabets, since real wallets emit either.
      */
     extractTokenString = (token: string): string => {
         if (!token || typeof token !== 'string') {
@@ -52,17 +54,15 @@ class CashuUtils {
         }
         token = token.trim();
 
-        // Find cashuA or cashuB prefix if present
-        const idxA = token.indexOf('cashuA');
-        const idxB = token.indexOf('cashuB');
-        // Pick the earliest match, or whichever exists
-        const idx =
-            idxA === -1 ? idxB : idxB === -1 ? idxA : Math.min(idxA, idxB);
-        if (idx !== -1) {
-            token = token.slice(idx);
+        // Greedy-match the cashu prefix + base64 body. This naturally stops
+        // at the first non-base64 character, trimming any trailing URL noise
+        // like `&memo=foo` that may follow the token in a web wrapper.
+        const match = token.match(/cashu[AB][0-9A-Za-z+/_=-]+/);
+        if (match) {
+            return match[0];
         }
 
-        // Remove URL prefixes
+        // No embedded cashu prefix found — strip a known URL prefix if any.
         for (const prefix of cashuTokenPrefixes) {
             if (token.startsWith(prefix)) {
                 token = token.slice(prefix.length).trim();
@@ -83,9 +83,9 @@ class CashuUtils {
             return false;
         }
 
-        // Structural shape check: cashuA/cashuB prefix + base64url body.
+        // Structural shape check: cashuA/cashuB prefix + base64 body.
         // Cryptographic validation lives in isValidCashuTokenAsync (CDK).
-        return /^cashu[AB][0-9A-Za-z_-]{10,}$/.test(cleanToken);
+        return /^cashu[AB][0-9A-Za-z+/_=-]{10,}$/.test(cleanToken);
     };
 
     isValidCashuTokenAsync = async (token: string): Promise<boolean> => {

--- a/utils/handleAnything.test.ts
+++ b/utils/handleAnything.test.ts
@@ -52,11 +52,26 @@ jest.mock('./BackendUtils', () => ({
 
 let mockIsValidCashuToken = false;
 let mockDecodedCashuToken = {};
-jest.mock('./CashuUtils', () => ({
-    isValidCashuToken: () => mockIsValidCashuToken,
-    isValidCashuTokenAsync: () => Promise.resolve(mockIsValidCashuToken),
-    decodeCashuTokenAsync: () => Promise.resolve(mockDecodedCashuToken)
+jest.mock('../cashu-cdk', () => ({
+    __esModule: true,
+    default: {
+        isValidToken: jest.fn(),
+        decodeToken: jest.fn()
+    }
 }));
+jest.mock('./CashuUtils', () => {
+    const actual = jest.requireActual('./CashuUtils').default;
+    return {
+        __esModule: true,
+        default: {
+            ...actual,
+            isValidCashuToken: () => mockIsValidCashuToken,
+            isValidCashuTokenAsync: () =>
+                Promise.resolve(mockIsValidCashuToken),
+            decodeCashuTokenAsync: () => Promise.resolve(mockDecodedCashuToken)
+        }
+    };
+});
 
 const mockProcessLndConnectUrl = jest.fn();
 const mockProcessCLNRestConnectUrl = jest.fn();
@@ -1549,10 +1564,11 @@ describe('handleAnything', () => {
         });
     });
 
-    // IMPORTANT: zeusln.com/e/ URLs must be checked BEFORE the lnurl block in handleAnything,
-    // because findlnurl() from js-lnurl can match patterns in Cashu tokens that look like bech32 lnurls.
-    // These tests verify the correct route is returned when findlnurl might otherwise match.
-    describe('zeusln.com ecash gift URLs', () => {
+    // IMPORTANT: web-wrapped Cashu token URLs must be checked BEFORE the lnurl block in
+    // handleAnything, because findlnurl() from js-lnurl can match bech32-like patterns
+    // inside Cashu tokens. These tests verify the correct route is returned when
+    // findlnurl might otherwise match, across multiple known web wrappers.
+    describe('web-wrapped cashu URLs', () => {
         const validCashuToken =
             'cashuBo2FteCJodHRwczovL21pbnQubWluaWJpdHMuY2FzaC9CaXRjb2luYXVjc2F0YXSComFpSAAQeTfbDMhlYXCCpGFhCGFzeEAxOWQ3YmRiNTIwMzRmOWQ5OGQwZTU5OTEwM2FkMTlmZTAyODc1ODQ2MThlYmViYTFkNzExM2FiMjI4MDM0YjNlYWNYIQI5u9Nss3cyYXJoLTwRMY4qgCNL7-J7EtBFnGOIeq6tcWFko2FlWCBYlzHfzFSuLuI31zvZGHme0QGeeEjNoGhIs6l2fbbHH2FzWCA2ecAUKZWjtQagWP7wOUVRgsHYlyOG7CUhUFdQjUed2GFyWCC67afI6qoB6bISgCWK24JOdD_-gxUyaSrgfrZJmHsBh6RhYQRhc3hANWYzMGRlMDA1NjVkYTRhZDg2Yzk1MzljYzYzMGE3NTBlYWU2OTJiY2Q5ODgwMWI0OTI0NDA1ZDAxN2UzNGE5MWFjWCECN8hTvJgIFBwN0QY3prfyf4z7BxPVLBPptzKcnb_OupNhZKNhZVggcx4XGwTyM4riizWgckD44KUJQtKHUGGjHIJHFKdPE31hc1ggqASxqD7ZTbA59c7SAHgQvLdLq_xYLL2rAVr2ziIGfkRhclgg-bTi6nbDj8Mdq9rnKhAGgrQ4w6ihk9pvu9xUommg6V-iYWlIAFAFUPBJQUZhcIGkYWEEYXN4QDBlMzhhZWIxYzIxMTk1N2U5Njg4YTdlY2YzNzQ4Y2E2MTA0MDMzNmZjZWJmMzE4M2EwMDAwOWFiYzJiMjcxNWFhY1ghAu0yuRBFejZTitq8LJufeiB2CUAEk-pHTIWqYtFcqtCSYWSjYWVYIDhNUWOMw2xaCZT4Ob8bdV5CxkErkHh-m2XUUqCKZS3WYXNYIBUltNlKIUTrHi4M1Z8SL3l3_EPp-5eOPltdS648bpVGYXJYIFZdUQc6c-waYIhOMSS_-cS19HiHZn4xZe4s65dGN8u5';
 
@@ -1739,6 +1755,62 @@ describe('handleAnything', () => {
 
             // http:// should not match the https:// pattern
             await expect(handleAnything(url)).rejects.toThrow();
+        });
+
+        it.each([
+            {
+                name: 'wallet.cashu.me',
+                url: `https://wallet.cashu.me/?token=${validCashuToken}`
+            },
+            {
+                name: 'wallet.nutstash.app',
+                url: `https://wallet.nutstash.app/#${validCashuToken}`
+            },
+            {
+                name: 'arbitrary web wrapper',
+                url: `https://example.com/redeem/${validCashuToken}`
+            }
+        ])('should route to CashuToken for $name URL', async ({ url }) => {
+            mockProcessBIP21Uri.mockReturnValue({ value: url });
+            mockIsValidCashuToken = true;
+            mockDecodedCashuToken = {
+                token: [
+                    {
+                        mint: 'https://mint.minibits.cash/Bitcoin',
+                        proofs: [{ amount: 16 }]
+                    }
+                ],
+                unit: 'sat'
+            };
+
+            const result = await handleAnything(url);
+
+            expect(result).toEqual([
+                'CashuToken',
+                {
+                    token: validCashuToken,
+                    decoded: expect.any(Object)
+                }
+            ]);
+        });
+
+        it('should return true for arbitrary web wrapper URL from clipboard', async () => {
+            const url = `https://example.com/redeem/${validCashuToken}`;
+            mockProcessBIP21Uri.mockReturnValue({ value: url });
+            mockIsValidCashuToken = true;
+            mockDecodedCashuToken = {
+                token: [
+                    {
+                        mint: 'https://mint.minibits.cash/Bitcoin',
+                        proofs: [{ amount: 16 }]
+                    }
+                ],
+                unit: 'sat'
+            };
+
+            const result = await handleAnything(url, undefined, true);
+
+            expect(result).toBe(true);
         });
     });
 });

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -733,11 +733,13 @@ const handleAnything = async (
             });
     } else if (
         /^https:\/\//i.test(value) &&
-        (value.includes('cashuA') || value.includes('cashuB'))
+        /cashu[AB][0-9A-Za-z_-]{10,}/.test(value)
     ) {
         // Handle web-wrapped cashu tokens (zeusln.com/e/, wallet.cashu.me/?token=,
         // wallet.nutstash.app/#, etc.). Must run before lnurl: findlnurl can match
-        // bech32-like substrings inside cashu tokens and misroute the input.
+        // bech32-like substrings inside cashu tokens and misroute the input. The
+        // base64url shape gate avoids consuming URLs that incidentally contain
+        // the literal "cashuA"/"cashuB" substring (e.g. "?ref=cashuAfrica").
         const cashuToken = CashuUtils.extractTokenString(value);
         if (CashuUtils.isValidCashuToken(cashuToken)) {
             if (isClipboardValue) return true;

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -4,7 +4,7 @@ import ReactNativeBlobUtil from 'react-native-blob-util';
 
 import { nodeInfoStore, invoicesStore, settingsStore } from '../stores/Stores';
 
-import AddressUtils, { ZEUS_ECASH_GIFT_URL } from './AddressUtils';
+import AddressUtils from './AddressUtils';
 import BackendUtils from './BackendUtils';
 import CashuUtils from './CashuUtils';
 import ConnectionFormatUtils from './ConnectionFormatUtils';
@@ -731,9 +731,14 @@ const handleAnything = async (
                     { cancelable: false }
                 );
             });
-    } else if (value.startsWith(ZEUS_ECASH_GIFT_URL)) {
-        // Handle zeusln.com ecash gift URLs - check before lnurl to avoid false matches
-        const cashuToken = value.replace(ZEUS_ECASH_GIFT_URL, '');
+    } else if (
+        /^https:\/\//i.test(value) &&
+        (value.includes('cashuA') || value.includes('cashuB'))
+    ) {
+        // Handle web-wrapped cashu tokens (zeusln.com/e/, wallet.cashu.me/?token=,
+        // wallet.nutstash.app/#, etc.). Must run before lnurl: findlnurl can match
+        // bech32-like substrings inside cashu tokens and misroute the input.
+        const cashuToken = CashuUtils.extractTokenString(value);
         if (CashuUtils.isValidCashuToken(cashuToken)) {
             if (isClipboardValue) return true;
             const cdkToken = await CashuUtils.decodeCashuTokenAsync(cashuToken);

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -733,13 +733,13 @@ const handleAnything = async (
             });
     } else if (
         /^https:\/\//i.test(value) &&
-        /cashu[AB][0-9A-Za-z_-]{10,}/.test(value)
+        /cashu[AB][0-9A-Za-z+/_=-]{10,}/.test(value)
     ) {
         // Handle web-wrapped cashu tokens (zeusln.com/e/, wallet.cashu.me/?token=,
         // wallet.nutstash.app/#, etc.). Must run before lnurl: findlnurl can match
         // bech32-like substrings inside cashu tokens and misroute the input. The
-        // base64url shape gate avoids consuming URLs that incidentally contain
-        // the literal "cashuA"/"cashuB" substring (e.g. "?ref=cashuAfrica").
+        // base64 shape gate avoids consuming URLs that incidentally contain the
+        // literal "cashuA"/"cashuB" substring (e.g. "?ref=cashuAfrica").
         const cashuToken = CashuUtils.extractTokenString(value);
         if (CashuUtils.isValidCashuToken(cashuToken)) {
             if (isClipboardValue) return true;


### PR DESCRIPTION
# Description

Generalizes the early Cashu token detection in `handleAnything` from a hardcoded `https://zeusln.com/e/` prefix check to any `https://` URL whose body contains a `cashuA` / `cashuB` marker. Token extraction now goes through `CashuUtils.extractTokenString`, which already understands `?token=`, `#`, `/e/`, and other common wrapper formats.

## Context

[agi.cash](https://agi.cash/) issues redemption QRs that wrap Cashu tokens in `https://agi.cash/...` URLs — the same general pattern Zeus already uses with `https://zeusln.com/e/<token>`. Before this change, Zeus would only fast-path the ZEUS gift URL, and any other wrapper (including agi.cash) risked being misrouted into the lnurl block, where `findlnurl()` can match bech32-like substrings inside a Cashu token.

We also confirmed reciprocity: agi.cash's wallet successfully reads Cashu QRs prefixed with `https://zeusln.com/e/`, so this change aligns Zeus to accept the same wrapper shape from any host.

This is safe against the lnurl block because bech32's charset excludes uppercase `A`/`B`, so a real lnurl payload cannot contain the `cashuA`/`cashuB` marker — no false positives. Raw `cashuA…` tokens (no URL wrapper) continue to fall through to the existing late `isValidCashuTokenAsync` check. The HTTPS-only restriction preserves the existing `http://` rejection behavior.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

Suggested manual test plan:

- Scan an agi.cash redemption QR → routes to the `CashuToken` view
- Scan a `https://zeusln.com/e/<token>` QR → still routes to `CashuToken` (regression)
- Scan a `https://wallet.cashu.me/?token=<token>` URL → routes to `CashuToken`
- Scan a `https://wallet.nutstash.app/#<token>` URL → routes to `CashuToken`
- Paste a raw `cashuA…` / `cashuB…` token → still handled by the existing late check
- Scan an arbitrary lnurl QR → still routes to lnurl handling (no regression)

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
