### PR TITLE
chore(android): consolidate duplicate intent-filters in AndroidManifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,9 +15,6 @@
         <intent>
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="http"/>
-        </intent>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
             <data android:scheme="https"/>
         </intent>
         <intent>
@@ -64,77 +61,17 @@
             <category android:name="android.intent.category.DEFAULT" />
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="bitcoin" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="BITCOIN" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="lightning" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="LIGHTNING" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="lnurl" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="lnurlw" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="lnurlc" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="lnurlp" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="keyauth" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="lndconnect" />
-        </intent-filter>
-         <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="cashu" />
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="zeusln" />
-        </intent-filter>
-         <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="zeuscontact" />
         </intent-filter>
         <intent-filter>


### PR DESCRIPTION
# Description

Consolidates duplicate `<intent-filter>` declarations in `android/app/src/main/AndroidManifest.xml`.

- Merged 13 separate `VIEW` deep-link intent filters on `MainActivity` (one per URI scheme: `bitcoin`, `BITCOIN`, `lightning`, `LIGHTNING`, `lnurl`, `lnurlw`, `lnurlc`, `lnurlp`, `keyauth`, `lndconnect`, `cashu`, `zeusln`, `zeuscontact`) into a single filter with all 13 `<data android:scheme="…"/>` entries. Android resolves multiple `<data>` elements within one filter as a union, so matching behavior is identical.
- Merged the two `<queries>` `VIEW` intents for `http` and `https` into one.
- Left untouched: the NFC `NDEF_DISCOVERED` filters (different action — `lightning`/`LIGHTNING` already coexist there), the `text/plain` NDEF filter, the `SEND` image filter, all four stealth `activity-alias` entries, and the three `specialUse` services.

Net result: `AndroidManifest.xml` drops from 270 to 207 lines with no behavior change.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

### Verification suggested before merge

- Confirm AAPT2 still accepts the manifest: `cd android && ./gradlew :app:processDebugManifest`
- Smoke-test a few deep links on Android (e.g. `bitcoin:`, `lightning:`, `lnurl:`, `zeusln:`) to confirm they still launch `MainActivity`.
