### PR TITLE
fix(ios): persist NWC ambient track selection across restarts and sessions

### DIFF
--- a/ios/NWCWidget/NWCLiveActivityShared.swift
+++ b/ios/NWCWidget/NWCLiveActivityShared.swift
@@ -10,6 +10,7 @@ enum NWCLiveActivityShared {
     private static let keyIsMuted = "nwc.isMuted"
     private static let keyRevision = "nwc.contentRevision"
     private static let keyActivityId = "nwc.activityId"
+    private static let keyPreferredTrackIndex = "nwc.preferredTrackIndex"
 
     private static var defaults: UserDefaults? {
         UserDefaults(suiteName: appGroupID)
@@ -34,6 +35,19 @@ enum NWCLiveActivityShared {
         d?.set(trackIndex, forKey: keyTrackIndex)
         d?.set(isMuted, forKey: keyIsMuted)
         d?.set(Int(revision), forKey: keyRevision)
+    }
+
+    /// Track the user prefers next start to play. Distinct from the display state
+    /// (`keyTrackIndex`) so picking in settings during an active session doesn't
+    /// race the refresh timer into showing a track the audio isn't actually playing.
+    static func readPreferredTrackIndex() -> Int? {
+        guard let d = defaults, d.object(forKey: keyPreferredTrackIndex) != nil
+        else { return nil }
+        return d.integer(forKey: keyPreferredTrackIndex)
+    }
+
+    static func writePreferredTrackIndex(_ index: Int) {
+        defaults?.set(index, forKey: keyPreferredTrackIndex)
     }
 
     static func setPreferredActivityId(_ id: String?) {
@@ -125,6 +139,7 @@ enum NWCLiveActivityShared {
     static func applyNextTrack() async {
         var (index, muted, _) = readDisplay()
         index = (index + 1) % max(tracks.count, 1)
+        writePreferredTrackIndex(index)
         await pushLiveActivity(trackIndex: index, isMuted: muted)
     }
 
@@ -133,6 +148,7 @@ enum NWCLiveActivityShared {
         var (index, muted, _) = readDisplay()
         let count = max(tracks.count, 1)
         index = (index - 1 + count) % count
+        writePreferredTrackIndex(index)
         await pushLiveActivity(trackIndex: index, isMuted: muted)
     }
 

--- a/ios/zeus/NWCAudioKeepAlive.m
+++ b/ios/zeus/NWCAudioKeepAlive.m
@@ -117,7 +117,16 @@ RCT_EXPORT_MODULE();
         _hasListeners      = NO;
         _disconnectCount   = 0;
         _trackNames        = [NWCAmbientTracks trackNames];
-        _currentTrackIndex = 0;
+
+        // Restore last-selected track from the app group (written by
+        // switchToTrackAtIndex: via NWCLiveActivityBridge). UserDefaults
+        // returns 0 if the key was never written, which matches the default.
+        NSInteger persisted = [NWCLiveActivityBridge appGroupTrackIndex];
+        NSInteger count = (NSInteger)_trackNames.count;
+        _currentTrackIndex = (count > 0 && persisted >= 0 && persisted < count)
+            ? persisted
+            : 0;
+
         _isMuted           = NO;
         _iosVersion        = [[UIDevice currentDevice] systemVersion];
         _deviceModel       = [self deviceModelIdentifier];

--- a/ios/zeus/NWCAudioKeepAlive.m
+++ b/ios/zeus/NWCAudioKeepAlive.m
@@ -118,10 +118,11 @@ RCT_EXPORT_MODULE();
         _disconnectCount   = 0;
         _trackNames        = [NWCAmbientTracks trackNames];
 
-        // Restore last-selected track from the app group (written by
-        // switchToTrackAtIndex: via NWCLiveActivityBridge). UserDefaults
-        // returns 0 if the key was never written, which matches the default.
-        NSInteger persisted = [NWCLiveActivityBridge appGroupTrackIndex];
+        // Restore the user's preferred track. Preference key wins; fall back
+        // to the display-state index (which reflects in-session changes made
+        // from the Dynamic Island) if the user never picked in settings.
+        NSInteger fallback = [NWCLiveActivityBridge appGroupTrackIndex];
+        NSInteger persisted = [NWCLiveActivityBridge preferredTrackIndexWithFallback:fallback];
         NSInteger count = (NSInteger)_trackNames.count;
         _currentTrackIndex = (count > 0 && persisted >= 0 && persisted < count)
             ? persisted
@@ -258,8 +259,10 @@ RCT_EXPORT_METHOD(setTrack:(NSInteger)index
 
 // Updates the preferred track without restarting playback. Used when the
 // settings UI changes selection during an active NWC session — the user's
-// pick should persist (app group, in-memory) so the next start uses it,
-// but the currently playing ambient track must not be interrupted.
+// pick should persist so the next start uses it, but the currently playing
+// ambient track and the Dynamic Island must not be interrupted. Writes only
+// the preference key in the app group; the display-state index (which the
+// Live Activity refresh timer reads every 15s) is intentionally left alone.
 RCT_EXPORT_METHOD(setTrackPreference:(NSInteger)index
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
@@ -268,9 +271,7 @@ RCT_EXPORT_METHOD(setTrackPreference:(NSInteger)index
         return;
     }
 
-    self.currentTrackIndex = index;
-    [NWCLiveActivityBridge syncAppGroupFromAudioWithTrackIndex:index
-                                                      isMuted:self.isMuted];
+    [NWCLiveActivityBridge setPreferredTrackIndex:index];
 
     resolve([self currentStatusDict]);
 }
@@ -345,6 +346,7 @@ RCT_EXPORT_METHOD(disarmNWCAudio:(RCTPromiseResolveBlock)resolve
 
     [NWCLiveActivityBridge syncAppGroupFromAudioWithTrackIndex:index
                                                       isMuted:self.isMuted];
+    [NWCLiveActivityBridge setPreferredTrackIndex:index];
 
     if (@available(iOS 16.1, *)) {
         NSString *trackName = self.trackNames[index];

--- a/ios/zeus/NWCAudioKeepAlive.m
+++ b/ios/zeus/NWCAudioKeepAlive.m
@@ -256,6 +256,25 @@ RCT_EXPORT_METHOD(setTrack:(NSInteger)index
     resolve([self currentStatusDict]);
 }
 
+// Updates the preferred track without restarting playback. Used when the
+// settings UI changes selection during an active NWC session — the user's
+// pick should persist (app group, in-memory) so the next start uses it,
+// but the currently playing ambient track must not be interrupted.
+RCT_EXPORT_METHOD(setTrackPreference:(NSInteger)index
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    if (index < 0 || index >= (NSInteger)self.trackNames.count) {
+        reject(@"INVALID_TRACK", @"Track index out of range", nil);
+        return;
+    }
+
+    self.currentTrackIndex = index;
+    [NWCLiveActivityBridge syncAppGroupFromAudioWithTrackIndex:index
+                                                      isMuted:self.isMuted];
+
+    resolve([self currentStatusDict]);
+}
+
 RCT_EXPORT_METHOD(nextTrack:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     NSInteger next = (self.currentTrackIndex + 1) % (NSInteger)self.trackNames.count;

--- a/ios/zeus/NWCLiveActivityBridge.swift
+++ b/ios/zeus/NWCLiveActivityBridge.swift
@@ -19,4 +19,18 @@ import Foundation
             revision: revision
         )
     }
+
+    /// Returns the persisted preferred track index, or `fallback` if unset.
+    /// Distinct from the display-state track index so the Live Activity
+    /// refresh timer doesn't surface the preference while a different track
+    /// is actually playing.
+    @objc(preferredTrackIndexWithFallback:)
+    static func preferredTrackIndex(fallback: Int) -> Int {
+        NWCLiveActivityShared.readPreferredTrackIndex() ?? fallback
+    }
+
+    @objc(setPreferredTrackIndex:)
+    static func setPreferredTrackIndex(_ index: Int) {
+        NWCLiveActivityShared.writePreferredTrackIndex(index)
+    }
 }

--- a/utils/IOSAudioKeepAliveUtils.ts
+++ b/utils/IOSAudioKeepAliveUtils.ts
@@ -63,6 +63,7 @@ interface NWCAudioKeepAliveModule {
     getStatus(): Promise<AudioKeepAliveStatus>;
     getAvailableTracks(): Promise<AudioTrack[]>;
     setTrack(index: number): Promise<AudioKeepAliveStatus>;
+    setTrackPreference(index: number): Promise<AudioKeepAliveStatus>;
     nextTrack(): Promise<AudioKeepAliveStatus>;
     previousTrack(): Promise<AudioKeepAliveStatus>;
     setMuted(muted: boolean): Promise<AudioKeepAliveStatus>;
@@ -164,6 +165,19 @@ class IOSAudioKeepAliveUtils {
             return await mod.setTrack(index);
         } catch (e) {
             console.error('[NWCAudio] setTrack() failed:', e);
+            return null;
+        }
+    }
+
+    async setTrackPreference(
+        index: number
+    ): Promise<AudioKeepAliveStatus | null> {
+        const mod = this.getModule();
+        if (!mod) return null;
+        try {
+            return await mod.setTrackPreference(index);
+        } catch (e) {
+            console.error('[NWCAudio] setTrackPreference() failed:', e);
             return null;
         }
     }

--- a/views/Settings/NostrWalletConnect/NWCSettings.tsx
+++ b/views/Settings/NostrWalletConnect/NWCSettings.tsx
@@ -238,7 +238,11 @@ export default class NWCSettings extends React.Component<
             this.state.previewingIndex !== null ||
             NostrWalletConnectStore.iosAudioKeepAliveActive;
 
-        if (!sessionActive) {
+        if (sessionActive) {
+            // Persist the pick without interrupting active playback —
+            // preview / next-session start will pick it up.
+            await IOSAudioKeepAliveUtils.setTrackPreference(index);
+        } else {
             await IOSAudioKeepAliveUtils.setTrack(index);
         }
     };


### PR DESCRIPTION
# Description

The iOS NWC background-audio track picker (Settings → Nostr Wallet Connect → Background audio) was not persisting the user's selection. Two distinct bugs:

1. **Across restarts:** `NWCAudioKeepAlive` always initialized `_currentTrackIndex = 0` on launch. The selection *was* being written to App Group `UserDefaults` (via `NWCLiveActivityBridge.syncAppGroupFromAudio`), but the audio module never read it back, so every cold launch reverted to the first track.
2. **During an active NWC session:** tapping a row in the picker while NWC was running updated only local React state — `selectTrack` short-circuited on `sessionActive`. The pick was lost on screen unmount and never persisted.

### Fix

- **`ios/zeus/NWCAudioKeepAlive.m`**
  - `init`: read the persisted index back from the app group via `[NWCLiveActivityBridge appGroupTrackIndex]`, clamp to `_trackNames` range, fall back to 0 if unset or stale.
  - New `RCT_EXPORT_METHOD(setTrackPreference:)`: updates `_currentTrackIndex` and writes the app group, but does **not** call `loadAndPlayTrackAtIndex:` or push a Live Activity update — so the currently playing ambient track and the Dynamic Island stay untouched.
- **`utils/IOSAudioKeepAliveUtils.ts`**: add `setTrackPreference(index)` wrapper.
- **`views/Settings/NostrWalletConnect/NWCSettings.tsx`**: when a session is active, `selectTrack` now calls `setTrackPreference` instead of being a no-op. The no-session branch still calls `setTrack` (unchanged).

Mute state intentionally not restored — it's a transient control during a session, not a persistent preference.

### Behavior matrix

| Picker tap context | Before | After |
| --- | --- | --- |
| No NWC, no preview | persisted in memory + app group, lost on relaunch | persisted in memory + app group, **restored on relaunch** |
| NWC running | local React state only, lost on unmount | persisted in memory + app group, **no audio interruption**, restored on relaunch and on next session start |
| Previewing different track | `stopSettingsPreview` → `setTrack` | unchanged |
| Previewing same track | no-op | no-op |

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

Manual test plan (iOS only — Android picker is not affected):
1. Open NWC settings, tap a non-default track (e.g. "Gentle Rain"). Confirm checkmark moves.
2. Force-quit Zeus and relaunch. Reopen NWC settings — previously chosen track is still checked.
3. Start NWC — it plays the previously chosen track.
4. With NWC running, open settings and tap a different track. Confirm:
   - Checkmark moves.
   - Audio keeps playing the original track (no stutter / reload).
   - Dynamic Island still shows the originally playing track.
5. Force-quit Zeus while NWC is running and the new pick is selected. Relaunch and start NWC — the new pick plays.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
