### PR TITLE
fix(OpenChannel): switch destination to Custom when importing node URI from clipboard

### DIFF
--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -201,14 +201,20 @@ export default class OpenChannel extends React.Component<
         const olympusPubkey = lspConfig.lsps1Pubkey;
         const olympusHost = lspConfig.lsps1Host;
 
+        const resolvedPubkey = node_pubkey_string
+            ? node_pubkey_string
+            : olympusPubkey;
+        const resolvedHost = node_pubkey_string ? host : olympusHost;
+
         this.setState({
             channelDestination: node_pubkey_string
                 ? 'Custom'
                 : 'Olympus by ZEUS',
-            node_pubkey_string: node_pubkey_string
-                ? node_pubkey_string
-                : olympusPubkey,
-            host: node_pubkey_string ? host : olympusHost
+            node_pubkey_string: resolvedPubkey,
+            host: resolvedHost,
+            isNodePubkeyValid:
+                ValidationUtils.validateNodePubkey(resolvedPubkey),
+            isNodeHostValid: ValidationUtils.validateNodeHost(resolvedHost)
         });
     }
 
@@ -240,7 +246,9 @@ export default class OpenChannel extends React.Component<
             channelDestination: 'Custom',
             node_pubkey_string: pubkey,
             host,
-            suggestImport: ''
+            suggestImport: '',
+            isNodePubkeyValid: ValidationUtils.validateNodePubkey(pubkey),
+            isNodeHostValid: ValidationUtils.validateNodeHost(host)
         });
 
         Clipboard.setString('');

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -237,6 +237,7 @@ export default class OpenChannel extends React.Component<
         );
 
         this.setState({
+            channelDestination: 'Custom',
             node_pubkey_string: pubkey,
             host,
             suggestImport: ''


### PR DESCRIPTION
# Description

Fixes a state inconsistency in `views/OpenChannel.tsx` when importing a node URI from the clipboard.

On mount, if the clipboard contains a valid node URI, the view offers an "Import" prompt. When the user tapped **Import**, `importClipboard()` wrote the parsed `pubkey` and `host` into state but did not change `channelDestination`, which defaults to `'Olympus by ZEUS'`. As a result:

- The destination dropdown kept showing "Olympus by ZEUS".
- The custom pubkey/host input fields stayed hidden (they are gated on `channelDestination === 'Custom'`), so the user could not see or edit the imported values.
- State was inconsistent: the UI claimed Olympus, but the underlying `node_pubkey_string`/`host` pointed at the imported node. If the user then toggled the dropdown to "Custom" themselves, the `onValueChange` handler reset both fields to `''`, silently wiping the import.

The fix sets `channelDestination: 'Custom'` inside the `importClipboard` `setState`, so the dropdown switches to Custom at the same moment the imported values land in state, the input fields render, and the user can review/edit what they're about to open a channel to.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
