### PR TITLE
fix(ui): remove CollapsedQR iconOnly prop to prevent button overflow

### DIFF
--- a/components/AnimatedQRDisplay.tsx
+++ b/components/AnimatedQRDisplay.tsx
@@ -77,7 +77,6 @@ const AnimatedQRDisplay: React.FC<AnimatedQRDisplayProps> = ({
                 <CollapsedQR
                     value={getDisplayValue()}
                     copyValue={getCopyValue()}
-                    iconOnly
                     showSpeed={
                         isBcurSelected || (isBbqrSelected && isMultiFrame)
                     }

--- a/components/CollapsedQR.tsx
+++ b/components/CollapsedQR.tsx
@@ -117,9 +117,7 @@ interface CollapsedQRProps {
     collapseText?: string;
     copyText?: string;
     copyValue?: string;
-    iconContainerStyle?: any;
     showSpeed?: boolean;
-    iconOnly?: boolean;
     hideText?: boolean;
     expanded?: boolean;
     textBottom?: boolean;
@@ -177,8 +175,6 @@ export default class CollapsedQR extends React.Component<
             copyText,
             copyValue,
             collapseText,
-            iconContainerStyle,
-            iconOnly,
             hideText,
             expanded,
             textBottom,
@@ -437,13 +433,7 @@ export default class CollapsedQR extends React.Component<
                         onPress={() => this.toggleCollapse()}
                     />
                 )}
-                <View
-                    style={{
-                        flexDirection: 'row',
-                        justifyContent: 'center',
-                        gap: showSpeed ? 8 : 40
-                    }}
-                >
+                <View style={[styles.actionRow, { gap: showSpeed ? 8 : 40 }]}>
                     {showSpeed && (
                         <QRSpeedMeterButton
                             showOptions={showSpeedOptions}
@@ -452,26 +442,18 @@ export default class CollapsedQR extends React.Component<
                                     showSpeedOptions: !showSpeedOptions
                                 })
                             }
-                            iconOnly={iconOnly}
+                            iconOnly
                         />
                     )}
                     <CopyButton
-                        iconContainerStyle={
-                            !showSpeed ? iconContainerStyle : undefined
-                        }
                         copyValue={copyValue || value}
                         title={copyText}
-                        iconOnly={iconOnly}
+                        iconOnly
                     />
                     <ShareButton
-                        iconContainerStyle={
-                            supportsNFC && !showSpeed
-                                ? iconContainerStyle
-                                : undefined
-                        }
                         value={copyValue || value}
                         qrRef={tempQRRef}
-                        iconOnly={iconOnly}
+                        iconOnly
                         onPress={handleShare}
                         onShareComplete={() =>
                             this.setState({ tempQRRef: null })
@@ -479,10 +461,7 @@ export default class CollapsedQR extends React.Component<
                         onShareGiftLink={onShareGiftLink}
                     />
                     {supportsNFC && (
-                        <NFCButton
-                            value={copyValue || value}
-                            iconOnly={iconOnly}
-                        />
+                        <NFCButton value={copyValue || value} iconOnly />
                     )}
                 </View>
                 {showSpeedOptions && onQRAnimationSpeedChange && showSpeed && (
@@ -545,6 +524,13 @@ export default class CollapsedQR extends React.Component<
 }
 
 const styles = StyleSheet.create({
+    actionRow: {
+        width: '100%',
+        flexDirection: 'row',
+        justifyContent: 'center',
+        alignItems: 'center',
+        paddingHorizontal: 20
+    },
     value: {
         marginBottom: 15,
         paddingHorizontal: 20,

--- a/views/Cashu/ReceiveEcash.tsx
+++ b/views/Cashu/ReceiveEcash.tsx
@@ -677,7 +677,6 @@ export default class ReceiveEcash extends React.Component<
                                                         copyValue={
                                                             lightningAddress
                                                         }
-                                                        iconOnly={true}
                                                         expanded
                                                         textBottom
                                                         hideText
@@ -713,7 +712,6 @@ export default class ReceiveEcash extends React.Component<
                                                         copyValue={
                                                             lnInvoiceCopyValue
                                                         }
-                                                        iconOnly={true}
                                                         expanded
                                                         textBottom
                                                         truncateLongValue

--- a/views/MultiQR.tsx
+++ b/views/MultiQR.tsx
@@ -94,7 +94,6 @@ const MultiQR: React.FC<MultiQRProps> = (props: MultiQRProps) => {
             hideText={route.params?.fromContactDetailsView && index === 0}
             textBottom
             truncateLongValue
-            iconOnly={true}
             valueStyle={
                 route.params?.fromContactDetailsView
                     ? { fontSize: 18 }

--- a/views/NodeInfo.tsx
+++ b/views/NodeInfo.tsx
@@ -99,7 +99,6 @@ export default class NodeInfo extends React.Component<
                             }}
                         >
                             <CollapsedQR
-                                iconOnly
                                 value={uri}
                                 copyText={localeString(
                                     'views.NodeInfo.copyUri'

--- a/views/PayCode.tsx
+++ b/views/PayCode.tsx
@@ -208,7 +208,6 @@ export default class PayCodeView extends React.Component<
                                 value={qrValue}
                                 copyValue={qrValue}
                                 expanded
-                                iconOnly
                                 textBottom
                                 truncateLongValue
                             />

--- a/views/QR.tsx
+++ b/views/QR.tsx
@@ -114,7 +114,6 @@ export default class QR extends React.PureComponent<QRProps, QRState> {
                         satAmount={satAmount}
                         displayAmount
                         labelBottom={labelBottom ? label || value : undefined}
-                        iconOnly={true}
                         nfcSupported={nfcSupported}
                     />
                 </ScrollView>

--- a/views/RawTxHex.tsx
+++ b/views/RawTxHex.tsx
@@ -88,12 +88,14 @@ export default class RawTxHex extends React.PureComponent<
                     style={{ padding: 15 }}
                     contentContainerStyle={{ alignItems: 'center' }}
                 >
-                    <CollapsedQR
-                        value={value}
-                        textBottom
-                        hideText={hideText}
-                        logo={logo}
-                    />
+                    <View style={{ marginBottom: 15, width: '100%' }}>
+                        <CollapsedQR
+                            value={value}
+                            textBottom
+                            hideText={hideText}
+                            logo={logo}
+                        />
+                    </View>
                     <Button
                         title={localeString(
                             'views.RawTxHex.broadcastToMempoolSpace'

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -2022,7 +2022,6 @@ export default class Receive extends React.Component<
                                             !creatingInvoice && (
                                                 <CollapsedQR
                                                     value={unifiedInvoice || ''}
-                                                    iconOnly={true}
                                                     expanded
                                                     textBottom
                                                     truncateLongValue
@@ -2047,7 +2046,6 @@ export default class Receive extends React.Component<
                                                     copyValue={
                                                         lnInvoiceCopyValue
                                                     }
-                                                    iconOnly={true}
                                                     expanded
                                                     textBottom
                                                     truncateLongValue
@@ -2072,7 +2070,6 @@ export default class Receive extends React.Component<
                                                     copyValue={
                                                         btcAddressCopyValue
                                                     }
-                                                    iconOnly={true}
                                                     expanded
                                                     textBottom
                                                     truncateLongValue
@@ -2122,7 +2119,6 @@ export default class Receive extends React.Component<
                                                 <CollapsedQR
                                                     value={`lightning:${lightningAddress}`}
                                                     copyValue={lightningAddress}
-                                                    iconOnly={true}
                                                     expanded
                                                     textBottom
                                                     hideText
@@ -2157,7 +2153,6 @@ export default class Receive extends React.Component<
                                                     copyValue={
                                                         lnInvoiceCopyValue
                                                     }
-                                                    iconOnly={true}
                                                     expanded
                                                     textBottom
                                                     truncateLongValue

--- a/views/Settings/NostrWalletConnect/NWCConnectionQR.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionQR.tsx
@@ -162,12 +162,7 @@ export default class NWCConnectionQR extends React.Component<
                         paddingHorizontal: 15
                     }}
                 >
-                    <CollapsedQR
-                        value={nostrUrl}
-                        hideText={true}
-                        expanded
-                        iconOnly={true}
-                    />
+                    <CollapsedQR value={nostrUrl} hideText={true} expanded />
 
                     {NostrWalletConnectStore.waitingForConnection && (
                         <View style={[styles.loadingContainer]}>

--- a/views/Tools/CreateWithdrawalRequest.tsx
+++ b/views/Tools/CreateWithdrawalRequest.tsx
@@ -215,7 +215,6 @@ export default class CreateWithdrawalRequest extends Component<
                     <View style={{ padding: 20 }}>
                         <CollapsedQR
                             value={this.state.bolt12 || ''}
-                            iconOnly={true}
                             expanded
                             textBottom
                             truncateLongValue


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

This PR removes the `iconOnly` and `iconContainerStyle` props from `CollapsedQR` and standardizes all actions to use icon-only buttons.

Previously, when `iconOnly={false}`, the Copy and Share actions were rendered as full-width labeled buttons inside a horizontal row (`width: '90%'`). On smaller layouts, this caused the buttons to overflow and clip off-screen.

Here are some examples of the issue:

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-22 at 13 46 42" src="https://github.com/user-attachments/assets/3a9e889b-860a-4724-ad31-706f736a3a16" />

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-22 at 14 00 41" src="https://github.com/user-attachments/assets/df8e74fa-d7ab-4485-9e9d-09b979439df0" />

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-22 at 13 56 45" src="https://github.com/user-attachments/assets/014f1ab8-4d86-4ff5-a6f7-31ca8f6b8670" />

This change simplifies the component API and keeps the UI consistent across Receive, QR, and related screens.

## Changes

- Removed `iconOnly` and `iconContainerStyle` props from `CollapsedQR`
- Always render Copy / Share / NFC / Speed actions as icon-only controls
- Removed redundant `iconOnly` usage from:
  - Receive
  - QR
  - PayCode
  - MultiQR
  - ReceiveEcash
  - NodeInfo
  - AnimatedQRDisplay
  - NWCConnectionQR
  - CreateWithdrawalRequest
- Wrapped `CollapsedQR` in `RawTxHex` with a full-width container for more consistent spacing and layout alignment

### After changes Screenshots : 

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-22 at 14 06 38" src="https://github.com/user-attachments/assets/87289f03-aea5-4747-8d62-6c6ba208d3a9" />

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-22 at 14 11 16" src="https://github.com/user-attachments/assets/814fe4fe-4387-4124-ac04-089c99a774e7" />

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-22 at 13 48 16" src="https://github.com/user-attachments/assets/38d2dcad-8d86-4516-8028-51d0d60d48da" />




This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [x] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
