### PR TITLE
fix(lightning-address): handle status() promise rejections (#2747)

### DIFF
--- a/views/LightningAddress/index.tsx
+++ b/views/LightningAddress/index.tsx
@@ -104,7 +104,7 @@ export default class LightningAddress extends React.Component<
 
         const skipStatus = route.params?.skipStatus;
 
-        if (!skipStatus) status();
+        if (!skipStatus) status().catch(this.handleStatusError);
 
         ChannelsStore.enrichedChannels?.every((channel) => {
             if (channel.remotePubkey === DEFAULT_LSPS1_PUBKEY_MAINNET) {
@@ -129,8 +129,17 @@ export default class LightningAddress extends React.Component<
         if (this.isInitialFocus) {
             this.isInitialFocus = false;
         } else {
-            this.props.LightningAddressStore.status();
+            this.props.LightningAddressStore.status().catch(
+                this.handleStatusError
+            );
         }
+    };
+
+    // status() records the failure in the store's observable error/error_msg
+    // (which the UI renders) and then re-throws, so fire-and-forget call sites
+    // must catch the rejection to avoid an unhandled promise rejection.
+    private handleStatusError = (error: any) => {
+        console.error('LightningAddressStore.status() failed', error);
     };
 
     render() {
@@ -1171,7 +1180,11 @@ export default class LightningAddress extends React.Component<
                                                 margin: 15,
                                                 alignItems: 'center'
                                             }}
-                                            onPress={() => status()}
+                                            onPress={() =>
+                                                status().catch(
+                                                    this.handleStatusError
+                                                )
+                                            }
                                         >
                                             <Text
                                                 style={{
@@ -1235,7 +1248,11 @@ export default class LightningAddress extends React.Component<
                                             ListFooterComponent={
                                                 <Spacer height={100} />
                                             }
-                                            onRefresh={() => status()}
+                                            onRefresh={() =>
+                                                status().catch(
+                                                    this.handleStatusError
+                                                )
+                                            }
                                             refreshing={loading}
                                             keyExtractor={(_, index) =>
                                                 `${index}`


### PR DESCRIPTION

# Description

Relates to issue: **ZEUS-#2747**

`LightningAddressStore.status()` is an async method that, on failure, records the error in its observable `error` / `error_msg` state (which the view renders) and then **re-throws**. The Lightning Address view called it fire-and-forget (no `await`, no `.catch`) in several places, so a rejection surfaced as an unhandled promise rejection.

This PR adds a single private handler, `handleStatusError`, and routes every fire-and-forget `status()` call in the view through it:

- `componentDidMount()` — `if (!skipStatus) status();`
- `handleFocus()` — `this.props.LightningAddressStore.status();`
- render `onPress` (refresh action) and `onRefresh` (pull-to-refresh)

The handler logs the error so it is not silently hidden; the user-facing error state continues to be driven by the store's observable `error` / `error_msg`, so there is no change to what the user sees on the happy path or on failure.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
