### PR TITLE
fix(keypad): prevent Fabric crash by restructuring baseline layout

### DIFF
--- a/components/KeypadAmountDisplay.tsx
+++ b/components/KeypadAmountDisplay.tsx
@@ -283,7 +283,7 @@ export default class KeypadAmountDisplay extends React.Component<
                     <View
                         style={{
                             flexDirection: 'row',
-                            alignItems: 'flex-end',
+                            alignItems: 'baseline',
                             justifyContent: 'center'
                         }}
                     >
@@ -303,7 +303,7 @@ export default class KeypadAmountDisplay extends React.Component<
                         <View
                             style={{
                                 flexDirection: 'row',
-                                alignItems: 'baseline',
+                                alignItems: 'flex-end',
                                 height: scaledLineHeight,
                                 overflow: 'hidden',
                                 zIndex: 0
@@ -348,22 +348,22 @@ export default class KeypadAmountDisplay extends React.Component<
                                     {decimalPlaceholder.string}
                                 </Text>
                             ) : null}
-                            {suffix ? (
-                                <Animated.Text
-                                    style={{
-                                        zIndex: 1,
-                                        color: textColor,
-                                        fontSize: Math.max(
-                                            scaledFontSize * 0.2,
-                                            12
-                                        ),
-                                        fontFamily: 'PPNeueMontreal-Medium'
-                                    }}
-                                >
-                                    {suffix}
-                                </Animated.Text>
-                            ) : null}
                         </View>
+                        {suffix ? (
+                            <Animated.Text
+                                style={{
+                                    zIndex: 1,
+                                    color: textColor,
+                                    fontSize: Math.max(
+                                        scaledFontSize * 0.2,
+                                        12
+                                    ),
+                                    fontFamily: 'PPNeueMontreal-Medium'
+                                }}
+                            >
+                                {suffix}
+                            </Animated.Text>
+                        ) : null}
                     </View>
                 </Animated.View>
 


### PR DESCRIPTION
# Description


## Summary

Fixes a crash in the keypad amount display caused by Fabric text layout during baseline measurement.

On the New Architecture, `alignItems: 'baseline'` was applied to the inner digit row with many direct children (animated digit cells, separators, and the `sats`/`sat` suffix). Yoga ran `ParagraphShadowNode::baseline` on each sibling during layout, which triggered `Sealable::ensureUnsealed()` and aborted the app with `SIGABRT`.

This change keeps correct baseline alignment for the unit label while limiting baseline measurement to the outer row: prefix, digit strip, and suffix.

## Problem

- **Symptom:** App crashes on the keypad flow, often toggling Amount units.
- **Stack:** `ParagraphShadowNode::baseline` → `justifyMainAxis` → `ShadowTree::commit` → `Sealable::ensureUnsealed()`
- **Root cause:** Baseline alignment on a flex row containing many text nodes (per-digit `AnimatedDigit` cells plus the unit suffix).

## Solution

Restructure layout in `components/KeypadAmountDisplay.tsx`:

- **Outer row** — `alignItems: 'baseline'` (prefix, digit block, unit suffix)
- **Inner digit strip** — `alignItems: 'flex-end'` (digits, decimal placeholder, exit animation only)
- **Unit suffix** (`sats` / `sat`) — moved out of the digit strip and rendered as a sibling of the digit `View`

Baseline is now computed between a small number of top-level children instead of every animated digit cell.

## Test plan

- [ ] Full native rebuild (not Metro-only refresh)
- [ ] Open send/keypad screen with amount `0` in sats mode — confirm `sats` sits beside the amount on the correct baseline
- [ ] Enter multi-digit amounts and confirm digit animations still work
- [ ] Toggle units (sats → BTC → fiat) on the keypad and confirm no crash
- [ ] Leave app on keypad/send flow for 15–20s and confirm no crash
- [ ] Verify BTC prefix (`₿`) and fiat symbol placement still look correct



This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
