### PR TITLE
fix: prevent keypad digit clipping and mid-animation misalignment

### DIFF
--- a/components/AnimatedDigit.tsx
+++ b/components/AnimatedDigit.tsx
@@ -3,6 +3,7 @@ import { Animated, StyleProp, TextStyle } from 'react-native';
 
 const TRANSITION_OPACITY_MS = 140;
 const TRANSITION_TRANSLATE_MS = 180;
+const TRANSLATE_OFFSET_RATIO = 0.125;
 
 interface AnimatedDigitProps {
     value: string;
@@ -11,6 +12,10 @@ interface AnimatedDigitProps {
     lineHeight: number;
     variant?: 'enter' | 'exit';
     onExitComplete?: () => void;
+}
+
+function translateOffset(lineHeight: number): number {
+    return lineHeight * TRANSLATE_OFFSET_RATIO;
 }
 
 export default function AnimatedDigit({
@@ -25,18 +30,58 @@ export default function AnimatedDigit({
         new Animated.Value(variant === 'exit' ? 1 : 0)
     ).current;
     const translateY = useRef(
-        new Animated.Value(variant === 'exit' ? 0 : 10)
+        new Animated.Value(variant === 'exit' ? 0 : translateOffset(lineHeight))
     ).current;
+    const animationRef = useRef<Animated.CompositeAnimation | null>(null);
+    const hasAnimatedEnterRef = useRef(false);
+    const prevLineHeightRef = useRef(lineHeight);
     const onExitCompleteRef = useRef(onExitComplete);
     onExitCompleteRef.current = onExitComplete;
+
+    useEffect(() => {
+        return () => {
+            animationRef.current?.stop();
+        };
+    }, []);
+
+    useEffect(() => {
+        if (prevLineHeightRef.current === lineHeight) {
+            return;
+        }
+        prevLineHeightRef.current = lineHeight;
+        animationRef.current?.stop();
+        animationRef.current = null;
+
+        if (variant === 'enter') {
+            opacity.setValue(1);
+            translateY.setValue(0);
+            return;
+        }
+
+        opacity.setValue(0);
+        translateY.setValue(translateOffset(lineHeight));
+        onExitCompleteRef.current?.();
+    }, [lineHeight, variant, opacity, translateY]);
 
     useEffect(() => {
         if (variant !== 'enter') {
             return;
         }
+
+        animationRef.current?.stop();
+        animationRef.current = null;
+
+        if (hasAnimatedEnterRef.current) {
+            opacity.setValue(1);
+            translateY.setValue(0);
+            return;
+        }
+
+        hasAnimatedEnterRef.current = true;
+        const offset = translateOffset(lineHeight);
         opacity.setValue(0);
-        translateY.setValue(10);
-        Animated.parallel([
+        translateY.setValue(offset);
+        animationRef.current = Animated.parallel([
             Animated.timing(opacity, {
                 toValue: 1,
                 duration: TRANSITION_OPACITY_MS,
@@ -47,30 +92,48 @@ export default function AnimatedDigit({
                 duration: TRANSITION_TRANSLATE_MS,
                 useNativeDriver: true
             })
-        ]).start();
-    }, [variant, value, opacity, translateY]);
+        ]);
+        animationRef.current.start(({ finished }) => {
+            animationRef.current = null;
+            if (finished) {
+                opacity.setValue(1);
+                translateY.setValue(0);
+            }
+        });
+    }, [variant, value, lineHeight, opacity, translateY]);
 
     useEffect(() => {
         if (variant !== 'exit') {
             return;
         }
-        Animated.parallel([
+
+        animationRef.current?.stop();
+        animationRef.current = null;
+
+        const offset = translateOffset(lineHeight);
+        opacity.setValue(1);
+        translateY.setValue(0);
+        animationRef.current = Animated.parallel([
             Animated.timing(opacity, {
                 toValue: 0,
                 duration: TRANSITION_OPACITY_MS,
                 useNativeDriver: true
             }),
             Animated.timing(translateY, {
-                toValue: 10,
+                toValue: offset,
                 duration: TRANSITION_TRANSLATE_MS,
                 useNativeDriver: true
             })
-        ]).start(({ finished }) => {
+        ]);
+        animationRef.current.start(({ finished }) => {
+            animationRef.current = null;
             if (finished) {
+                opacity.setValue(0);
+                translateY.setValue(offset);
                 onExitCompleteRef.current?.();
             }
         });
-    }, [variant, opacity, translateY]);
+    }, [variant, lineHeight, opacity, translateY]);
 
     return (
         <Animated.View

--- a/components/KeypadAmountDisplay.tsx
+++ b/components/KeypadAmountDisplay.tsx
@@ -141,7 +141,8 @@ export default class KeypadAmountDisplay extends React.Component<
         formattedNumber: string,
         textColor: Animated.AnimatedInterpolation<string> | string,
         fontSize: number,
-        lineHeight: number
+        lineHeight: number,
+        isPlaceholderZero: boolean
     ) {
         let digitIndex = 0;
         const textStyle = {
@@ -154,6 +155,23 @@ export default class KeypadAmountDisplay extends React.Component<
             if (isDigit) {
                 const key = `digit_${digitIndex}`;
                 digitIndex++;
+                if (isPlaceholderZero) {
+                    return (
+                        <View
+                            key={key}
+                            style={{
+                                height: lineHeight,
+                                justifyContent: 'flex-end'
+                            }}
+                        >
+                            <Animated.Text
+                                style={[textStyle, { color: textColor }]}
+                            >
+                                {char}
+                            </Animated.Text>
+                        </View>
+                    );
+                }
                 return (
                     <AnimatedDigit
                         key={key}
@@ -313,7 +331,8 @@ export default class KeypadAmountDisplay extends React.Component<
                                 formattedNumber,
                                 textColor,
                                 scaledFontSize,
-                                scaledLineHeight
+                                scaledLineHeight,
+                                amount === '0'
                             )}
                             {this.state.exitingDigit ? (
                                 <AnimatedDigit


### PR DESCRIPTION
# Description

In this PR, we fix visual glitches in the keypad amount digit enter/exit animations where digits could disappear, stop mid-slide, or render at the wrong height during fast typing and font scaling.

AnimatedDigit: Animate enter only once per mount; stop overlapping animations; scale, translate, and offset with lineHeight; snap settled digits when font size changes mid-typing
KeypadAmountDisplay: Render placeholder 0 as static text so the first typed digit mounts fresh and gets the enter animation

## Problem
When typing quickly or as the amount grew (and font size shrank), digits could:

- Become invisible (stuck at opacity: 0 / clipped by overflow: hidden)
- Stop mid-animation with misaligned vertical position
- Fail to animate on the first typed digit (placeholder 0 consumed the enter animation)

<img width="365" height="84" alt="Screenshot 2026-06-15 at 11 43 29 AM" src="https://github.com/user-attachments/assets/9ab9c6ed-a4e1-41a0-a088-b83fd0551fad" />
<img width="374" height="88" alt="Screenshot_2026-06-15_at_11 44 29_AM-60d10161-5e31" src="https://github.com/user-attachments/assets/0ad65726-bf7a-464d-85c0-ea849bab2ac6" />




## Solution

AnimatedDigit.tsx
- Run enter animation only on first mount; in-place value updates snap to final position
- Track and stop in-flight animations before starting new ones
- Use lineHeight * 0.125 instead of a fixed 10px translate offset
- Reset to settled state when lineHeight changes during font scaling
- Explicitly set final animated values on completion

KeypadAmountDisplay.tsx
- When amount === '0', render the digit as static Animated.Text (same height wrapper for alignment)
- First real digit mounts a new AnimatedDigit and animates normally

## Test plan

- [ ]  Start at 0, type a single digit — enter animation plays
- [ ]  Type a long sats amount quickly (e.g. 8666655555, 3333333) — no missing or misaligned digits
- [ ]  Backspace through multiple digits — exit animation works for each removed digit
- [ ]  Type until font scales down — existing digits stay aligned, new digits animate correctly
- [ ]  Switch units (sats / BTC / fiat) — amount display remains stable
- [ ]  Verify placeholder 0 shows immediately with no enter animation on load



This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
