### PR TITLE
fix(clink): route bolt11 through handleAnything to reach payment source screen

### DIFF
--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -327,10 +327,7 @@ export default class LightningSwipeableRow extends Component<
         const { settings } = settingsStore;
         if (clinkNoffer) {
             this.props.navigation.navigate('ClinkPay', {
-                noffer: clinkNoffer,
-                ecash:
-                    BackendUtils.supportsCashuWallet() &&
-                    settings?.ecash?.enableCashu
+                noffer: clinkNoffer
             });
         } else if (offer) {
             this.props.navigation.navigate('Send', {

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -274,7 +274,7 @@ const handleAnything = async (
         if (!AddressUtils.isValidNoffer(clinkNoffer)) {
             throw new Error(localeString('utils.handleAnything.invalidNoffer'));
         }
-        return ['ClinkPay', { noffer: clinkNoffer, ecash }];
+        return ['ClinkPay', { noffer: clinkNoffer }];
     } else if (offer) {
         if (isClipboardValue) return true;
         return [
@@ -400,7 +400,7 @@ const handleAnything = async (
         ];
     } else if (!hasAt && AddressUtils.isValidNoffer(value)) {
         if (isClipboardValue) return true;
-        return ['ClinkPay', { noffer: value, ecash }];
+        return ['ClinkPay', { noffer: value }];
     } else if (value.includes('clnrest://') || value.includes('clnrest+')) {
         if (isClipboardValue) return true;
         const { host, port, rune, implementation, enableTor } =

--- a/views/ClinkPay/ClinkPay.tsx
+++ b/views/ClinkPay/ClinkPay.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Alert, StyleSheet, Text, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
-import { inject, observer } from 'mobx-react';
+import { observer } from 'mobx-react';
 import { Route } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 // @ts-ignore:next-line
@@ -13,9 +13,6 @@ import Header from '../../components/Header';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import Screen from '../../components/Screen';
 
-import CashuStore from '../../stores/CashuStore';
-import InvoicesStore from '../../stores/InvoicesStore';
-
 import ClinkUtils, {
     ClinkRequestError,
     NofferData,
@@ -24,21 +21,14 @@ import ClinkUtils, {
     isNofferSuccess
 } from '../../utils/ClinkUtils';
 import { errorToUserFriendly } from '../../utils/ErrorUtils';
+import handleAnything from '../../utils/handleAnything';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import { getAmountFromSats } from '../../utils/AmountUtils';
 
 interface ClinkPayProps {
     navigation: NativeStackNavigationProp<any, any>;
-    InvoicesStore: InvoicesStore;
-    CashuStore: CashuStore;
-    route: Route<
-        'ClinkPay',
-        {
-            noffer: string;
-            ecash?: boolean;
-        }
-    >;
+    route: Route<'ClinkPay', { noffer: string }>;
 }
 
 interface ClinkPayState {
@@ -107,7 +97,6 @@ const errorCodeToLocaleKey = (code?: NofferErrorCode): string | null => {
     }
 };
 
-@inject('InvoicesStore', 'CashuStore')
 @observer
 export default class ClinkPay extends React.Component<
     ClinkPayProps,
@@ -154,8 +143,7 @@ export default class ClinkPay extends React.Component<
     }
 
     confirm = async () => {
-        const { navigation, InvoicesStore, CashuStore, route } = this.props;
-        const ecash = route.params?.ecash;
+        const { navigation } = this.props;
         const { nofferData, satAmount } = this.state;
         if (!nofferData) return;
 
@@ -235,32 +223,9 @@ export default class ClinkPay extends React.Component<
         }
 
         try {
-            if (ecash) {
-                // Load both stores so ChoosePaymentMethod can offer the
-                // Lightning and ecash routes side-by-side. Mirrors LnurlPay.
-                await Promise.all([
-                    InvoicesStore.getPayReq(res.bolt11),
-                    CashuStore.getPayReq(res.bolt11)
-                ]);
-                this.setState({ loading: false });
-                if (CashuStore.getPayReqError) {
-                    Alert.alert(
-                        localeString('views.ClinkPay.title'),
-                        CashuStore.getPayReqError,
-                        [{ text: localeString('general.ok') }],
-                        { cancelable: false }
-                    );
-                    return;
-                }
-                navigation.navigate('ChoosePaymentMethod', {
-                    lightning: res.bolt11,
-                    locked: true
-                });
-            } else {
-                await InvoicesStore.getPayReq(res.bolt11);
-                this.setState({ loading: false });
-                navigation.navigate('PaymentRequest');
-            }
+            const [route, params] = await handleAnything(res.bolt11);
+            this.setState({ loading: false });
+            navigation.navigate(route, params);
         } catch (e: any) {
             this.setState({ loading: false });
             Alert.alert(

--- a/views/Settings/Contacts.tsx
+++ b/views/Settings/Contacts.tsx
@@ -19,7 +19,6 @@ import Header from '../../components/Header';
 import { ContactAvatar } from '../../components/ContactAvatar';
 
 import { confirmAction } from '../../utils/ActionUtils';
-import BackendUtils from '../../utils/BackendUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 
@@ -28,7 +27,6 @@ import Storage from '../../storage';
 import Contact from '../../models/Contact';
 
 import ContactStore, { CONTACTS_KEY } from '../../stores/ContactStore';
-import { settingsStore } from '../../stores/Stores';
 
 import Add from '../../assets/images/SVG/Add.svg';
 import NostrichIcon from '../../assets/images/SVG/Nostrich.svg';
@@ -200,10 +198,7 @@ export default class Contacts extends React.Component<
                             });
                         } else if (contact.isSingleNoffer) {
                             this.props.navigation.navigate('ClinkPay', {
-                                noffer: item.noffer[0],
-                                ecash:
-                                    BackendUtils.supportsCashuWallet() &&
-                                    settingsStore?.settings?.ecash?.enableCashu
+                                noffer: item.noffer[0]
                             });
                         } else if (contact.isSingleOnchainAddress) {
                             this.props.navigation.navigate('Send', {


### PR DESCRIPTION
# Description

Relates to issue: [**#4151**](https://github.com/ZeusLN/zeus/issues/4151)

Fixes a bug where paying a CLINK offer (noffer) would never reach the payment source selection screen when the payer's Cashu wallet was not configured or had insufficient funds.

**Root cause:** `ClinkPay.confirm()` manually called `InvoicesStore.getPayReq` and `CashuStore.getPayReq` after fetching the bolt11 from the CLINK relay, then blocked navigation to `ChoosePaymentMethod` if `CashuStore.getPayReqError` was set for any reason — including "not properly configured" (no mint added) and "not enough funds". A payer with only Lightning channels would always hit one of these errors and never reach the payment screen.

**Fix:** After receiving the bolt11 from the noffer relay, pass it through `handleAnything`, which already has the correct routing logic: with ecash enabled it navigates directly to `ChoosePaymentMethod` (letting that screen handle store loading gracefully); without ecash it calls `InvoicesStore.getPayReq` and goes to `PaymentRequest`. The Cashu configuration state no longer blocks the Lightning payment path.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
