### PR TITLE
fix: center circular progress value in recovering wallet view

### DIFF
--- a/components/SyncCircularProgress.tsx
+++ b/components/SyncCircularProgress.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Dimensions, Text, View } from 'react-native';
+import CircularProgress from 'react-native-circular-progress-indicator';
+
+import { formatProgressPercentage } from '../utils/FormatUtils';
+import { themeColor } from '../utils/ThemeUtils';
+
+interface SyncCircularProgressProps {
+    value: number;
+}
+
+export default function SyncCircularProgress({
+    value
+}: SyncCircularProgressProps) {
+    const { width } = Dimensions.get('window');
+    const ringRadius = width / 3;
+    const ringSize = ringRadius * 2;
+    const progressFontSize = ringRadius / 2;
+
+    return (
+        <View
+            style={{
+                width: ringSize,
+                height: ringSize,
+                alignItems: 'center',
+                justifyContent: 'center'
+            }}
+        >
+            <CircularProgress
+                value={value}
+                radius={ringRadius}
+                showProgressValue={false}
+                inActiveStrokeOpacity={0.5}
+                activeStrokeWidth={width / 20}
+                inActiveStrokeWidth={width / 40}
+                activeStrokeColor={themeColor('highlight')}
+                activeStrokeSecondaryColor={themeColor('error')}
+                inActiveStrokeColor={themeColor('secondaryBackground')}
+                duration={500}
+            />
+            <View
+                pointerEvents="none"
+                style={{
+                    position: 'absolute',
+                    left: 0,
+                    right: 0,
+                    top: 0,
+                    bottom: 0,
+                    justifyContent: 'center',
+                    alignItems: 'center'
+                }}
+            >
+                <Text
+                    style={{
+                        fontWeight: '100',
+                        color: themeColor('text'),
+                        fontSize: progressFontSize,
+                        textAlign: 'center'
+                    }}
+                >
+                    {formatProgressPercentage(value)}%
+                </Text>
+            </View>
+        </View>
+    );
+}

--- a/views/Sync.tsx
+++ b/views/Sync.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
-import { Dimensions, Text, View } from 'react-native';
+import { View } from 'react-native';
 import { inject, observer } from 'mobx-react';
-import CircularProgress from 'react-native-circular-progress-indicator';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import Button from '../components/Button';
 import KeyValue from '../components/KeyValue';
 import Screen from '../components/Screen';
 import Header from '../components/Header';
+import SyncCircularProgress from '../components/SyncCircularProgress';
 
 import SyncStore from '../stores/SyncStore';
 
-import { formatProgressPercentage } from '../utils/FormatUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
 import { numberWithCommas } from '../utils/UnitsUtils';
@@ -29,10 +28,6 @@ export default class Sync extends React.PureComponent<SyncProps, {}> {
         const { bestBlockHeight, currentBlockHeight, numBlocksUntilSynced } =
             SyncStore;
 
-        const { width } = Dimensions.get('window');
-        const ringRadius = width / 3;
-        const ringSize = ringRadius * 2;
-        const progressFontSize = ringRadius / 2;
         const syncPercent =
             currentBlockHeight && bestBlockHeight
                 ? Number(
@@ -57,55 +52,7 @@ export default class Sync extends React.PureComponent<SyncProps, {}> {
                 />
                 <View style={{ flex: 1, justifyContent: 'center' }}>
                     <View style={{ alignItems: 'center', marginBottom: 40 }}>
-                        <View
-                            style={{
-                                width: ringSize,
-                                height: ringSize,
-                                alignItems: 'center',
-                                justifyContent: 'center'
-                            }}
-                        >
-                            <CircularProgress
-                                value={syncPercent}
-                                radius={ringRadius}
-                                showProgressValue={false}
-                                inActiveStrokeOpacity={0.5}
-                                activeStrokeWidth={width / 20}
-                                inActiveStrokeWidth={width / 40}
-                                activeStrokeColor={themeColor('highlight')}
-                                activeStrokeSecondaryColor={themeColor('error')}
-                                inActiveStrokeColor={themeColor(
-                                    'secondaryBackground'
-                                )}
-                                duration={500}
-                            />
-                            <View
-                                pointerEvents="none"
-                                style={{
-                                    position: 'absolute',
-                                    left: 0,
-                                    right: 0,
-                                    top: 0,
-                                    bottom: 0,
-                                    justifyContent: 'center',
-                                    alignItems: 'center'
-                                }}
-                            >
-                                <Text
-                                    style={{
-                                        fontWeight: '100',
-                                        color: themeColor('text'),
-                                        fontSize: progressFontSize,
-                                        textAlign: 'center',
-                                        lineHeight: Math.ceil(
-                                            progressFontSize * 1.05
-                                        )
-                                    }}
-                                >
-                                    {formatProgressPercentage(syncPercent)}%
-                                </Text>
-                            </View>
-                        </View>
+                        <SyncCircularProgress value={syncPercent} />
                     </View>
 
                     <View

--- a/views/SyncRecovery.tsx
+++ b/views/SyncRecovery.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
-import { Dimensions, Text, View } from 'react-native';
+import { View } from 'react-native';
 import { inject, observer } from 'mobx-react';
-import CircularProgress from 'react-native-circular-progress-indicator';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import Button from '../components/Button';
 import Screen from '../components/Screen';
 import Header from '../components/Header';
+import SyncCircularProgress from '../components/SyncCircularProgress';
 
 import SyncStore from '../stores/SyncStore';
 
-import { formatProgressPercentage } from '../utils/FormatUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
 
@@ -29,12 +28,8 @@ export default class SyncRecovery extends React.PureComponent<
         const { navigation, SyncStore } = this.props;
         const { recoveryProgress } = SyncStore;
 
-        const { width } = Dimensions.get('window');
-        const ringRadius = width / 3;
-        const ringSize = ringRadius * 2;
-        const progressFontSize = ringRadius / 2;
         const progressValue = recoveryProgress
-            ? Number(Math.floor(recoveryProgress * 1000) / 1000) * 100
+            ? (Math.floor(recoveryProgress * 1000) / 1000) * 100
             : 0;
 
         return (
@@ -52,55 +47,7 @@ export default class SyncRecovery extends React.PureComponent<
                 />
                 <View style={{ flex: 1, justifyContent: 'center' }}>
                     <View style={{ alignItems: 'center', marginBottom: 40 }}>
-                        <View
-                            style={{
-                                width: ringSize,
-                                height: ringSize,
-                                alignItems: 'center',
-                                justifyContent: 'center'
-                            }}
-                        >
-                            <CircularProgress
-                                value={progressValue}
-                                radius={ringRadius}
-                                showProgressValue={false}
-                                inActiveStrokeOpacity={0.5}
-                                activeStrokeWidth={width / 20}
-                                inActiveStrokeWidth={width / 40}
-                                activeStrokeColor={themeColor('highlight')}
-                                activeStrokeSecondaryColor={themeColor('error')}
-                                inActiveStrokeColor={themeColor(
-                                    'secondaryBackground'
-                                )}
-                                duration={500}
-                            />
-                            <View
-                                pointerEvents="none"
-                                style={{
-                                    position: 'absolute',
-                                    left: 0,
-                                    right: 0,
-                                    top: 0,
-                                    bottom: 0,
-                                    justifyContent: 'center',
-                                    alignItems: 'center'
-                                }}
-                            >
-                                <Text
-                                    style={{
-                                        fontWeight: '100',
-                                        color: themeColor('text'),
-                                        fontSize: progressFontSize,
-                                        textAlign: 'center',
-                                        lineHeight: Math.ceil(
-                                            progressFontSize * 1.05
-                                        )
-                                    }}
-                                >
-                                    {formatProgressPercentage(progressValue)}%
-                                </Text>
-                            </View>
-                        </View>
+                        <SyncCircularProgress value={progressValue} />
                     </View>
                 </View>
                 <View style={{ bottom: 15 }}>

--- a/views/SyncRecovery.tsx
+++ b/views/SyncRecovery.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dimensions, View } from 'react-native';
+import { Dimensions, Text, View } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import CircularProgress from 'react-native-circular-progress-indicator';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -30,6 +30,12 @@ export default class SyncRecovery extends React.PureComponent<
         const { recoveryProgress } = SyncStore;
 
         const { width } = Dimensions.get('window');
+        const ringRadius = width / 3;
+        const ringSize = ringRadius * 2;
+        const progressFontSize = ringRadius / 2;
+        const progressValue = recoveryProgress
+            ? Number(Math.floor(recoveryProgress * 1000) / 1000) * 100
+            : 0;
 
         return (
             <Screen>
@@ -46,32 +52,55 @@ export default class SyncRecovery extends React.PureComponent<
                 />
                 <View style={{ flex: 1, justifyContent: 'center' }}>
                     <View style={{ alignItems: 'center', marginBottom: 40 }}>
-                        <CircularProgress
-                            value={
-                                recoveryProgress
-                                    ? Number(
-                                          Math.floor(recoveryProgress * 1000) /
-                                              1000
-                                      ) * 100
-                                    : 0
-                            }
-                            radius={width / 3}
-                            inActiveStrokeOpacity={0.5}
-                            activeStrokeWidth={width / 20}
-                            inActiveStrokeWidth={width / 40}
-                            progressValueStyle={{
-                                fontWeight: '100',
-                                color: 'white'
+                        <View
+                            style={{
+                                width: ringSize,
+                                height: ringSize,
+                                alignItems: 'center',
+                                justifyContent: 'center'
                             }}
-                            activeStrokeColor={themeColor('highlight')}
-                            activeStrokeSecondaryColor={themeColor('error')}
-                            inActiveStrokeColor={themeColor(
-                                'secondaryBackground'
-                            )}
-                            duration={500}
-                            progressFormatter={formatProgressPercentage}
-                            valueSuffix="%"
-                        />
+                        >
+                            <CircularProgress
+                                value={progressValue}
+                                radius={ringRadius}
+                                showProgressValue={false}
+                                inActiveStrokeOpacity={0.5}
+                                activeStrokeWidth={width / 20}
+                                inActiveStrokeWidth={width / 40}
+                                activeStrokeColor={themeColor('highlight')}
+                                activeStrokeSecondaryColor={themeColor('error')}
+                                inActiveStrokeColor={themeColor(
+                                    'secondaryBackground'
+                                )}
+                                duration={500}
+                            />
+                            <View
+                                pointerEvents="none"
+                                style={{
+                                    position: 'absolute',
+                                    left: 0,
+                                    right: 0,
+                                    top: 0,
+                                    bottom: 0,
+                                    justifyContent: 'center',
+                                    alignItems: 'center'
+                                }}
+                            >
+                                <Text
+                                    style={{
+                                        fontWeight: '100',
+                                        color: themeColor('text'),
+                                        fontSize: progressFontSize,
+                                        textAlign: 'center',
+                                        lineHeight: Math.ceil(
+                                            progressFontSize * 1.05
+                                        )
+                                    }}
+                                >
+                                    {formatProgressPercentage(progressValue)}%
+                                </Text>
+                            </View>
+                        </View>
                     </View>
                 </View>
                 <View style={{ bottom: 15 }}>


### PR DESCRIPTION
# Description
<table>
  <tr>
    <td align="center"><b>Before</b></td>
    <td align="center"><b>After</b></td>
  </tr>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/94135f97-86a1-4ea2-a889-deee8b1ec5d7" width="250" />
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/cbf31f4e-2486-4634-a1a0-7f27e4bbb17e" width="250" />
    </td>
  </tr>
</table>

This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [X] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [X] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
