### PR TITLE
fix: empty fiat inputs on Currency Converter initial render

### DIFF
--- a/components/CurrencyConverterContent.tsx
+++ b/components/CurrencyConverterContent.tsx
@@ -73,6 +73,7 @@ export default class CurrencyConverterContent extends React.Component<
     CurrencyConverterContentProps,
     CurrencyConverterContentState
 > {
+    private blurListener: (() => void) | undefined;
     constructor(props: CurrencyConverterContentProps) {
         super(props);
         this.state = {
@@ -92,6 +93,16 @@ export default class CurrencyConverterContent extends React.Component<
             this.props.FiatStore?.getFiatRates?.();
         }
         this.addDefaultCurrenciesToStorage();
+
+        this.blurListener = this.props.navigation?.addListener?.(
+            'blur',
+            this.saveInputValues
+        );
+    }
+
+    componentWillUnmount() {
+        this.blurListener?.();
+        this.saveInputValues();
     }
 
     componentDidUpdate(
@@ -232,7 +243,10 @@ export default class CurrencyConverterContent extends React.Component<
                 }
             });
 
-            this.setState({ inputValues: convertedValues });
+            this.setState(
+                { inputValues: convertedValues },
+                this.saveInputValues
+            );
             return;
         }
 
@@ -310,7 +324,7 @@ export default class CurrencyConverterContent extends React.Component<
             }
         });
 
-        this.setState({ inputValues: convertedValues });
+        this.setState({ inputValues: convertedValues }, this.saveInputValues);
     };
 
     handleDeleteCurrency = async (currency: string) => {

--- a/components/CurrencyConverterContent.tsx
+++ b/components/CurrencyConverterContent.tsx
@@ -6,11 +6,12 @@ import {
     Animated,
     Easing,
     ScrollView,
-    FlatListProps
+    FlatListProps,
+    Text
 } from 'react-native';
 
 import { observer, inject } from 'mobx-react';
-import Svg, { Text } from 'react-native-svg';
+import Svg, { Text as SvgText } from 'react-native-svg';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import DragList, { DragListRenderItemInfo } from 'react-native-draglist';
 import { Icon } from '@rneui/themed';
@@ -90,7 +91,6 @@ export default class CurrencyConverterContent extends React.Component<
         if (isEmpty(this.props.FiatStore?.fiatRates)) {
             this.props.FiatStore?.getFiatRates?.();
         }
-        this.retrieveInputValues();
         this.addDefaultCurrenciesToStorage();
     }
 
@@ -118,9 +118,12 @@ export default class CurrencyConverterContent extends React.Component<
         if (isEmpty(this.props.FiatStore?.fiatRates)) return;
 
         const { inputValues } = this.state;
-        const source = Object.keys(inputValues).find(
-            (key) => inputValues[key].replace(/,/g, '').trim() !== ''
-        );
+        const source = Object.keys(inputValues).find((key) => {
+            const val = inputValues[key];
+            return (
+                typeof val === 'string' && val.replace(/,/g, '').trim() !== ''
+            );
+        });
         if (!source) return;
 
         this.handleInputChange(inputValues[source], source);
@@ -573,50 +576,11 @@ export default class CurrencyConverterContent extends React.Component<
                                                         : null
                                                 ]}
                                             >
-                                                <View
-                                                    style={{
-                                                        position: 'absolute',
-                                                        right: [
-                                                            'BTC',
-                                                            'sats'
-                                                        ].includes(item)
-                                                            ? 20
-                                                            : 16,
-                                                        zIndex: 1
-                                                    }}
-                                                >
-                                                    {['BTC', 'sats'].includes(
-                                                        item
-                                                    ) ? (
-                                                        <BitcoinIcon
-                                                            height={20}
-                                                            width={20}
-                                                        />
-                                                    ) : (
-                                                        <Svg
-                                                            height="24"
-                                                            width="24"
-                                                        >
-                                                            <Text
-                                                                fontSize="16"
-                                                                x="0"
-                                                                y="18"
-                                                            >
-                                                                {getFlagEmoji(
-                                                                    item
-                                                                )}
-                                                            </Text>
-                                                        </Svg>
-                                                    )}
-                                                </View>
-
                                                 <TextInput
                                                     keyboardType="numeric"
-                                                    suffix={item}
                                                     style={{
                                                         flex: 1
                                                     }}
-                                                    right={80}
                                                     placeholder={localeString(
                                                         'views.Settings.CurrencyConverter.enterAmount'
                                                     )}
@@ -630,6 +594,50 @@ export default class CurrencyConverterContent extends React.Component<
                                                         )
                                                     }
                                                     autoCapitalize="none"
+                                                    trailing={
+                                                        <View
+                                                            style={
+                                                                styles.currencyTrailing
+                                                            }
+                                                        >
+                                                            <Text
+                                                                style={[
+                                                                    styles.currencyLabel,
+                                                                    {
+                                                                        color: themeColor(
+                                                                            'text'
+                                                                        )
+                                                                    }
+                                                                ]}
+                                                            >
+                                                                {item}
+                                                            </Text>
+                                                            {[
+                                                                'BTC',
+                                                                'sats'
+                                                            ].includes(item) ? (
+                                                                <BitcoinIcon
+                                                                    height={20}
+                                                                    width={20}
+                                                                />
+                                                            ) : (
+                                                                <Svg
+                                                                    height="24"
+                                                                    width="24"
+                                                                >
+                                                                    <SvgText
+                                                                        fontSize="16"
+                                                                        x="0"
+                                                                        y="18"
+                                                                    >
+                                                                        {getFlagEmoji(
+                                                                            item
+                                                                        )}
+                                                                    </SvgText>
+                                                                </Svg>
+                                                            )}
+                                                        </View>
+                                                    }
                                                 />
                                             </Animated.View>
 
@@ -696,9 +704,7 @@ const styles = StyleSheet.create({
         alignItems: 'center'
     },
     inputBox: {
-        flex: 1,
-        flexDirection: 'row-reverse',
-        alignItems: 'center'
+        flex: 1
     },
     deleteIcon: {
         marginRight: 16,
@@ -712,5 +718,14 @@ const styles = StyleSheet.create({
     dragHandle: {
         marginLeft: 16,
         marginRight: 0
+    },
+    currencyTrailing: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8
+    },
+    currencyLabel: {
+        fontSize: 20,
+        fontFamily: 'PPNeueMontreal-Book'
     }
 });

--- a/components/CurrencyConverterContent.tsx
+++ b/components/CurrencyConverterContent.tsx
@@ -86,12 +86,16 @@ export default class CurrencyConverterContent extends React.Component<
     }
 
     componentDidMount() {
+        // Fetch rates on entry only if we don't already have them.
+        if (isEmpty(this.props.FiatStore?.fiatRates)) {
+            this.props.FiatStore?.getFiatRates?.();
+        }
         this.retrieveInputValues();
         this.addDefaultCurrenciesToStorage();
     }
 
     componentDidUpdate(
-        _prevProps: CurrencyConverterContentProps,
+        prevProps: CurrencyConverterContentProps,
         prevState: CurrencyConverterContentState
     ) {
         const { onInputValuesChanged } = this.props;
@@ -101,7 +105,26 @@ export default class CurrencyConverterContent extends React.Component<
         ) {
             onInputValuesChanged(Object.keys(this.state.inputValues).length);
         }
+        // Backfill  fields once rates arrive (e.g. user typed BTC before rates loaded).
+        if (
+            isEmpty(prevProps.FiatStore?.fiatRates) &&
+            !isEmpty(this.props.FiatStore?.fiatRates)
+        ) {
+            this.syncConversions();
+        }
     }
+
+    syncConversions = () => {
+        if (isEmpty(this.props.FiatStore?.fiatRates)) return;
+
+        const { inputValues } = this.state;
+        const source = Object.keys(inputValues).find(
+            (key) => inputValues[key].replace(/,/g, '').trim() !== ''
+        );
+        if (!source) return;
+
+        this.handleInputChange(inputValues[source], source);
+    };
 
     public addCurrency = (currency: string) => {
         this.handleCurrencySelect(currency);
@@ -135,7 +158,9 @@ export default class CurrencyConverterContent extends React.Component<
             }
 
             await Storage.setItem(CURRENCY_CODES_KEY, existingInputValues);
-            this.setState({ inputValues: existingInputValues });
+            this.setState({ inputValues: existingInputValues }, () => {
+                this.syncConversions();
+            });
         } catch (error) {
             console.error('Error adding default currencies:', error);
         }
@@ -154,7 +179,9 @@ export default class CurrencyConverterContent extends React.Component<
             const inputValuesString = await Storage.getItem(CURRENCY_CODES_KEY);
             if (inputValuesString) {
                 const inputValues = JSON.parse(inputValuesString);
-                this.setState({ inputValues });
+                this.setState({ inputValues }, () => {
+                    this.syncConversions();
+                });
             }
         } catch (error) {
             console.error('Error retrieving input values:', error);
@@ -168,6 +195,7 @@ export default class CurrencyConverterContent extends React.Component<
             const updatedInputValues = { ...inputValues, [currency]: '' };
             this.setState({ inputValues: updatedInputValues }, () => {
                 this.saveInputValues();
+                this.syncConversions();
             });
         }
     };
@@ -454,7 +482,7 @@ export default class CurrencyConverterContent extends React.Component<
                             <AddButton />
                         </Row>
                     )}
-                    {loading && (
+                    {loading && ratesNotFetched && (
                         <View style={{ flex: 1, padding: 15 }}>
                             <LoadingIndicator />
                         </View>

--- a/components/TextInput.tsx
+++ b/components/TextInput.tsx
@@ -39,6 +39,7 @@ interface TextInputProps {
     onFocus?: any;
     onBlur?: any;
     onSubmitEditing?: () => void;
+    trailing?: React.ReactNode;
 }
 
 const TextInput = React.forwardRef<TextInputRN, TextInputProps>(
@@ -64,10 +65,10 @@ const TextInput = React.forwardRef<TextInputRN, TextInputProps>(
             suffix,
             toggleUnits,
             onPressIn,
-            right,
             error,
             onFocus,
-            onBlur
+            onBlur,
+            trailing
         } = props;
         const defaultStyle = numberOfLines
             ? {
@@ -110,15 +111,17 @@ const TextInput = React.forwardRef<TextInputRN, TextInputProps>(
                     toggleUnits
                         ? {
                               ...styles.unit,
+                              flexShrink: 0,
+                              marginLeft: 8,
                               paddingLeft: 5,
                               paddingRight: 5,
-                              right: right || 45,
                               color: themeColor('text'),
                               backgroundColor: themeColor('background')
                           }
                         : {
                               ...styles.unit,
-                              right: right || 45,
+                              flexShrink: 0,
+                              marginLeft: 8,
                               color: themeColor('text')
                           }
                 }
@@ -164,6 +167,8 @@ const TextInput = React.forwardRef<TextInputRN, TextInputProps>(
                     style={{
                         ...StyleSheet.flatten(textInputStyle),
                         ...styles.input,
+                        flex: 1,
+                        minWidth: 0,
                         color:
                             textColor ||
                             (locked
@@ -197,6 +202,9 @@ const TextInput = React.forwardRef<TextInputRN, TextInputProps>(
                         <Suffix />
                     )
                 ) : null}
+                {trailing ? (
+                    <View style={styles.trailing}>{trailing}</View>
+                ) : null}
             </View>
         );
     }
@@ -221,8 +229,13 @@ const styles = StyleSheet.create({
     },
     input: {
         fontSize: 20,
-        width: '100%',
         fontFamily: 'PPNeueMontreal-Book'
+    },
+    trailing: {
+        flexShrink: 0,
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginLeft: 8
     }
 });
 

--- a/components/TextInput.tsx
+++ b/components/TextInput.tsx
@@ -33,7 +33,6 @@ interface TextInputProps {
     suffix?: string;
     toggleUnits?: any;
     onPressIn?: any;
-    right?: number;
     ref?: React.Ref<TextInputRN>;
     error?: boolean;
     onFocus?: any;

--- a/views/LightningAddress/WebPortalPOS.tsx
+++ b/views/LightningAddress/WebPortalPOS.tsx
@@ -331,7 +331,6 @@ export default class WebPortalPOS extends React.Component<
                                         });
                                     }}
                                     suffix="%"
-                                    right={20}
                                 />
                             </View>
                             <ListItem

--- a/views/Order.tsx
+++ b/views/Order.tsx
@@ -1019,7 +1019,6 @@ export default class OrderView extends React.Component<OrderProps, OrderState> {
                                     <TextInput
                                         suffix="%"
                                         keyboardType="numeric"
-                                        right={25}
                                         placeholder={
                                             DEFAULT_CUSTOM_TIP_PERCENTAGE
                                         }

--- a/views/POS/ProductDetails.tsx
+++ b/views/POS/ProductDetails.tsx
@@ -407,7 +407,6 @@ export default class ProductDetails extends React.Component<
                                                 );
                                             }}
                                             suffix="%"
-                                            right={20}
                                             style={styles.textInput}
                                         />
                                         <DropdownSetting

--- a/views/Settings/PointOfSale.tsx
+++ b/views/Settings/PointOfSale.tsx
@@ -488,7 +488,6 @@ export default class PointOfSale extends React.Component<
                                         });
                                     }}
                                     suffix="%"
-                                    right={20}
                                 />
                             </>
                         )}


### PR DESCRIPTION
# Description

This PR fixes two Currency Converter issues and improves the shared TextInput layout used by the converter.

1. Empty fiat fields on initial render
Fiat fields (e.g. USD) could appear empty on first open, even when BTC and sats already had values.

Previously, fiat conversion only ran inside handleInputChange during user input. BTC ↔ sats conversion worked immediately because it does not depend on exchange rates, but fiat conversion requires fiatRates from FiatStore. If rates were not yet loaded when the screen opened—or when values were restored from storage—fiat fields stayed blank and were never backfilled.

2. Long amounts overlapping currency labels
Very long BTC/sats values could render behind the BTC label and Bitcoin icon because the amount, label, and icon were absolutely positioned on top of each other.  Here is a screenshot : 

<img width="414" height="147" alt="Screenshot 2026-06-17 at 12 46 45 PM" src="https://github.com/user-attachments/assets/41cd3391-9048-4025-8c0b-9caba665df9d" />


## Changes

components/CurrencyConverterContent.tsx

- Fetch exchange rates on screen entry only when rates are not already available
- Add syncConversions() to reuse existing conversion logic and backfill fiat values once rates load or stored values are restored
- Trigger sync after loading saved values, initialising default currencies, and adding a new currency
- Show the loading indicator only when rates are missing, avoiding unnecessary loading UI when values are already populated
- Move currency code and icon into a TextInput trailing slot so long amounts no longer overlap labels 

components/TextInput.tsx

- Add optional trailing prop for fixed right-side content (label, icon, etc.)
- Lay out input, suffix, and trailing in a flex row (flex: 1 + minWidth: 0 on input)
- Render suffix in normal flex flow instead of absolute positioning 


After Changes Screen Recording : 

https://github.com/user-attachments/assets/e236a7a2-202d-4c1c-bf69-dbe892d579f4


 

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
