### PR TITLE
fix(pos): label Order action "Request payment" instead of "Pay" (#2696)

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1824,6 +1824,7 @@
     "pos.views.Order.totalFiat": "Total (fiat)",
     "pos.views.Order.totalBitcoin": "Total (Bitcoin)",
     "pos.views.Order.total": "Total",
+    "pos.views.Order.requestPayment": "Request payment",
     "pos.views.Order.paymentType": "Payment type",
     "pos.views.Order.printReceipt": "Print Receipt",
     "pos.views.Order.printInvoice": "Print Invoice",

--- a/views/Order.tsx
+++ b/views/Order.tsx
@@ -1310,7 +1310,9 @@ export default class OrderView extends React.Component<OrderProps, OrderState> {
 
                     {!isPaid && (
                         <Button
-                            title={localeString('general.pay')}
+                            title={localeString(
+                                'pos.views.Order.requestPayment'
+                            )}
                             containerStyle={{ marginTop: 40 }}
                             onPress={() =>
                                 navigation.navigate(


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-#2696**

In the Point of Sale Order view, the primary action button was labelled **"Pay"**
(`general.pay`). That button does not pay anything, it navigates to the
`Receive` / `ReceiveEcash` screen with `autoGenerate: true` to generate an
invoice for the customer, i.e. the merchant is **requesting** payment. The label
was therefore misleading.

This PR relabels the button to **"Request payment"**. A new locale key
`pos.views.Order.requestPayment` is added to `locales/en.json` (English source)
and used in `views/Order.tsx`. Non-English locales fall back to the English
string until translated via Transifex.


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
