### PR TITLE
fix: repair stale invoice expiry display ("3600 hours") for upgraded users

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1920,6 +1920,9 @@ export default class SettingsStore {
                 const parsedSettings = JSON.parse(modernSettings);
                 this.settings = parsedSettings;
                 await MigrationsUtils.migrateRgsDefaultToZeus(parsedSettings);
+                await MigrationsUtils.migrateInvoiceExpiryDisplay(
+                    parsedSettings
+                );
                 this.settings = parsedSettings;
             } else {
                 console.log('attempting to load legacy settings');

--- a/utils/ExpiryUtils.test.ts
+++ b/utils/ExpiryUtils.test.ts
@@ -1,5 +1,6 @@
 import {
     ExpirationPreset,
+    displayFromExpirySeconds,
     expirationIndexFromSeconds,
     expirySecondsFromInput
 } from './ExpiryUtils';
@@ -73,6 +74,65 @@ describe('ExpiryUtils', () => {
             expect(expirationIndexFromSeconds('999')).toBeNull();
             expect(expirationIndexFromSeconds('')).toBeNull();
             expect(expirationIndexFromSeconds('NaN')).toBeNull();
+        });
+    });
+
+    describe('displayFromExpirySeconds', () => {
+        it('prefers the largest evenly-dividing unit', () => {
+            expect(displayFromExpirySeconds('604800')).toEqual({
+                expiry: '1',
+                timePeriod: 'Weeks'
+            });
+            expect(displayFromExpirySeconds('86400')).toEqual({
+                expiry: '1',
+                timePeriod: 'Days'
+            });
+            expect(displayFromExpirySeconds('3600')).toEqual({
+                expiry: '1',
+                timePeriod: 'Hours'
+            });
+            expect(displayFromExpirySeconds('600')).toEqual({
+                expiry: '10',
+                timePeriod: 'Minutes'
+            });
+            expect(displayFromExpirySeconds('7200')).toEqual({
+                expiry: '2',
+                timePeriod: 'Hours'
+            });
+            expect(displayFromExpirySeconds('1209600')).toEqual({
+                expiry: '2',
+                timePeriod: 'Weeks'
+            });
+        });
+
+        it('falls back to Seconds for non-divisible values', () => {
+            expect(displayFromExpirySeconds('90')).toEqual({
+                expiry: '90',
+                timePeriod: 'Seconds'
+            });
+            expect(displayFromExpirySeconds('1')).toEqual({
+                expiry: '1',
+                timePeriod: 'Seconds'
+            });
+        });
+
+        it('falls back to 1 Hours for empty or invalid input', () => {
+            expect(displayFromExpirySeconds('')).toEqual({
+                expiry: '1',
+                timePeriod: 'Hours'
+            });
+            expect(displayFromExpirySeconds('0')).toEqual({
+                expiry: '1',
+                timePeriod: 'Hours'
+            });
+            expect(displayFromExpirySeconds('-3600')).toEqual({
+                expiry: '1',
+                timePeriod: 'Hours'
+            });
+            expect(displayFromExpirySeconds('NaN')).toEqual({
+                expiry: '1',
+                timePeriod: 'Hours'
+            });
         });
     });
 });

--- a/utils/ExpiryUtils.ts
+++ b/utils/ExpiryUtils.ts
@@ -60,3 +60,23 @@ export const expirationIndexFromSeconds = (
             return null;
     }
 };
+
+// Inverse of expirySecondsFromInput: given seconds, returns the largest
+// natural (value, unit) pair that divides evenly. Falls back to Seconds for
+// non-divisible inputs, and to ('1', 'Hours') for empty/invalid input.
+export const displayFromExpirySeconds = (
+    expirySeconds: string
+): { expiry: string; timePeriod: TimePeriod } => {
+    const n = Number(expirySeconds);
+    if (!Number.isFinite(n) || n <= 0)
+        return { expiry: '1', timePeriod: 'Hours' };
+    if (n % SECONDS_IN_WEEK === 0)
+        return { expiry: String(n / SECONDS_IN_WEEK), timePeriod: 'Weeks' };
+    if (n % SECONDS_IN_DAY === 0)
+        return { expiry: String(n / SECONDS_IN_DAY), timePeriod: 'Days' };
+    if (n % SECONDS_IN_HOUR === 0)
+        return { expiry: String(n / SECONDS_IN_HOUR), timePeriod: 'Hours' };
+    if (n % SECONDS_IN_MINUTE === 0)
+        return { expiry: String(n / SECONDS_IN_MINUTE), timePeriod: 'Minutes' };
+    return { expiry: String(n), timePeriod: 'Seconds' };
+};

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -288,6 +288,86 @@ describe('MigrationUtils', () => {
         });
     });
 
+    describe('migrateInvoiceExpiryDisplay', () => {
+        const EncryptedStorage = require('react-native-encrypted-storage');
+
+        beforeEach(() => {
+            EncryptedStorage.getItem.mockReset();
+            EncryptedStorage.setItem.mockReset();
+        });
+
+        it('repairs inconsistent expiry/timePeriod on v2 settings', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                invoices: {
+                    expiry: '3600',
+                    timePeriod: 'Hours',
+                    expirySeconds: '3600'
+                }
+            };
+
+            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
+
+            expect(settings.invoices).toEqual({
+                expiry: '1',
+                timePeriod: 'Hours',
+                expirySeconds: '3600'
+            });
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'invoices-expiry-display-fix',
+                'true'
+            );
+        });
+
+        it('leaves consistent settings untouched', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                invoices: {
+                    expiry: '2',
+                    timePeriod: 'Hours',
+                    expirySeconds: '7200'
+                }
+            };
+
+            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
+
+            expect(settings.invoices).toEqual({
+                expiry: '2',
+                timePeriod: 'Hours',
+                expirySeconds: '7200'
+            });
+        });
+
+        it('is a no-op when the migration flag is already set', async () => {
+            EncryptedStorage.getItem.mockResolvedValue('true');
+            const settings: any = {
+                invoices: {
+                    expiry: '3600',
+                    timePeriod: 'Hours',
+                    expirySeconds: '3600'
+                }
+            };
+
+            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
+
+            expect(settings.invoices.expiry).toBe('3600');
+            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
+        });
+
+        it('does nothing when invoices.expirySeconds is missing', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {};
+
+            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
+
+            expect(settings).toEqual({});
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'invoices-expiry-display-fix',
+                'true'
+            );
+        });
+    });
+
     describe('migrateCashuSeedVersion', () => {
         beforeEach(() => {
             // Clear mock history before each test

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -246,6 +246,46 @@ describe('MigrationUtils', () => {
                 }
             });
         });
+        it('repairs invoice expiry display fields when out of sync with expirySeconds', async () => {
+            await expect(
+                MigrationUtils.legacySettingsMigrations(
+                    JSON.stringify({
+                        invoices: {
+                            expiry: '3600',
+                            timePeriod: 'Hours',
+                            expirySeconds: '3600'
+                        }
+                    })
+                )
+            ).resolves.toEqual({
+                ...defaultSettings,
+                invoices: {
+                    expiry: '1',
+                    timePeriod: 'Hours',
+                    expirySeconds: '3600'
+                }
+            });
+        });
+        it('leaves consistent invoice expiry settings untouched', async () => {
+            await expect(
+                MigrationUtils.legacySettingsMigrations(
+                    JSON.stringify({
+                        invoices: {
+                            expiry: '2',
+                            timePeriod: 'Hours',
+                            expirySeconds: '7200'
+                        }
+                    })
+                )
+            ).resolves.toEqual({
+                ...defaultSettings,
+                invoices: {
+                    expiry: '2',
+                    timePeriod: 'Hours',
+                    expirySeconds: '7200'
+                }
+            });
+        });
     });
 
     describe('migrateCashuSeedVersion', () => {

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -430,32 +430,7 @@ class MigrationsUtils {
             await EncryptedStorage.setItem(MOD_KEY8, 'true');
         }
 
-        // Repair invoice expiry display fields when out of sync with the
-        // authoritative `expirySeconds` (e.g. older installs that defaulted
-        // `expiry` to '3600' instead of '1', causing the UI to read
-        // "3600 hours" while the invoice actually expired in one hour).
-        const MOD_KEY9 = 'invoices-expiry-display-fix';
-        const mod9 = await EncryptedStorage.getItem(MOD_KEY9);
-        if (!mod9) {
-            const invoices: any = newSettings?.invoices;
-            const expirySeconds = invoices?.expirySeconds;
-            if (expirySeconds) {
-                const inconsistent =
-                    !invoices.expiry ||
-                    !invoices.timePeriod ||
-                    expirySecondsFromInput(
-                        invoices.expiry,
-                        invoices.timePeriod as TimePeriod
-                    ) !== expirySeconds;
-                if (inconsistent) {
-                    const repaired = displayFromExpirySeconds(expirySeconds);
-                    invoices.expiry = repaired.expiry;
-                    invoices.timePeriod = repaired.timePeriod;
-                }
-            }
-            await settingsStore.setSettings(JSON.stringify(newSettings));
-            await EncryptedStorage.setItem(MOD_KEY9, 'true');
-        }
+        await this.migrateInvoiceExpiryDisplay(newSettings);
 
         // migrate old POS squareEnabled setting to posEnabled
         if (newSettings?.pos?.squareEnabled) {
@@ -508,6 +483,41 @@ class MigrationsUtils {
         }
         await settingsStore.setSettings(JSON.stringify(settings));
         await EncryptedStorage.setItem(MOD_KEY_RGS, 'true');
+        return settings;
+    }
+
+    // Repair invoice expiry display fields when out of sync with the
+    // authoritative `expirySeconds` (e.g. older installs that defaulted
+    // `expiry` to '3600' instead of '1', causing the UI to read
+    // "3600 hours" while the invoice actually expired in one hour).
+    // Must run on both the legacy and modern (zeus-settings-v2) paths,
+    // since affected users may already have migrated to v2 carrying the
+    // stale value forward.
+    public async migrateInvoiceExpiryDisplay(settings: any) {
+        const MOD_KEY_INVOICE_EXPIRY = 'invoices-expiry-display-fix';
+        const modInvoiceExpiry = await EncryptedStorage.getItem(
+            MOD_KEY_INVOICE_EXPIRY
+        );
+        if (modInvoiceExpiry) return settings;
+
+        const invoices: any = settings?.invoices;
+        const expirySeconds = invoices?.expirySeconds;
+        if (expirySeconds) {
+            const inconsistent =
+                !invoices.expiry ||
+                !invoices.timePeriod ||
+                expirySecondsFromInput(
+                    invoices.expiry,
+                    invoices.timePeriod as TimePeriod
+                ) !== expirySeconds;
+            if (inconsistent) {
+                const repaired = displayFromExpirySeconds(expirySeconds);
+                invoices.expiry = repaired.expiry;
+                invoices.timePeriod = repaired.timePeriod;
+            }
+        }
+        await settingsStore.setSettings(JSON.stringify(settings));
+        await EncryptedStorage.setItem(MOD_KEY_INVOICE_EXPIRY, 'true');
         return settings;
     }
 

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -306,7 +306,7 @@ class MigrationsUtils {
         const mod = await EncryptedStorage.getItem(MOD_KEY);
         if (!mod) {
             newSettings.requestSimpleTaproot = true;
-            settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY, 'true');
         }
 
@@ -319,7 +319,7 @@ class MigrationsUtils {
             if (newSettings?.lspTestnet === 'https://testnet-lsp.lnolymp.us') {
                 newSettings.lspTestnet = DEFAULT_LSP_TESTNET;
             }
-            settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY2, 'true');
         }
 
@@ -340,7 +340,7 @@ class MigrationsUtils {
                 newSettings.neutrinoPeersMainnet =
                     DEFAULT_NEUTRINO_PEERS_MAINNET;
             }
-            settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY3, 'true');
         }
 
@@ -370,7 +370,7 @@ class MigrationsUtils {
                 newSettings.lsps1Token = '';
             }
 
-            settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY4, 'true');
         }
 
@@ -387,7 +387,7 @@ class MigrationsUtils {
                 }
             }
 
-            settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY5, 'true');
         }
 
@@ -399,7 +399,7 @@ class MigrationsUtils {
                 newSettings.customSpeedloader = '';
             }
 
-            settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY6, 'true');
         }
 
@@ -412,7 +412,7 @@ class MigrationsUtils {
                 newSettings.bimodalPathfinding = false;
             }
 
-            settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY7, 'true');
         }
 
@@ -426,7 +426,7 @@ class MigrationsUtils {
                 newSettings.lightningAddress.nostrRelays = DEFAULT_NOSTR_RELAYS;
             }
 
-            settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY8, 'true');
         }
 
@@ -453,7 +453,7 @@ class MigrationsUtils {
                     invoices.timePeriod = repaired.timePeriod;
                 }
             }
-            settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY9, 'true');
         }
 

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -72,6 +72,12 @@ import {
 } from '../utils/SwapUtils';
 
 import {
+    TimePeriod,
+    displayFromExpirySeconds,
+    expirySecondsFromInput
+} from '../utils/ExpiryUtils';
+
+import {
     LEGACY_ACTIVITY_FILTERS_KEY,
     ACTIVITY_FILTERS_KEY
 } from '../stores/ActivityStore';
@@ -422,6 +428,33 @@ class MigrationsUtils {
 
             settingsStore.setSettings(JSON.stringify(newSettings));
             await EncryptedStorage.setItem(MOD_KEY8, 'true');
+        }
+
+        // Repair invoice expiry display fields when out of sync with the
+        // authoritative `expirySeconds` (e.g. older installs that defaulted
+        // `expiry` to '3600' instead of '1', causing the UI to read
+        // "3600 hours" while the invoice actually expired in one hour).
+        const MOD_KEY9 = 'invoices-expiry-display-fix';
+        const mod9 = await EncryptedStorage.getItem(MOD_KEY9);
+        if (!mod9) {
+            const invoices: any = newSettings?.invoices;
+            const expirySeconds = invoices?.expirySeconds;
+            if (expirySeconds) {
+                const inconsistent =
+                    !invoices.expiry ||
+                    !invoices.timePeriod ||
+                    expirySecondsFromInput(
+                        invoices.expiry,
+                        invoices.timePeriod as TimePeriod
+                    ) !== expirySeconds;
+                if (inconsistent) {
+                    const repaired = displayFromExpirySeconds(expirySeconds);
+                    invoices.expiry = repaired.expiry;
+                    invoices.timePeriod = repaired.timePeriod;
+                }
+            }
+            settingsStore.setSettings(JSON.stringify(newSettings));
+            await EncryptedStorage.setItem(MOD_KEY9, 'true');
         }
 
         // migrate old POS squareEnabled setting to posEnabled


### PR DESCRIPTION
# Description

Fixes a stale-settings display bug in the Receive screen: affected users saw the default invoice expiration rendered as **"3600 hours"** even though invoices actually expired in 1 hour.

## Root cause

`views/Receive.tsx` stores three loosely-coupled invoice fields in saved settings:

- `expirySeconds` — the authoritative value passed to the backend (`Receive.tsx:596-598` → `backends/LND.ts:341`).
- `expiry` + `timePeriod` — used only by `getFormattedDuration` (`Receive.tsx:1214-1225`) to render the duration label.

A historical regression (commit `e4339e137`, March 2023) initialized the default `invoices.expiry` to `'3600'` instead of `'1'`. The default in `stores/SettingsStore.ts:1516` is now correct (`expiry: '1'`), but users who installed during the affected window still carry the buggy value in their saved settings, and there was no migration to repair it.

Invoices themselves were unaffected because the backend reads `expirySeconds` (still `'3600'` → 1 hour). Only the displayed label was wrong.

This is not backend-specific — it affects any user with the stale value, regardless of node implementation.

## Fix

- **`utils/ExpiryUtils.ts`** — add `displayFromExpirySeconds(expirySeconds)`, the inverse of `expirySecondsFromInput`. Picks the largest evenly-dividing unit (`604800 → 1 Weeks`, `86400 → 1 Days`, `3600 → 1 Hours`, `600 → 10 Minutes`), falls back to `Seconds` for non-divisible values, and to `1 Hours` for empty/invalid input.
- **`utils/MigrationUtils.ts`** — new one-shot migration `MOD_KEY9 = 'invoices-expiry-display-fix'` in `legacySettingsMigrations`. When `expirySecondsFromInput(expiry, timePeriod) !== expirySeconds`, recompute `expiry`+`timePeriod` from the authoritative `expirySeconds`. Follows the existing `MOD_KEY` pattern and runs once per install.
- **`utils/ExpiryUtils.test.ts`** — new test cases covering the largest-divisor preference, the Seconds fallback, and invalid input.
- **`utils/MigrationUtils.test.ts`** — new test cases asserting that the documented buggy state (`expiry: '3600'`, `timePeriod: 'Hours'`, `expirySeconds: '3600'`) is repaired to `(expiry: '1', timePeriod: 'Hours', expirySeconds: '3600')` and that already-consistent state passes through untouched.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
