### PR TITLE
fix(modals): block screenshot leaks in nested modals via Portal + CenteredModal

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -69,6 +69,7 @@ import RestoreChannelModal from './components/Modals/RestoreChannelModal';
 import ScreenRecordingWarningModal from './components/Modals/ScreenRecordingWarningModal';
 import ActionSheetModal from './components/Modals/ActionSheetModal';
 import EnlargedQRModal from './components/Modals/EnlargedQRModal';
+import { PortalProvider } from './components/Portal';
 
 // Views
 import Transaction from './views/Transaction';
@@ -471,6 +472,7 @@ export default class App extends React.PureComponent {
                     <AppContainer>
                         <PushNotificationManager>
                             <GestureHandlerRootView style={{ flex: 1 }}>
+                                <PortalProvider>
                                 <StealthModeWrapper>
                                     <SafeAreaView
                                         style={{ flex: 1 }}
@@ -1818,6 +1820,7 @@ export default class App extends React.PureComponent {
                                 <ActionSheetModal />
                                 {/* @ts-ignore:next-line */}
                                 <EnlargedQRModal />
+                                </PortalProvider>
                             </GestureHandlerRootView>
                         </PushNotificationManager>
                     </AppContainer>

--- a/components/HopPicker.tsx
+++ b/components/HopPicker.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {
+    Dimensions,
     FlatList,
-    Modal,
     Platform,
     StyleSheet,
     View,
@@ -10,7 +10,6 @@ import {
     TouchableHighlight,
     ViewStyle
 } from 'react-native';
-import { SafeAreaView, SafeAreaProvider } from 'react-native-safe-area-context';
 import { inject, observer } from 'mobx-react';
 
 import { themeColor } from '../utils/ThemeUtils';
@@ -21,6 +20,8 @@ import Button from '../components/Button';
 import { ChannelItem } from './Channels/ChannelItem';
 import ChannelsFilter from './Channels/ChannelsFilter';
 import LoadingIndicator from './LoadingIndicator';
+import ModalBox from './ModalBox';
+import { Portal } from './Portal';
 
 import CaretRight from '../assets/images/SVG/Caret Right.svg';
 
@@ -53,6 +54,7 @@ interface ChannelPickerState {
 
 const DEFAULT_TITLE = localeString('components.HopPicker.defaultTitle');
 const MAX_NUMBER_ROUTE_HINTS_LND = 20;
+const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 
 @inject('ChannelsStore', 'UnitsStore')
 @observer
@@ -221,119 +223,105 @@ export default class ChannelPicker extends React.Component<
 
         return (
             <React.Fragment>
-                <Modal
-                    animationType="slide"
-                    transparent={true}
-                    visible={showChannelModal}
-                    onRequestClose={() =>
-                        this.setState({ showChannelModal: false })
-                    }
-                >
-                    <SafeAreaProvider>
-                        <SafeAreaView style={styles.centeredView}>
-                            <View style={styles.modalBackground}>
-                                <View
-                                    style={[
-                                        styles.modal,
-                                        {
-                                            backgroundColor:
-                                                themeColor('modalBackground')
-                                        }
-                                    ]}
-                                >
-                                    <View
-                                        style={[
-                                            styles.handleBar,
-                                            {
-                                                backgroundColor:
-                                                    themeColor('secondaryText')
-                                            }
-                                        ]}
-                                    />
+                <Portal>
+                    <ModalBox
+                        isOpen={showChannelModal}
+                        position="bottom"
+                        swipeToClose={true}
+                        backdropPressToClose={true}
+                        backButtonClose={true}
+                        backdropOpacity={0.5}
+                        onClosed={() =>
+                            this.setState({ showChannelModal: false })
+                        }
+                        style={{
+                            ...styles.modal,
+                            backgroundColor: themeColor('modalBackground'),
+                            height: SCREEN_HEIGHT * 0.9
+                        }}
+                    >
+                        <View style={styles.sheetInner}>
+                            <View
+                                style={[
+                                    styles.handleBar,
+                                    {
+                                        backgroundColor:
+                                            themeColor('secondaryText')
+                                    }
+                                ]}
+                            />
 
-                                    <Text
-                                        style={[
-                                            styles.modalTitle,
-                                            { color: themeColor('text') }
-                                        ]}
-                                    >
-                                        {selectionMode === 'multiple'
-                                            ? localeString(
-                                                  'components.ChannelPicker.modal.title.multiple'
-                                              )
-                                            : localeString(
-                                                  'components.ChannelPicker.modal.title'
-                                              )}
-                                    </Text>
+                            <Text
+                                style={[
+                                    styles.modalTitle,
+                                    { color: themeColor('text') }
+                                ]}
+                            >
+                                {selectionMode === 'multiple'
+                                    ? localeString(
+                                          'components.ChannelPicker.modal.title.multiple'
+                                      )
+                                    : localeString(
+                                          'components.ChannelPicker.modal.title'
+                                      )}
+                            </Text>
 
-                                    <View style={styles.filterContainer}>
-                                        <ChannelsFilter />
-                                    </View>
-
-                                    {loading && (
-                                        <View style={styles.loadingContainer}>
-                                            <LoadingIndicator />
-                                        </View>
-                                    )}
-
-                                    {!loading && (
-                                        <FlatList
-                                            data={channels}
-                                            renderItem={(item) =>
-                                                this.renderItem(item)
-                                            }
-                                            style={styles.list}
-                                            contentContainerStyle={
-                                                styles.listContent
-                                            }
-                                            onEndReachedThreshold={50}
-                                            refreshing={loading}
-                                            onRefresh={() =>
-                                                this.refreshChannels()
-                                            }
-                                        />
-                                    )}
-
-                                    <View style={styles.buttonRow}>
-                                        <Button
-                                            title={localeString(
-                                                'general.cancel'
-                                            )}
-                                            onPress={() => {
-                                                this.setState({
-                                                    showChannelModal: false
-                                                });
-                                                onCancel?.();
-                                            }}
-                                            containerStyle={styles.flexButton}
-                                            secondary
-                                        />
-                                        <Button
-                                            title={localeString(
-                                                'general.confirm'
-                                            )}
-                                            disabled={
-                                                selectedChannels.length === 0 ||
-                                                (selectionMode === 'multiple' &&
-                                                    backendUtils.isLNDBased() &&
-                                                    selectedChannels.length >
-                                                        MAX_NUMBER_ROUTE_HINTS_LND)
-                                            }
-                                            onPress={() => {
-                                                this.updateValueSet();
-                                                this.setState({
-                                                    showChannelModal: false
-                                                });
-                                                onValueChange(selectedChannels);
-                                            }}
-                                            containerStyle={styles.flexButton}
-                                        />
-                                    </View>
-                                </View>
+                            <View style={styles.filterContainer}>
+                                <ChannelsFilter />
                             </View>
-                        </SafeAreaView>
-                    </SafeAreaProvider>
-                </Modal>
+
+                            {loading && (
+                                <View style={styles.loadingContainer}>
+                                    <LoadingIndicator />
+                                </View>
+                            )}
+
+                            {!loading && (
+                                <FlatList
+                                    data={channels}
+                                    renderItem={(item) => this.renderItem(item)}
+                                    style={styles.list}
+                                    contentContainerStyle={styles.listContent}
+                                    onEndReachedThreshold={50}
+                                    refreshing={loading}
+                                    onRefresh={() => this.refreshChannels()}
+                                />
+                            )}
+
+                            <View style={styles.buttonRow}>
+                                <Button
+                                    title={localeString('general.cancel')}
+                                    onPress={() => {
+                                        this.setState({
+                                            showChannelModal: false
+                                        });
+                                        onCancel?.();
+                                    }}
+                                    containerStyle={styles.flexButton}
+                                    secondary
+                                />
+                                <Button
+                                    title={localeString('general.confirm')}
+                                    disabled={
+                                        selectedChannels.length === 0 ||
+                                        (selectionMode === 'multiple' &&
+                                            backendUtils.isLNDBased() &&
+                                            selectedChannels.length >
+                                                MAX_NUMBER_ROUTE_HINTS_LND)
+                                    }
+                                    onPress={() => {
+                                        this.updateValueSet();
+                                        this.setState({
+                                            showChannelModal: false
+                                        });
+                                        onValueChange(selectedChannels);
+                                    }}
+                                    containerStyle={styles.flexButton}
+                                />
+                            </View>
+                        </View>
+                    </ModalBox>
+                </Portal>
 
                 <View style={{ ...containerStyle, ...styles.field }}>
                     {!hideTitle && (
@@ -421,17 +409,10 @@ const styles = StyleSheet.create({
     modal: {
         borderTopLeftRadius: 20,
         borderTopRightRadius: 20,
-        paddingBottom: 8,
-        height: '100%'
+        paddingBottom: 8
     },
-    centeredView: {
-        flex: 1,
-        justifyContent: 'flex-end',
-        backgroundColor: 'rgba(0,0,0,0.5)'
-    },
-    modalBackground: {
-        flex: 1,
-        justifyContent: 'flex-end'
+    sheetInner: {
+        flex: 1
     },
     handleBar: {
         width: 40,
@@ -470,7 +451,7 @@ const styles = StyleSheet.create({
         gap: 12,
         paddingHorizontal: 16,
         paddingTop: 8,
-        paddingBottom: 16
+        paddingBottom: 24
     },
     flexButton: {
         flex: 1

--- a/components/Modals/CenteredModal.tsx
+++ b/components/Modals/CenteredModal.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { TouchableWithoutFeedback, View } from 'react-native';
+
+import ModalBox from '../ModalBox';
+
+interface CenteredModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    children: React.ReactNode;
+}
+
+const CenteredModal: React.FC<CenteredModalProps> = ({
+    isOpen,
+    onClose,
+    children
+}) => (
+    <ModalBox
+        isOpen={isOpen}
+        onClosed={onClose}
+        entry="center"
+        backdrop
+        backdropPressToClose
+        backButtonClose
+        swipeToClose={false}
+        backdropOpacity={0.5}
+        style={{ backgroundColor: 'transparent' }}
+    >
+        <TouchableWithoutFeedback onPress={onClose}>
+            <View
+                style={{
+                    flex: 1,
+                    justifyContent: 'center',
+                    alignItems: 'center'
+                }}
+            >
+                <TouchableWithoutFeedback onPress={() => {}}>
+                    {children}
+                </TouchableWithoutFeedback>
+            </View>
+        </TouchableWithoutFeedback>
+    </ModalBox>
+);
+
+export default CenteredModal;

--- a/components/PaymentDetailsSheet.tsx
+++ b/components/PaymentDetailsSheet.tsx
@@ -2,18 +2,17 @@ import * as React from 'react';
 import {
     Animated,
     Image,
-    Modal,
     PanResponder,
     PanResponderInstance,
     ScrollView,
     Text,
     TouchableOpacity,
-    TouchableWithoutFeedback,
     View
 } from 'react-native';
 
 import Amount from './Amount';
 import KeyValue from './KeyValue';
+import CenteredModal from './Modals/CenteredModal';
 import { Row } from './layout/Row';
 
 import { getFeePercentage } from '../utils/AmountUtils';
@@ -197,169 +196,143 @@ export default class PaymentDetailsSheet extends React.Component<PaymentDetailsS
 
         return (
             <>
-                <Modal
-                    visible={isOpen}
-                    transparent={true}
-                    animationType="fade"
-                    onRequestClose={onClose}
-                >
-                    <TouchableWithoutFeedback onPress={onClose}>
+                <CenteredModal isOpen={isOpen} onClose={onClose}>
+                    <View
+                        style={{
+                            backgroundColor: themeColor('secondary'),
+                            borderRadius: 24,
+                            padding: 20,
+                            width: '90%',
+                            maxHeight: '80%'
+                        }}
+                    >
                         <View
                             style={{
-                                flex: 1,
-                                backgroundColor: 'rgba(0,0,0,0.5)',
+                                flexDirection: 'row',
                                 justifyContent: 'center',
-                                alignItems: 'center'
+                                alignItems: 'center',
+                                marginBottom: 16
                             }}
                         >
-                            <TouchableWithoutFeedback>
-                                <View
-                                    style={{
-                                        backgroundColor:
-                                            themeColor('secondary'),
-                                        borderRadius: 24,
-                                        padding: 20,
-                                        width: '90%',
-                                        maxHeight: '80%'
-                                    }}
-                                >
-                                    <View
-                                        style={{
-                                            flexDirection: 'row',
-                                            justifyContent: 'center',
-                                            alignItems: 'center',
-                                            marginBottom: 16
-                                        }}
-                                    >
-                                        <Text
-                                            style={{
-                                                fontFamily:
-                                                    'PPNeueMontreal-Medium',
-                                                color: themeColor('text'),
-                                                fontSize: 20,
-                                                textAlign: 'center',
-                                                flex: 1
-                                            }}
-                                        >
-                                            {localeString(
-                                                'views.Payment.details'
-                                            )}
-                                        </Text>
-                                        <TouchableOpacity
-                                            onPress={onClose}
-                                            hitSlop={{
-                                                top: 8,
-                                                bottom: 8,
-                                                left: 8,
-                                                right: 8
-                                            }}
-                                            style={{ padding: 4 }}
-                                        >
-                                            <CloseSvg
-                                                fill={themeColor('text')}
-                                                width={16}
-                                                height={16}
-                                            />
-                                        </TouchableOpacity>
-                                    </View>
-                                    <ScrollView>
-                                        {paymentAmount != null && (
-                                            <KeyValue
-                                                keyValue={localeString(
-                                                    'views.Receive.amount'
-                                                )}
-                                                value={
-                                                    <Amount
-                                                        sats={paymentAmount}
-                                                        debit
-                                                        sensitive
-                                                        toggleable
-                                                    />
-                                                }
-                                            />
-                                        )}
-
-                                        {feeAmount != null && (
-                                            <KeyValue
-                                                keyValue={localeString(
-                                                    'views.Payment.fee'
-                                                )}
-                                                value={
-                                                    <Row>
-                                                        <Amount
-                                                            sats={feeAmount}
-                                                            debit
-                                                            sensitive
-                                                            toggleable
-                                                        />
-                                                        {feePercentage ? (
-                                                            <Text
-                                                                style={{
-                                                                    fontFamily:
-                                                                        'PPNeueMontreal-Book',
-                                                                    color: themeColor(
-                                                                        'text'
-                                                                    )
-                                                                }}
-                                                            >
-                                                                {` (${feePercentage})`}
-                                                            </Text>
-                                                        ) : null}
-                                                    </Row>
-                                                }
-                                            />
-                                        )}
-
-                                        {paymentDuration != null && (
-                                            <KeyValue
-                                                keyValue={localeString(
-                                                    'views.Payment.settlementTime'
-                                                )}
-                                                value={`${paymentDuration.toFixed(
-                                                    2
-                                                )}s`}
-                                                disableCopy
-                                            />
-                                        )}
-
-                                        {memo ? (
-                                            <KeyValue
-                                                keyValue={localeString(
-                                                    'views.Invoice.memo'
-                                                )}
-                                                value={memo}
-                                            />
-                                        ) : null}
-
-                                        {this.renderContactRow()}
-
-                                        {paymentHash ? (
-                                            <KeyValue
-                                                keyValue={localeString(
-                                                    'views.Payment.paymentHash'
-                                                )}
-                                                value={paymentHash}
-                                                sensitive
-                                            />
-                                        ) : null}
-
-                                        {paymentPreimage ? (
-                                            <KeyValue
-                                                keyValue={localeString(
-                                                    'views.Payment.paymentPreimage'
-                                                )}
-                                                value={paymentPreimage}
-                                                sensitive
-                                            />
-                                        ) : null}
-
-                                        {this.renderPathRow()}
-                                    </ScrollView>
-                                </View>
-                            </TouchableWithoutFeedback>
+                            <Text
+                                style={{
+                                    fontFamily: 'PPNeueMontreal-Medium',
+                                    color: themeColor('text'),
+                                    fontSize: 20,
+                                    textAlign: 'center',
+                                    flex: 1
+                                }}
+                            >
+                                {localeString('views.Payment.details')}
+                            </Text>
+                            <TouchableOpacity
+                                onPress={onClose}
+                                hitSlop={{
+                                    top: 8,
+                                    bottom: 8,
+                                    left: 8,
+                                    right: 8
+                                }}
+                                style={{ padding: 4 }}
+                            >
+                                <CloseSvg
+                                    fill={themeColor('text')}
+                                    width={16}
+                                    height={16}
+                                />
+                            </TouchableOpacity>
                         </View>
-                    </TouchableWithoutFeedback>
-                </Modal>
+                        <ScrollView>
+                            {paymentAmount != null && (
+                                <KeyValue
+                                    keyValue={localeString(
+                                        'views.Receive.amount'
+                                    )}
+                                    value={
+                                        <Amount
+                                            sats={paymentAmount}
+                                            debit
+                                            sensitive
+                                            toggleable
+                                        />
+                                    }
+                                />
+                            )}
+
+                            {feeAmount != null && (
+                                <KeyValue
+                                    keyValue={localeString('views.Payment.fee')}
+                                    value={
+                                        <Row>
+                                            <Amount
+                                                sats={feeAmount}
+                                                debit
+                                                sensitive
+                                                toggleable
+                                            />
+                                            {feePercentage ? (
+                                                <Text
+                                                    style={{
+                                                        fontFamily:
+                                                            'PPNeueMontreal-Book',
+                                                        color: themeColor(
+                                                            'text'
+                                                        )
+                                                    }}
+                                                >
+                                                    {` (${feePercentage})`}
+                                                </Text>
+                                            ) : null}
+                                        </Row>
+                                    }
+                                />
+                            )}
+
+                            {paymentDuration != null && (
+                                <KeyValue
+                                    keyValue={localeString(
+                                        'views.Payment.settlementTime'
+                                    )}
+                                    value={`${paymentDuration.toFixed(2)}s`}
+                                    disableCopy
+                                />
+                            )}
+
+                            {memo ? (
+                                <KeyValue
+                                    keyValue={localeString(
+                                        'views.Invoice.memo'
+                                    )}
+                                    value={memo}
+                                />
+                            ) : null}
+
+                            {this.renderContactRow()}
+
+                            {paymentHash ? (
+                                <KeyValue
+                                    keyValue={localeString(
+                                        'views.Payment.paymentHash'
+                                    )}
+                                    value={paymentHash}
+                                    sensitive
+                                />
+                            ) : null}
+
+                            {paymentPreimage ? (
+                                <KeyValue
+                                    keyValue={localeString(
+                                        'views.Payment.paymentPreimage'
+                                    )}
+                                    value={paymentPreimage}
+                                    sensitive
+                                />
+                            ) : null}
+
+                            {this.renderPathRow()}
+                        </ScrollView>
+                    </View>
+                </CenteredModal>
                 {this.renderTrigger()}
             </>
         );

--- a/components/Portal.tsx
+++ b/components/Portal.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { View, StyleSheet } from 'react-native';
+
+// A minimal keyed teleport (no extra dependency). <Portal> publishes its
+// children to a single <PortalProvider> host mounted at the App root, where
+// an in-tree overlay fills the full (screen-capture-secured) main window.
+// This keeps ModalBox content rendered in the main activity window so the
+// native FLAG_SECURE / iOS secure-canvas overlay covers it, unlike a separate
+// RN <Modal> window.
+
+type PortalMethods = {
+    setNode: (key: string, children: React.ReactNode) => void;
+    removeNode: (key: string) => void;
+};
+
+const PortalContext = React.createContext<PortalMethods | null>(null);
+
+export const PortalProvider: React.FC<{ children?: React.ReactNode }> = ({
+    children
+}) => {
+    const [nodes, setNodes] = React.useState<Record<string, React.ReactNode>>(
+        {}
+    );
+
+    const methods = React.useMemo<PortalMethods>(
+        () => ({
+            setNode: (key, node) =>
+                setNodes((prev) => ({ ...prev, [key]: node })),
+            removeNode: (key) =>
+                setNodes((prev) => {
+                    const next = { ...prev };
+                    delete next[key];
+                    return next;
+                })
+        }),
+        []
+    );
+
+    return (
+        <PortalContext.Provider value={methods}>
+            {children}
+            {/* Rendered after children so portalled content paints above the
+                app; box-none keeps an empty host touch-transparent. */}
+            <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+                {Object.keys(nodes).map((key) => (
+                    <React.Fragment key={key}>{nodes[key]}</React.Fragment>
+                ))}
+            </View>
+        </PortalContext.Provider>
+    );
+};
+
+let portalCounter = 0;
+
+export const Portal: React.FC<{ children?: React.ReactNode }> = ({
+    children
+}) => {
+    const ctx = React.useContext(PortalContext);
+    const [key] = React.useState(() => `portal-${portalCounter++}`);
+
+    // Publish on mount and re-publish on every update so a picker's setState
+    // flows through to the root-mounted node.
+    React.useEffect(() => {
+        ctx?.setNode(key, children);
+    });
+
+    // Remove from the host only when this Portal unmounts.
+    React.useEffect(() => () => ctx?.removeNode(key), [ctx, key]);
+
+    return null;
+};

--- a/components/UTXOPicker.tsx
+++ b/components/UTXOPicker.tsx
@@ -15,6 +15,7 @@ import Amount from './Amount';
 import Button from '../components/Button';
 import LoadingIndicator from './LoadingIndicator';
 import ModalBox from './ModalBox';
+import { Portal } from './Portal';
 
 import BackendUtils from '../utils/BackendUtils';
 import { localeString } from '../utils/LocaleUtils';
@@ -303,125 +304,60 @@ export default class UTXOPicker extends React.Component<
 
         return (
             <React.Fragment>
-                <ModalBox
-                    isOpen={showUtxoModal}
-                    style={{
-                        ...styles.sheet,
-                        backgroundColor: themeColor('modalBackground'),
-                        height: SCREEN_HEIGHT * 0.9
-                    }}
-                    swipeToClose={true}
-                    backdropPressToClose={true}
-                    backButtonClose={true}
-                    position="bottom"
-                    coverScreen={true}
-                    onClosed={this.closePicker}
-                >
-                    <View style={styles.sheetInner}>
-                        <View
-                            style={{
-                                ...styles.handle,
-                                backgroundColor: themeColor('secondaryText')
-                            }}
-                        />
-
-                        <Text
-                            style={[
-                                styles.sheetTitle,
-                                { color: themeColor('text') }
-                            ]}
-                        >
-                            {localeString('components.UTXOPicker.modal.title')}
-                        </Text>
-                        <Text
-                            style={[
-                                styles.sheetDescription,
-                                { color: themeColor('secondaryText') }
-                            ]}
-                        >
-                            {localeString(
-                                'components.UTXOPicker.modal.description'
-                            )}
-                        </Text>
-
-                        <View style={styles.amountBlock}>
-                            <Amount
-                                sats={selectedBalance}
-                                sensitive={true}
-                                toggleable
-                                jumboText
-                            />
-                            <View style={styles.selectionMetaRow}>
-                                <Text
-                                    style={[
-                                        styles.selectionMetaText,
-                                        { color: themeColor('secondaryText') }
-                                    ]}
-                                >
-                                    {`${localeString('general.selected')}: ${
-                                        utxosSelected.length
-                                    }`}
-                                </Text>
-                                {utxosSelected.length > 0 && (
-                                    <TouchableOpacity
-                                        onPress={this.clearPickerSelection}
-                                        accessibilityRole="button"
-                                        accessibilityLabel={localeString(
-                                            'general.clear'
-                                        )}
-                                    >
-                                        <Text
-                                            style={[
-                                                styles.selectionMetaAction,
-                                                {
-                                                    color: themeColor(
-                                                        'highlight'
-                                                    )
-                                                }
-                                            ]}
-                                        >
-                                            {localeString('general.clear')}
-                                        </Text>
-                                    </TouchableOpacity>
-                                )}
-                            </View>
-                        </View>
-
-                        {BackendUtils.supportsAccounts() && (
-                            <AccountFilter
-                                default={account}
-                                items={accounts.filter(
-                                    (item: any) => !item.hidden
-                                )}
-                                refresh={(newAccount: string) => {
-                                    getUTXOs({ account: newAccount });
-                                    this.setState({ account: newAccount });
-                                }}
-                                onChangeAccount={() => {
-                                    this.setState({
-                                        utxosSelected: [],
-                                        selectedBalance: 0,
-                                        clearedDraftInModal: false
-                                    });
+                <Portal>
+                    <ModalBox
+                        isOpen={showUtxoModal}
+                        style={{
+                            ...styles.sheet,
+                            backgroundColor: themeColor('modalBackground'),
+                            height: SCREEN_HEIGHT * 0.9
+                        }}
+                        swipeToClose={true}
+                        backdropPressToClose={true}
+                        backButtonClose={true}
+                        position="bottom"
+                        onClosed={this.closePicker}
+                    >
+                        <View style={styles.sheetInner}>
+                            <View
+                                style={{
+                                    ...styles.handle,
+                                    backgroundColor: themeColor('secondaryText')
                                 }}
                             />
-                        )}
 
-                        <View
-                            style={{
-                                ...styles.body,
-                                backgroundColor: themeColor('background')
-                            }}
-                        >
-                            {loading ? (
-                                <View style={styles.loadingWrap}>
-                                    <LoadingIndicator />
-                                </View>
-                            ) : utxos.length === 0 ? (
-                                <View style={styles.emptyState}>
+                            <Text
+                                style={[
+                                    styles.sheetTitle,
+                                    { color: themeColor('text') }
+                                ]}
+                            >
+                                {localeString(
+                                    'components.UTXOPicker.modal.title'
+                                )}
+                            </Text>
+                            <Text
+                                style={[
+                                    styles.sheetDescription,
+                                    { color: themeColor('secondaryText') }
+                                ]}
+                            >
+                                {localeString(
+                                    'components.UTXOPicker.modal.description'
+                                )}
+                            </Text>
+
+                            <View style={styles.amountBlock}>
+                                <Amount
+                                    sats={selectedBalance}
+                                    sensitive={true}
+                                    toggleable
+                                    jumboText
+                                />
+                                <View style={styles.selectionMetaRow}>
                                     <Text
                                         style={[
-                                            styles.text,
+                                            styles.selectionMetaText,
                                             {
                                                 color: themeColor(
                                                     'secondaryText'
@@ -429,73 +365,152 @@ export default class UTXOPicker extends React.Component<
                                             }
                                         ]}
                                     >
-                                        {localeString(
-                                            'views.UTXOs.CoinControl.noUTXOs'
-                                        )}
+                                        {`${localeString(
+                                            'general.selected'
+                                        )}: ${utxosSelected.length}`}
                                     </Text>
-                                </View>
-                            ) : (
-                                <FlatList
-                                    showsVerticalScrollIndicator={false}
-                                    data={utxos}
-                                    contentContainerStyle={styles.listContent}
-                                    extraData={utxosSelected}
-                                    renderItem={(info) =>
-                                        this.renderUtxoItem(info, selectedSet)
-                                    }
-                                    keyExtractor={(item: Utxo) =>
-                                        item.getOutpoint ??
-                                        `${item.txid}:${String(item.output)}`
-                                    }
-                                    onEndReachedThreshold={50}
-                                    refreshing={loading}
-                                    onRefresh={() => getUTXOs({ account })}
-                                />
-                            )}
-                        </View>
-
-                        <View style={styles.footer}>
-                            <View style={styles.footerButton}>
-                                <Button
-                                    title={localeString(
-                                        'components.UTXOPicker.modal.set'
+                                    {utxosSelected.length > 0 && (
+                                        <TouchableOpacity
+                                            onPress={this.clearPickerSelection}
+                                            accessibilityRole="button"
+                                            accessibilityLabel={localeString(
+                                                'general.clear'
+                                            )}
+                                        >
+                                            <Text
+                                                style={[
+                                                    styles.selectionMetaAction,
+                                                    {
+                                                        color: themeColor(
+                                                            'highlight'
+                                                        )
+                                                    }
+                                                ]}
+                                            >
+                                                {localeString('general.clear')}
+                                            </Text>
+                                        </TouchableOpacity>
                                     )}
-                                    disabled={
-                                        loading ||
-                                        utxos.length === 0 ||
-                                        utxosSelected.length === 0
-                                    }
-                                    onPress={() => {
-                                        const {
-                                            utxosSelected,
-                                            selectedBalance
-                                        } = this.state;
-                                        this.setState({
-                                            showUtxoModal: false,
-                                            clearedDraftInModal: false,
-                                            utxosSet: utxosSelected,
-                                            setBalance: selectedBalance
-                                        });
+                                </View>
+                            </View>
 
-                                        onValueChange(
-                                            utxosSelected,
-                                            selectedBalance,
-                                            account
-                                        );
+                            {BackendUtils.supportsAccounts() && (
+                                <AccountFilter
+                                    default={account}
+                                    items={accounts.filter(
+                                        (item: any) => !item.hidden
+                                    )}
+                                    refresh={(newAccount: string) => {
+                                        getUTXOs({ account: newAccount });
+                                        this.setState({ account: newAccount });
+                                    }}
+                                    onChangeAccount={() => {
+                                        this.setState({
+                                            utxosSelected: [],
+                                            selectedBalance: 0,
+                                            clearedDraftInModal: false
+                                        });
                                     }}
                                 />
+                            )}
+
+                            <View
+                                style={{
+                                    ...styles.body,
+                                    backgroundColor: themeColor('background')
+                                }}
+                            >
+                                {loading ? (
+                                    <View style={styles.loadingWrap}>
+                                        <LoadingIndicator />
+                                    </View>
+                                ) : utxos.length === 0 ? (
+                                    <View style={styles.emptyState}>
+                                        <Text
+                                            style={[
+                                                styles.text,
+                                                {
+                                                    color: themeColor(
+                                                        'secondaryText'
+                                                    )
+                                                }
+                                            ]}
+                                        >
+                                            {localeString(
+                                                'views.UTXOs.CoinControl.noUTXOs'
+                                            )}
+                                        </Text>
+                                    </View>
+                                ) : (
+                                    <FlatList
+                                        showsVerticalScrollIndicator={false}
+                                        data={utxos}
+                                        contentContainerStyle={
+                                            styles.listContent
+                                        }
+                                        extraData={utxosSelected}
+                                        renderItem={(info) =>
+                                            this.renderUtxoItem(
+                                                info,
+                                                selectedSet
+                                            )
+                                        }
+                                        keyExtractor={(item: Utxo) =>
+                                            item.getOutpoint ??
+                                            `${item.txid}:${String(
+                                                item.output
+                                            )}`
+                                        }
+                                        onEndReachedThreshold={50}
+                                        refreshing={loading}
+                                        onRefresh={() => getUTXOs({ account })}
+                                    />
+                                )}
                             </View>
 
-                            <View style={styles.footerButton}>
-                                <Button
-                                    title={localeString('general.cancel')}
-                                    onPress={this.closePicker}
-                                    secondary
-                                />
+                            <View style={styles.footer}>
+                                <View style={styles.footerButton}>
+                                    <Button
+                                        title={localeString(
+                                            'components.UTXOPicker.modal.set'
+                                        )}
+                                        disabled={
+                                            loading ||
+                                            utxos.length === 0 ||
+                                            utxosSelected.length === 0
+                                        }
+                                        onPress={() => {
+                                            const {
+                                                utxosSelected,
+                                                selectedBalance
+                                            } = this.state;
+                                            this.setState({
+                                                showUtxoModal: false,
+                                                clearedDraftInModal: false,
+                                                utxosSet: utxosSelected,
+                                                setBalance: selectedBalance
+                                            });
+
+                                            onValueChange(
+                                                utxosSelected,
+                                                selectedBalance,
+                                                account
+                                            );
+                                        }}
+                                    />
+                                </View>
+
+                                <View style={styles.footerButton}>
+                                    <Button
+                                        title={localeString('general.cancel')}
+                                        onPress={this.closePicker}
+                                        secondary
+                                    />
+                                </View>
                             </View>
                         </View>
-                    </View>
-                </ModalBox>
+                    </ModalBox>
+                </Portal>
 
                 <View>
                     <Text

--- a/views/Tools/NodeConfigExportImport.tsx
+++ b/views/Tools/NodeConfigExportImport.tsx
@@ -4,7 +4,6 @@ import {
     StyleSheet,
     Alert,
     ScrollView,
-    Modal,
     TouchableOpacity,
     Platform,
     Image
@@ -29,6 +28,7 @@ import Text from '../../components/Text';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import NodeIdenticon, { NodeTitle } from '../../components/NodeIdenticon';
 import ShowHideToggle from '../../components/ShowHideToggle';
+import CenteredModal from '../../components/Modals/CenteredModal';
 
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor, isLightTheme } from '../../utils/ThemeUtils';
@@ -157,47 +157,50 @@ export default class NodeConfigExportImport extends React.Component<
         const { activeModal } = this.state;
 
         return (
-            <Modal
-                animationType="slide"
-                transparent
-                visible={activeModal === 'info'}
-                onRequestClose={() => this.setState({ activeModal: 'none' })}
+            <CenteredModal
+                isOpen={activeModal === 'info'}
+                onClose={() => {
+                    if (this.state.activeModal === 'info')
+                        this.setState({ activeModal: 'none' });
+                }}
             >
-                <View style={styles.modalOverlay}>
-                    <View
+                <View
+                    style={{
+                        backgroundColor: isLightTheme()
+                            ? '#ffffff'
+                            : themeColor('secondary'),
+                        borderRadius: 24,
+                        padding: 20,
+                        width: '85%',
+                        maxHeight: '80%',
+                        alignItems: 'center'
+                    }}
+                >
+                    <Text
                         style={{
-                            backgroundColor: isLightTheme()
-                                ? '#ffffff'
-                                : themeColor('secondary'),
-                            borderRadius: 24,
-                            padding: 20,
-                            alignItems: 'center'
+                            fontSize: 20,
+                            marginBottom: 20
                         }}
                     >
-                        <Text
-                            style={{
-                                fontSize: 20,
-                                marginBottom: 20
-                            }}
-                        >
-                            {Platform.OS === 'android'
-                                ? localeString(
-                                      'views.Tools.nodeConfigExportImport.explainerAndroid'
-                                  )
-                                : localeString(
-                                      'views.Tools.nodeConfigExportImport.explaineriOS'
-                                  )}
-                        </Text>
-                        <Button
-                            title={localeString('general.ok')}
-                            onPress={() =>
-                                this.setState({ activeModal: 'none' })
-                            }
-                            secondary
-                        />
-                    </View>
+                        {Platform.OS === 'android'
+                            ? localeString(
+                                  'views.Tools.nodeConfigExportImport.explainerAndroid'
+                              )
+                            : localeString(
+                                  'views.Tools.nodeConfigExportImport.explaineriOS'
+                              )}
+                    </Text>
+                    <Button
+                        title={localeString('general.ok')}
+                        onPress={() =>
+                            this.setState({
+                                activeModal: 'none'
+                            })
+                        }
+                        secondary
+                    />
                 </View>
-            </Modal>
+            </CenteredModal>
         );
     };
 
@@ -217,208 +220,197 @@ export default class NodeConfigExportImport extends React.Component<
                 ).length;
 
         return (
-            <Modal
-                visible={activeModal === 'nodeSelection'}
-                transparent={true}
-                animationType="slide"
-                onRequestClose={() => {
-                    this.setState({
-                        selectedNodes: []
-                    });
+            <CenteredModal
+                isOpen={activeModal === 'nodeSelection'}
+                onClose={() => {
+                    if (this.state.activeModal === 'nodeSelection')
+                        this.setState({
+                            activeModal: 'none',
+                            selectedNodes: []
+                        });
                 }}
             >
-                <View style={styles.modalOverlay}>
-                    <View
-                        style={[
-                            styles.modalContent,
-                            {
-                                maxHeight: '80%',
-                                backgroundColor: isLightTheme()
-                                    ? '#ffffff'
-                                    : themeColor('background')
-                            }
-                        ]}
-                    >
-                        <ScrollView showsVerticalScrollIndicator={false}>
-                            {nodes.length > 0 && (
-                                <CheckBox
-                                    title={localeString(
-                                        'views.Tools.nodeConfigExportImport.selectAllConfigs'
-                                    )}
-                                    checked={allNodesSelected}
-                                    onPress={() => {
-                                        if (allNodesSelected) {
-                                            this.setState({
-                                                selectedNodes: []
-                                            });
-                                        } else {
-                                            const selectableNodes = nodes
-                                                .map((_, index) => index)
-                                                .filter(
-                                                    (index) =>
-                                                        nodes[index]
-                                                            .implementation !==
-                                                            'embedded-lnd' &&
-                                                        nodes[index]
-                                                            .implementation !==
-                                                            'ldk-node'
-                                                );
-                                            this.setState({
-                                                selectedNodes: selectableNodes
-                                            });
-                                        }
-                                    }}
-                                    containerStyle={{
-                                        backgroundColor: 'transparent',
-                                        borderWidth: 0,
-                                        marginBottom: 15
-                                    }}
-                                    textStyle={{
-                                        color: themeColor('text'),
-                                        fontWeight: 'bold'
-                                    }}
-                                    checkedColor={themeColor('text')}
-                                />
-                            )}
+                <View
+                    style={[
+                        styles.modalContent,
+                        {
+                            maxHeight: '80%',
+                            backgroundColor: isLightTheme()
+                                ? '#ffffff'
+                                : themeColor('background')
+                        }
+                    ]}
+                >
+                    <ScrollView showsVerticalScrollIndicator={false}>
+                        {nodes.length > 0 && (
+                            <CheckBox
+                                title={localeString(
+                                    'views.Tools.nodeConfigExportImport.selectAllConfigs'
+                                )}
+                                checked={allNodesSelected}
+                                onPress={() => {
+                                    if (allNodesSelected) {
+                                        this.setState({
+                                            selectedNodes: []
+                                        });
+                                    } else {
+                                        const selectableNodes = nodes
+                                            .map((_, index) => index)
+                                            .filter(
+                                                (index) =>
+                                                    nodes[index]
+                                                        .implementation !==
+                                                        'embedded-lnd' &&
+                                                    nodes[index]
+                                                        .implementation !==
+                                                        'ldk-node'
+                                            );
+                                        this.setState({
+                                            selectedNodes: selectableNodes
+                                        });
+                                    }
+                                }}
+                                containerStyle={{
+                                    backgroundColor: 'transparent',
+                                    borderWidth: 0,
+                                    marginBottom: 15
+                                }}
+                                textStyle={{
+                                    color: themeColor('text'),
+                                    fontWeight: 'bold'
+                                }}
+                                checkedColor={themeColor('text')}
+                            />
+                        )}
 
-                            {nodes.map((node: Node, index: number) => {
-                                const isEmbedded =
-                                    node.implementation === 'embedded-lnd' ||
-                                    node.implementation === 'ldk-node';
-                                const isSelected =
-                                    selectedNodes.includes(index);
+                        {nodes.map((node: Node, index: number) => {
+                            const isEmbedded =
+                                node.implementation === 'embedded-lnd' ||
+                                node.implementation === 'ldk-node';
+                            const isSelected = selectedNodes.includes(index);
 
-                                return (
-                                    <View key={index} style={styles.nodeItem}>
-                                        <CheckBox
-                                            title={
-                                                <View style={styles.nodeInfo}>
-                                                    {node.photo ? (
-                                                        <Image
-                                                            source={{
-                                                                uri: getPhoto(
-                                                                    node.photo
-                                                                )
-                                                            }}
-                                                            style={
-                                                                styles.nodePhoto
-                                                            }
-                                                        />
-                                                    ) : (
-                                                        <NodeIdenticon
-                                                            selectedNode={node}
-                                                            width={42}
-                                                            rounded
-                                                        />
-                                                    )}
-                                                    <View
-                                                        style={styles.nodeText}
+                            return (
+                                <View key={index} style={styles.nodeItem}>
+                                    <CheckBox
+                                        title={
+                                            <View style={styles.nodeInfo}>
+                                                {node.photo ? (
+                                                    <Image
+                                                        source={{
+                                                            uri: getPhoto(
+                                                                node.photo
+                                                            )
+                                                        }}
+                                                        style={styles.nodePhoto}
+                                                    />
+                                                ) : (
+                                                    <NodeIdenticon
+                                                        selectedNode={node}
+                                                        width={42}
+                                                        rounded
+                                                    />
+                                                )}
+                                                <View style={styles.nodeText}>
+                                                    <Text
+                                                        numberOfLines={1}
+                                                        ellipsizeMode="tail"
+                                                        style={{
+                                                            color: isEmbedded
+                                                                ? themeColor(
+                                                                      'secondaryText'
+                                                                  )
+                                                                : themeColor(
+                                                                      'text'
+                                                                  ),
+                                                            fontSize: 16
+                                                        }}
                                                     >
-                                                        <Text
-                                                            numberOfLines={1}
-                                                            ellipsizeMode="tail"
-                                                            style={{
-                                                                color: isEmbedded
-                                                                    ? themeColor(
-                                                                          'secondaryText'
-                                                                      )
-                                                                    : themeColor(
-                                                                          'text'
-                                                                      ),
-                                                                fontSize: 16
-                                                            }}
-                                                        >
-                                                            {NodeTitle(node)}
-                                                        </Text>
-                                                        <Text
-                                                            style={{
-                                                                color: themeColor(
-                                                                    'secondaryText'
-                                                                ),
-                                                                fontSize: 12
-                                                            }}
-                                                        >
-                                                            {isEmbedded
-                                                                ? `${localeString(
-                                                                      'views.Tools.nodeConfigExportImport.notExportable'
-                                                                  ).toUpperCase()} - ${getImplementationDisplayName(
-                                                                      node.implementation
-                                                                  )}`
-                                                                : getImplementationDisplayName(
-                                                                      node.implementation
-                                                                  )}
-                                                        </Text>
-                                                    </View>
+                                                        {NodeTitle(node)}
+                                                    </Text>
+                                                    <Text
+                                                        style={{
+                                                            color: themeColor(
+                                                                'secondaryText'
+                                                            ),
+                                                            fontSize: 12
+                                                        }}
+                                                    >
+                                                        {isEmbedded
+                                                            ? `${localeString(
+                                                                  'views.Tools.nodeConfigExportImport.notExportable'
+                                                              ).toUpperCase()} - ${getImplementationDisplayName(
+                                                                  node.implementation
+                                                              )}`
+                                                            : getImplementationDisplayName(
+                                                                  node.implementation
+                                                              )}
+                                                    </Text>
                                                 </View>
-                                            }
-                                            checked={isSelected}
-                                            disabled={isEmbedded}
-                                            onPress={() => {
-                                                if (isEmbedded) return;
+                                            </View>
+                                        }
+                                        checked={isSelected}
+                                        disabled={isEmbedded}
+                                        onPress={() => {
+                                            if (isEmbedded) return;
 
-                                                this.setState((prevState) => ({
-                                                    selectedNodes:
-                                                        prevState.selectedNodes.includes(
-                                                            index
-                                                        )
-                                                            ? prevState.selectedNodes.filter(
-                                                                  (n) =>
-                                                                      n !==
-                                                                      index
-                                                              )
-                                                            : [
-                                                                  ...prevState.selectedNodes,
-                                                                  index
-                                                              ]
-                                                }));
-                                            }}
-                                            iconRight={true}
-                                            containerStyle={{
-                                                backgroundColor: 'transparent',
-                                                borderWidth: 0,
-                                                marginBottom: 10,
-                                                padding: 0
-                                            }}
-                                            uncheckedColor={
-                                                isEmbedded
-                                                    ? themeColor(
-                                                          'secondaryText'
-                                                      )
-                                                    : themeColor('text')
-                                            }
-                                            checkedColor={themeColor('text')}
-                                        />
-                                    </View>
-                                );
-                            })}
-                        </ScrollView>
+                                            this.setState((prevState) => ({
+                                                selectedNodes:
+                                                    prevState.selectedNodes.includes(
+                                                        index
+                                                    )
+                                                        ? prevState.selectedNodes.filter(
+                                                              (n) => n !== index
+                                                          )
+                                                        : [
+                                                              ...prevState.selectedNodes,
+                                                              index
+                                                          ]
+                                            }));
+                                        }}
+                                        iconRight={true}
+                                        containerStyle={{
+                                            backgroundColor: 'transparent',
+                                            borderWidth: 0,
+                                            marginBottom: 10,
+                                            padding: 0
+                                        }}
+                                        uncheckedColor={
+                                            isEmbedded
+                                                ? themeColor('secondaryText')
+                                                : themeColor('text')
+                                        }
+                                        checkedColor={themeColor('text')}
+                                    />
+                                </View>
+                            );
+                        })}
+                    </ScrollView>
 
-                        <View style={styles.buttonContainer}>
-                            <Button
-                                title={localeString('general.confirm')}
-                                onPress={() => {
-                                    this.setState({
-                                        activeModal: 'export',
-                                        useEncryption: true
-                                    });
-                                }}
-                                disabled={selectedNodes.length === 0}
-                                buttonStyle={{ marginBottom: 10 }}
-                            />
-                            <Button
-                                title={localeString('general.close')}
-                                onPress={() => {
-                                    this.setState({
-                                        activeModal: 'none',
-                                        selectedNodes: []
-                                    });
-                                }}
-                                secondary
-                            />
-                        </View>
+                    <View style={styles.buttonContainer}>
+                        <Button
+                            title={localeString('general.confirm')}
+                            onPress={() => {
+                                this.setState({
+                                    activeModal: 'export',
+                                    useEncryption: true
+                                });
+                            }}
+                            disabled={selectedNodes.length === 0}
+                            buttonStyle={{ marginBottom: 10 }}
+                        />
+                        <Button
+                            title={localeString('general.close')}
+                            onPress={() => {
+                                this.setState({
+                                    activeModal: 'none',
+                                    selectedNodes: []
+                                });
+                            }}
+                            secondary
+                        />
                     </View>
                 </View>
-            </Modal>
+            </CenteredModal>
         );
     };
 
@@ -427,100 +419,106 @@ export default class NodeConfigExportImport extends React.Component<
             this.state;
 
         return (
-            <Modal
-                visible={activeModal === 'export'}
-                transparent={true}
-                animationType="slide"
-                onRequestClose={this.resetExportState}
+            <CenteredModal
+                isOpen={activeModal === 'export'}
+                onClose={() => {
+                    if (this.state.activeModal === 'export')
+                        this.resetExportState();
+                }}
             >
-                <View style={styles.modalOverlay}>
-                    <View
-                        style={[
-                            styles.modalContent,
-                            {
-                                backgroundColor: isLightTheme()
-                                    ? '#ffffff'
-                                    : themeColor('background')
-                            }
-                        ]}
-                    >
-                        <CheckBox
-                            title={localeString('general.encrypt')}
-                            checked={useEncryption}
-                            onPress={() =>
-                                this.setState({ useEncryption: !useEncryption })
-                            }
-                            containerStyle={{
-                                backgroundColor: 'transparent',
-                                borderWidth: 0
-                            }}
-                            textStyle={{
-                                color: themeColor('text')
-                            }}
-                            checkedColor={themeColor('text')}
-                        />
+                <View
+                    style={[
+                        styles.modalContent,
+                        {
+                            maxHeight: '80%',
+                            backgroundColor: isLightTheme()
+                                ? '#ffffff'
+                                : themeColor('background')
+                        }
+                    ]}
+                >
+                    <CheckBox
+                        title={localeString('general.encrypt')}
+                        checked={useEncryption}
+                        onPress={() =>
+                            this.setState({
+                                useEncryption: !useEncryption
+                            })
+                        }
+                        containerStyle={{
+                            backgroundColor: 'transparent',
+                            borderWidth: 0
+                        }}
+                        textStyle={{
+                            color: themeColor('text')
+                        }}
+                        checkedColor={themeColor('text')}
+                    />
 
-                        {useEncryption && (
-                            <>
-                                <TextInput
-                                    placeholder={localeString(
-                                        'views.Tools.nodeConfigExportImport.password'
-                                    )}
-                                    value={exportPassword}
-                                    onChangeText={(text: string) =>
-                                        this.setState({ exportPassword: text })
-                                    }
-                                    secureTextEntry
-                                />
-                                <TextInput
-                                    placeholder={localeString(
-                                        'views.Tools.nodeConfigExportImport.confirmPassword'
-                                    )}
-                                    value={confirmPassword}
-                                    onChangeText={(text: string) =>
-                                        this.setState({ confirmPassword: text })
-                                    }
-                                    secureTextEntry
-                                />
-                            </>
-                        )}
-
-                        {!useEncryption && (
-                            <Text
-                                style={{
-                                    color: themeColor('error'),
-                                    fontWeight: 'bold',
-                                    marginBottom: 10
-                                }}
-                            >
-                                {localeString(
-                                    'views.Tools.nodeConfigExportImport.unencryptedWarning'
+                    {useEncryption && (
+                        <>
+                            <TextInput
+                                placeholder={localeString(
+                                    'views.Tools.nodeConfigExportImport.password'
                                 )}
-                            </Text>
-                        )}
-
-                        <View style={styles.buttonContainer}>
-                            <Button
-                                title={localeString(
-                                    'views.Tools.nodeConfigExportImport.exportConfigs'
-                                )}
-                                onPress={this.executeExport}
-                                disabled={
-                                    useEncryption &&
-                                    (!exportPassword ||
-                                        exportPassword !== confirmPassword)
+                                value={exportPassword}
+                                onChangeText={(text: string) =>
+                                    this.setState({
+                                        exportPassword: text
+                                    })
                                 }
-                                buttonStyle={{ marginBottom: 10 }}
+                                secureTextEntry
                             />
-                            <Button
-                                title={localeString('general.close')}
-                                onPress={this.resetExportState}
-                                secondary
+                            <TextInput
+                                placeholder={localeString(
+                                    'views.Tools.nodeConfigExportImport.confirmPassword'
+                                )}
+                                value={confirmPassword}
+                                onChangeText={(text: string) =>
+                                    this.setState({
+                                        confirmPassword: text
+                                    })
+                                }
+                                secureTextEntry
                             />
-                        </View>
+                        </>
+                    )}
+
+                    {!useEncryption && (
+                        <Text
+                            style={{
+                                color: themeColor('error'),
+                                fontWeight: 'bold',
+                                marginBottom: 10
+                            }}
+                        >
+                            {localeString(
+                                'views.Tools.nodeConfigExportImport.unencryptedWarning'
+                            )}
+                        </Text>
+                    )}
+
+                    <View style={styles.buttonContainer}>
+                        <Button
+                            title={localeString(
+                                'views.Tools.nodeConfigExportImport.exportConfigs'
+                            )}
+                            onPress={this.executeExport}
+                            disabled={
+                                useEncryption &&
+                                (!exportPassword ||
+                                    exportPassword !== confirmPassword)
+                            }
+                            buttonStyle={{ marginBottom: 10 }}
+                        />
+                        <Button
+                            title={localeString('general.close')}
+                            onPress={this.resetExportState}
+                            secondary
+                        />
                     </View>
                 </View>
-            </Modal>
+            </CenteredModal>
         );
     };
 
@@ -642,68 +640,71 @@ export default class NodeConfigExportImport extends React.Component<
             this.state;
 
         return (
-            <Modal
-                visible={activeModal === 'password'}
-                transparent={true}
-                animationType="slide"
+            <CenteredModal
+                isOpen={activeModal === 'password'}
+                onClose={() => {
+                    if (this.state.activeModal === 'password')
+                        this.resetImportState();
+                }}
             >
-                <View style={styles.modalOverlay}>
-                    <View
-                        style={[
-                            styles.modalContent,
-                            {
-                                backgroundColor: isLightTheme()
-                                    ? '#ffffff'
-                                    : themeColor('background')
+                <View
+                    style={[
+                        styles.modalContent,
+                        {
+                            maxHeight: '80%',
+                            backgroundColor: isLightTheme()
+                                ? '#ffffff'
+                                : themeColor('background')
+                        }
+                    ]}
+                >
+                    <Text style={styles.modalTitle}>
+                        {localeString('views.Lockscreen.enterPassword')}
+                    </Text>
+
+                    <View style={styles.inputContainer}>
+                        <TextInput
+                            placeholder={'****************'}
+                            value={importPassword}
+                            onChangeText={(text: string) =>
+                                this.setState({
+                                    importPassword: text
+                                })
                             }
-                        ]}
-                    >
-                        <Text style={styles.modalTitle}>
-                            {localeString('views.Lockscreen.enterPassword')}
-                        </Text>
-
-                        <View style={styles.inputContainer}>
-                            <TextInput
-                                placeholder={'****************'}
-                                value={importPassword}
-                                onChangeText={(text: string) =>
-                                    this.setState({ importPassword: text })
+                            autoCapitalize="none"
+                            autoCorrect={false}
+                            secureTextEntry={importPasswordHidden}
+                            style={styles.textInput}
+                        />
+                        <View style={styles.showHideToggle}>
+                            <ShowHideToggle
+                                onPress={() =>
+                                    this.setState({
+                                        importPasswordHidden:
+                                            !importPasswordHidden
+                                    })
                                 }
-                                autoCapitalize="none"
-                                autoCorrect={false}
-                                secureTextEntry={importPasswordHidden}
-                                style={styles.textInput}
-                            />
-                            <View style={styles.showHideToggle}>
-                                <ShowHideToggle
-                                    onPress={() =>
-                                        this.setState({
-                                            importPasswordHidden:
-                                                !importPasswordHidden
-                                        })
-                                    }
-                                />
-                            </View>
-                        </View>
-
-                        <View style={styles.buttonContainer}>
-                            <Button
-                                title={localeString('general.proceed')}
-                                onPress={() => {
-                                    this.handlePasswordSubmit(importPassword);
-                                }}
-                                disabled={!importPassword}
-                                buttonStyle={{ marginBottom: 10 }}
-                            />
-                            <Button
-                                title={localeString('general.close')}
-                                onPress={this.resetImportState}
-                                secondary
                             />
                         </View>
                     </View>
+
+                    <View style={styles.buttonContainer}>
+                        <Button
+                            title={localeString('general.proceed')}
+                            onPress={() => {
+                                this.handlePasswordSubmit(importPassword);
+                            }}
+                            disabled={!importPassword}
+                            buttonStyle={{ marginBottom: 10 }}
+                        />
+                        <Button
+                            title={localeString('general.close')}
+                            onPress={this.resetImportState}
+                            secondary
+                        />
+                    </View>
                 </View>
-            </Modal>
+            </CenteredModal>
         );
     };
 
@@ -715,157 +716,152 @@ export default class NodeConfigExportImport extends React.Component<
             selectedImportNodes.length === importNodes.length;
 
         return (
-            <Modal
-                visible={activeModal === 'importNodeSelection'}
-                transparent={true}
-                animationType="slide"
-                onRequestClose={this.resetImportState}
+            <CenteredModal
+                isOpen={activeModal === 'importNodeSelection'}
+                onClose={() => {
+                    if (this.state.activeModal === 'importNodeSelection')
+                        this.resetImportState();
+                }}
             >
-                <View style={styles.modalOverlay}>
-                    <View
-                        style={[
-                            styles.modalContent,
-                            {
-                                maxHeight: '80%',
-                                backgroundColor: isLightTheme()
-                                    ? '#ffffff'
-                                    : themeColor('background')
-                            }
-                        ]}
-                    >
-                        <Text style={styles.modalTitle}>
-                            {localeString(
-                                'views.Tools.nodeConfigExportImport.selectConfigsToImport'
-                            )}
-                        </Text>
+                <View
+                    style={[
+                        styles.modalContent,
+                        {
+                            maxHeight: '80%',
+                            backgroundColor: isLightTheme()
+                                ? '#ffffff'
+                                : themeColor('background')
+                        }
+                    ]}
+                >
+                    <Text style={styles.modalTitle}>
+                        {localeString(
+                            'views.Tools.nodeConfigExportImport.selectConfigsToImport'
+                        )}
+                    </Text>
 
-                        <ScrollView showsVerticalScrollIndicator={false}>
-                            {importNodes.length > 1 && (
-                                <CheckBox
-                                    title={localeString(
-                                        'views.Tools.nodeConfigExportImport.selectAllConfigs'
-                                    )}
-                                    checked={allNodesSelected}
-                                    onPress={() => {
-                                        if (allNodesSelected) {
-                                            this.setState({
-                                                selectedImportNodes: []
-                                            });
-                                        } else {
-                                            this.setState({
-                                                selectedImportNodes:
-                                                    importNodes.map((_, i) => i)
-                                            });
-                                        }
-                                    }}
-                                    containerStyle={{
-                                        backgroundColor: 'transparent',
-                                        borderWidth: 0,
-                                        marginBottom: 15
-                                    }}
-                                    textStyle={{
-                                        color: themeColor('text'),
-                                        fontWeight: 'bold'
-                                    }}
-                                    checkedColor={themeColor('text')}
-                                />
-                            )}
-
-                            {importNodes.map((node: Node, index: number) => {
-                                const isSelected =
-                                    selectedImportNodes.includes(index);
-
-                                return (
-                                    <View key={index} style={styles.nodeItem}>
-                                        <CheckBox
-                                            title={
-                                                <View style={styles.nodeInfo}>
-                                                    <NodeIdenticon
-                                                        selectedNode={node}
-                                                        width={42}
-                                                        rounded
-                                                    />
-                                                    <View
-                                                        style={styles.nodeText}
-                                                    >
-                                                        <Text
-                                                            numberOfLines={1}
-                                                            ellipsizeMode="tail"
-                                                            style={{
-                                                                color: themeColor(
-                                                                    'text'
-                                                                ),
-                                                                fontSize: 16
-                                                            }}
-                                                        >
-                                                            {NodeTitle(node)}
-                                                        </Text>
-                                                        <Text
-                                                            style={{
-                                                                color: themeColor(
-                                                                    'secondaryText'
-                                                                ),
-                                                                fontSize: 12
-                                                            }}
-                                                        >
-                                                            {getImplementationDisplayName(
-                                                                node.implementation
-                                                            )}
-                                                        </Text>
-                                                    </View>
-                                                </View>
-                                            }
-                                            checked={isSelected}
-                                            onPress={() => {
-                                                this.setState((prevState) => ({
-                                                    selectedImportNodes:
-                                                        prevState.selectedImportNodes.includes(
-                                                            index
-                                                        )
-                                                            ? prevState.selectedImportNodes.filter(
-                                                                  (n) =>
-                                                                      n !==
-                                                                      index
-                                                              )
-                                                            : [
-                                                                  ...prevState.selectedImportNodes,
-                                                                  index
-                                                              ]
-                                                }));
-                                            }}
-                                            iconRight={true}
-                                            containerStyle={{
-                                                backgroundColor: 'transparent',
-                                                borderWidth: 0,
-                                                marginBottom: 10,
-                                                padding: 0
-                                            }}
-                                            uncheckedColor={themeColor('text')}
-                                            checkedColor={themeColor('text')}
-                                        />
-                                    </View>
-                                );
-                            })}
-                        </ScrollView>
-
-                        <View style={styles.buttonContainer}>
-                            <Button
+                    <ScrollView showsVerticalScrollIndicator={false}>
+                        {importNodes.length > 1 && (
+                            <CheckBox
                                 title={localeString(
-                                    'views.Tools.nodeConfigExportImport.importSelected'
+                                    'views.Tools.nodeConfigExportImport.selectAllConfigs'
                                 )}
-                                onPress={this.executeImport}
-                                disabled={selectedImportNodes.length === 0}
-                                buttonStyle={{ marginBottom: 10 }}
+                                checked={allNodesSelected}
+                                onPress={() => {
+                                    if (allNodesSelected) {
+                                        this.setState({
+                                            selectedImportNodes: []
+                                        });
+                                    } else {
+                                        this.setState({
+                                            selectedImportNodes:
+                                                importNodes.map((_, i) => i)
+                                        });
+                                    }
+                                }}
+                                containerStyle={{
+                                    backgroundColor: 'transparent',
+                                    borderWidth: 0,
+                                    marginBottom: 15
+                                }}
+                                textStyle={{
+                                    color: themeColor('text'),
+                                    fontWeight: 'bold'
+                                }}
+                                checkedColor={themeColor('text')}
                             />
-                            <Button
-                                title={localeString('general.close')}
-                                onPress={this.resetImportState}
-                                secondary
-                            />
-                        </View>
+                        )}
+
+                        {importNodes.map((node: Node, index: number) => {
+                            const isSelected =
+                                selectedImportNodes.includes(index);
+
+                            return (
+                                <View key={index} style={styles.nodeItem}>
+                                    <CheckBox
+                                        title={
+                                            <View style={styles.nodeInfo}>
+                                                <NodeIdenticon
+                                                    selectedNode={node}
+                                                    width={42}
+                                                    rounded
+                                                />
+                                                <View style={styles.nodeText}>
+                                                    <Text
+                                                        numberOfLines={1}
+                                                        ellipsizeMode="tail"
+                                                        style={{
+                                                            color: themeColor(
+                                                                'text'
+                                                            ),
+                                                            fontSize: 16
+                                                        }}
+                                                    >
+                                                        {NodeTitle(node)}
+                                                    </Text>
+                                                    <Text
+                                                        style={{
+                                                            color: themeColor(
+                                                                'secondaryText'
+                                                            ),
+                                                            fontSize: 12
+                                                        }}
+                                                    >
+                                                        {getImplementationDisplayName(
+                                                            node.implementation
+                                                        )}
+                                                    </Text>
+                                                </View>
+                                            </View>
+                                        }
+                                        checked={isSelected}
+                                        onPress={() => {
+                                            this.setState((prevState) => ({
+                                                selectedImportNodes:
+                                                    prevState.selectedImportNodes.includes(
+                                                        index
+                                                    )
+                                                        ? prevState.selectedImportNodes.filter(
+                                                              (n) => n !== index
+                                                          )
+                                                        : [
+                                                              ...prevState.selectedImportNodes,
+                                                              index
+                                                          ]
+                                            }));
+                                        }}
+                                        iconRight={true}
+                                        containerStyle={{
+                                            backgroundColor: 'transparent',
+                                            borderWidth: 0,
+                                            marginBottom: 10,
+                                            padding: 0
+                                        }}
+                                        uncheckedColor={themeColor('text')}
+                                        checkedColor={themeColor('text')}
+                                    />
+                                </View>
+                            );
+                        })}
+                    </ScrollView>
+
+                    <View style={styles.buttonContainer}>
+                        <Button
+                            title={localeString(
+                                'views.Tools.nodeConfigExportImport.importSelected'
+                            )}
+                            onPress={this.executeImport}
+                            disabled={selectedImportNodes.length === 0}
+                            buttonStyle={{ marginBottom: 10 }}
+                        />
+                        <Button
+                            title={localeString('general.close')}
+                            onPress={this.resetImportState}
+                            secondary
+                        />
                     </View>
                 </View>
-            </Modal>
+            </CenteredModal>
         );
     };
 
@@ -1118,112 +1114,109 @@ export default class NodeConfigExportImport extends React.Component<
         const hasRecoverableData = recoverableSettings.length > 0;
 
         return (
-            <Modal
-                animationType="slide"
-                transparent
-                visible={activeModal === 'recovery'}
-                onRequestClose={this.resetRecoveryState}
+            <CenteredModal
+                isOpen={activeModal === 'recovery'}
+                onClose={() => {
+                    if (this.state.activeModal === 'recovery')
+                        this.resetRecoveryState();
+                }}
             >
-                <View style={styles.modalOverlay}>
-                    <View
-                        style={[
-                            styles.modalContent,
-                            {
-                                backgroundColor: isLightTheme()
-                                    ? '#ffffff'
-                                    : themeColor('background'),
-                                maxHeight: '85%'
-                            }
-                        ]}
-                    >
-                        <Text style={styles.modalTitle}>
-                            {localeString(
-                                'views.Tools.nodeConfigExportImport.recovery.title'
-                            )}
-                        </Text>
-
-                        {isScanning ? (
-                            <View style={styles.scanningContainer}>
-                                <LoadingIndicator />
-                                <Text style={{ marginTop: 15 }}>
-                                    {localeString(
-                                        'views.Tools.nodeConfigExportImport.recovery.scanning'
-                                    )}
-                                </Text>
-                            </View>
-                        ) : (
-                            <ScrollView
-                                style={{ maxHeight: 400 }}
-                                showsVerticalScrollIndicator={false}
-                            >
-                                {Platform.OS === 'ios' && (
-                                    <View style={styles.warningBanner}>
-                                        <Icon
-                                            name="alert-circle"
-                                            type="feather"
-                                            color={themeColor('warning')}
-                                            size={18}
-                                        />
-                                        <Text style={styles.warningBannerText}>
-                                            {localeString(
-                                                'views.Tools.nodeConfigExportImport.recovery.iOSWarning'
-                                            )}
-                                        </Text>
-                                    </View>
-                                )}
-
-                                {hasRecoverableData ? (
-                                    <>
-                                        <Text style={styles.recoverySubtitle}>
-                                            {localeString(
-                                                'views.Tools.nodeConfigExportImport.recovery.foundData'
-                                            )}
-                                        </Text>
-                                        {recoverableSettings.map(
-                                            (result, index) =>
-                                                this.renderRecoveryItem(
-                                                    result,
-                                                    index
-                                                )
-                                        )}
-                                    </>
-                                ) : scanResult ? (
-                                    <View style={styles.emptyState}>
-                                        <Text style={styles.emptyStateText}>
-                                            {localeString(
-                                                'views.Tools.nodeConfigExportImport.recovery.noDataFound'
-                                            )}
-                                        </Text>
-                                        <Text style={styles.emptyStateSubtext}>
-                                            {localeString(
-                                                'views.Tools.nodeConfigExportImport.recovery.noDataFoundDesc'
-                                            )}
-                                        </Text>
-                                    </View>
-                                ) : null}
-                            </ScrollView>
+                <View
+                    style={[
+                        styles.modalContent,
+                        {
+                            maxHeight: '85%',
+                            backgroundColor: isLightTheme()
+                                ? '#ffffff'
+                                : themeColor('background')
+                        }
+                    ]}
+                >
+                    <Text style={styles.modalTitle}>
+                        {localeString(
+                            'views.Tools.nodeConfigExportImport.recovery.title'
                         )}
+                    </Text>
 
-                        <View style={styles.buttonContainer}>
-                            {!isScanning && scanResult && (
-                                <Button
-                                    title={localeString(
-                                        'views.Tools.nodeConfigExportImport.recovery.rescan'
-                                    )}
-                                    onPress={() => this.handleRecoveryScan()}
-                                    secondary
-                                    buttonStyle={{ marginBottom: 10 }}
-                                />
-                            )}
-                            <Button
-                                title={localeString('general.close')}
-                                onPress={this.resetRecoveryState}
-                                secondary
-                            />
+                    {isScanning ? (
+                        <View style={styles.scanningContainer}>
+                            <LoadingIndicator />
+                            <Text style={{ marginTop: 15 }}>
+                                {localeString(
+                                    'views.Tools.nodeConfigExportImport.recovery.scanning'
+                                )}
+                            </Text>
                         </View>
+                    ) : (
+                        <ScrollView
+                            style={{ maxHeight: 400 }}
+                            showsVerticalScrollIndicator={false}
+                        >
+                            {Platform.OS === 'ios' && (
+                                <View style={styles.warningBanner}>
+                                    <Icon
+                                        name="alert-circle"
+                                        type="feather"
+                                        color={themeColor('warning')}
+                                        size={18}
+                                    />
+                                    <Text style={styles.warningBannerText}>
+                                        {localeString(
+                                            'views.Tools.nodeConfigExportImport.recovery.iOSWarning'
+                                        )}
+                                    </Text>
+                                </View>
+                            )}
+
+                            {hasRecoverableData ? (
+                                <>
+                                    <Text style={styles.recoverySubtitle}>
+                                        {localeString(
+                                            'views.Tools.nodeConfigExportImport.recovery.foundData'
+                                        )}
+                                    </Text>
+                                    {recoverableSettings.map((result, index) =>
+                                        this.renderRecoveryItem(result, index)
+                                    )}
+                                </>
+                            ) : scanResult ? (
+                                <View style={styles.emptyState}>
+                                    <Text style={styles.emptyStateText}>
+                                        {localeString(
+                                            'views.Tools.nodeConfigExportImport.recovery.noDataFound'
+                                        )}
+                                    </Text>
+                                    <Text style={styles.emptyStateSubtext}>
+                                        {localeString(
+                                            'views.Tools.nodeConfigExportImport.recovery.noDataFoundDesc'
+                                        )}
+                                    </Text>
+                                </View>
+                            ) : null}
+                        </ScrollView>
+                    )}
+
+                    <View style={styles.buttonContainer}>
+                        {!isScanning && scanResult && (
+                            <Button
+                                title={localeString(
+                                    'views.Tools.nodeConfigExportImport.recovery.rescan'
+                                )}
+                                onPress={() => this.handleRecoveryScan()}
+                                secondary
+                                buttonStyle={{
+                                    marginBottom: 10
+                                }}
+                            />
+                        )}
+                        <Button
+                            title={localeString('general.close')}
+                            onPress={this.resetRecoveryState}
+                            secondary
+                        />
                     </View>
                 </View>
-            </Modal>
+            </CenteredModal>
         );
     };
 
@@ -1291,177 +1284,168 @@ export default class NodeConfigExportImport extends React.Component<
             selectedRecoveryNodes.length === recoveryNodes.length;
 
         return (
-            <Modal
-                animationType="slide"
-                transparent
-                visible={activeModal === 'recoveryNodeSelection'}
-                onRequestClose={() =>
-                    this.setState({ activeModal: 'recovery' })
-                }
+            <CenteredModal
+                isOpen={activeModal === 'recoveryNodeSelection'}
+                onClose={() => {
+                    if (this.state.activeModal === 'recoveryNodeSelection')
+                        this.setState({ activeModal: 'recovery' });
+                }}
             >
-                <View style={styles.modalOverlay}>
-                    <View
-                        style={[
-                            styles.modalContent,
-                            {
-                                maxHeight: '80%',
-                                backgroundColor: isLightTheme()
-                                    ? '#ffffff'
-                                    : themeColor('background')
-                            }
-                        ]}
-                    >
-                        <Text style={styles.modalTitle}>
+                <View
+                    style={[
+                        styles.modalContent,
+                        {
+                            maxHeight: '80%',
+                            backgroundColor: isLightTheme()
+                                ? '#ffffff'
+                                : themeColor('background')
+                        }
+                    ]}
+                >
+                    <Text style={styles.modalTitle}>
+                        {localeString(
+                            'views.Tools.nodeConfigExportImport.recovery.selectConfigsToRestore'
+                        )}
+                    </Text>
+
+                    <View style={styles.previewSection}>
+                        <Text style={styles.previewLabel}>
                             {localeString(
-                                'views.Tools.nodeConfigExportImport.recovery.selectConfigsToRestore'
+                                'views.Tools.nodeConfigExportImport.recovery.source'
                             )}
                         </Text>
+                        <Text style={styles.previewValue}>{sourceName}</Text>
+                    </View>
 
-                        <View style={styles.previewSection}>
-                            <Text style={styles.previewLabel}>
-                                {localeString(
-                                    'views.Tools.nodeConfigExportImport.recovery.source'
-                                )}
-                            </Text>
-                            <Text style={styles.previewValue}>
-                                {sourceName}
-                            </Text>
-                        </View>
-
-                        <ScrollView
-                            style={{ maxHeight: 300 }}
-                            showsVerticalScrollIndicator={false}
-                        >
-                            {recoveryNodes.length > 1 && (
-                                <CheckBox
-                                    title={localeString(
-                                        'views.Tools.nodeConfigExportImport.selectAllConfigs'
-                                    )}
-                                    checked={allNodesSelected}
-                                    onPress={() => {
-                                        if (allNodesSelected) {
-                                            this.setState({
-                                                selectedRecoveryNodes: []
-                                            });
-                                        } else {
-                                            this.setState({
-                                                selectedRecoveryNodes:
-                                                    recoveryNodes.map(
-                                                        (_, i) => i
-                                                    )
-                                            });
-                                        }
-                                    }}
-                                    containerStyle={{
-                                        backgroundColor: 'transparent',
-                                        borderWidth: 0,
-                                        marginBottom: 15
-                                    }}
-                                    textStyle={{
-                                        color: themeColor('text'),
-                                        fontWeight: 'bold'
-                                    }}
-                                    checkedColor={themeColor('text')}
-                                />
-                            )}
-
-                            {recoveryNodes.map((node: Node, index: number) => {
-                                const isSelected =
-                                    selectedRecoveryNodes.includes(index);
-
-                                return (
-                                    <View key={index} style={styles.nodeItem}>
-                                        <CheckBox
-                                            title={
-                                                <View style={styles.nodeInfo}>
-                                                    <NodeIdenticon
-                                                        selectedNode={node}
-                                                        width={42}
-                                                        rounded
-                                                    />
-                                                    <View
-                                                        style={styles.nodeText}
-                                                    >
-                                                        <Text
-                                                            numberOfLines={1}
-                                                            ellipsizeMode="tail"
-                                                            style={{
-                                                                color: themeColor(
-                                                                    'text'
-                                                                ),
-                                                                fontSize: 16
-                                                            }}
-                                                        >
-                                                            {NodeTitle(node)}
-                                                        </Text>
-                                                        <Text
-                                                            style={{
-                                                                color: themeColor(
-                                                                    'secondaryText'
-                                                                ),
-                                                                fontSize: 12
-                                                            }}
-                                                        >
-                                                            {getImplementationDisplayName(
-                                                                node.implementation
-                                                            )}
-                                                        </Text>
-                                                    </View>
-                                                </View>
-                                            }
-                                            checked={isSelected}
-                                            onPress={() => {
-                                                this.setState((prevState) => ({
-                                                    selectedRecoveryNodes:
-                                                        prevState.selectedRecoveryNodes.includes(
-                                                            index
-                                                        )
-                                                            ? prevState.selectedRecoveryNodes.filter(
-                                                                  (n) =>
-                                                                      n !==
-                                                                      index
-                                                              )
-                                                            : [
-                                                                  ...prevState.selectedRecoveryNodes,
-                                                                  index
-                                                              ]
-                                                }));
-                                            }}
-                                            iconRight={true}
-                                            containerStyle={{
-                                                backgroundColor: 'transparent',
-                                                borderWidth: 0,
-                                                marginBottom: 10,
-                                                padding: 0
-                                            }}
-                                            uncheckedColor={themeColor('text')}
-                                            checkedColor={themeColor('text')}
-                                        />
-                                    </View>
-                                );
-                            })}
-                        </ScrollView>
-
-                        <View style={styles.buttonContainer}>
-                            <Button
+                    <ScrollView
+                        style={{ maxHeight: 300 }}
+                        showsVerticalScrollIndicator={false}
+                    >
+                        {recoveryNodes.length > 1 && (
+                            <CheckBox
                                 title={localeString(
-                                    'views.Tools.nodeConfigExportImport.recovery.restoreSelected'
+                                    'views.Tools.nodeConfigExportImport.selectAllConfigs'
                                 )}
-                                onPress={this.handleRecoveryRestore}
-                                disabled={selectedRecoveryNodes.length === 0}
-                                buttonStyle={{ marginBottom: 10 }}
+                                checked={allNodesSelected}
+                                onPress={() => {
+                                    if (allNodesSelected) {
+                                        this.setState({
+                                            selectedRecoveryNodes: []
+                                        });
+                                    } else {
+                                        this.setState({
+                                            selectedRecoveryNodes:
+                                                recoveryNodes.map((_, i) => i)
+                                        });
+                                    }
+                                }}
+                                containerStyle={{
+                                    backgroundColor: 'transparent',
+                                    borderWidth: 0,
+                                    marginBottom: 15
+                                }}
+                                textStyle={{
+                                    color: themeColor('text'),
+                                    fontWeight: 'bold'
+                                }}
+                                checkedColor={themeColor('text')}
                             />
-                            <Button
-                                title={localeString('general.goBack')}
-                                onPress={() =>
-                                    this.setState({ activeModal: 'recovery' })
-                                }
-                                secondary
-                            />
-                        </View>
+                        )}
+
+                        {recoveryNodes.map((node: Node, index: number) => {
+                            const isSelected =
+                                selectedRecoveryNodes.includes(index);
+
+                            return (
+                                <View key={index} style={styles.nodeItem}>
+                                    <CheckBox
+                                        title={
+                                            <View style={styles.nodeInfo}>
+                                                <NodeIdenticon
+                                                    selectedNode={node}
+                                                    width={42}
+                                                    rounded
+                                                />
+                                                <View style={styles.nodeText}>
+                                                    <Text
+                                                        numberOfLines={1}
+                                                        ellipsizeMode="tail"
+                                                        style={{
+                                                            color: themeColor(
+                                                                'text'
+                                                            ),
+                                                            fontSize: 16
+                                                        }}
+                                                    >
+                                                        {NodeTitle(node)}
+                                                    </Text>
+                                                    <Text
+                                                        style={{
+                                                            color: themeColor(
+                                                                'secondaryText'
+                                                            ),
+                                                            fontSize: 12
+                                                        }}
+                                                    >
+                                                        {getImplementationDisplayName(
+                                                            node.implementation
+                                                        )}
+                                                    </Text>
+                                                </View>
+                                            </View>
+                                        }
+                                        checked={isSelected}
+                                        onPress={() => {
+                                            this.setState((prevState) => ({
+                                                selectedRecoveryNodes:
+                                                    prevState.selectedRecoveryNodes.includes(
+                                                        index
+                                                    )
+                                                        ? prevState.selectedRecoveryNodes.filter(
+                                                              (n) => n !== index
+                                                          )
+                                                        : [
+                                                              ...prevState.selectedRecoveryNodes,
+                                                              index
+                                                          ]
+                                            }));
+                                        }}
+                                        iconRight={true}
+                                        containerStyle={{
+                                            backgroundColor: 'transparent',
+                                            borderWidth: 0,
+                                            marginBottom: 10,
+                                            padding: 0
+                                        }}
+                                        uncheckedColor={themeColor('text')}
+                                        checkedColor={themeColor('text')}
+                                    />
+                                </View>
+                            );
+                        })}
+                    </ScrollView>
+
+                    <View style={styles.buttonContainer}>
+                        <Button
+                            title={localeString(
+                                'views.Tools.nodeConfigExportImport.recovery.restoreSelected'
+                            )}
+                            onPress={this.handleRecoveryRestore}
+                            disabled={selectedRecoveryNodes.length === 0}
+                            buttonStyle={{ marginBottom: 10 }}
+                        />
+                        <Button
+                            title={localeString('general.goBack')}
+                            onPress={() =>
+                                this.setState({
+                                    activeModal: 'recovery'
+                                })
+                            }
+                            secondary
+                        />
                     </View>
                 </View>
-            </Modal>
+            </CenteredModal>
         );
     };
 
@@ -1470,6 +1454,13 @@ export default class NodeConfigExportImport extends React.Component<
 
         return (
             <Screen>
+                {this.renderNodeSelectionModal()}
+                {this.renderExportModal()}
+                {this.renderInfoModal()}
+                {this.renderPasswordModal()}
+                {this.renderImportNodeSelectionModal()}
+                {this.renderRecoveryModal()}
+                {this.renderRecoveryNodeSelectionModal()}
                 <ScrollView showsVerticalScrollIndicator={false}>
                     <Header
                         leftComponent="Back"
@@ -1494,13 +1485,6 @@ export default class NodeConfigExportImport extends React.Component<
                         }
                         navigation={this.props.navigation}
                     />
-                    {this.renderNodeSelectionModal()}
-                    {this.renderExportModal()}
-                    {this.renderInfoModal()}
-                    {this.renderPasswordModal()}
-                    {this.renderImportNodeSelectionModal()}
-                    {this.renderRecoveryModal()}
-                    {this.renderRecoveryNodeSelectionModal()}
 
                     <View style={styles.container}>
                         {isLoading ? (
@@ -1669,12 +1653,6 @@ const styles = StyleSheet.create({
     optionText: {
         marginLeft: 15,
         fontSize: 16
-    },
-    modalOverlay: {
-        flex: 1,
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        justifyContent: 'center',
-        alignItems: 'center'
     },
     modalContent: {
         width: '85%',


### PR DESCRIPTION
## Summary

Fixes screenshot/screen-record leaks in modal dialogs that were not covered by FLAG_SECURE (Android) / iOS secure canvas.

**Root cause:** RN `<Modal>` and ModalBox `coverScreen={true}` create a *separate native window* which the platform's screen-capture protection doesn't cover. Content must render inside the main activity window.

**Fix:** An in-house `Portal` primitive teleports modal content to a root-mounted `absoluteFill` host inside `PortalProvider` (added to `App.tsx` inside `GestureHandlerRootView`). A new `CenteredModal` component encapsulates the full centered-dialog pattern (transparent full-screen ModalBox + flexbox centering + tap-to-close) so it isn't duplicated across call sites.

## Changes

- **`components/Portal.tsx`** — keyed teleport: `<Portal>` publishes children to `<PortalProvider>`'s root-mounted host. Implemented as function components with hooks to avoid Babel/Metro `declare context` issues.
- **`components/Modals/CenteredModal.tsx`** — reusable centered-dialog wrapper matching the existing `ActionSheetModal` / `AlertModal` pattern. Used by PaymentDetailsSheet and all 7 NodeConfigExportImport modals.
- **`App.tsx`** — wraps `GestureHandlerRootView` content in `<PortalProvider>` so portalled modals render inside the secured main window.
- **`components/HopPicker.tsx`** — replaced RN `<Modal>` + `SafeAreaView` with a Portal-wrapped bottom-sheet `ModalBox`.
- **`components/UTXOPicker.tsx`** — removed `coverScreen={true}`, wrapped in `<Portal>`.
- **`components/PaymentDetailsSheet.tsx`** — replaced RN `<Modal>` with `<CenteredModal>`.
- **`views/Tools/NodeConfigExportImport.tsx`** — replaced 7 RN `<Modal>`s with `<CenteredModal>`; moved modal renders outside `<ScrollView>` so they render at the `<Screen>` root (required since `CenteredModal` doesn't use Portal — avoids first-open centering bug).

## Test plan

- [ ] Screenshot and screen-record are blocked while each affected modal is open (HopPicker, UTXOPicker, PaymentDetailsSheet, all 7 NodeConfig dialogs)
- [ ] Modals open centered on **first** tap (no left-stick)
- [ ] Backdrop tap, Android hardware back, and in-modal close button all dismiss correctly
- [ ] NodeConfig multi-step flow: `nodeSelection → export`, `recovery → recoveryNodeSelection → goBack`
- [ ] HopPicker / UTXOPicker bottom sheets slide up, fill ~90% of screen, swipe-to-close works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)