### PR TITLE
fix(migrations): repair invoice expiry display for pre-Feb-2024 installs

### DIFF
--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -266,6 +266,24 @@ describe('MigrationUtils', () => {
                 }
             });
         });
+        it('backfills expirySeconds + timePeriod on pre-Feb-2024 installs with only `expiry: 3600`', async () => {
+            await expect(
+                MigrationUtils.legacySettingsMigrations(
+                    JSON.stringify({
+                        invoices: {
+                            expiry: '3600'
+                        }
+                    })
+                )
+            ).resolves.toEqual({
+                ...defaultSettings,
+                invoices: {
+                    expiry: '1',
+                    timePeriod: 'Hours',
+                    expirySeconds: '3600'
+                }
+            });
+        });
         it('leaves consistent invoice expiry settings untouched', async () => {
             await expect(
                 MigrationUtils.legacySettingsMigrations(
@@ -290,10 +308,12 @@ describe('MigrationUtils', () => {
 
     describe('migrateInvoiceExpiryDisplay', () => {
         const EncryptedStorage = require('react-native-encrypted-storage');
+        const { settingsStore } = require('../stores/Stores');
 
         beforeEach(() => {
             EncryptedStorage.getItem.mockReset();
             EncryptedStorage.setItem.mockReset();
+            settingsStore.setSettings.mockReset();
         });
 
         it('repairs inconsistent expiry/timePeriod on v2 settings', async () => {
@@ -313,13 +333,48 @@ describe('MigrationUtils', () => {
                 timePeriod: 'Hours',
                 expirySeconds: '3600'
             });
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
             expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'invoices-expiry-display-fix',
+                'invoices-expiry-display-fix-v2',
                 'true'
             );
         });
 
-        it('leaves consistent settings untouched', async () => {
+        it('backfills missing expirySeconds + timePeriod for pre-Feb-2024 installs', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = { invoices: { expiry: '3600' } };
+
+            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
+
+            expect(settings.invoices).toEqual({
+                expiry: '1',
+                timePeriod: 'Hours',
+                expirySeconds: '3600'
+            });
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'invoices-expiry-display-fix-v2',
+                'true'
+            );
+        });
+
+        it('backfills missing expirySeconds when expiry + timePeriod are valid', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                invoices: { expiry: '2', timePeriod: 'Hours' }
+            };
+
+            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
+
+            expect(settings.invoices).toEqual({
+                expiry: '2',
+                timePeriod: 'Hours',
+                expirySeconds: '7200'
+            });
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+        });
+
+        it('leaves consistent settings untouched and does not rewrite storage', async () => {
             EncryptedStorage.getItem.mockResolvedValue(null);
             const settings: any = {
                 invoices: {
@@ -336,6 +391,11 @@ describe('MigrationUtils', () => {
                 timePeriod: 'Hours',
                 expirySeconds: '7200'
             });
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'invoices-expiry-display-fix-v2',
+                'true'
+            );
         });
 
         it('is a no-op when the migration flag is already set', async () => {
@@ -351,20 +411,41 @@ describe('MigrationUtils', () => {
             await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
 
             expect(settings.invoices.expiry).toBe('3600');
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
             expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
         });
 
-        it('does nothing when invoices.expirySeconds is missing', async () => {
+        it('only sets the flag when settings have no invoices block', async () => {
             EncryptedStorage.getItem.mockResolvedValue(null);
             const settings: any = {};
 
             await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
 
             expect(settings).toEqual({});
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
             expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'invoices-expiry-display-fix',
+                'invoices-expiry-display-fix-v2',
                 'true'
             );
+        });
+
+        it('re-runs for users who already ran the v1 migration', async () => {
+            // v1 set 'invoices-expiry-display-fix' before the guard was
+            // fixed; v2 must run independently.
+            EncryptedStorage.getItem.mockImplementation((key: string) =>
+                key === 'invoices-expiry-display-fix-v2'
+                    ? Promise.resolve(null)
+                    : Promise.resolve('true')
+            );
+            const settings: any = { invoices: { expiry: '3600' } };
+
+            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
+
+            expect(settings.invoices).toEqual({
+                expiry: '1',
+                timePeriod: 'Hours',
+                expirySeconds: '3600'
+            });
         });
     });
 

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -486,37 +486,52 @@ class MigrationsUtils {
         return settings;
     }
 
-    // Repair invoice expiry display fields when out of sync with the
-    // authoritative `expirySeconds` (e.g. older installs that defaulted
-    // `expiry` to '3600' instead of '1', causing the UI to read
-    // "3600 hours" while the invoice actually expired in one hour).
-    // Must run on both the legacy and modern (zeus-settings-v2) paths,
-    // since affected users may already have migrated to v2 carrying the
-    // stale value forward.
+    // Repair invoice expiry display fields when out of sync with
+    // `expirySeconds`. Older installs default `expiry: '3600'` and
+    // never stored `timePeriod`/`expirySeconds`, so once Receive.tsx's
+    // fallback for `timePeriod` became 'Hours' the UI rendered
+    // "3600 hours" while invoices still expired in one hour. Derive a
+    // canonical seconds value (stored → derived from expiry+timePeriod
+    // → '3600') and rewrite all three fields from it when anything is
+    // missing or inconsistent. Must run on both the legacy and modern
+    // (zeus-settings-v2) paths.
     public async migrateInvoiceExpiryDisplay(settings: any) {
-        const MOD_KEY_INVOICE_EXPIRY = 'invoices-expiry-display-fix';
+        const MOD_KEY_INVOICE_EXPIRY = 'invoices-expiry-display-fix-v2';
         const modInvoiceExpiry = await EncryptedStorage.getItem(
             MOD_KEY_INVOICE_EXPIRY
         );
         if (modInvoiceExpiry) return settings;
 
         const invoices: any = settings?.invoices;
-        const expirySeconds = invoices?.expirySeconds;
-        if (expirySeconds) {
+        if (invoices) {
+            const storedValid = Number(invoices.expirySeconds) > 0;
+            const derivable = invoices.expiry && invoices.timePeriod;
+            const canonical = storedValid
+                ? invoices.expirySeconds
+                : derivable
+                ? expirySecondsFromInput(
+                      invoices.expiry,
+                      invoices.timePeriod as TimePeriod
+                  )
+                : '3600';
+
             const inconsistent =
                 !invoices.expiry ||
                 !invoices.timePeriod ||
+                invoices.expirySeconds !== canonical ||
                 expirySecondsFromInput(
                     invoices.expiry,
                     invoices.timePeriod as TimePeriod
-                ) !== expirySeconds;
+                ) !== canonical;
+
             if (inconsistent) {
-                const repaired = displayFromExpirySeconds(expirySeconds);
+                const repaired = displayFromExpirySeconds(canonical);
                 invoices.expiry = repaired.expiry;
                 invoices.timePeriod = repaired.timePeriod;
+                invoices.expirySeconds = canonical;
+                await settingsStore.setSettings(JSON.stringify(settings));
             }
         }
-        await settingsStore.setSettings(JSON.stringify(settings));
         await EncryptedStorage.setItem(MOD_KEY_INVOICE_EXPIRY, 'true');
         return settings;
     }


### PR DESCRIPTION
# Description

Follow-up to #4128. The repair migration added in that PR landed in v13.1.0-beta1, but the original reporter still sees **"3600 Hours"** in Receive while their invoice expires in 1 hour. This PR repairs the cohort the v1 migration missed.

## Why the v1 migration missed them

The v1 migration in `utils/MigrationUtils.ts` only fires when `invoices.expirySeconds` is present in saved settings:

```ts
const expirySeconds = invoices?.expirySeconds;
if (expirySeconds) { /* repair */ }
await EncryptedStorage.setItem(MOD_KEY_INVOICE_EXPIRY, 'true');
```

But the affected cohort installed during the March 2023 – February 2024 window, when `invoices.expirySeconds` did not exist as a field yet:

- **Mar 2023** (e4339e137) — `invoices` defaults shipped with `expiry: '3600'` only. The `InvoicesSettings` interface had no `timePeriod` or `expirySeconds`.
- **Feb 2024** (38dab8538) — `timePeriod` and `expirySeconds` were added as new defaults, but **existing user settings were never backfilled**.
- **Jul 2025** (ac40e59e7) — `Receive.tsx`'s fallback for missing `timePeriod` flipped from `'Seconds'` → `'Hours'`. This is when the visible "3600 hours" surfaced for the affected cohort.

For an affected user the stored shape is:

```json
{ "invoices": { "expiry": "3600" } }
```

The v1 migration's `if (expirySeconds)` guard is falsy, the repair block is skipped, the one-shot flag is set anyway, and the user is locked out of the fix forever.

## Fix

- **`utils/MigrationUtils.ts`** — rewrite `migrateInvoiceExpiryDisplay`:
    - Bump the one-shot flag from `invoices-expiry-display-fix` → `invoices-expiry-display-fix-v2` so users who already booted v13.1.0-beta1 get re-migrated.
    - Drop the `if (expirySeconds)` guard. Derive a canonical seconds value (stored `expirySeconds` if valid → derived from `expiry`+`timePeriod` → `'3600'` fallback), then rewrite all three fields from `displayFromExpirySeconds(canonical)` whenever anything is missing or inconsistent.
    - Only persist to storage when something actually changed. The flag is still set unconditionally to preserve one-shot semantics.
- **`utils/MigrationUtils.test.ts`** — add coverage for the previously uncovered states:
    - Legacy path: `{ invoices: { expiry: '3600' } }` repairs to `(1, Hours, 3600)`.
    - Direct call: same case, plus a `{ expiry: '2', timePeriod: 'Hours' }` backfill that synthesizes the missing `expirySeconds`.
    - Write-guard: consistent settings no longer trigger `settingsStore.setSettings`.
    - Re-run: simulates `v1` flag set + `v2` flag unset and verifies the migration still runs.
    - Updated existing assertions to the new flag key.

## Reproduction & verification

Reproduced and fixed end-to-end against the original `(expiry: '3600', timePeriod: undefined, expirySeconds: undefined)` state on an iOS simulator:

1. Forced the simulator's saved settings into the pre-Feb-2024 shape. Receive displayed **"3600 Hours"** while `LND.addInvoice` was called with `expiry: 3600` (1 hour) — matches the original report exactly.
2. Restored the migration. On the next launch the repair fired, settings were rewritten to `(expiry: '1', timePeriod: 'Hours', expirySeconds: '3600')`, and Receive displayed **"1 Hour"**. Invoice expiry unchanged.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
