### PR TITLE
fix(android): apply LDK and LND persistent mode toggles without app restart

### DIFF
--- a/android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt
+++ b/android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt
@@ -535,6 +535,22 @@ class LdkNodeModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
         return false
     }
 
+    @ReactMethod
+    fun setPersistentMode(enabled: Boolean, promise: Promise) {
+        try {
+            if (enabled) {
+                if (node != null) {
+                    LdkNodeService.startService(reactApplicationContext)
+                }
+            } else {
+                LdkNodeService.stopService(reactApplicationContext)
+            }
+            promise.resolve(null)
+        } catch (e: Exception) {
+            promise.reject("error", errorMessage(e))
+        }
+    }
+
     // Node Lifecycle Methods
 
     @ReactMethod

--- a/android/app/src/main/java/com/zeus/LndMobileService.java
+++ b/android/app/src/main/java/com/zeus/LndMobileService.java
@@ -579,6 +579,34 @@ public class LndMobileService extends Service {
           notificationManager.notify(ONGOING_NOTIFICATION_ID, buildNotification());
         }
         return START_NOT_STICKY;
+      } else if (intent.getAction().equals("app.zeusln.zeus.android.intent.action.APPLY_PERSISTENT_MODE")) {
+        if (notificationManager == null) {
+          notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        }
+        boolean enabled = intent.hasExtra("enabled")
+          ? intent.getBooleanExtra("enabled", false)
+          : getPersistentServicesEnabled(this);
+        if (enabled) {
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel chan = new NotificationChannel(BuildConfig.APPLICATION_ID, "ZEUS", NotificationManager.IMPORTANCE_NONE);
+            chan.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+            notificationManager.createNotificationChannel(chan);
+          }
+          Notification notification = buildNotification();
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(ONGOING_NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE);
+          } else {
+            startForeground(ONGOING_NOTIFICATION_ID, notification);
+          }
+        } else {
+          try {
+            stopForeground(STOP_FOREGROUND_REMOVE);
+          } catch (Exception e) {
+            Log.e(TAG, "Error stopping foreground service", e);
+          }
+          notificationManager.cancel(ONGOING_NOTIFICATION_ID);
+        }
+        return enabled ? START_STICKY : START_NOT_STICKY;
       }
     }
     

--- a/android/app/src/main/java/com/zeus/LndMobileService.java
+++ b/android/app/src/main/java/com/zeus/LndMobileService.java
@@ -93,6 +93,7 @@ public class LndMobileService extends Service {
   private Map<String, lndmobile.SendStream> writeStreams = new HashMap<>();
 
   private NotificationManager notificationManager;
+  private boolean isNotificationActive = false;
 
   private static boolean isReceiveStream(Method m) {
     return m.toString().contains("RecvStream");
@@ -555,12 +556,14 @@ public class LndMobileService extends Service {
       if (intent.getAction().equals("app.zeusln.zeus.android.intent.action.STOP")) {
         Log.i(TAG, "Received stopForeground Intent");
         stopForeground(STOP_FOREGROUND_REMOVE);
+        isNotificationActive = false;
         stopSelf();
         return START_NOT_STICKY;
       } else if (intent.getAction().equals("app.zeusln.zeus.android.intent.action.GRACEFUL_STOP")) {
         Handler handler = new Handler(Looper.getMainLooper(), msg -> {
           if (msg.what == MSG_STOP_LND_RESULT) {
             stopForeground(STOP_FOREGROUND_REMOVE);
+            isNotificationActive = false;
             stopSelf();
             Process.killProcess(Process.myPid());
             return true;
@@ -572,7 +575,9 @@ public class LndMobileService extends Service {
         stopLnd(messenger, -1);
         return START_NOT_STICKY;
       } else if (intent.getAction().equals("app.zeusln.zeus.android.intent.action.UPDATE_NOTIFICATION")) {
-        if (getPersistentServicesEnabled(this)) {
+        // Only refresh an existing notification — don't recreate one that's
+        // been dismissed (e.g. by setPersistentMode(false) on wallet switch).
+        if (isNotificationActive && getPersistentServicesEnabled(this)) {
           if (notificationManager == null) {
             notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
           }
@@ -598,6 +603,7 @@ public class LndMobileService extends Service {
           } else {
             startForeground(ONGOING_NOTIFICATION_ID, notification);
           }
+          isNotificationActive = true;
         } else {
           try {
             stopForeground(STOP_FOREGROUND_REMOVE);
@@ -605,6 +611,7 @@ public class LndMobileService extends Service {
             Log.e(TAG, "Error stopping foreground service", e);
           }
           notificationManager.cancel(ONGOING_NOTIFICATION_ID);
+          isNotificationActive = false;
         }
         return enabled ? START_STICKY : START_NOT_STICKY;
       }
@@ -628,6 +635,7 @@ public class LndMobileService extends Service {
       } else {
         startForeground(ONGOING_NOTIFICATION_ID, notification);
       }
+      isNotificationActive = true;
     } else {
       try {
         stopForeground(STOP_FOREGROUND_REMOVE);
@@ -640,6 +648,7 @@ public class LndMobileService extends Service {
       if (notificationManager != null) {
         notificationManager.cancel(ONGOING_NOTIFICATION_ID);
       }
+      isNotificationActive = false;
     }
 
     // else noop, instead of calling startService, start will be handled by binding
@@ -702,6 +711,7 @@ public class LndMobileService extends Service {
       if (notificationManager != null) {
         notificationManager.cancel(ONGOING_NOTIFICATION_ID);
       }
+      isNotificationActive = false;
     }
   }
 
@@ -710,6 +720,7 @@ public class LndMobileService extends Service {
     if (notificationManager != null) {
       notificationManager.cancel(ONGOING_NOTIFICATION_ID);
     }
+    isNotificationActive = false;
     if (handlerThread != null) {
       handlerThread.quitSafely();
       handlerThread = null;
@@ -731,6 +742,7 @@ public class LndMobileService extends Service {
       if (notificationManager != null) {
         notificationManager.cancel(ONGOING_NOTIFICATION_ID);
       }
+      isNotificationActive = false;
       stopSelf();
     }
     super.onTaskRemoved(rootIntent);
@@ -778,6 +790,7 @@ public class LndMobileService extends Service {
     if (notificationManager != null) {
       notificationManager.cancelAll();
     }
+    isNotificationActive = false;
     Lndmobile.stopDaemon(
       lnrpc.LightningOuterClass.StopRequest.newBuilder().build().toByteArray(),
       new Callback() {
@@ -819,6 +832,7 @@ public class LndMobileService extends Service {
     if (notificationManager != null) {
       notificationManager.cancelAll();
     }
+    isNotificationActive = false;
     Lndmobile.cancelGossipSync();
   }
 }

--- a/android/app/src/main/java/com/zeus/LndMobileTools.java
+++ b/android/app/src/main/java/com/zeus/LndMobileTools.java
@@ -613,6 +613,23 @@ class LndMobileTools extends ReactContextBaseJavaModule {
     ProcessPhoenix.triggerRebirth(getReactApplicationContext());
   }
 
+  @ReactMethod
+  public void setPersistentMode(boolean enabled, Promise promise) {
+    try {
+      Intent intent = new Intent(getReactApplicationContext(), LndMobileService.class);
+      intent.setAction("app.zeusln.zeus.android.intent.action.APPLY_PERSISTENT_MODE");
+      intent.putExtra("enabled", enabled);
+      if (enabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        getReactApplicationContext().startForegroundService(intent);
+      } else {
+        getReactApplicationContext().startService(intent);
+      }
+      promise.resolve(null);
+    } catch (Exception e) {
+      promise.reject("error", e.getMessage());
+    }
+  }
+
   private void checkWriteExternalStoragePermission(@NonNull RequestWriteExternalStoragePermissionCallback successCallback,
                                                    @NonNull Runnable failCallback,
                                                    @NonNull Runnable failPermissionCheckcallback) {

--- a/ldknode/LdkNode.d.ts
+++ b/ldknode/LdkNode.d.ts
@@ -474,6 +474,7 @@ export interface ILdkNodeModule {
     start(): Promise<void>;
     stop(): Promise<void>;
     syncWallets(): Promise<void>;
+    setPersistentMode(enabled: boolean): Promise<void>;
 
     // Node Info Methods
     nodeId(): Promise<string>;

--- a/ldknode/LdkNodeInjection.ts
+++ b/ldknode/LdkNodeInjection.ts
@@ -3,7 +3,7 @@
  * Similar pattern to LndMobileInjection
  */
 
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 import RNFS from 'react-native-fs';
 import { generateVssAuthHeaders } from '../utils/VssAuthUtils';
 import type {
@@ -169,6 +169,11 @@ const stop = async (): Promise<void> => {
 
 const syncWallets = async (): Promise<void> => {
     return await LdkNodeModule.syncWallets();
+};
+
+const setPersistentMode = async (enabled: boolean): Promise<void> => {
+    if (Platform.OS !== 'android') return;
+    return await LdkNodeModule.setPersistentMode(enabled);
 };
 
 // ============================================================================
@@ -1025,6 +1030,7 @@ export interface ILdkNodeInjections {
         start: () => Promise<void>;
         stop: () => Promise<void>;
         syncWallets: () => Promise<void>;
+        setPersistentMode: (enabled: boolean) => Promise<void>;
         nodeId: () => Promise<string>;
         status: () => Promise<NodeStatus>;
         listBalances: () => Promise<BalanceDetails>;
@@ -1273,6 +1279,7 @@ const LdkNodeInjection: ILdkNodeInjections = {
         start,
         stop,
         syncWallets,
+        setPersistentMode,
         nodeId,
         status,
         listBalances,

--- a/lndmobile/LndMobile.d.ts
+++ b/lndmobile/LndMobile.d.ts
@@ -133,6 +133,7 @@ export interface ILndMobileTools {
     checkLndProcessExist(): Promise<boolean>;
     deleteTLSCerts(): Promise<boolean>;
     restartApp(): void;
+    setPersistentMode(enabled: boolean): Promise<void>;
 
     // iOS-specific
     checkICloudEnabled(): Promise<boolean>;

--- a/views/PendingHTLCs.tsx
+++ b/views/PendingHTLCs.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { FlatList, Platform, Text, View, StyleSheet } from 'react-native';
+import {
+    FlatList,
+    NativeModules,
+    Platform,
+    Text,
+    View,
+    StyleSheet
+} from 'react-native';
 import { Button, ListItem } from '@rneui/themed';
 import { inject, observer } from 'mobx-react';
 import { Route } from '@react-navigation/native';
@@ -13,7 +20,6 @@ import Screen from '../components/Screen';
 import Switch from '../components/Switch';
 
 import { localeString } from '../utils/LocaleUtils';
-import { restartNeeded } from '../utils/RestartUtils';
 import { themeColor } from '../utils/ThemeUtils';
 import { numberWithCommas } from '../utils/UnitsUtils';
 
@@ -321,21 +327,46 @@ export default class PendingHTLCs extends React.PureComponent<
                                                 <Switch
                                                     value={persistentMode}
                                                     onValueChange={async () => {
+                                                        const previousValue =
+                                                            persistentMode;
+                                                        const newValue =
+                                                            !previousValue;
                                                         this.setState({
                                                             persistentMode:
-                                                                !persistentMode
+                                                                newValue
                                                         });
                                                         await updateSettings({
                                                             persistentMode:
-                                                                !persistentMode
+                                                                newValue
                                                         });
-                                                        const newValue =
-                                                            !persistentMode;
                                                         await AsyncStorage.setItem(
                                                             PERSISTENT_KEY,
                                                             newValue.toString()
                                                         );
-                                                        restartNeeded();
+                                                        try {
+                                                            await NativeModules.LndMobileTools.setPersistentMode(
+                                                                newValue
+                                                            );
+                                                        } catch (e) {
+                                                            console.error(
+                                                                'Failed to toggle LND persistent mode:',
+                                                                e
+                                                            );
+                                                            this.setState({
+                                                                persistentMode:
+                                                                    previousValue
+                                                            });
+                                                            await updateSettings(
+                                                                {
+                                                                    persistentMode:
+                                                                        previousValue
+                                                                }
+                                                            );
+                                                            await AsyncStorage.setItem(
+                                                                PERSISTENT_KEY,
+                                                                previousValue.toString()
+                                                            );
+                                                        }
                                                     }}
                                                     trackEnabledColor={themeColor(
                                                         'background'

--- a/views/Settings/EmbeddedNode/Advanced.tsx
+++ b/views/Settings/EmbeddedNode/Advanced.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Platform, ScrollView, Text, View } from 'react-native';
+import { NativeModules, Platform, ScrollView, Text, View } from 'react-native';
 import { Icon, ListItem } from '@rneui/themed';
 import { inject, observer } from 'mobx-react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -215,21 +215,41 @@ export default class EmbeddedNodeAdvancedSettings extends React.Component<
                                         <Switch
                                             value={persistentMode}
                                             onValueChange={async () => {
+                                                const previousValue =
+                                                    persistentMode;
+                                                const newValue = !previousValue;
                                                 this.setState({
-                                                    persistentMode:
-                                                        !persistentMode
+                                                    persistentMode: newValue
                                                 });
                                                 await updateSettings({
-                                                    persistentMode:
-                                                        !persistentMode
+                                                    persistentMode: newValue
                                                 });
-                                                const newValue =
-                                                    !persistentMode;
                                                 await AsyncStorage.setItem(
                                                     PERSISTENT_KEY,
                                                     newValue.toString()
                                                 );
-                                                restartNeeded();
+                                                try {
+                                                    await NativeModules.LndMobileTools.setPersistentMode(
+                                                        newValue
+                                                    );
+                                                } catch (e) {
+                                                    console.error(
+                                                        'Failed to toggle LND persistent mode:',
+                                                        e
+                                                    );
+                                                    this.setState({
+                                                        persistentMode:
+                                                            previousValue
+                                                    });
+                                                    await updateSettings({
+                                                        persistentMode:
+                                                            previousValue
+                                                    });
+                                                    await AsyncStorage.setItem(
+                                                        PERSISTENT_KEY,
+                                                        previousValue.toString()
+                                                    );
+                                                }
                                             }}
                                         />
                                     </View>
@@ -244,13 +264,11 @@ export default class EmbeddedNodeAdvancedSettings extends React.Component<
                                             color: themeColor('secondaryText')
                                         }}
                                     >
-                                        {`${localeString(
+                                        {localeString(
                                             embeddedTor
                                                 ? 'views.Settings.EmbeddedNode.persistentMode.subtitleTor'
                                                 : 'views.Settings.EmbeddedNode.persistentMode.subtitle'
-                                        )} ${localeString(
-                                            'views.Settings.EmbeddedNode.restart'
-                                        )}`}
+                                        )}
                                     </Text>
                                 </View>
                             </>

--- a/views/Settings/EmbeddedNode/index.tsx
+++ b/views/Settings/EmbeddedNode/index.tsx
@@ -12,8 +12,9 @@ import Switch from '../../../components/Switch';
 import SettingsStore from '../../../stores/SettingsStore';
 
 import { localeString } from '../../../utils/LocaleUtils';
-import { restartNeeded } from '../../../utils/RestartUtils';
 import { themeColor } from '../../../utils/ThemeUtils';
+
+import LdkNode from '../../../ldknode/LdkNodeInjection';
 
 const PERSISTENT_LDK_KEY = 'persistentLdkNodeServicesEnabled';
 
@@ -434,8 +435,9 @@ export default class EmbeddedNode extends React.Component<
                                         <Switch
                                             value={this.state.persistentMode}
                                             onValueChange={async () => {
-                                                const newValue =
-                                                    !this.state.persistentMode;
+                                                const previousValue =
+                                                    this.state.persistentMode;
+                                                const newValue = !previousValue;
                                                 this.setState({
                                                     persistentMode: newValue
                                                 });
@@ -443,7 +445,24 @@ export default class EmbeddedNode extends React.Component<
                                                     PERSISTENT_LDK_KEY,
                                                     newValue.toString()
                                                 );
-                                                restartNeeded();
+                                                try {
+                                                    await LdkNode.node.setPersistentMode(
+                                                        newValue
+                                                    );
+                                                } catch (e) {
+                                                    console.error(
+                                                        'Failed to toggle LDK persistent mode:',
+                                                        e
+                                                    );
+                                                    this.setState({
+                                                        persistentMode:
+                                                            previousValue
+                                                    });
+                                                    await AsyncStorage.setItem(
+                                                        PERSISTENT_LDK_KEY,
+                                                        previousValue.toString()
+                                                    );
+                                                }
                                             }}
                                         />
                                     </View>
@@ -454,11 +473,9 @@ export default class EmbeddedNode extends React.Component<
                                             color: themeColor('secondaryText')
                                         }}
                                     >
-                                        {`${localeString(
+                                        {localeString(
                                             'views.Settings.EmbeddedNode.persistentModeLdk.subtitle'
-                                        )} ${localeString(
-                                            'views.Settings.EmbeddedNode.restart'
-                                        )}`}
+                                        )}
                                     </Text>
                                 </View>
                             </>

--- a/views/Settings/Wallets.tsx
+++ b/views/Settings/Wallets.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import {
+    NativeModules,
+    Platform,
     View,
     Text,
     TouchableOpacity,
@@ -19,6 +21,8 @@ import Header from '../../components/Header';
 import NodeIdenticon, { NodeTitle } from '../../components/NodeIdenticon';
 import Screen from '../../components/Screen';
 import LoadingIndicator from '../../components/LoadingIndicator';
+
+import LdkNode from '../../ldknode/LdkNodeInjection';
 
 import SettingsStore, {
     INTERFACE_KEYS,
@@ -283,6 +287,27 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                 const currentImplementation = implementation;
                 if (currentImplementation === 'lightning-node-connect') {
                     BackendUtils.disconnect();
+                }
+
+                if (Platform.OS === 'android') {
+                    // Dismiss the previously selected embedded node's
+                    // persistent notification so users aren't left
+                    // looking at a notification for a wallet they
+                    // just switched away from.
+                    try {
+                        if (currentImplementation === 'ldk-node') {
+                            await LdkNode.node.setPersistentMode(false);
+                        } else if (currentImplementation === 'embedded-lnd') {
+                            await NativeModules.LndMobileTools.setPersistentMode(
+                                false
+                            );
+                        }
+                    } catch (e) {
+                        console.log(
+                            'Failed to dismiss previous embedded node notification:',
+                            e
+                        );
+                    }
                 }
 
                 // Store startup state before updating settings


### PR DESCRIPTION
# Description

Previously, toggling "Persistent Mode" for the LDK Node or Embedded LND required the user to manually restart the app for the change to take effect.

The toggle handler would call `restartNeeded()`, which presents an Alert dialog asking the user to confirm an app restart. The restart flow stops the node and then calls `ProcessPhoenix.triggerRebirth()` to relaunch the process — but if the user dismissed the dialog, or if `node.stop()` hung (Tor/VSS shutdown stalls have been observed), the foreground service was never started/stopped, leaving the user in an inconsistent state where the AsyncStorage flag said one thing but the running service reflected another.

This PR removes the restart requirement entirely. The foreground service can be controlled at runtime via static `startService`/`stopService` methods, so the toggle now reaches the native bridge directly and the change takes effect immediately.

### LDK Node (`LdkNodeModule.kt` / `LdkNodeService.kt`)

The LDK service exists purely to keep the app process alive — it can be started or stopped freely as long as the node is running. Added a `setPersistentMode(enabled)` React method that calls `LdkNodeService.startService` / `stopService` directly.

### Embedded LND (`LndMobileService.java` / `LndMobileTools.java`)

The LND service is fundamentally different — it's a bound Messenger-based IPC bridge to LND itself, so it must stay alive even when persistent mode is off. Added a new `APPLY_PERSISTENT_MODE` intent action whose `onStartCommand` branch only toggles `startForeground` / `stopForeground` + the notification, without ever calling `stopSelf`. Exposed via `LndMobileTools.setPersistentMode(enabled)`.

### UI

Both toggles (`views/Settings/EmbeddedNode/index.tsx` for LDK, `views/Settings/EmbeddedNode/Advanced.tsx` for LND) now call the new native methods after persisting to AsyncStorage. The " Restart to take effect." suffix is removed from both subtitles since no restart is required. `restartNeeded` is still imported in `Advanced.tsx` for the fee estimator / rescan / compactDb toggles, which legitimately do require an LND restart.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
