### PR TITLE
fix: validate Nostr Wallet Connect URIs before saving config

### DIFF
--- a/utils/ValidationUtils.test.ts
+++ b/utils/ValidationUtils.test.ts
@@ -326,6 +326,134 @@ describe('hasValidPairingPhraseCharsAndWordcount', () => {
     });
 });
 
+describe('isValidNostrWalletConnectUrl', () => {
+    const walletPubKeyHex =
+        'b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4';
+    const secret =
+        '71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c';
+
+    it('accepts a complete nostr wallet connect URI', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss%3A%2F%2Frelay.damus.io&secret=${secret}`
+            )
+        ).toBe(true);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://relay.example.com&secret=${secret}`
+            )
+        ).toBe(true);
+    });
+
+    it('accepts optional query params such as lud16', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://relay.example.com&secret=${secret}&lud16=alice@domain.com`
+            )
+        ).toBe(true);
+    });
+
+    it('accepts multiple relay parameters', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://relay.one.com&relay=wss://relay.two.com&secret=${secret}`
+            )
+        ).toBe(true);
+    });
+
+    it('accepts URLs with surrounding whitespace', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `  nostr+walletconnect://${walletPubKeyHex}?relay=wss://relay.example.com&secret=${secret}  `
+            )
+        ).toBe(true);
+    });
+
+    it('accepts relay URLs with literal percent characters', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://relay.example.com/50%25_discount&secret=${secret}`
+            )
+        ).toBe(true);
+    });
+
+    it('rejects empty, whitespace-only, null, and undefined URLs', () => {
+        expect(ValidationUtils.isValidNostrWalletConnectUrl('')).toBe(false);
+        expect(ValidationUtils.isValidNostrWalletConnectUrl('   ')).toBe(false);
+        expect(ValidationUtils.isValidNostrWalletConnectUrl(null as any)).toBe(
+            false
+        );
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(undefined as any)
+        ).toBe(false);
+    });
+
+    it('rejects URIs missing required query params', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}`
+            )
+        ).toBe(false);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://relay.example.com`
+            )
+        ).toBe(false);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?secret=${secret}`
+            )
+        ).toBe(false);
+    });
+
+    it('rejects malformed pubkeys, secrets, and relays', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                'nostr+walletconnect://'
+            )
+        ).toBe(false);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                'nostr+walletconnect://:'
+            )
+        ).toBe(false);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://abc123?relay=wss://relay.example.com&secret=${secret}`
+            )
+        ).toBe(false);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://relay.example.com&secret=tooshort`
+            )
+        ).toBe(false);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=https://relay.example.com&secret=${secret}`
+            )
+        ).toBe(false);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://?relay=wss://relay.example.com&secret=${secret}`
+            )
+        ).toBe(false);
+    });
+
+    it('rejects non-nwc URLs', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl('https://example.com')
+        ).toBe(false);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl('nostr+walletconnect')
+        ).toBe(false);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                'nostr+walletconnect:/abc123'
+            )
+        ).toBe(false);
+    });
+});
+
 describe('validateNodePubkey', () => {
     it('accepts valid 66-character hex pubkeys', () => {
         expect(

--- a/utils/ValidationUtils.test.ts
+++ b/utils/ValidationUtils.test.ts
@@ -401,6 +401,32 @@ describe('isValidNostrWalletConnectUrl', () => {
         ).toBe(false);
     });
 
+    it('accepts ws:// relays for local regtest', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=ws://127.0.0.1:8080&secret=${secret}`
+            )
+        ).toBe(true);
+    });
+
+    it('accepts relay URLs with paths, ports, and IPv6 hosts', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://relay.example.com/path?x=1&secret=${secret}`
+            )
+        ).toBe(true);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://relay.example.com:443&secret=${secret}`
+            )
+        ).toBe(true);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://[::1]:8080&secret=${secret}`
+            )
+        ).toBe(true);
+    });
+
     it('rejects relay URLs with embedded spaces', () => {
         expect(
             ValidationUtils.isValidNostrWalletConnectUrl(
@@ -410,6 +436,14 @@ describe('isValidNostrWalletConnectUrl', () => {
         expect(
             ValidationUtils.isValidNostrWalletConnectUrl(
                 `nostr+walletconnect://${walletPubKeyHex}?relay=wss://a+b.io&secret=${secret}`
+            )
+        ).toBe(false);
+    });
+
+    it('rejects no-slash nostr+walletconnect: form', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect:${walletPubKeyHex}?relay=wss://relay.example.com&secret=${secret}`
             )
         ).toBe(false);
     });
@@ -467,6 +501,11 @@ describe('isValidNostrWalletConnectUrl', () => {
         expect(
             ValidationUtils.isValidNostrWalletConnectUrl(
                 `nostr+walletconnect://${walletPubKeyHex}?relay=https://relay.example.com&secret=${secret}`
+            )
+        ).toBe(false);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://&secret=${secret}`
             )
         ).toBe(false);
         expect(

--- a/utils/ValidationUtils.test.ts
+++ b/utils/ValidationUtils.test.ts
@@ -385,12 +385,13 @@ describe('isValidNostrWalletConnectUrl', () => {
         ).toBe(true);
     });
 
-    it('accepts uppercase hex pubkeys', () => {
+    it('rejects uppercase hex pubkeys', () => {
+        // React Native's URL polyfill preserves host case, unlike Node's URL.
         expect(
             ValidationUtils.isValidNostrWalletConnectUrl(
                 `nostr+walletconnect://${walletPubKeyHex.toUpperCase()}?relay=wss://relay.example.com&secret=${secret}`
             )
-        ).toBe(true);
+        ).toBe(false);
     });
 
     it('rejects uppercase hex secrets', () => {
@@ -444,6 +445,22 @@ describe('isValidNostrWalletConnectUrl', () => {
         expect(
             ValidationUtils.isValidNostrWalletConnectUrl(
                 `nostr+walletconnect:${walletPubKeyHex}?relay=wss://relay.example.com&secret=${secret}`
+            )
+        ).toBe(false);
+    });
+
+    it('rejects legacy nostrwalletconnect scheme', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostrwalletconnect://${walletPubKeyHex}?relay=wss://relay.example.com&secret=${secret}`
+            )
+        ).toBe(false);
+    });
+
+    it('rejects non-WebSocket relay URLs', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=http://relay.example.com&secret=${secret}`
             )
         ).toBe(false);
     });

--- a/utils/ValidationUtils.test.ts
+++ b/utils/ValidationUtils.test.ts
@@ -377,6 +377,43 @@ describe('isValidNostrWalletConnectUrl', () => {
         ).toBe(true);
     });
 
+    it('accepts a trailing slash after the pubkey', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}/?relay=wss://relay.example.com&secret=${secret}`
+            )
+        ).toBe(true);
+    });
+
+    it('accepts uppercase hex pubkeys', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex.toUpperCase()}?relay=wss://relay.example.com&secret=${secret}`
+            )
+        ).toBe(true);
+    });
+
+    it('rejects uppercase hex secrets', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://relay.example.com&secret=${secret.toUpperCase()}`
+            )
+        ).toBe(false);
+    });
+
+    it('rejects relay URLs with embedded spaces', () => {
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://a b&secret=${secret}`
+            )
+        ).toBe(false);
+        expect(
+            ValidationUtils.isValidNostrWalletConnectUrl(
+                `nostr+walletconnect://${walletPubKeyHex}?relay=wss://a+b.io&secret=${secret}`
+            )
+        ).toBe(false);
+    });
+
     it('rejects empty, whitespace-only, null, and undefined URLs', () => {
         expect(ValidationUtils.isValidNostrWalletConnectUrl('')).toBe(false);
         expect(ValidationUtils.isValidNostrWalletConnectUrl('   ')).toBe(false);

--- a/utils/ValidationUtils.ts
+++ b/utils/ValidationUtils.ts
@@ -4,6 +4,9 @@ const HOST_REGEX =
 // in paths we have more allowed chars
 const PATH_REGEX = /^\/([a-zA-Z0-9\-._~!$&'()*+,;=]+\/?)*$/;
 const PORT_REGEX = /^:\d+$/;
+const NOSTR_WALLET_CONNECT_PREFIX = 'nostr+walletconnect://';
+const NWC_HEX_32_BYTES = /^[a-fA-F0-9]{64}$/;
+const NWC_RELAY_URL = /^wss?:\/\/.+/i;
 
 interface ValidationOptions {
     requireHttps?: boolean;
@@ -77,6 +80,34 @@ const hasValidPairingPhraseCharsAndWordcount = (phrase: string): boolean => {
     const normalizedPhrase = phrase.trim().replace(/\s+/g, ' ');
     if (!/^[a-zA-Z\s]+$/.test(normalizedPhrase)) return false;
     return normalizedPhrase.split(' ').length === 10;
+};
+
+const isValidNwcRelayUrl = (relay: string): boolean => {
+    return typeof relay === 'string' && NWC_RELAY_URL.test(relay);
+};
+
+const isValidNostrWalletConnectUrl = (url: string): boolean => {
+    if (!url || typeof url !== 'string') return false;
+    const normalizedUrl = url.trim().replace(/\s+/g, ' ');
+    if (!normalizedUrl.startsWith(NOSTR_WALLET_CONNECT_PREFIX)) return false;
+
+    const pathAndQuery = normalizedUrl.slice(
+        NOSTR_WALLET_CONNECT_PREFIX.length
+    );
+    const queryIndex = pathAndQuery.indexOf('?');
+    if (queryIndex === -1) return false;
+
+    const walletPubKeyHex = pathAndQuery.slice(0, queryIndex);
+    if (!NWC_HEX_32_BYTES.test(walletPubKeyHex)) return false;
+
+    const params = new URLSearchParams(pathAndQuery.slice(queryIndex + 1));
+    const relays = params.getAll('relay');
+    const secret = params.get('secret');
+
+    if (!secret || !NWC_HEX_32_BYTES.test(secret)) return false;
+    if (relays.length === 0 || !relays.every(isValidNwcRelayUrl)) return false;
+
+    return true;
 };
 
 const validateNodePubkey = (pubkey: string): boolean => {
@@ -160,6 +191,7 @@ const ValidationUtils = {
     hasValidRuneChars,
     hasValidMacaroonChars,
     hasValidPairingPhraseCharsAndWordcount,
+    isValidNostrWalletConnectUrl,
     validateNodePubkey,
     validateNodeHost
 };

--- a/utils/ValidationUtils.ts
+++ b/utils/ValidationUtils.ts
@@ -6,8 +6,9 @@ const PATH_REGEX = /^\/([a-zA-Z0-9\-._~!$&'()*+,;=]+\/?)*$/;
 const PORT_REGEX = /^:\d+$/;
 const NOSTR_WALLET_CONNECT_PREFIX = 'nostr+walletconnect://';
 const NWC_HEX_32_BYTES = /^[a-fA-F0-9]{64}$/;
+// @getalby/sdk checks secret against /^[0-9a-f]{64}$/; query values are not
+// case-folded like URL hosts, so uppercase hex must be rejected here.
 const NWC_SECRET_HEX = /^[0-9a-f]{64}$/;
-const NWC_RELAY_URL = /^wss?:\/\/\S+$/i;
 
 interface ValidationOptions {
     requireHttps?: boolean;
@@ -84,7 +85,17 @@ const hasValidPairingPhraseCharsAndWordcount = (phrase: string): boolean => {
 };
 
 const isValidNwcRelayUrl = (relay: string): boolean => {
-    return typeof relay === 'string' && NWC_RELAY_URL.test(relay);
+    if (typeof relay !== 'string') return false;
+    try {
+        const parsed = new URL(relay);
+        // ws:// allowed for local/regtest relays; wss:// for production.
+        return (
+            (parsed.protocol === 'wss:' || parsed.protocol === 'ws:') &&
+            !!parsed.host
+        );
+    } catch {
+        return false;
+    }
 };
 
 const isValidNostrWalletConnectUrl = (url: string): boolean => {

--- a/utils/ValidationUtils.ts
+++ b/utils/ValidationUtils.ts
@@ -107,6 +107,8 @@ const isValidNostrWalletConnectUrl = (url: string): boolean => {
     try {
         // Swap in a special scheme so the pubkey parses as a host, the way
         // NWCClient.parseWalletConnectUrl does in @getalby/sdk.
+        // Relay values with unencoded ? or & in the outer query can confuse
+        // URL parsing; wallets almost always percent-encode those.
         parsed = new URL(
             `http://${normalizedUrl.slice(NOSTR_WALLET_CONNECT_PREFIX.length)}`
         );

--- a/utils/ValidationUtils.ts
+++ b/utils/ValidationUtils.ts
@@ -6,7 +6,8 @@ const PATH_REGEX = /^\/([a-zA-Z0-9\-._~!$&'()*+,;=]+\/?)*$/;
 const PORT_REGEX = /^:\d+$/;
 const NOSTR_WALLET_CONNECT_PREFIX = 'nostr+walletconnect://';
 const NWC_HEX_32_BYTES = /^[a-fA-F0-9]{64}$/;
-const NWC_RELAY_URL = /^wss?:\/\/.+/i;
+const NWC_SECRET_HEX = /^[0-9a-f]{64}$/;
+const NWC_RELAY_URL = /^wss?:\/\/\S+$/i;
 
 interface ValidationOptions {
     requireHttps?: boolean;
@@ -88,23 +89,26 @@ const isValidNwcRelayUrl = (relay: string): boolean => {
 
 const isValidNostrWalletConnectUrl = (url: string): boolean => {
     if (!url || typeof url !== 'string') return false;
-    const normalizedUrl = url.trim().replace(/\s+/g, ' ');
+    const normalizedUrl = url.trim();
     if (!normalizedUrl.startsWith(NOSTR_WALLET_CONNECT_PREFIX)) return false;
 
-    const pathAndQuery = normalizedUrl.slice(
-        NOSTR_WALLET_CONNECT_PREFIX.length
-    );
-    const queryIndex = pathAndQuery.indexOf('?');
-    if (queryIndex === -1) return false;
+    let parsed: URL;
+    try {
+        // Swap in a special scheme so the pubkey parses as a host, the way
+        // NWCClient.parseWalletConnectUrl does in @getalby/sdk.
+        parsed = new URL(
+            `http://${normalizedUrl.slice(NOSTR_WALLET_CONNECT_PREFIX.length)}`
+        );
+    } catch {
+        return false;
+    }
 
-    const walletPubKeyHex = pathAndQuery.slice(0, queryIndex);
-    if (!NWC_HEX_32_BYTES.test(walletPubKeyHex)) return false;
+    if (!NWC_HEX_32_BYTES.test(parsed.host)) return false;
 
-    const params = new URLSearchParams(pathAndQuery.slice(queryIndex + 1));
-    const relays = params.getAll('relay');
-    const secret = params.get('secret');
+    const relays = parsed.searchParams.getAll('relay');
+    const secret = parsed.searchParams.get('secret');
 
-    if (!secret || !NWC_HEX_32_BYTES.test(secret)) return false;
+    if (!secret || !NWC_SECRET_HEX.test(secret)) return false;
     if (relays.length === 0 || !relays.every(isValidNwcRelayUrl)) return false;
 
     return true;

--- a/utils/ValidationUtils.ts
+++ b/utils/ValidationUtils.ts
@@ -5,10 +5,9 @@ const HOST_REGEX =
 const PATH_REGEX = /^\/([a-zA-Z0-9\-._~!$&'()*+,;=]+\/?)*$/;
 const PORT_REGEX = /^:\d+$/;
 const NOSTR_WALLET_CONNECT_PREFIX = 'nostr+walletconnect://';
-const NWC_HEX_32_BYTES = /^[a-fA-F0-9]{64}$/;
-// @getalby/sdk checks secret against /^[0-9a-f]{64}$/; query values are not
-// case-folded like URL hosts, so uppercase hex must be rejected here.
-const NWC_SECRET_HEX = /^[0-9a-f]{64}$/;
+// @getalby/sdk checks both the wallet pubkey and secret against this pattern.
+// React Native's URL polyfill does not case-fold hosts like Node's URL does.
+const NWC_HEX64 = /^[0-9a-f]{64}$/;
 
 interface ValidationOptions {
     requireHttps?: boolean;
@@ -116,12 +115,17 @@ const isValidNostrWalletConnectUrl = (url: string): boolean => {
         return false;
     }
 
-    if (!NWC_HEX_32_BYTES.test(parsed.host)) return false;
+    // Check the raw pubkey as Node's URL lowercases hosts while React Native's
+    // URL polyfill preserves their case.
+    const pubkey = normalizedUrl
+        .slice(NOSTR_WALLET_CONNECT_PREFIX.length)
+        .split(/[/?#]/, 1)[0];
+    if (!NWC_HEX64.test(pubkey)) return false;
 
     const relays = parsed.searchParams.getAll('relay');
     const secret = parsed.searchParams.get('secret');
 
-    if (!secret || !NWC_SECRET_HEX.test(secret)) return false;
+    if (!secret || !NWC_HEX64.test(secret)) return false;
     if (relays.length === 0 || !relays.every(isValidNwcRelayUrl)) return false;
 
     return true;

--- a/views/LightningAddress/CreateNWCLightningAddress.tsx
+++ b/views/LightningAddress/CreateNWCLightningAddress.tsx
@@ -22,6 +22,7 @@ import SettingsStore from '../../stores/SettingsStore';
 
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
+import ValidationUtils from '../../utils/ValidationUtils';
 
 import ZeusPayIcon from '../../assets/images/SVG/zeus-pay.svg';
 
@@ -64,6 +65,10 @@ export default class CreateNWCLightningAddress extends React.Component<
         const updateConnection = route.params?.updateConnection;
 
         const loading = this.state.loading || LightningAddressStore.loading;
+
+        const nwcConnectionStringInvalid =
+            !!nwcConnectionString &&
+            !ValidationUtils.isValidNostrWalletConnectUrl(nwcConnectionString);
 
         const InfoButton = () => (
             <View>
@@ -134,6 +139,15 @@ export default class CreateNWCLightningAddress extends React.Component<
                                                         placeholder={
                                                             'nostr+walletconnect://'
                                                         }
+                                                        textColor={
+                                                            nwcConnectionStringInvalid
+                                                                ? themeColor(
+                                                                      'error'
+                                                                  )
+                                                                : themeColor(
+                                                                      'text'
+                                                                  )
+                                                        }
                                                         value={
                                                             nwcConnectionString
                                                         }
@@ -143,6 +157,12 @@ export default class CreateNWCLightningAddress extends React.Component<
                                                             this.setState({
                                                                 nwcConnectionString:
                                                                     text
+                                                                        .trim()
+                                                                        .replace(
+                                                                            /\s+/g,
+                                                                            ' '
+                                                                        ),
+                                                                tested: false
                                                             })
                                                         }
                                                         autoCapitalize="none"
@@ -226,7 +246,10 @@ export default class CreateNWCLightningAddress extends React.Component<
                                             }
                                         }}
                                         disabled={
-                                            !nwcConnectionString || loading
+                                            loading ||
+                                            !ValidationUtils.isValidNostrWalletConnectUrl(
+                                                nwcConnectionString
+                                            )
                                         }
                                     />
                                 </View>

--- a/views/LightningAddress/CreateNWCLightningAddress.tsx
+++ b/views/LightningAddress/CreateNWCLightningAddress.tsx
@@ -66,9 +66,10 @@ export default class CreateNWCLightningAddress extends React.Component<
 
         const loading = this.state.loading || LightningAddressStore.loading;
 
+        const nwcConnectionStringValid =
+            ValidationUtils.isValidNostrWalletConnectUrl(nwcConnectionString);
         const nwcConnectionStringInvalid =
-            !!nwcConnectionString &&
-            !ValidationUtils.isValidNostrWalletConnectUrl(nwcConnectionString);
+            !!nwcConnectionString && !nwcConnectionStringValid;
 
         const InfoButton = () => (
             <View>
@@ -156,13 +157,7 @@ export default class CreateNWCLightningAddress extends React.Component<
                                                         ) =>
                                                             this.setState({
                                                                 nwcConnectionString:
-                                                                    text
-                                                                        .trim()
-                                                                        .replace(
-                                                                            /\s+/g,
-                                                                            ' '
-                                                                        ),
-                                                                tested: false
+                                                                    text.trim()
                                                             })
                                                         }
                                                         autoCapitalize="none"
@@ -246,10 +241,7 @@ export default class CreateNWCLightningAddress extends React.Component<
                                             }
                                         }}
                                         disabled={
-                                            loading ||
-                                            !ValidationUtils.isValidNostrWalletConnectUrl(
-                                                nwcConnectionString
-                                            )
+                                            loading || !nwcConnectionStringValid
                                         }
                                     />
                                 </View>

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -1784,18 +1784,19 @@ export default class WalletConfiguration extends React.Component<
                                         }
                                         value={nostrWalletConnectUrl}
                                         autoCapitalize="none"
-                                        onChangeText={(text: string) =>
+                                        onChangeText={(text: string) => {
+                                            const nostrWalletConnectUrl = text
+                                                .trim()
+                                                .replace(/\s+/g, ' ');
                                             this.setState({
-                                                nostrWalletConnectUrl: text
-                                                    .trim()
-                                                    .replace(/\s+/g, ' '),
+                                                nostrWalletConnectUrl,
                                                 nostrWalletConnectUrlError:
-                                                    !text.startsWith(
-                                                        'nostr+walletconnect://'
+                                                    !ValidationUtils.isValidNostrWalletConnectUrl(
+                                                        nostrWalletConnectUrl
                                                     ),
                                                 saved: false
-                                            })
-                                        }
+                                            });
+                                        }}
                                         locked={loading}
                                         autoCorrect={false}
                                     />
@@ -3066,6 +3067,11 @@ export default class WalletConfiguration extends React.Component<
                                                     pairingPhrase
                                                 )) ||
                                             nostrWalletConnectUrlError ||
+                                            (implementation ===
+                                                'nostr-wallet-connect' &&
+                                                !ValidationUtils.isValidNostrWalletConnectUrl(
+                                                    nostrWalletConnectUrl
+                                                )) ||
                                             // Required input check
                                             // Port is optional, it will fallback to 80 or 443
                                             (implementation === 'lndhub' &&

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -2053,12 +2053,10 @@ export default class WalletConfiguration extends React.Component<
                                                 marginRight: 15
                                             }}
                                             onChangeText={(text: string) => {
-                                                const nostrWalletConnectUrl =
-                                                    text
-                                                        .trim()
-                                                        .replace(/\s+/g, ' ');
                                                 this.setState({
-                                                    nostrWalletConnectUrl,
+                                                    nostrWalletConnectUrl: text
+                                                        .trim()
+                                                        .replace(/\s+/g, ' '),
                                                     saved: false
                                                 });
                                             }}

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -183,7 +183,6 @@ interface WalletConfigurationState {
     portError: boolean;
     customMailboxServerError: boolean;
     pairingPhraseError: boolean;
-    nostrWalletConnectUrlError: boolean;
 }
 
 const ScanBadge = ({ onPress }: { onPress: () => void }) => (
@@ -266,8 +265,7 @@ export default class WalletConfiguration extends React.Component<
         macaroonHexError: false,
         portError: false,
         customMailboxServerError: false,
-        pairingPhraseError: false,
-        nostrWalletConnectUrlError: false
+        pairingPhraseError: false
     };
 
     scrollViewRef = React.createRef<ScrollView>();
@@ -1415,8 +1413,7 @@ export default class WalletConfiguration extends React.Component<
             macaroonHexError,
             portError,
             customMailboxServerError,
-            pairingPhraseError,
-            nostrWalletConnectUrlError
+            pairingPhraseError
         } = this.state;
         const {
             loading,
@@ -1440,6 +1437,12 @@ export default class WalletConfiguration extends React.Component<
             implementation !== 'lightning-node-connect' &&
             !isLocalImpl &&
             implementation !== 'nostr-wallet-connect';
+
+        const nostrWalletConnectUrlInvalid =
+            implementation === 'nostr-wallet-connect' &&
+            !ValidationUtils.isValidNostrWalletConnectUrl(
+                nostrWalletConnectUrl
+            );
 
         const CertInstallInstructions = () => (
             <View style={styles.button}>
@@ -2037,7 +2040,8 @@ export default class WalletConfiguration extends React.Component<
                                                 'nostr+walletconnect://'
                                             }
                                             textColor={
-                                                nostrWalletConnectUrlError
+                                                nostrWalletConnectUrlInvalid &&
+                                                nostrWalletConnectUrl
                                                     ? themeColor('error')
                                                     : themeColor('text')
                                             }
@@ -2055,10 +2059,6 @@ export default class WalletConfiguration extends React.Component<
                                                         .replace(/\s+/g, ' ');
                                                 this.setState({
                                                     nostrWalletConnectUrl,
-                                                    nostrWalletConnectUrlError:
-                                                        !ValidationUtils.isValidNostrWalletConnectUrl(
-                                                            nostrWalletConnectUrl
-                                                        ),
                                                     saved: false
                                                 });
                                             }}
@@ -3406,12 +3406,7 @@ export default class WalletConfiguration extends React.Component<
                                                 !ValidationUtils.hasValidPairingPhraseCharsAndWordcount(
                                                     pairingPhrase
                                                 )) ||
-                                            nostrWalletConnectUrlError ||
-                                            (implementation ===
-                                                'nostr-wallet-connect' &&
-                                                !ValidationUtils.isValidNostrWalletConnectUrl(
-                                                    nostrWalletConnectUrl
-                                                )) ||
+                                            nostrWalletConnectUrlInvalid ||
                                             // Required input check
                                             // Port is optional, it will fallback to 80 or 443
                                             (implementation === 'lndhub' &&

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -2048,18 +2048,20 @@ export default class WalletConfiguration extends React.Component<
                                                 flex: 1,
                                                 marginRight: 15
                                             }}
-                                            onChangeText={(text: string) =>
-                                                this.setState({
-                                                    nostrWalletConnectUrl: text
+                                            onChangeText={(text: string) => {
+                                                const nostrWalletConnectUrl =
+                                                    text
                                                         .trim()
-                                                        .replace(/\s+/g, ' '),
+                                                        .replace(/\s+/g, ' ');
+                                                this.setState({
+                                                    nostrWalletConnectUrl,
                                                     nostrWalletConnectUrlError:
-                                                        !text.startsWith(
-                                                            'nostr+walletconnect://'
+                                                        !ValidationUtils.isValidNostrWalletConnectUrl(
+                                                            nostrWalletConnectUrl
                                                         ),
                                                     saved: false
-                                                })
-                                            }
+                                                });
+                                            }}
                                             locked={loading}
                                             autoCorrect={false}
                                         />
@@ -3405,6 +3407,11 @@ export default class WalletConfiguration extends React.Component<
                                                     pairingPhrase
                                                 )) ||
                                             nostrWalletConnectUrlError ||
+                                            (implementation ===
+                                                'nostr-wallet-connect' &&
+                                                !ValidationUtils.isValidNostrWalletConnectUrl(
+                                                    nostrWalletConnectUrl
+                                                )) ||
                                             // Required input check
                                             // Port is optional, it will fallback to 80 or 443
                                             (implementation === 'lndhub' &&


### PR DESCRIPTION
# Description


# Description

Prevents invalid Nostr Wallet Connect (NWC) connection strings from being saved or submitted by validating them against NIP-47 before the user can continue.

Previously, NWC only checked that the value started with `nostr+walletconnect://`. Users could save empty or malformed URIs (including via QR scan, which prefills state without firing `onChangeText`). That produced broken wallet entries and late failures when `@getalby/sdk` tried to connect. The same weak prefix check existed on the ZEUS Pay NWC lightning-address create flow.

## Changes

- **`ValidationUtils.isValidNostrWalletConnectUrl()`**
  - Requires `nostr+walletconnect://` scheme
  - 64-char hex wallet-service pubkey as host (upper/lower allowed; parsed via the same `http://` host-swap as `@getalby/sdk` `parseWalletConnectUrl`)
  - Required `secret`: 64-char **lowercase** hex (matches `@getalby/sdk` `/^[0-9a-f]{64}$/`)
  - Required ≥1 `relay` params; each validated with `new URL()` and must be `ws:` or `wss:` with a non-empty host
  - Allows optional params (e.g. `lud16`) and multiple relays
  - Trims input; rejects null / undefined / empty / non-string

- **`WalletConfiguration.tsx`**
  - Derives validity from current state on every render (covers QR-prefill)
  - Disables Save while the NWC URL is invalid
  - Error text color only when the field is non-empty and invalid
  - Scoped to `implementation === 'nostr-wallet-connect'`

- **`CreateNWCLightningAddress.tsx`**
  - Reuses the same validator (replaces prefix-only check)
  - Error text color for invalid non-empty input
  - Normalizes input on change (trim + collapse whitespace)
  - Disables Test until the connection string is valid

- **Unit tests** for valid URIs, multi-relay, `lud16`, whitespace, trailing slash, uppercase pubkey, uppercase secret rejection, `ws://` local relays, paths/ports/IPv6, embedded spaces, no-slash scheme, missing params, and non-NWC schemes

## Deliberate decisions

- `ws://` cleartext relays are **accepted** for local/regtest (documented in code + tested)
- `nostr+walletconnect:` (no `//`) is **rejected** even if some SDKs accept it
- Legacy `nostrwalletconnect://` remains rejected (unchanged)
- Relay check uses `new URL()` for parity with `@getalby/sdk` at connect time

## Out of scope

- No migration of already-saved invalid NWC wallet configs (user must re-edit)

## Test plan

- [x] **Wallet config:** paste valid NWC URI → Save enabled, field not red
- [x] **Wallet config:** clear field → Save disabled, field not red
- [x] **Wallet config:** missing `secret` / `relay` / bad pubkey → Save disabled, field red
- [x] **Wallet config:** QR-scan valid NWC URI → Save enabled without typing
- [x] **Wallet config:** QR-scan invalid string → Save disabled, field red
- [x] **Create NWC LN address:** invalid string → Test disabled, field red
- [x] **Create NWC LN address:** valid string → Test enabled → after success, Create/Switch works
- [x] Save and connect a real NWC wallet (e.g. Alby) end-to-end
- [x] `yarn test` — `isValidNostrWalletConnectUrl` suite green

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
