### PR TITLE
fix(ios): NWC Dynamic Island lifecycle when host app is dismissed

### DIFF
--- a/ios/NWCWidget/NWCLiveActivityShared.swift
+++ b/ios/NWCWidget/NWCLiveActivityShared.swift
@@ -128,7 +128,7 @@ enum NWCLiveActivityShared {
         )
         let content = ActivityContent(
             state: state,
-            staleDate: Date().addingTimeInterval(3600)
+            staleDate: Date().addingTimeInterval(30)
         )
         await act.update(content)
         NSLog("[NWCLiveActivityShared] pushed – track=%@ muted=%d rev=%u",

--- a/ios/NWCWidget/NWCWidgetIntent.swift
+++ b/ios/NWCWidget/NWCWidgetIntent.swift
@@ -19,9 +19,7 @@ private func postDarwin(_ name: String) {
 struct NWCNextTrackIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Next Track"
     func perform() async throws -> some IntentResult {
-        if #available(iOS 16.2, *) {
-            await NWCLiveActivityShared.applyNextTrack()
-        }
+        await NWCLiveActivityShared.applyNextTrack()
         postDarwin(kNWCNextTrack)
         return .result()
     }
@@ -31,9 +29,7 @@ struct NWCNextTrackIntent: LiveActivityIntent {
 struct NWCPrevTrackIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Previous Track"
     func perform() async throws -> some IntentResult {
-        if #available(iOS 16.2, *) {
-            await NWCLiveActivityShared.applyPrevTrack()
-        }
+        await NWCLiveActivityShared.applyPrevTrack()
         postDarwin(kNWCPrevTrack)
         return .result()
     }
@@ -43,9 +39,7 @@ struct NWCPrevTrackIntent: LiveActivityIntent {
 struct NWCToggleMuteIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Toggle Mute"
     func perform() async throws -> some IntentResult {
-        if #available(iOS 16.2, *) {
-            await NWCLiveActivityShared.applyToggleMute()
-        }
+        await NWCLiveActivityShared.applyToggleMute()
         postDarwin(kNWCToggleMute)
         return .result()
     }
@@ -56,9 +50,7 @@ struct NWCStopIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Stop NWC"
     func perform() async throws -> some IntentResult {
         postDarwin(kNWCStop)
-        if #available(iOS 16.2, *) {
-            await NWCLiveActivityShared.endDuplicateActivities(keepingId: nil)
-        }
+        await NWCLiveActivityShared.endDuplicateActivities(keepingId: nil)
         return .result()
     }
 }

--- a/ios/NWCWidget/NWCWidgetIntent.swift
+++ b/ios/NWCWidget/NWCWidgetIntent.swift
@@ -56,6 +56,9 @@ struct NWCStopIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Stop NWC"
     func perform() async throws -> some IntentResult {
         postDarwin(kNWCStop)
+        if #available(iOS 16.2, *) {
+            await NWCLiveActivityShared.endDuplicateActivities(keepingId: nil)
+        }
         return .result()
     }
 }

--- a/ios/NWCWidget/NWCWidgetLiveActivity.swift
+++ b/ios/NWCWidget/NWCWidgetLiveActivity.swift
@@ -110,37 +110,98 @@ private struct NWCExpandedView: View {
     }
 }
 
+private struct NWCStaleView: View {
+    var body: some View {
+        Button(intent: NWCStopIntent()) {
+            HStack(spacing: 12) {
+                ZeusIcon(size: 28)
+                    .opacity(0.35)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Session ended")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.6))
+                    Text("Tap to dismiss")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.4))
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 22))
+                    .foregroundStyle(.red.opacity(0.75))
+            }
+            .padding(.horizontal, 4)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
 struct NWCWidgetLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: NWCLiveActivityAttributes.self) { context in
-            NWCExpandedView(context: context)
-                .padding(.horizontal, 20)
-                .padding(.vertical, 14)
-                .background(Color.black)
+            Group {
+                if context.isStale {
+                    NWCStaleView()
+                } else {
+                    NWCExpandedView(context: context)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 14)
+            .background(Color.black)
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.bottom) {
-                    NWCExpandedView(context: context)
-                        .padding(.horizontal, 8)
-                        .padding(.bottom, 6)
+                    Group {
+                        if context.isStale {
+                            NWCStaleView()
+                        } else {
+                            NWCExpandedView(context: context)
+                        }
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.bottom, 6)
                 }
             } compactLeading: {
                 ZeusIcon(size: 20)
+                    .opacity(context.isStale ? 0.35 : 1)
             } compactTrailing: {
-                Button(intent: NWCToggleMuteIntent()) {
-                    Image(systemName: context.state.isMuted
-                          ? "speaker.slash.fill"
-                          : "speaker.wave.2.fill")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(context.state.isMuted ? .orange : .white)
+                if context.isStale {
+                    Button(intent: NWCStopIntent()) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.red.opacity(0.85))
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.trailing, 2)
+                } else {
+                    Button(intent: NWCToggleMuteIntent()) {
+                        Image(systemName: context.state.isMuted
+                              ? "speaker.slash.fill"
+                              : "speaker.wave.2.fill")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(context.state.isMuted ? .orange : .white)
+                    }
+                    .id(context.state.contentRevision)
+                    .buttonStyle(.plain)
+                    .padding(.trailing, 2)
                 }
-                .id(context.state.contentRevision)
-                .buttonStyle(.plain)
-                .padding(.trailing, 2)
             } minimal: {
-                ZeusIcon(size: 16)
+                if context.isStale {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.red.opacity(0.85))
+                } else {
+                    ZeusIcon(size: 16)
+                }
             }
-            .keylineTint(Color(red: 1, green: 0.82, blue: 0))
+            .keylineTint(context.isStale
+                         ? Color.gray.opacity(0.5)
+                         : Color(red: 1, green: 0.82, blue: 0))
         }
     }
 }

--- a/ios/zeus/NWCActivityManager.swift
+++ b/ios/zeus/NWCActivityManager.swift
@@ -36,9 +36,19 @@ import UIKit
     @objc func endAllActivitiesImmediately() {
         stopRefreshTimer()
         activity = nil
+
+        // Synchronous wait so `applicationWillTerminate:` doesn't return
+        // before ActivityKit's async `end()` lands. iOS gives ~5s before
+        // SIGKILL; cap at 3s to leave headroom.
+        let sem = DispatchSemaphore(value: 0)
         Task.detached(priority: .userInitiated) {
             await Self.endEveryNWCLiveActivity()
-            NSLog("[NWCActivity] ended all (immediate)")
+            sem.signal()
+        }
+        if sem.wait(timeout: .now() + 3.0) == .timedOut {
+            NSLog("[NWCActivity] end-all timed out after 3s")
+        } else {
+            NSLog("[NWCActivity] ended all (sync)")
         }
     }
 

--- a/ios/zeus/NWCActivityManager.swift
+++ b/ios/zeus/NWCActivityManager.swift
@@ -44,7 +44,7 @@ import UIKit
 
     // MARK: - Private
 
-    private var staleDate: Date { Date().addingTimeInterval(3600) }
+    private var staleDate: Date { Date().addingTimeInterval(30) }
 
     private func runOnMain(_ block: @escaping () -> Void) {
         if Thread.isMainThread {
@@ -186,7 +186,7 @@ import UIKit
     private func startRefreshTimer() {
         stopRefreshTimer()
         let timer = DispatchSource.makeTimerSource(queue: .main)
-        timer.schedule(deadline: .now() + 15, repeating: 15)
+        timer.schedule(deadline: .now() + 10, repeating: 10)
         timer.setEventHandler { [weak self] in
             guard let self else { return }
             guard self.resolveLiveActivity() != nil else { return }

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2711,12 +2711,13 @@ export default class NostrWalletConnectStore {
         // Remove any stale listener before registering a new one
         this.teardownIOSAppStateMonitor();
 
-        // If we're already in the background (rare edge case), start immediately
-        if (AppState.currentState === 'background') {
-            this.startIOSAudioKeepAlive();
-        } else {
-            IOSAudioKeepAliveUtils.arm();
-        }
+        // Arm so the next foreground→background transition starts keep-alive.
+        // Don't auto-start when this method runs while already backgrounded —
+        // that happens when iOS cold-launches the app to service a Live
+        // Activity intent (e.g. user tapped "End Session" in the Dynamic
+        // Island). Starting here would restart audio and pop a fresh island
+        // the user just dismissed.
+        IOSAudioKeepAliveUtils.arm();
 
         let previousState: string = AppState.currentState;
 


### PR DESCRIPTION
# Description

Fixes three related bugs in the NWC iOS Live Activity / Dynamic Island flow that surfaced when the host app was killed (swipe-dismiss, OOM, reboot).

**1. End Session button was inert when the host app was dead.**
`NWCStopIntent.perform()` only posted a Darwin notification, which requires a live observer in the app process. When the app is killed, the notification is silently dropped and the activity is never ended. Fixed by calling `NWCLiveActivityShared.endDuplicateActivities` directly via ActivityKit from inside the intent, mirroring the pattern already used by the next / prev / toggle-mute intents. The Darwin post is preserved so the audio module still stops cleanly when the app is alive.

**2. Pressing End Session resurrected audio and a fresh island ~20s later.**
iOS launches the host app in the background to service a `LiveActivityIntent`. The NWC store's `setupIOSAppStateMonitoring` saw `AppState.currentState === 'background'` during init and auto-called `startIOSAudioKeepAlive`, which restarted audio and created a brand-new Live Activity — undoing the user's End Session tap after the ~20s it took JS to bootstrap. Removed the background-cold-launch auto-start branch. The normal foreground→background transition still arms and starts the keep-alive as before; what's gone is the speculative "we missed the transition" path that was being abused by intent-driven cold launches.

**3. Orphan island stayed visually fresh for up to an hour after force-close.**
`staleDate` was `+3600s` with a 15s refresh, so after the app died the island looked alive indefinitely. Tightened to `staleDate = 30s` and refresh = 10s (3× safety margin — tolerates short audio interruptions without false-stale flicker). Within ~30s of host death, the activity flips to a new stale presentation that is the entire island as a tap-to-dismiss surface:

- Lock screen / expanded view replaced with `NWCStaleView` — "Session ended / Tap to dismiss" + red `xmark.circle.fill`, the whole row wrapped in `NWCStopIntent`.
- Compact leading: Zeus icon dimmed to 35% opacity.
- Compact trailing: speaker icon → red `xmark.circle.fill`, bound to `NWCStopIntent` for one-tap dismissal from the collapsed island.
- Minimal: Zeus icon → red `xmark.circle.fill`.
- Keyline tint: yellow → gray.
- All playback controls (prev / mute / next, live timer) are hidden in the stale state since they would only relaunch the host app for no good reason.

### iOS lifecycle caveat
iOS provides no callback that reliably fires on user swipe-dismiss, and Live Activities are explicitly designed to outlive the host app. We cannot synchronously end an activity at force-close time. The combined fix instead makes the persisted island honest about its state (stale UI within 30s), self-dismissable (every relevant tap target ends the activity directly via ActivityKit), and non-self-healing (the host app no longer revives audio + a new island when cold-launched for an intent).

### Files
- `ios/NWCWidget/NWCWidgetIntent.swift` — `NWCStopIntent` ends activity directly.
- `ios/NWCWidget/NWCWidgetLiveActivity.swift` — new `NWCStaleView`, `context.isStale` branches across all four island presentations.
- `ios/NWCWidget/NWCLiveActivityShared.swift` — intent-push `staleDate` 60min → 30s.
- `ios/zeus/NWCActivityManager.swift` — host-push `staleDate` 60min → 30s, refresh timer 15s → 10s.
- `stores/NostrWalletConnectStore.ts` — drop `AppState === 'background'` auto-start branch in `setupIOSAppStateMonitoring`.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [x] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
