### PR TITLE
fix(rebalance): respect bottom safe area on Rebalance success screen (#4014)

### DIFF
--- a/views/Tools/RebalancingChannels.tsx
+++ b/views/Tools/RebalancingChannels.tsx
@@ -12,6 +12,7 @@ import {
 import { inject, observer } from 'mobx-react';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Route } from '@react-navigation/native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import Button from '../../components/Button';
 import Screen from '../../components/Screen';
@@ -768,163 +769,167 @@ export default class RebalancingChannels extends React.Component<
                             )}
                         </View>
 
-                        {success && (
-                            <View
-                                style={{
-                                    width: '100%',
-                                    marginBottom: 5,
-                                    bottom: 30
-                                }}
-                            >
-                                <Button
-                                    title={localeString(
-                                        'views.RebalancingChannels.rebalanceSummary'
-                                    )}
-                                    onPress={() =>
-                                        this.navigateToRebalanceSummary()
-                                    }
-                                    secondary
-                                    buttonStyle={{ height: 40 }}
-                                    containerStyle={{ width: '100%' }}
-                                />
-                            </View>
-                        )}
-
-                        {(paymentPathExists || noteKey) && (
-                            <Row
-                                align="flex-end"
-                                style={{
-                                    marginBottom: 5,
-                                    bottom: 25,
-                                    alignSelf: 'center'
-                                }}
-                            >
-                                {paymentPathExists && (
-                                    <Button
-                                        title={`${localeString(
-                                            'views.Payment.title'
-                                        )} ${
-                                            enhancedPath?.length > 1
-                                                ? `${localeString(
-                                                      'views.Payment.paths'
-                                                  )} (${enhancedPath.length})`
-                                                : localeString(
-                                                      'views.Payment.path'
-                                                  )
-                                        } `}
-                                        onPress={this.handleViewPath}
-                                        secondary
-                                        buttonStyle={{
-                                            height: 40,
-                                            width: '100%'
-                                        }}
-                                        containerStyle={{
-                                            maxWidth: noteKey ? '45%' : '100%',
-                                            paddingRight: noteKey ? 5 : 0
-                                        }}
-                                    />
-                                )}
-                                {noteKey && (
-                                    <Button
-                                        title={
-                                            storedNotes
-                                                ? localeString(
-                                                      'views.SendingLightning.UpdateNote'
-                                                  )
-                                                : localeString(
-                                                      'views.SendingLightning.AddANote'
-                                                  )
-                                        }
-                                        onPress={this.handleAddNote}
-                                        secondary
-                                        buttonStyle={{
-                                            height: 40,
-                                            width: '100%'
-                                        }}
-                                        containerStyle={{
-                                            maxWidth: paymentPathExists
-                                                ? '45%'
-                                                : '100%',
-                                            paddingLeft: paymentPathExists
-                                                ? 5
-                                                : 0
-                                        }}
-                                    />
-                                )}
-                            </Row>
-                        )}
-
-                        <View
-                            style={[
-                                styles.buttons,
-                                !(
-                                    (paymentPathExists || noteKey) &&
-                                    success
-                                ) && { marginTop: 14 }
-                            ]}
-                        >
-                            {!!error && (
-                                <>
-                                    <Button
-                                        title={localeString(
-                                            'views.SendingLightning.tryAgain'
-                                        )}
-                                        icon={{
-                                            name: 'rotate-ccw',
-                                            type: 'feather',
-                                            size: 25
-                                        }}
-                                        onPress={this.handleTryAgain}
-                                        buttonStyle={{
-                                            backgroundColor: 'white',
-                                            height: 40
-                                        }}
-                                        containerStyle={{
-                                            width: '100%',
-                                            margin: 3
-                                        }}
-                                    />
-                                </>
-                            )}
-
-                            {(!!error || !!success) && (
-                                <Row
-                                    align="flex-end"
+                        <SafeAreaView edges={['bottom']}>
+                            {success && (
+                                <View
                                     style={{
-                                        alignSelf: 'center'
+                                        width: '100%',
+                                        marginBottom: 5
                                     }}
                                 >
                                     <Button
                                         title={localeString(
-                                            'views.SendingLightning.goToWallet'
+                                            'views.RebalancingChannels.rebalanceSummary'
                                         )}
-                                        icon={{
-                                            name: 'list',
-                                            size: 25,
-                                            color: themeColor('background')
-                                        }}
-                                        onPress={() => {
-                                            navigation.popTo('Wallet');
-
-                                            if (success) {
-                                                this.props.ChannelsStore?.getChannels();
-                                            }
-                                        }}
-                                        buttonStyle={{
-                                            height: 40,
-                                            width: '100%'
-                                        }}
-                                        titleStyle={{
-                                            color: themeColor('background')
-                                        }}
-                                        containerStyle={{
-                                            maxWidth: '100%',
-                                            margin: 3
-                                        }}
+                                        onPress={() =>
+                                            this.navigateToRebalanceSummary()
+                                        }
+                                        secondary
+                                        buttonStyle={{ height: 40 }}
+                                        containerStyle={{ width: '100%' }}
                                     />
+                                </View>
+                            )}
+
+                            {(paymentPathExists || noteKey) && (
+                                <Row
+                                    align="flex-end"
+                                    style={{
+                                        marginBottom: 5,
+                                        alignSelf: 'center'
+                                    }}
+                                >
+                                    {paymentPathExists && (
+                                        <Button
+                                            title={`${localeString(
+                                                'views.Payment.title'
+                                            )} ${
+                                                enhancedPath?.length > 1
+                                                    ? `${localeString(
+                                                          'views.Payment.paths'
+                                                      )} (${
+                                                          enhancedPath.length
+                                                      })`
+                                                    : localeString(
+                                                          'views.Payment.path'
+                                                      )
+                                            } `}
+                                            onPress={this.handleViewPath}
+                                            secondary
+                                            buttonStyle={{
+                                                height: 40,
+                                                width: '100%'
+                                            }}
+                                            containerStyle={{
+                                                maxWidth: noteKey
+                                                    ? '45%'
+                                                    : '100%',
+                                                paddingRight: noteKey ? 5 : 0
+                                            }}
+                                        />
+                                    )}
+                                    {noteKey && (
+                                        <Button
+                                            title={
+                                                storedNotes
+                                                    ? localeString(
+                                                          'views.SendingLightning.UpdateNote'
+                                                      )
+                                                    : localeString(
+                                                          'views.SendingLightning.AddANote'
+                                                      )
+                                            }
+                                            onPress={this.handleAddNote}
+                                            secondary
+                                            buttonStyle={{
+                                                height: 40,
+                                                width: '100%'
+                                            }}
+                                            containerStyle={{
+                                                maxWidth: paymentPathExists
+                                                    ? '45%'
+                                                    : '100%',
+                                                paddingLeft: paymentPathExists
+                                                    ? 5
+                                                    : 0
+                                            }}
+                                        />
+                                    )}
                                 </Row>
                             )}
-                        </View>
+
+                            <View
+                                style={[
+                                    styles.buttons,
+                                    !(
+                                        (paymentPathExists || noteKey) &&
+                                        success
+                                    ) && { marginTop: 14 }
+                                ]}
+                            >
+                                {!!error && (
+                                    <>
+                                        <Button
+                                            title={localeString(
+                                                'views.SendingLightning.tryAgain'
+                                            )}
+                                            icon={{
+                                                name: 'rotate-ccw',
+                                                type: 'feather',
+                                                size: 25
+                                            }}
+                                            onPress={this.handleTryAgain}
+                                            buttonStyle={{
+                                                backgroundColor: 'white',
+                                                height: 40
+                                            }}
+                                            containerStyle={{
+                                                width: '100%',
+                                                margin: 3
+                                            }}
+                                        />
+                                    </>
+                                )}
+
+                                {(!!error || !!success) && (
+                                    <Row
+                                        align="flex-end"
+                                        style={{
+                                            alignSelf: 'center'
+                                        }}
+                                    >
+                                        <Button
+                                            title={localeString(
+                                                'views.SendingLightning.goToWallet'
+                                            )}
+                                            icon={{
+                                                name: 'list',
+                                                size: 25,
+                                                color: themeColor('background')
+                                            }}
+                                            onPress={() => {
+                                                navigation.popTo('Wallet');
+
+                                                if (success) {
+                                                    this.props.ChannelsStore?.getChannels();
+                                                }
+                                            }}
+                                            buttonStyle={{
+                                                height: 40,
+                                                width: '100%'
+                                            }}
+                                            titleStyle={{
+                                                color: themeColor('background')
+                                            }}
+                                            containerStyle={{
+                                                maxWidth: '100%',
+                                                margin: 3
+                                            }}
+                                        />
+                                    </Row>
+                                )}
+                            </View>
+                        </SafeAreaView>
                     </ScrollView>
                 )}
             </Screen>
@@ -1018,7 +1023,6 @@ const styles = StyleSheet.create({
     buttons: {
         width: '100%',
         justifyContent: 'space-between',
-        gap: 15,
-        bottom: 15
+        gap: 15
     }
 });


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-#4014**

The Rebalance success screen (`views/Tools/RebalancingChannels.tsx`) anchored its bottom buttons using hardcoded relative offsets (`bottom: 30 / 25 / 15`) and did **not** wrap them in a `SafeAreaView`. As a result, on devices with a home
indicator / gesture navigation bar the bottom buttons did not respect the bottom safe-area inset (see screenshots in the issue, iOS and Android).

The app's other "sending/success" screens already use the correct pattern `views/SendingLightning.tsx` and `views/Cashu/CashuSendingLightning.tsx` wrap their bottom buttons in `<SafeAreaView edges={['bottom']}>` (see
`components/sendingStyles.ts`). This PR makes the Rebalance success screen consistent with that pattern:

- Import `SafeAreaView` from `react-native-safe-area-context` (already a project
  dependency, v5.6.2).
- Wrap the bottom action area (summary button, payment-path / note row, and the
  primary action buttons) in `<SafeAreaView edges={['bottom']}>`.
- Remove the now-redundant `bottom: 30 / 25 / 15` offset hacks, matching the
  canonical `sendingStyles.buttons` style.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
