### PR TITLE
refactor: free channel and extension payment flow

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1649,7 +1649,7 @@
     "views.LSPS1.restartNow": "Restart Now",
     "views.LSPS7.type": "Channel lease extension",
     "views.LSPS7.channelExtensionBlocks": "Number of blocks to extend channel lease by",
-    "views.LSPS7.extensionExpiryBlocks": "Number of blocks channel lease is extended by",
+    "views.LSPS7.extensionExpiryBlocks": "Blocks extended by",
     "views.LSPS7.maxChannelExtensionExpiryBlocks": "Max number of blocks channel lease can be extended by",
     "views.LSPS7.expirationBlock": "Current expiration block",
     "views.LSPS7.proposedExpirationBlock": "Proposed expiration block",

--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -16,6 +16,8 @@ import { LndMobileEventEmitter } from '../utils/LndMobileUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
 
+import Storage from '../storage';
+
 export const LEGACY_LSPS1_ORDERS_KEY = 'orderResponses';
 export const LSPS_ORDERS_KEY = 'zeus-lsps1-orders';
 
@@ -129,6 +131,51 @@ export default class LSPStore {
     @action
     public clearLSPS7Order = () => {
         this.createExtensionOrderResponse = {};
+    };
+
+    public saveOrderToHistory = async (
+        orderResponse: any,
+        service: 'LSPS1' | 'LSPS7'
+    ): Promise<void> => {
+        const result = orderResponse?.result || orderResponse;
+        const orderId = result?.order_id;
+        if (!orderId) return;
+
+        try {
+            const responseArrayString = await Storage.getItem(LSPS_ORDERS_KEY);
+            const responseArray: any[] = responseArrayString
+                ? JSON.parse(responseArrayString)
+                : [];
+
+            const exists = responseArray.some((response: any) => {
+                const stored = JSON.parse(response);
+                const storedId =
+                    stored.order?.order_id || stored.order?.result?.order_id;
+                return storedId === orderId;
+            });
+            if (exists) return;
+
+            const orderData: any = {
+                order: orderResponse,
+                clientPubkey: this.nodeInfoStore.nodeInfo?.nodeId,
+                service
+            };
+
+            if (service === 'LSPS1' && BackendUtils.supportsLSPS1native()) {
+                orderData.native = true;
+            } else if (BackendUtils.supportsLSPScustomMessage()) {
+                orderData.peer = this.getLSPSPubkey();
+                orderData.uri = `${this.getLSPSPubkey()}@${this.getLSPSHost()}`;
+            }
+            if (service === 'LSPS1' && BackendUtils.supportsLSPS1rest()) {
+                orderData.endpoint = this.getLSPS1Rest();
+            }
+
+            responseArray.push(JSON.stringify(orderData));
+            await Storage.setItem(LSPS_ORDERS_KEY, responseArray);
+        } catch (error) {
+            console.error(`Error saving ${service} order:`, error);
+        }
     };
 
     private getLspConfig = () =>

--- a/views/LSPS1/OrderResponse.tsx
+++ b/views/LSPS1/OrderResponse.tsx
@@ -164,11 +164,13 @@ export default class LSPS1OrderResponse extends React.Component<
                         {/* Legacy format */}
                         {payment && !payment.bolt11 && !payment.onchain && (
                             <>
-                                <KeyValue
-                                    keyValue={localeString(
-                                        'views.Payment.title'
-                                    )}
-                                />
+                                {!isFreeOrder && (
+                                    <KeyValue
+                                        keyValue={localeString(
+                                            'views.Payment.title'
+                                        )}
+                                    />
+                                )}
                                 {payment?.state && (
                                     <KeyValue
                                         keyValue={localeString('general.state')}
@@ -326,7 +328,7 @@ export default class LSPS1OrderResponse extends React.Component<
                             <>
                                 <KeyValue
                                     keyValue={localeString(
-                                        'iews.LSPS1.onchainPayment'
+                                        'views.LSPS1.onchainPayment'
                                     )}
                                 />
                                 {payment?.onchain.fee_total_sat && (
@@ -443,7 +445,6 @@ export default class LSPS1OrderResponse extends React.Component<
                             </>
                         )}
                         {orderResponse?.order_state === LSPOrderState.CREATED &&
-                            orderView &&
                             isFreeOrder && (
                                 <SuccessMessage
                                     message={localeString(

--- a/views/LSPS1/index.tsx
+++ b/views/LSPS1/index.tsx
@@ -72,8 +72,8 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
         this.state = {
             lspBalanceSat: 0,
             clientBalanceSat: 0,
-            requiredChannelConfirmations: '',
-            confirmsWithinBlocks: '',
+            requiredChannelConfirmations: null,
+            confirmsWithinBlocks: null,
             channelExpiryBlocks: 'N/A',
             expirationIndex: 0,
             token: props.SettingsStore.settings?.lsps1Token || '',
@@ -163,7 +163,7 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
         }
 
         if (
-            requiredChannelConfirmations === '' &&
+            requiredChannelConfirmations === null &&
             info?.min_required_channel_confirmations
         ) {
             this.setState({
@@ -173,7 +173,7 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
         }
 
         if (
-            confirmsWithinBlocks === '' &&
+            confirmsWithinBlocks === null &&
             info?.min_funding_confirms_within_blocks
         ) {
             this.setState({
@@ -1010,7 +1010,8 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                                 )}
                                                 value={
                                                     this.state
-                                                        .requiredChannelConfirmations
+                                                        .requiredChannelConfirmations ??
+                                                    ''
                                                 }
                                                 onChangeText={(text: string) =>
                                                     this.setState({
@@ -1039,7 +1040,8 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                                 )}
                                                 value={
                                                     this.state
-                                                        .confirmsWithinBlocks
+                                                        .confirmsWithinBlocks ??
+                                                    ''
                                                 }
                                                 onChangeText={(text: string) =>
                                                     this.setState({
@@ -1169,25 +1171,56 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                             Object.keys(createOrderResponse)
                                                 .length === 0
                                         ) {
+                                            let finalConfirmations =
+                                                this.state
+                                                    .requiredChannelConfirmations;
+                                            let finalBlocks =
+                                                this.state.confirmsWithinBlocks;
+
                                             if (
-                                                BackendUtils.supportsLSPS1native()
+                                                finalConfirmations === '' ||
+                                                finalConfirmations === null
                                             ) {
-                                                LSPStore.lsps1CreateOrderNative(
-                                                    this.state
-                                                );
-                                            } else if (
-                                                BackendUtils.supportsLSPS1rest()
-                                            ) {
-                                                LSPStore.lsps1CreateOrderREST(
-                                                    this.state
-                                                );
-                                            } else if (
-                                                BackendUtils.supportsLSPScustomMessage()
-                                            ) {
-                                                LSPStore.lsps1CreateOrderCustomMessage(
-                                                    this.state
-                                                );
+                                                finalConfirmations =
+                                                    info?.min_required_channel_confirmations?.toString();
                                             }
+                                            if (
+                                                finalBlocks === '' ||
+                                                finalBlocks === null
+                                            ) {
+                                                finalBlocks =
+                                                    info?.min_funding_confirms_within_blocks?.toString();
+                                            }
+
+                                            this.setState(
+                                                {
+                                                    requiredChannelConfirmations:
+                                                        finalConfirmations,
+                                                    confirmsWithinBlocks:
+                                                        finalBlocks
+                                                },
+                                                () => {
+                                                    if (
+                                                        BackendUtils.supportsLSPS1native()
+                                                    ) {
+                                                        LSPStore.lsps1CreateOrderNative(
+                                                            this.state
+                                                        );
+                                                    } else if (
+                                                        BackendUtils.supportsLSPS1rest()
+                                                    ) {
+                                                        LSPStore.lsps1CreateOrderREST(
+                                                            this.state
+                                                        );
+                                                    } else if (
+                                                        BackendUtils.supportsLSPScustomMessage()
+                                                    ) {
+                                                        LSPStore.lsps1CreateOrderCustomMessage(
+                                                            this.state
+                                                        );
+                                                    }
+                                                }
+                                            );
                                         } else {
                                             LSPStore.saveOrderToHistory(
                                                 createOrderResponse,

--- a/views/LSPS1/index.tsx
+++ b/views/LSPS1/index.tsx
@@ -1013,12 +1013,19 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                                         .requiredChannelConfirmations ??
                                                     ''
                                                 }
-                                                onChangeText={(text: string) =>
+                                                onChangeText={(
+                                                    text: string
+                                                ) => {
+                                                    const numericValue =
+                                                        text.replace(
+                                                            /[^0-9]/g,
+                                                            ''
+                                                        );
                                                     this.setState({
                                                         requiredChannelConfirmations:
-                                                            text
-                                                    })
-                                                }
+                                                            numericValue
+                                                    });
+                                                }}
                                                 style={styles.textInput}
                                                 keyboardType="numeric"
                                             />
@@ -1043,12 +1050,19 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                                         .confirmsWithinBlocks ??
                                                     ''
                                                 }
-                                                onChangeText={(text: string) =>
+                                                onChangeText={(
+                                                    text: string
+                                                ) => {
+                                                    const numericValue =
+                                                        text.replace(
+                                                            /[^0-9]/g,
+                                                            ''
+                                                        );
                                                     this.setState({
                                                         confirmsWithinBlocks:
-                                                            text
-                                                    })
-                                                }
+                                                            numericValue
+                                                    });
+                                                }}
                                                 style={styles.textInput}
                                                 keyboardType="numeric"
                                             />

--- a/views/LSPS1/index.tsx
+++ b/views/LSPS1/index.tsx
@@ -36,14 +36,10 @@ import { localeString } from '../../utils/LocaleUtils';
 import { numberWithCommas } from '../../utils/UnitsUtils';
 import handleAnything from '../../utils/handleAnything';
 
-import Storage from '../../storage';
-
-import LSPStore, { LSPS_ORDERS_KEY } from '../../stores/LSPStore';
+import LSPStore from '../../stores/LSPStore';
 import ChannelsStore from '../../stores/ChannelsStore';
 import SettingsStore from '../../stores/SettingsStore';
 import NodeInfoStore from '../../stores/NodeInfoStore';
-
-import { LSPOrderResponse as Order } from './OrdersPane';
 
 interface LSPS1Props {
     LSPStore: LSPStore;
@@ -70,6 +66,7 @@ interface LSPS1State {
 export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
     listener: any;
     private scrollViewRef = React.createRef<ScrollView>();
+    private lastSavedOrderId: string | null = null;
     constructor(props: LSPS1Props) {
         super(props);
         this.state = {
@@ -185,11 +182,18 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
             });
         }
 
-        const { createOrderResponse } = this.props.LSPStore;
+        const { LSPStore } = this.props;
+        const { createOrderResponse } = LSPStore;
         const result = createOrderResponse?.result || createOrderResponse;
+        const orderId = result?.order_id;
 
-        if (result?.order_id && isOrderFree(result?.payment)) {
-            this.saveOrder();
+        if (
+            orderId &&
+            orderId !== this.lastSavedOrderId &&
+            isOrderFree(result?.payment)
+        ) {
+            this.lastSavedOrderId = orderId;
+            LSPStore.saveOrderToHistory(createOrderResponse, 'LSPS1');
         }
     }
 
@@ -248,46 +252,6 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
             );
         } catch (err) {
             console.log(err);
-        }
-    };
-
-    saveOrder = async (): Promise<void> => {
-        const { LSPStore, NodeInfoStore } = this.props;
-        const { createOrderResponse } = LSPStore;
-        const result = createOrderResponse?.result || createOrderResponse;
-        const orderId = result?.order_id;
-        if (!orderId) return;
-
-        try {
-            const responseArrayString = await Storage.getItem(LSPS_ORDERS_KEY);
-            const responseArray: any[] = responseArrayString
-                ? JSON.parse(responseArrayString)
-                : [];
-
-            const exists = responseArray.some((response: any) => {
-                const stored = JSON.parse(response);
-                const storedId =
-                    stored.order?.order_id || stored.order?.result?.order_id;
-                return storedId === orderId;
-            });
-            if (exists) return;
-
-            const orderData: Order | any = { order: createOrderResponse };
-            orderData.clientPubkey = NodeInfoStore.nodeInfo.nodeId;
-            if (BackendUtils.supportsLSPS1native()) {
-                orderData.native = true;
-            } else if (BackendUtils.supportsLSPScustomMessage()) {
-                orderData.peer = LSPStore.getLSPSPubkey();
-                orderData.uri = `${LSPStore.getLSPSPubkey()}@${LSPStore.getLSPSHost()}`;
-            }
-            if (BackendUtils.supportsLSPS1rest()) {
-                orderData.endpoint = LSPStore.getLSPS1Rest();
-            }
-            orderData.service = 'LSPS1';
-            responseArray.push(JSON.stringify(orderData));
-            await Storage.setItem(LSPS_ORDERS_KEY, responseArray);
-        } catch (error) {
-            console.error('Error saving LSPS1 order:', error);
         }
     };
 
@@ -1225,7 +1189,10 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                                 );
                                             }
                                         } else {
-                                            this.saveOrder().then(() => {
+                                            LSPStore.saveOrderToHistory(
+                                                createOrderResponse,
+                                                'LSPS1'
+                                            ).then(() => {
                                                 handleAnything(
                                                     payment.bolt11?.invoice ||
                                                         payment.lightning_invoice ||

--- a/views/LSPS1/index.tsx
+++ b/views/LSPS1/index.tsx
@@ -30,6 +30,7 @@ import { ErrorMessage } from '../../components/SuccessErrorMessage';
 import { Row } from '../../components/layout/Row';
 
 import BackendUtils from '../../utils/BackendUtils';
+import { isOrderFree } from '../../models/LSP';
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { numberWithCommas } from '../../utils/UnitsUtils';
@@ -183,6 +184,13 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                     (info?.min_funding_confirms_within_blocks).toString()
             });
         }
+
+        const { createOrderResponse } = this.props.LSPStore;
+        const result = createOrderResponse?.result || createOrderResponse;
+
+        if (result?.order_id && isOrderFree(result?.payment)) {
+            this.saveOrder();
+        }
     }
 
     subscribeToCustomMessages() {
@@ -243,6 +251,46 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
         }
     };
 
+    saveOrder = async (): Promise<void> => {
+        const { LSPStore, NodeInfoStore } = this.props;
+        const { createOrderResponse } = LSPStore;
+        const result = createOrderResponse?.result || createOrderResponse;
+        const orderId = result?.order_id;
+        if (!orderId) return;
+
+        try {
+            const responseArrayString = await Storage.getItem(LSPS_ORDERS_KEY);
+            const responseArray: any[] = responseArrayString
+                ? JSON.parse(responseArrayString)
+                : [];
+
+            const exists = responseArray.some((response: any) => {
+                const stored = JSON.parse(response);
+                const storedId =
+                    stored.order?.order_id || stored.order?.result?.order_id;
+                return storedId === orderId;
+            });
+            if (exists) return;
+
+            const orderData: Order | any = { order: createOrderResponse };
+            orderData.clientPubkey = NodeInfoStore.nodeInfo.nodeId;
+            if (BackendUtils.supportsLSPS1native()) {
+                orderData.native = true;
+            } else if (BackendUtils.supportsLSPScustomMessage()) {
+                orderData.peer = LSPStore.getLSPSPubkey();
+                orderData.uri = `${LSPStore.getLSPSPubkey()}@${LSPStore.getLSPSHost()}`;
+            }
+            if (BackendUtils.supportsLSPS1rest()) {
+                orderData.endpoint = LSPStore.getLSPS1Rest();
+            }
+            orderData.service = 'LSPS1';
+            responseArray.push(JSON.stringify(orderData));
+            await Storage.setItem(LSPS_ORDERS_KEY, responseArray);
+        } catch (error) {
+            console.error('Error saving LSPS1 order:', error);
+        }
+    };
+
     updateExpirationIndex = (expirationIndex: number) => {
         if (expirationIndex === 0) {
             this.setState({
@@ -284,6 +332,7 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
             getInfoData;
         const result = createOrderResponse?.result || createOrderResponse;
         const payment = result?.payment;
+        const isFreeOrder = isOrderFree(payment);
 
         const HistoryBtn = () => (
             <TouchableOpacity
@@ -1137,143 +1186,46 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                 </ScrollView>
                             )}
                         </ScrollView>
-                        <View style={{ marginTop: 10 }}>
-                            <Button
-                                title={
-                                    Object.keys(createOrderResponse).length == 0
-                                        ? `${localeString(
-                                              'views.LSPS1.createOrder'
-                                          )}`
-                                        : `${localeString(
-                                              'views.LSPS1.makePayment'
-                                          )}`
-                                }
-                                onPress={() => {
-                                    if (
+                        {(Object.keys(createOrderResponse).length === 0 ||
+                            !isFreeOrder) && (
+                            <View style={{ marginTop: 10 }}>
+                                <Button
+                                    title={
                                         Object.keys(createOrderResponse)
-                                            .length === 0
-                                    ) {
+                                            .length == 0
+                                            ? `${localeString(
+                                                  'views.LSPS1.createOrder'
+                                              )}`
+                                            : `${localeString(
+                                                  'views.LSPS1.makePayment'
+                                              )}`
+                                    }
+                                    onPress={() => {
                                         if (
-                                            BackendUtils.supportsLSPS1native()
+                                            Object.keys(createOrderResponse)
+                                                .length === 0
                                         ) {
-                                            LSPStore.lsps1CreateOrderNative(
-                                                this.state
-                                            );
-                                        } else if (
-                                            BackendUtils.supportsLSPS1rest()
-                                        ) {
-                                            LSPStore.lsps1CreateOrderREST(
-                                                this.state
-                                            );
-                                        } else if (
-                                            BackendUtils.supportsLSPScustomMessage()
-                                        ) {
-                                            LSPStore.lsps1CreateOrderCustomMessage(
-                                                this.state
-                                            );
-                                        }
-                                    } else {
-                                        const orderId = result.order_id;
-
-                                        // Retrieve existing responses from encrypted storage or initialize an empty array
-                                        Storage.getItem(LSPS_ORDERS_KEY)
-                                            .then((responseArrayString) => {
-                                                let responseArray = [];
-                                                if (responseArrayString) {
-                                                    responseArray =
-                                                        JSON.parse(
-                                                            responseArrayString
-                                                        );
-                                                }
-
-                                                // Check if the order_id already exists in the stored responses
-                                                const existingResponseIndex =
-                                                    responseArray.findIndex(
-                                                        (response: any) => {
-                                                            const currentOrderId =
-                                                                JSON.parse(
-                                                                    response
-                                                                ).order
-                                                                    ?.order_id ||
-                                                                JSON.parse(
-                                                                    response
-                                                                ).order?.result
-                                                                    ?.order_id;
-                                                            return (
-                                                                currentOrderId ===
-                                                                orderId
-                                                            );
-                                                        }
-                                                    );
-
-                                                if (
-                                                    existingResponseIndex === -1
-                                                ) {
-                                                    const orderData:
-                                                        | Order
-                                                        | any = {
-                                                        order: createOrderResponse
-                                                    };
-
-                                                    orderData.clientPubkey =
-                                                        this.props.NodeInfoStore.nodeInfo.nodeId;
-
-                                                    if (
-                                                        BackendUtils.supportsLSPS1native()
-                                                    ) {
-                                                        orderData.native = true;
-                                                    } else if (
-                                                        BackendUtils.supportsLSPScustomMessage()
-                                                    ) {
-                                                        orderData.peer =
-                                                            LSPStore.getLSPSPubkey();
-                                                        orderData.uri = `${LSPStore.getLSPSPubkey()}@${LSPStore.getLSPSHost()}`;
-                                                    }
-                                                    if (
-                                                        BackendUtils.supportsLSPS1rest()
-                                                    ) {
-                                                        orderData.endpoint =
-                                                            LSPStore.getLSPS1Rest();
-                                                    }
-
-                                                    orderData.service = 'LSPS1';
-
-                                                    console.log(orderData);
-
-                                                    // Serialize the orderData object into a JSON string
-                                                    const serializedResponse =
-                                                        JSON.stringify(
-                                                            orderData
-                                                        );
-
-                                                    // Append the serialized response to the array
-                                                    responseArray.push(
-                                                        serializedResponse
-                                                    );
-
-                                                    // Save the updated array back to encrypted storage
-                                                    Storage.setItem(
-                                                        LSPS_ORDERS_KEY,
-                                                        responseArray
-                                                    )
-                                                        .then(() => {
-                                                            console.log(
-                                                                'Response saved successfully.'
-                                                            );
-                                                        })
-                                                        .catch((error) =>
-                                                            console.error(
-                                                                'Error saving order response:',
-                                                                error
-                                                            )
-                                                        );
-                                                } else {
-                                                    console.log(
-                                                        'Response with same order_id already exists. Skipping save.'
-                                                    );
-                                                }
-
-                                                // Navigate to payment
+                                            if (
+                                                BackendUtils.supportsLSPS1native()
+                                            ) {
+                                                LSPStore.lsps1CreateOrderNative(
+                                                    this.state
+                                                );
+                                            } else if (
+                                                BackendUtils.supportsLSPS1rest()
+                                            ) {
+                                                LSPStore.lsps1CreateOrderREST(
+                                                    this.state
+                                                );
+                                            } else if (
+                                                BackendUtils.supportsLSPScustomMessage()
+                                            ) {
+                                                LSPStore.lsps1CreateOrderCustomMessage(
+                                                    this.state
+                                                );
+                                            }
+                                        } else {
+                                            this.saveOrder().then(() => {
                                                 handleAnything(
                                                     payment.bolt11?.invoice ||
                                                         payment.lightning_invoice ||
@@ -1284,19 +1236,14 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                                         props
                                                     );
                                                 });
-                                            })
-                                            .catch((error) =>
-                                                console.error(
-                                                    'Error retrieving order responses:',
-                                                    error
-                                                )
-                                            );
-                                    }
-                                }}
-                                containerStyle={{ paddingBottom: 10 }}
-                                secondary
-                            />
-                        </View>
+                                            });
+                                        }
+                                    }}
+                                    containerStyle={{ paddingBottom: 10 }}
+                                    secondary
+                                />
+                            </View>
+                        )}
                     </>
                 )}
 

--- a/views/LSPS7/OrderResponse.tsx
+++ b/views/LSPS7/OrderResponse.tsx
@@ -236,7 +236,7 @@ export default class LSPS7OrderResponse extends React.Component<
                                 {!isFreeOrder && (
                                     <KeyValue
                                         keyValue={localeString(
-                                            'iews.LSPS1.onchainPayment'
+                                            'views.LSPS1.onchainPayment'
                                         )}
                                     />
                                 )}

--- a/views/LSPS7/OrderResponse.tsx
+++ b/views/LSPS7/OrderResponse.tsx
@@ -161,11 +161,13 @@ export default class LSPS7OrderResponse extends React.Component<
                         {/* BOLT11 */}
                         {payment && payment.bolt11 && (
                             <>
-                                <KeyValue
-                                    keyValue={localeString(
-                                        'views.LSPS1.bolt11Payment'
-                                    )}
-                                />
+                                {!isFreeOrder && (
+                                    <KeyValue
+                                        keyValue={localeString(
+                                            'views.LSPS1.bolt11Payment'
+                                        )}
+                                    />
+                                )}
                                 {payment?.bolt11.state && (
                                     <KeyValue
                                         keyValue={localeString('general.state')}
@@ -231,11 +233,13 @@ export default class LSPS7OrderResponse extends React.Component<
                         {/* On-chain */}
                         {payment && payment.onchain && (
                             <>
-                                <KeyValue
-                                    keyValue={localeString(
-                                        'iews.LSPS1.onchainPayment'
-                                    )}
-                                />
+                                {!isFreeOrder && (
+                                    <KeyValue
+                                        keyValue={localeString(
+                                            'iews.LSPS1.onchainPayment'
+                                        )}
+                                    />
+                                )}
                                 {payment?.onchain.fee_total_sat && (
                                     <KeyValue
                                         keyValue={localeString(
@@ -313,7 +317,6 @@ export default class LSPS7OrderResponse extends React.Component<
                             </>
                         )}
                         {orderResponse?.order_state === LSPOrderState.CREATED &&
-                            orderView &&
                             isFreeOrder && (
                                 <SuccessMessage
                                     message={localeString(

--- a/views/LSPS7/index.tsx
+++ b/views/LSPS7/index.tsx
@@ -29,14 +29,10 @@ import { localeString } from '../../utils/LocaleUtils';
 import { numberWithCommas } from '../../utils/UnitsUtils';
 import handleAnything from '../../utils/handleAnything';
 
-import LSPStore, { LSPS_ORDERS_KEY } from '../../stores/LSPStore';
+import LSPStore from '../../stores/LSPStore';
 import ChannelsStore from '../../stores/ChannelsStore';
 import SettingsStore from '../../stores/SettingsStore';
 import NodeInfoStore from '../../stores/NodeInfoStore';
-
-import { LSPOrderResponse as Order } from '../LSPS1/OrdersPane';
-
-import Storage from '../../storage';
 
 interface LSPS7Props {
     LSPStore: LSPStore;
@@ -69,6 +65,7 @@ interface LSPS7State {
 export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
     listener: any;
     private scrollViewRef = React.createRef<ScrollView>();
+    private lastSavedOrderId: string | null = null;
     constructor(props: LSPS7Props) {
         super(props);
 
@@ -109,52 +106,22 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
     }
 
     componentDidUpdate(_prevProps: LSPS7Props) {
-        const { createExtensionOrderResponse } = this.props.LSPStore;
-        const result =
-            createExtensionOrderResponse?.result ||
-            createExtensionOrderResponse;
-
-        if (result?.order_id && isOrderFree(result?.payment)) {
-            this.saveOrder();
-        }
-    }
-
-    saveOrder = async (): Promise<void> => {
-        const { LSPStore, NodeInfoStore } = this.props;
+        const { LSPStore } = this.props;
         const { createExtensionOrderResponse } = LSPStore;
         const result =
             createExtensionOrderResponse?.result ||
             createExtensionOrderResponse;
         const orderId = result?.order_id;
-        if (!orderId) return;
 
-        try {
-            const responseArrayString = await Storage.getItem(LSPS_ORDERS_KEY);
-            const responseArray: any[] = responseArrayString
-                ? JSON.parse(responseArrayString)
-                : [];
-
-            const exists = responseArray.some((response: any) => {
-                const stored = JSON.parse(response);
-                const storedId =
-                    stored.order?.order_id || stored.order?.result?.order_id;
-                return storedId === orderId;
-            });
-            if (exists) return;
-
-            const orderData: Order | any = {
-                order: createExtensionOrderResponse
-            };
-            orderData.clientPubkey = NodeInfoStore.nodeInfo?.nodeId;
-            orderData.peer = LSPStore.getLSPSPubkey();
-            orderData.uri = `${LSPStore.getLSPSPubkey()}@${LSPStore.getLSPSHost()}`;
-            orderData.service = 'LSPS7';
-            responseArray.push(JSON.stringify(orderData));
-            await Storage.setItem(LSPS_ORDERS_KEY, responseArray);
-        } catch (error) {
-            console.error('Error saving LSPS7 order:', error);
+        if (
+            orderId &&
+            orderId !== this.lastSavedOrderId &&
+            isOrderFree(result?.payment)
+        ) {
+            this.lastSavedOrderId = orderId;
+            LSPStore.saveOrderToHistory(createExtensionOrderResponse, 'LSPS7');
         }
-    };
+    }
 
     updateExpirationIndex = (expirationIndex: number) => {
         if (expirationIndex === 0) {
@@ -682,7 +649,10 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
                                                 this.state
                                             );
                                         } else {
-                                            this.saveOrder().then(() => {
+                                            LSPStore.saveOrderToHistory(
+                                                createExtensionOrderResponse,
+                                                'LSPS7'
+                                            ).then(() => {
                                                 handleAnything(
                                                     payment.bolt11?.invoice ||
                                                         payment.lightning_invoice ||

--- a/views/LSPS7/index.tsx
+++ b/views/LSPS7/index.tsx
@@ -23,6 +23,7 @@ import { ErrorMessage } from '../../components/SuccessErrorMessage';
 import { Row } from '../../components/layout/Row';
 
 import BackendUtils from '../../utils/BackendUtils';
+import { isOrderFree } from '../../models/LSP';
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { numberWithCommas } from '../../utils/UnitsUtils';
@@ -107,6 +108,54 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
         });
     }
 
+    componentDidUpdate(_prevProps: LSPS7Props) {
+        const { createExtensionOrderResponse } = this.props.LSPStore;
+        const result =
+            createExtensionOrderResponse?.result ||
+            createExtensionOrderResponse;
+
+        if (result?.order_id && isOrderFree(result?.payment)) {
+            this.saveOrder();
+        }
+    }
+
+    saveOrder = async (): Promise<void> => {
+        const { LSPStore, NodeInfoStore } = this.props;
+        const { createExtensionOrderResponse } = LSPStore;
+        const result =
+            createExtensionOrderResponse?.result ||
+            createExtensionOrderResponse;
+        const orderId = result?.order_id;
+        if (!orderId) return;
+
+        try {
+            const responseArrayString = await Storage.getItem(LSPS_ORDERS_KEY);
+            const responseArray: any[] = responseArrayString
+                ? JSON.parse(responseArrayString)
+                : [];
+
+            const exists = responseArray.some((response: any) => {
+                const stored = JSON.parse(response);
+                const storedId =
+                    stored.order?.order_id || stored.order?.result?.order_id;
+                return storedId === orderId;
+            });
+            if (exists) return;
+
+            const orderData: Order | any = {
+                order: createExtensionOrderResponse
+            };
+            orderData.clientPubkey = NodeInfoStore.nodeInfo?.nodeId;
+            orderData.peer = LSPStore.getLSPSPubkey();
+            orderData.uri = `${LSPStore.getLSPSPubkey()}@${LSPStore.getLSPSHost()}`;
+            orderData.service = 'LSPS7';
+            responseArray.push(JSON.stringify(orderData));
+            await Storage.setItem(LSPS_ORDERS_KEY, responseArray);
+        } catch (error) {
+            console.error('Error saving LSPS7 order:', error);
+        }
+    };
+
     updateExpirationIndex = (expirationIndex: number) => {
         if (expirationIndex === 0) {
             this.setState({
@@ -151,6 +200,7 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
             createExtensionOrderResponse?.result ||
             createExtensionOrderResponse;
         const payment = result?.payment;
+        const isFreeOrder = isOrderFree(payment);
 
         const HistoryBtn = () => (
             <TouchableOpacity
@@ -606,115 +656,33 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
                                 </ScrollView>
                             )}
                         </ScrollView>
-                        <View style={{ marginTop: 10 }}>
-                            <Button
-                                title={
-                                    Object.keys(createExtensionOrderResponse)
-                                        .length == 0
-                                        ? `${localeString(
-                                              'views.LSPS1.createOrder'
-                                          )}`
-                                        : `${localeString(
-                                              'views.LSPS1.makePayment'
-                                          )}`
-                                }
-                                onPress={() => {
-                                    if (
+                        {(Object.keys(createExtensionOrderResponse).length ===
+                            0 ||
+                            !isFreeOrder) && (
+                            <View style={{ marginTop: 10 }}>
+                                <Button
+                                    title={
                                         Object.keys(
                                             createExtensionOrderResponse
-                                        ).length === 0
-                                    ) {
-                                        LSPStore.lsps7CreateOrderCustomMessage(
-                                            this.state
-                                        );
-                                    } else {
-                                        const orderId = result.order_id;
-
-                                        // Retrieve existing responses from encrypted storage or initialize an empty array
-                                        Storage.getItem(LSPS_ORDERS_KEY)
-                                            .then((responseArrayString) => {
-                                                let responseArray = [];
-                                                if (responseArrayString) {
-                                                    responseArray =
-                                                        JSON.parse(
-                                                            responseArrayString
-                                                        );
-                                                }
-
-                                                // Check if the order_id already exists in the stored responses
-                                                const existingResponseIndex =
-                                                    responseArray.findIndex(
-                                                        (response: any) => {
-                                                            const currentOrderId =
-                                                                JSON.parse(
-                                                                    response
-                                                                ).order
-                                                                    ?.order_id ||
-                                                                JSON.parse(
-                                                                    response
-                                                                ).order?.result
-                                                                    ?.order_id;
-                                                            return (
-                                                                currentOrderId ===
-                                                                orderId
-                                                            );
-                                                        }
-                                                    );
-
-                                                if (
-                                                    existingResponseIndex === -1
-                                                ) {
-                                                    const orderData:
-                                                        | Order
-                                                        | any = {
-                                                        order: createExtensionOrderResponse
-                                                    };
-
-                                                    orderData.clientPubkey =
-                                                        nodeInfo?.nodeId;
-                                                    orderData.peer =
-                                                        LSPStore.getLSPSPubkey();
-                                                    orderData.uri = `${LSPStore.getLSPSPubkey()}@${LSPStore.getLSPSHost()}`;
-                                                    orderData.service = 'LSPS7';
-
-                                                    console.log(orderData);
-
-                                                    // Serialize the orderData object into a JSON string
-                                                    const serializedResponse =
-                                                        JSON.stringify(
-                                                            orderData
-                                                        );
-
-                                                    // Append the serialized response to the array
-                                                    responseArray.push(
-                                                        serializedResponse
-                                                    );
-
-                                                    // Save the updated array back to encrypted storage
-                                                    Storage.setItem(
-                                                        LSPS_ORDERS_KEY,
-                                                        JSON.stringify(
-                                                            responseArray
-                                                        )
-                                                    )
-                                                        .then(() => {
-                                                            console.log(
-                                                                'Response saved successfully.'
-                                                            );
-                                                        })
-                                                        .catch((error) =>
-                                                            console.error(
-                                                                'Error saving order response:',
-                                                                error
-                                                            )
-                                                        );
-                                                } else {
-                                                    console.log(
-                                                        'Response with same order_id already exists. Skipping save.'
-                                                    );
-                                                }
-
-                                                // Navigate to the payment
+                                        ).length == 0
+                                            ? `${localeString(
+                                                  'views.LSPS1.createOrder'
+                                              )}`
+                                            : `${localeString(
+                                                  'views.LSPS1.makePayment'
+                                              )}`
+                                    }
+                                    onPress={() => {
+                                        if (
+                                            Object.keys(
+                                                createExtensionOrderResponse
+                                            ).length === 0
+                                        ) {
+                                            LSPStore.lsps7CreateOrderCustomMessage(
+                                                this.state
+                                            );
+                                        } else {
+                                            this.saveOrder().then(() => {
                                                 handleAnything(
                                                     payment.bolt11?.invoice ||
                                                         payment.lightning_invoice ||
@@ -725,22 +693,17 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
                                                         props
                                                     );
                                                 });
-                                            })
-                                            .catch((error) =>
-                                                console.error(
-                                                    'Error retrieving order responses:',
-                                                    error
-                                                )
-                                            );
-                                    }
-                                }}
-                                disabled={new BigNumber(
-                                    channelExtensionBlocks
-                                ).gt(maxExtensionInBlocks)}
-                                containerStyle={{ paddingBottom: 10 }}
-                                secondary
-                            />
-                        </View>
+                                            });
+                                        }
+                                    }}
+                                    disabled={new BigNumber(
+                                        channelExtensionBlocks
+                                    ).gt(maxExtensionInBlocks)}
+                                    containerStyle={{ paddingBottom: 10 }}
+                                    secondary
+                                />
+                            </View>
+                        )}
                     </>
                 )}
             </Screen>


### PR DESCRIPTION
# Description

- Hide "Make payment" button when the LSP returns the order with no payment object
- Auto-save free orders to history since the button that previously triggered the save is no longer shown
- Show the free channel / free extension success banner directly in both cases (when we are on LSPS1/LSPS7 views and also when we are coming from OrdersPane view)

Refactor - Extracted order-history save logic from LSPS1 and LSPS7 into `LSPStore.saveOrderToHistory(orderResponse, service)`

- [ ] New feature
- [X] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [X] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
