### PR TITLE
feat(lightning-address): copy address to clipboard on tap

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -53,6 +53,7 @@ import PushNotificationManager from './PushNotificationManager';
 import StealthModeUtils from './utils/StealthModeUtils';
 import StealthModeWrapper from './components/StealthModeWrapper';
 import { AppContainer } from './components/layout/AppContainer';
+import CopiedToastHost from './components/CopiedToast';
 import AlertModal from './components/Modals/AlertModal';
 import ExternalLinkModal from './components/Modals/ExternalLinkModal';
 import AndroidNfcModal from './components/Modals/AndroidNfcModal';
@@ -1811,6 +1812,7 @@ export default class App extends React.PureComponent {
                                 <RatingModal />
                                 {/* @ts-ignore:next-line */}
                                 <RestoreChannelModal />
+                                <CopiedToastHost />
                             </GestureHandlerRootView>
                         </PushNotificationManager>
                     </AppContainer>

--- a/components/CopiedToast.tsx
+++ b/components/CopiedToast.tsx
@@ -1,55 +1,65 @@
 import * as React from 'react';
-import { Dimensions, Modal, StyleSheet, Text, View } from 'react-native';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
 import { Icon } from '@rneui/themed';
 
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
 
-interface CopiedToastProps {
-    visible: boolean;
+const DURATION = 2000;
+
+let listeners: Array<(visible: boolean) => void> = [];
+let hideTimeout: ReturnType<typeof setTimeout> | null = null;
+
+export function showCopiedToast() {
+    if (hideTimeout) clearTimeout(hideTimeout);
+    listeners.forEach((l) => l(true));
+    hideTimeout = setTimeout(() => {
+        listeners.forEach((l) => l(false));
+        hideTimeout = null;
+    }, DURATION);
 }
 
-export default function CopiedToast({ visible }: CopiedToastProps) {
+export default function CopiedToastHost() {
+    const [visible, setVisible] = React.useState(false);
+    React.useEffect(() => {
+        listeners.push(setVisible);
+        return () => {
+            listeners = listeners.filter((l) => l !== setVisible);
+        };
+    }, []);
+
+    if (!visible) return null;
     return (
-        <Modal
-            transparent
-            visible={visible}
-            animationType="fade"
-            onRequestClose={() => {}}
-        >
-            <View style={styles.container}>
-                <View
+        <View pointerEvents="none" style={styles.container}>
+            <View
+                style={[styles.toast, { backgroundColor: themeColor('text') }]}
+            >
+                <Icon
+                    name="check"
+                    size={18}
+                    color={themeColor('background')}
+                    containerStyle={{ marginRight: 6 }}
+                />
+                <Text
                     style={[
-                        styles.toast,
-                        { backgroundColor: themeColor('text') }
+                        styles.toastText,
+                        { color: themeColor('background') }
                     ]}
                 >
-                    <Icon
-                        name="check"
-                        size={18}
-                        color={themeColor('background')}
-                        containerStyle={{ marginRight: 6 }}
-                    />
-                    <Text
-                        style={[
-                            styles.toastText,
-                            { color: themeColor('background') }
-                        ]}
-                    >
-                        {localeString('components.CopyButton.copied')}
-                    </Text>
-                </View>
+                    {localeString('components.CopyButton.copied')}
+                </Text>
             </View>
-        </Modal>
+        </View>
     );
 }
 
 const styles = StyleSheet.create({
     container: {
-        flex: 1,
-        justifyContent: 'flex-end',
-        alignItems: 'center',
-        paddingBottom: Math.max(Dimensions.get('window').height * 0.15, 160)
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: Math.max(Dimensions.get('window').height * 0.15, 160),
+        alignItems: 'center'
     },
     toast: {
         borderRadius: 8,

--- a/components/KeyValue.tsx
+++ b/components/KeyValue.tsx
@@ -10,7 +10,7 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import { inject, observer } from 'mobx-react';
 
 import { Body } from './text/Body';
-import CopiedToast from './CopiedToast';
+import { showCopiedToast } from './CopiedToast';
 import { Row } from './layout/Row';
 
 import { themeColor } from '../utils/ThemeUtils';
@@ -38,37 +38,15 @@ interface KeyValueProps {
     SettingsStore?: SettingsStore;
 }
 
-interface KeyValueState {
-    showCopiedToast: boolean;
-}
-
 @inject('ModalStore', 'SettingsStore')
 @observer
-export default class KeyValue extends React.Component<
-    KeyValueProps,
-    KeyValueState
-> {
-    private toastTimeout: ReturnType<typeof setTimeout> | null = null;
-
-    state = {
-        showCopiedToast: false
-    };
-
+export default class KeyValue extends React.Component<KeyValueProps> {
     copyText = () => {
         const { value } = this.props;
         Clipboard.setString(value.toString());
         Vibration.vibrate(50);
-        this.setState({ showCopiedToast: true });
-        if (this.toastTimeout) clearTimeout(this.toastTimeout);
-        this.toastTimeout = setTimeout(
-            () => this.setState({ showCopiedToast: false }),
-            2000
-        );
+        showCopiedToast();
     };
-
-    componentWillUnmount() {
-        if (this.toastTimeout) clearTimeout(this.toastTimeout);
-    }
 
     render() {
         const {
@@ -209,12 +187,9 @@ export default class KeyValue extends React.Component<
         );
 
         return (
-            <>
-                <View style={{ paddingTop: 10, paddingBottom: 10 }}>
-                    <KeyValueRow />
-                </View>
-                <CopiedToast visible={this.state.showCopiedToast} />
-            </>
+            <View style={{ paddingTop: 10, paddingBottom: 10 }}>
+                <KeyValueRow />
+            </View>
         );
     }
 }

--- a/components/MintReviewsModal.tsx
+++ b/components/MintReviewsModal.tsx
@@ -13,6 +13,7 @@ import { Icon } from '@rneui/themed';
 import { observer } from 'mobx-react';
 
 import Button from './Button';
+import { showCopiedToast } from './CopiedToast';
 import LoadingIndicator from './LoadingIndicator';
 import ModalBox from './ModalBox';
 
@@ -34,7 +35,6 @@ interface MintReviewsModalProps {
 
 interface MintReviewsModalState {
     expandedReviews: Set<number>;
-    showCopiedToast: boolean;
 }
 
 @observer
@@ -42,11 +42,8 @@ export default class MintReviewsModal extends React.Component<
     MintReviewsModalProps,
     MintReviewsModalState
 > {
-    private toastTimeout: ReturnType<typeof setTimeout> | null = null;
-
     state: MintReviewsModalState = {
-        expandedReviews: new Set(),
-        showCopiedToast: false
+        expandedReviews: new Set()
     };
 
     componentDidUpdate(prevProps: MintReviewsModalProps) {
@@ -54,10 +51,6 @@ export default class MintReviewsModal extends React.Component<
             this.setState({ expandedReviews: new Set() });
             this.fetchProfiles();
         }
-    }
-
-    componentWillUnmount() {
-        if (this.toastTimeout) clearTimeout(this.toastTimeout);
     }
 
     fetchProfiles = async () => {
@@ -70,12 +63,7 @@ export default class MintReviewsModal extends React.Component<
     copyToClipboard = (text: string) => {
         Clipboard.setString(text);
         Vibration.vibrate(50);
-        this.setState({ showCopiedToast: true });
-        if (this.toastTimeout) clearTimeout(this.toastTimeout);
-        this.toastTimeout = setTimeout(
-            () => this.setState({ showCopiedToast: false }),
-            2000
-        );
+        showCopiedToast();
     };
 
     toggleReviewExpanded = (index: number) => {

--- a/views/LightningAddress/index.tsx
+++ b/views/LightningAddress/index.tsx
@@ -20,7 +20,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import ZaplockerPayment from './ZaplockerPayment';
 import CashuPayment from './CashuPayment';
 
-import CopiedToast from '../../components/CopiedToast';
+import { showCopiedToast } from '../../components/CopiedToast';
 
 import Button from '../../components/Button';
 import Pill from '../../components/Pill';
@@ -63,7 +63,6 @@ interface LightningAddressProps {
 
 interface LightningAddressState {
     hasZeusLspChannel: boolean;
-    showCopiedToast: boolean;
 }
 
 @inject('LightningAddressStore', 'ChannelsStore', 'SettingsStore')
@@ -75,15 +74,13 @@ export default class LightningAddress extends React.Component<
     private pan: Animated.ValueXY;
     private panResponder: PanResponderInstance;
     private scrollViewRef = React.createRef<ScrollView>();
-    private toastTimeout: ReturnType<typeof setTimeout> | null = null;
 
     isInitialFocus = true;
 
     constructor(props: LightningAddressProps) {
         super(props);
         this.state = {
-            hasZeusLspChannel: false,
-            showCopiedToast: false
+            hasZeusLspChannel: false
         };
         this.pan = new Animated.ValueXY();
         this.panResponder = PanResponder.create({
@@ -130,7 +127,6 @@ export default class LightningAddress extends React.Component<
     componentWillUnmount() {
         this.props.navigation.removeListener &&
             this.props.navigation.removeListener('focus', this.handleFocus);
-        if (this.toastTimeout) clearTimeout(this.toastTimeout);
     }
 
     handleFocus = () => {
@@ -149,17 +145,12 @@ export default class LightningAddress extends React.Component<
             `${lightningAddressHandle}@${lightningAddressDomain}`
         );
         Vibration.vibrate(50);
-        this.setState({ showCopiedToast: true });
-        if (this.toastTimeout) clearTimeout(this.toastTimeout);
-        this.toastTimeout = setTimeout(
-            () => this.setState({ showCopiedToast: false }),
-            2000
-        );
+        showCopiedToast();
     };
 
     render() {
         const { navigation, LightningAddressStore, SettingsStore } = this.props;
-        const { hasZeusLspChannel, showCopiedToast } = this.state;
+        const { hasZeusLspChannel } = this.state;
         const {
             status,
             redeemAllOpenPaymentsZaplocker,
@@ -385,7 +376,6 @@ export default class LightningAddress extends React.Component<
                                             </Text>
                                         </Row>
                                     </TouchableOpacity>
-                                    <CopiedToast visible={showCopiedToast} />
                                     <Row
                                         style={{
                                             alignSelf: 'center',

--- a/views/LightningAddress/index.tsx
+++ b/views/LightningAddress/index.tsx
@@ -8,8 +8,10 @@ import {
     ScrollView,
     StyleSheet,
     TouchableOpacity,
+    Vibration,
     View
 } from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
 import { Icon } from '@rneui/themed';
 import { inject, observer } from 'mobx-react';
 import { Route } from '@react-navigation/native';
@@ -17,6 +19,8 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import ZaplockerPayment from './ZaplockerPayment';
 import CashuPayment from './CashuPayment';
+
+import CopiedToast from '../../components/CopiedToast';
 
 import Button from '../../components/Button';
 import Pill from '../../components/Pill';
@@ -59,6 +63,7 @@ interface LightningAddressProps {
 
 interface LightningAddressState {
     hasZeusLspChannel: boolean;
+    showCopiedToast: boolean;
 }
 
 @inject('LightningAddressStore', 'ChannelsStore', 'SettingsStore')
@@ -70,13 +75,15 @@ export default class LightningAddress extends React.Component<
     private pan: Animated.ValueXY;
     private panResponder: PanResponderInstance;
     private scrollViewRef = React.createRef<ScrollView>();
+    private toastTimeout: ReturnType<typeof setTimeout> | null = null;
 
     isInitialFocus = true;
 
     constructor(props: LightningAddressProps) {
         super(props);
         this.state = {
-            hasZeusLspChannel: false
+            hasZeusLspChannel: false,
+            showCopiedToast: false
         };
         this.pan = new Animated.ValueXY();
         this.panResponder = PanResponder.create({
@@ -123,6 +130,7 @@ export default class LightningAddress extends React.Component<
     componentWillUnmount() {
         this.props.navigation.removeListener &&
             this.props.navigation.removeListener('focus', this.handleFocus);
+        if (this.toastTimeout) clearTimeout(this.toastTimeout);
     }
 
     handleFocus = () => {
@@ -133,9 +141,25 @@ export default class LightningAddress extends React.Component<
         }
     };
 
+    copyLightningAddress = () => {
+        const { LightningAddressStore } = this.props;
+        const { lightningAddressHandle, lightningAddressDomain } =
+            LightningAddressStore;
+        Clipboard.setString(
+            `${lightningAddressHandle}@${lightningAddressDomain}`
+        );
+        Vibration.vibrate(50);
+        this.setState({ showCopiedToast: true });
+        if (this.toastTimeout) clearTimeout(this.toastTimeout);
+        this.toastTimeout = setTimeout(
+            () => this.setState({ showCopiedToast: false }),
+            2000
+        );
+    };
+
     render() {
         const { navigation, LightningAddressStore, SettingsStore } = this.props;
-        const { hasZeusLspChannel } = this.state;
+        const { hasZeusLspChannel, showCopiedToast } = this.state;
         const {
             status,
             redeemAllOpenPaymentsZaplocker,
@@ -341,9 +365,7 @@ export default class LightningAddress extends React.Component<
                                     }}
                                 >
                                     <TouchableOpacity
-                                        onPress={() =>
-                                            navigation.navigate('ZeusPayPlus')
-                                        }
+                                        onPress={this.copyLightningAddress}
                                     >
                                         <Row
                                             style={{
@@ -362,13 +384,22 @@ export default class LightningAddress extends React.Component<
                                                 {`${lightningAddressHandle}@${lightningAddressDomain}`}
                                             </Text>
                                         </Row>
-                                        <Row
-                                            style={{
-                                                alignSelf: 'center',
-                                                marginTop: 15
-                                            }}
-                                        >
-                                            {!zeusPlus && (
+                                    </TouchableOpacity>
+                                    <CopiedToast visible={showCopiedToast} />
+                                    <Row
+                                        style={{
+                                            alignSelf: 'center',
+                                            marginTop: 15
+                                        }}
+                                    >
+                                        {!zeusPlus && (
+                                            <TouchableOpacity
+                                                onPress={() =>
+                                                    navigation.navigate(
+                                                        'ZeusPayPlus'
+                                                    )
+                                                }
+                                            >
                                                 <Pill
                                                     title={localeString(
                                                         'views.Settings.LightningAddress.upgrade'
@@ -383,8 +414,16 @@ export default class LightningAddress extends React.Component<
                                                     )}
                                                     borderWidth={1}
                                                 />
-                                            )}
-                                            {zeusPlus && (
+                                            </TouchableOpacity>
+                                        )}
+                                        {zeusPlus && (
+                                            <TouchableOpacity
+                                                onPress={() =>
+                                                    navigation.navigate(
+                                                        'ZeusPayPlus'
+                                                    )
+                                                }
+                                            >
                                                 <Pill
                                                     title="ZEUS Pay+"
                                                     width={100}
@@ -394,9 +433,9 @@ export default class LightningAddress extends React.Component<
                                                     )}
                                                     borderWidth={1}
                                                 />
-                                            )}
-                                        </Row>
-                                    </TouchableOpacity>
+                                            </TouchableOpacity>
+                                        )}
+                                    </Row>
                                     {lightningAddressType === 'zaplocker' && (
                                         <Row
                                             style={{
@@ -465,7 +504,7 @@ export default class LightningAddress extends React.Component<
                                     <Row
                                         style={{
                                             alignSelf: 'center',
-                                            marginTop: 5
+                                            marginTop: 30
                                         }}
                                     >
                                         <QRButton />


### PR DESCRIPTION
# Description

On the Lightning address view, tapping the address handle now copies it to clipboard instead of navigating to the ZEUS Pay+ upgrade view. The upgrade and Pay+ pill badges below the address are now their own tappable buttons that navigate to the ZEUS Pay+ view. Uses the same `CopiedToast` + `Vibration.vibrate(50)` feedback pattern as `KeyValue`. Also increased the spacing between the address block and the QR/portal buttons below it.

This PR also refactors the toast component by hoisting it to the root of the app so that it stops blocking navigation, and behaves uniformly on all views.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding