### PR TITLE
fix(migrations): pass object to setSettings to avoid MobX observable corruption (#4150)

### DIFF
--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -340,6 +340,27 @@ describe('MigrationUtils', () => {
             );
         });
 
+        it('persists the settings object rather than a JSON string', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                invoices: {
+                    expiry: '3600',
+                    timePeriod: 'Hours',
+                    expirySeconds: '3600'
+                }
+            };
+
+            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
+
+            // Guards against regressing #4150: passing a stringified payload
+            // briefly turns the MobX `settings` observable into a string,
+            // which can crash observers reading nested keys.
+            const persistedSettings =
+                settingsStore.setSettings.mock.calls[0][0];
+            expect(typeof persistedSettings).not.toBe('string');
+            expect(persistedSettings).toBe(settings);
+        });
+
         it('backfills missing expirySeconds + timePeriod for pre-Feb-2024 installs', async () => {
             EncryptedStorage.getItem.mockResolvedValue(null);
             const settings: any = { invoices: { expiry: '3600' } };

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -306,7 +306,7 @@ class MigrationsUtils {
         const mod = await EncryptedStorage.getItem(MOD_KEY);
         if (!mod) {
             newSettings.requestSimpleTaproot = true;
-            await settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(newSettings);
             await EncryptedStorage.setItem(MOD_KEY, 'true');
         }
 
@@ -319,7 +319,7 @@ class MigrationsUtils {
             if (newSettings?.lspTestnet === 'https://testnet-lsp.lnolymp.us') {
                 newSettings.lspTestnet = DEFAULT_LSP_TESTNET;
             }
-            await settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(newSettings);
             await EncryptedStorage.setItem(MOD_KEY2, 'true');
         }
 
@@ -340,7 +340,7 @@ class MigrationsUtils {
                 newSettings.neutrinoPeersMainnet =
                     DEFAULT_NEUTRINO_PEERS_MAINNET;
             }
-            await settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(newSettings);
             await EncryptedStorage.setItem(MOD_KEY3, 'true');
         }
 
@@ -370,7 +370,7 @@ class MigrationsUtils {
                 newSettings.lsps1Token = '';
             }
 
-            await settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(newSettings);
             await EncryptedStorage.setItem(MOD_KEY4, 'true');
         }
 
@@ -387,7 +387,7 @@ class MigrationsUtils {
                 }
             }
 
-            await settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(newSettings);
             await EncryptedStorage.setItem(MOD_KEY5, 'true');
         }
 
@@ -399,7 +399,7 @@ class MigrationsUtils {
                 newSettings.customSpeedloader = '';
             }
 
-            await settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(newSettings);
             await EncryptedStorage.setItem(MOD_KEY6, 'true');
         }
 
@@ -412,7 +412,7 @@ class MigrationsUtils {
                 newSettings.bimodalPathfinding = false;
             }
 
-            await settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(newSettings);
             await EncryptedStorage.setItem(MOD_KEY7, 'true');
         }
 
@@ -426,7 +426,7 @@ class MigrationsUtils {
                 newSettings.lightningAddress.nostrRelays = DEFAULT_NOSTR_RELAYS;
             }
 
-            await settingsStore.setSettings(JSON.stringify(newSettings));
+            await settingsStore.setSettings(newSettings);
             await EncryptedStorage.setItem(MOD_KEY8, 'true');
         }
 
@@ -481,7 +481,7 @@ class MigrationsUtils {
                 }
             }
         }
-        await settingsStore.setSettings(JSON.stringify(settings));
+        await settingsStore.setSettings(settings);
         await EncryptedStorage.setItem(MOD_KEY_RGS, 'true');
         return settings;
     }
@@ -529,7 +529,7 @@ class MigrationsUtils {
                 invoices.expiry = repaired.expiry;
                 invoices.timePeriod = repaired.timePeriod;
                 invoices.expirySeconds = canonical;
-                await settingsStore.setSettings(JSON.stringify(settings));
+                await settingsStore.setSettings(settings);
             }
         }
         await EncryptedStorage.setItem(MOD_KEY_INVOICE_EXPIRY, 'true');


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-#4150**

`SettingsStore.setSettings(settings)` assigns its argument directly to the MobX
observable (`this.settings = settings`), and `storage/index.ts:setItem` already
serializes objects before persisting (`typeof value === 'string' ? value : JSON.stringify(value)`).

The migrations in `utils/MigrationUtils.ts` were calling
`setSettings(JSON.stringify(...))`, which briefly made `settingsStore.settings`
a **string**. Any MobX observer that fired in that window read nested keys
(e.g. `settings.invoices`) as `undefined` and could crash.

This PR drops the `JSON.stringify(...)` wrapper at all **10** migration call
sites so the observable stays a coherent object. The persisted form is
byte-identical (storage still serializes), so there is no behavior change to
what's written to disk.

Note: one of the call sites is inside `migrateInvoiceExpiryDisplay`, which the
issue believed was already fixed — it was not; that line still stringified, and
is corrected here. A regression test was added asserting `setSettings` receives
an object rather than a string.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

> Logic-only change in a migration utility with no UI surface; covered by unit
> tests (`utils/MigrationUtils.test.ts`, 22/22 passing). No device-specific
> behavior to exercise.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

> N/A — settings migration runs independent of the active node backend.

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transifex page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding