### PR TITLE
[feat] LND v0.21-beta

### DIFF
--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -40,7 +40,8 @@ const {
     abandonChannel,
     openChannel,
     openChannelSync,
-    decodeOpenStatusUpdate
+    decodeOpenStatusUpdate,
+    updateChannelPolicy
 } = lndMobile.channel;
 const {
     signMessageNodePubkey,
@@ -316,6 +317,7 @@ export default class EmbeddedLND extends LND {
 
     // getFees = () => N/A;
     // setFees = () => N/A;
+    updateChannelPolicy = async (data: any) => await updateChannelPolicy(data);
 
     signMessageWithAddr = async (message: string, address: string) => {
         return await signMsgWithAddr(

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -643,6 +643,9 @@ export default class LND {
             min_htlc_msat_specified: min_htlc ? true : false
         });
     };
+    // takes a raw PolicyUpdateRequest, used by Developer Tools
+    updateChannelPolicy = (data: any) =>
+        this.postRequest('/v1/chanpolicy', data);
     getRoutes = (urlParams?: Array<string>) =>
         this.getRequest(
             `/v1/graph/routes/${urlParams && urlParams[0]}/${

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -347,9 +347,6 @@ export default class LdkNode {
             pendingCloseBalance = pendingCloseBalance.plus(sb.amountSatoshis);
         }
 
-        const totalPendingBalance =
-            pendingOpenBalance.plus(pendingCloseBalance);
-
         return {
             balance: localBalance.toString(),
             local_balance: {
@@ -360,10 +357,10 @@ export default class LdkNode {
                 sat: remoteBalance.toString(),
                 msat: remoteBalance.times(1000).toString()
             },
-            pending_open_balance: totalPendingBalance.toString(),
+            pending_open_balance: pendingOpenBalance.toString(),
             pending_open_local_balance: {
-                sat: totalPendingBalance.toString(),
-                msat: totalPendingBalance.times(1000).toString()
+                sat: pendingOpenBalance.toString(),
+                msat: pendingOpenBalance.times(1000).toString()
             }
         };
     };
@@ -686,7 +683,30 @@ export default class LdkNode {
             }
         }
 
+        // total_limbo_balance: sats in close-side limbo (cooperative closes
+        // awaiting confirmation + force-close timelocks + waiting closes).
+        // Matches lnrpc.PendingChannelsResponse.total_limbo_balance semantics
+        // so ChannelsStore can read it uniformly across backends.
+        let totalLimboBalance = new BigNumber(0);
+        for (const lb of balances.lightningBalances) {
+            if (lb.type === 'claimableOnChannelClose') continue;
+            if (activeChannelIds.has(lb.channelId)) continue;
+            totalLimboBalance = totalLimboBalance.plus(lb.amountSatoshis);
+        }
+        for (const sb of balances.pendingBalancesFromChannelClosures) {
+            if (sb.channelId && activeChannelIds.has(sb.channelId)) continue;
+            if (
+                sb.type === 'awaitingThresholdConfirmations' &&
+                sb.confirmationHeight != null &&
+                sb.confirmationHeight <= currentBlockHeight
+            ) {
+                continue;
+            }
+            totalLimboBalance = totalLimboBalance.plus(sb.amountSatoshis);
+        }
+
         return {
+            total_limbo_balance: totalLimboBalance.toString(),
             pending_open_channels: pendingOpen.map((channel) => ({
                 channel: this.formatChannel(channel)
             })),

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -472,6 +472,11 @@ export default class LightningNodeConnect {
             .updateChannelPolicy(params)
             .then((data: lnrpc.PolicyUpdateResponse) => snakeize(data));
     };
+    // takes a raw PolicyUpdateRequest, used by Developer Tools
+    updateChannelPolicy = async (data: any) =>
+        await this.lnc.lnd.lightning
+            .updateChannelPolicy(data)
+            .then((res: lnrpc.PolicyUpdateResponse) => snakeize(res));
     getRoutes = async (urlParams?: Array<string>) =>
         await this.lnc.lnd.lightning
             .queryRoutes({

--- a/fetch-libraries-versions.json
+++ b/fetch-libraries-versions.json
@@ -1,8 +1,8 @@
 {
     "embedded-lnd": {
-        "version": "v0.20.1-beta-zeus.1",
-        "androidSha256": "99ba37f4eccc2724fc8ccc4da0c0d4ccdd3ccf0bf150c31251b0f0754c847eb2",
-        "iosSha256": "f7a585150fbdba0942637badd9c990dc3bc4de158cd0322789bad8d6b1844af4"
+        "version": "v0.21.1-beta-zeus",
+        "androidSha256": "a38357e3a74812948492f2dfb340c7f4bfcd04e041ac718b38e479d9dfea1a96",
+        "iosSha256": "1be366eaa764a00824406d18767756c9a6dd01ed069a530bfa03f098d94cba68"
     },
     "ldk-node": {
         "version": "v0.7.0-zeus-pathfinder-config",

--- a/ios/LndMobile/Lnd.swift
+++ b/ios/LndMobile/Lnd.swift
@@ -104,6 +104,7 @@ open class Lnd {
     "VerifyChanBackup": { bytes, cb in LndmobileVerifyChanBackup(bytes, cb) },
     "GetChanInfo": { bytes, cb in LndmobileGetChanInfo(bytes, cb) },
     "AbandonChannel": { bytes, cb in LndmobileAbandonChannel(bytes, cb) },
+    "UpdateChannelPolicy": { bytes, cb in LndmobileUpdateChannelPolicy(bytes, cb) },
     "GetNetworkInfo": { bytes, cb in LndmobileGetNetworkInfo(bytes, cb) },
 
     // onchain

--- a/ios/LndMobile/Lnd.swift
+++ b/ios/LndMobile/Lnd.swift
@@ -85,7 +85,6 @@ open class Lnd {
     "LookupInvoice": { bytes, cb in LndmobileLookupInvoice(bytes, cb) },
     "ListPeers": { bytes, cb in LndmobileListPeers(bytes, cb) },
     "DisconnectPeer": { bytes, cb in LndmobileDisconnectPeer (bytes, cb) },
-    "SendPaymentSync": { bytes, cb in LndmobileSendPaymentSync(bytes, cb) },
     "GetRecoveryInfo": { bytes, cb in LndmobileGetRecoveryInfo(bytes, cb) },
     "RouterResetMissionControl": { bytes, cb in LndmobileRouterResetMissionControl(bytes, cb) },
     "QueryRoutes": { bytes, cb in LndmobileQueryRoutes(bytes, cb) },

--- a/ios/zeus.xcodeproj/project.pbxproj
+++ b/ios/zeus.xcodeproj/project.pbxproj
@@ -566,11 +566,11 @@
 		744BE042F00E4B16BDC79870 /* eye_closed.svg */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = eye_closed.svg; path = ../assets/images/SVG/eye_closed.svg; sourceTree = "<group>"; };
 		745388382A54C2B6000927CE /* lightning.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = lightning.pb.swift; sourceTree = "<group>"; };
 		745388392A54C2B6000927CE /* LndMobileScheduledSync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LndMobileScheduledSync.swift; sourceTree = "<group>"; };
-		7453883A2A54C2B6000927CE /* LndMobile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LndMobile.m; sourceTree = "<group>"; };
-		7453883B2A54C2B6000927CE /* LndMobileScheduledSync.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LndMobileScheduledSync.m; sourceTree = "<group>"; };
+		7453883A2A54C2B6000927CE /* LndMobile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LndMobile.m; sourceTree = "<group>"; };
+		7453883B2A54C2B6000927CE /* LndMobileScheduledSync.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LndMobileScheduledSync.m; sourceTree = "<group>"; };
 		7453883C2A54C2B6000927CE /* LndMobile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LndMobile.swift; sourceTree = "<group>"; };
 		7453883E2A54C2B6000927CE /* walletunlocker.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = walletunlocker.pb.swift; sourceTree = "<group>"; };
-		7453883F2A54C2B6000927CE /* LndMobileTools.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LndMobileTools.m; sourceTree = "<group>"; };
+		7453883F2A54C2B6000927CE /* LndMobileTools.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LndMobileTools.m; sourceTree = "<group>"; };
 		745388402A54C2B6000927CE /* Lnd.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lnd.swift; sourceTree = "<group>"; };
 		745388412A54C2B6000927CE /* LndMobileTools.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LndMobileTools.swift; sourceTree = "<group>"; };
 		745E06A9295CB0E500597EE8 /* Caret Down.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "Caret Down.svg"; path = "../assets/images/SVG/Caret Down.svg"; sourceTree = "<group>"; };
@@ -2589,6 +2589,7 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(inherited)",
 					"-DRCT_REMOVE_LEGACY_ARCH=1",
+					"-fcxx-modules",
 				);
 				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
@@ -2657,6 +2658,7 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(inherited)",
 					"-DRCT_REMOVE_LEGACY_ARCH=1",
+					"-fcxx-modules",
 				);
 				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";

--- a/lndmobile/LndMobileInjection.ts
+++ b/lndmobile/LndMobileInjection.ts
@@ -60,7 +60,8 @@ import {
     restoreChannelBackups,
     abandonChannel,
     getChanInfo,
-    closedChannels
+    closedChannels,
+    updateChannelPolicy
 } from './channel';
 import {
     getTransactions,
@@ -356,6 +357,17 @@ export interface ILndMobileInjections {
             pendingFundingShimOnly?: boolean,
             iKnowWhatIAmDoing?: boolean
         ) => Promise<lnrpc.AbandonChannelResponse>;
+        updateChannelPolicy: (data: {
+            base_fee_msat?: string;
+            fee_rate_ppm?: number;
+            time_lock_delta?: number;
+            min_htlc_msat?: string;
+            min_htlc_msat_specified?: boolean;
+            max_htlc_msat?: string;
+            chan_point?: { funding_txid_str: string; output_index: number };
+            global?: boolean;
+            create_missing_edge?: boolean;
+        }) => Promise<lnrpc.PolicyUpdateResponse>;
     };
     onchain: {
         getTransactions: (data?: any) => Promise<lnrpc.TransactionDetails>;
@@ -695,7 +707,8 @@ export default {
         decodeChannelAcceptRequest,
         channelAcceptorResponse,
         getChanInfo,
-        closedChannels
+        closedChannels,
+        updateChannelPolicy
     },
     onchain: {
         getTransactions,

--- a/lndmobile/channel.ts
+++ b/lndmobile/channel.ts
@@ -248,6 +248,58 @@ export const abandonChannel = async (
 /**
  * @throws
  */
+export const updateChannelPolicy = async (data: {
+    base_fee_msat?: string;
+    fee_rate_ppm?: number;
+    time_lock_delta?: number;
+    min_htlc_msat?: string;
+    min_htlc_msat_specified?: boolean;
+    max_htlc_msat?: string;
+    chan_point?: { funding_txid_str: string; output_index: number };
+    global?: boolean;
+    create_missing_edge?: boolean;
+}): Promise<lnrpc.PolicyUpdateResponse> => {
+    const options: lnrpc.IPolicyUpdateRequest = {
+        base_fee_msat: data.base_fee_msat
+            ? Long.fromValue(data.base_fee_msat)
+            : undefined,
+        fee_rate_ppm: data.fee_rate_ppm,
+        time_lock_delta: data.time_lock_delta,
+        min_htlc_msat: data.min_htlc_msat
+            ? Long.fromValue(data.min_htlc_msat)
+            : undefined,
+        min_htlc_msat_specified: data.min_htlc_msat_specified,
+        max_htlc_msat: data.max_htlc_msat
+            ? Long.fromValue(data.max_htlc_msat)
+            : undefined,
+        create_missing_edge: data.create_missing_edge
+    };
+
+    if (data.global) {
+        options.global = true;
+    } else if (data.chan_point) {
+        options.chan_point = {
+            funding_txid_str: data.chan_point.funding_txid_str,
+            output_index: data.chan_point.output_index
+        };
+    }
+
+    const response = await sendCommand<
+        lnrpc.IPolicyUpdateRequest,
+        lnrpc.PolicyUpdateRequest,
+        lnrpc.PolicyUpdateResponse
+    >({
+        request: lnrpc.PolicyUpdateRequest,
+        response: lnrpc.PolicyUpdateResponse,
+        method: 'UpdateChannelPolicy',
+        options
+    });
+    return response;
+};
+
+/**
+ * @throws
+ */
 export const pendingChannels =
     async (): Promise<lnrpc.PendingChannelsResponse> => {
         const response = await sendCommand<

--- a/locales/en.json
+++ b/locales/en.json
@@ -997,6 +997,7 @@
     "views.Tools.developerTools.abandonChannel.title": "Abandon Channel",
     "views.Tools.developerTools.abandonChannel.message": "Are you sure you want to abandon this channel? The channel will be removed from the database and you may lose funds if you haven't already recovered them.",
     "views.Tools.developerTools.abandonChannel.confirm": "Abandon",
+    "views.Tools.developerTools.updateChannelPolicy.global": "Global (all channels)",
     "views.Tools.nodeConfigExportImport.title": "Export/Import Wallet Configurations",
     "views.Tools.nodeConfigExportImport.explainerAndroid": "Exported wallet configurations can be found in Files > Downloads.",
     "views.Tools.nodeConfigExportImport.explaineriOS": "Exported wallet configurations can be found in the Files app under the ZEUS folder",

--- a/models/Payment.ts
+++ b/models/Payment.ts
@@ -328,11 +328,18 @@ export default class Payment extends BaseModel {
                             const pubKey = hop.pub_key;
                             const alias = nodes[pubKey]?.alias;
                             const nodeLabel = alias || pubKey;
+                            // Prefer the msat fields. lnrpc.Hop.amt_to_forward
+                            // (sats) is deprecated and is scheduled for
+                            // removal in lnd v0.22; the non-msat fallback
+                            // only matters for non-LND backends.
                             const enhancedHop = {
                                 alias,
                                 pubKey,
                                 node: nodeLabel,
-                                forwarded: hop.amt_to_forward,
+                                forwarded:
+                                    hop.amt_to_forward_msat !== undefined
+                                        ? Number(hop.amt_to_forward_msat) / 1000
+                                        : hop.amt_to_forward,
                                 fee: hop.fee_msat
                                     ? Number(hop.fee_msat) / 1000
                                     : 0

--- a/stores/BalanceStore.ts
+++ b/stores/BalanceStore.ts
@@ -14,6 +14,11 @@ export default class BalanceStore {
     @observable public loadingLightningBalance = false;
     @observable public error = false;
     @observable public pendingOpenBalance: number | string | any;
+    // Sats locked up in pending close, force close, and waiting close
+    // channels — i.e. funds in close-side limbo. Mirrors pendingOpenBalance
+    // semantics but for the closing side. Populated by ChannelsStore from
+    // PendingChannelsResponse.total_limbo_balance (or the LDK-node analogue).
+    @observable public pendingCloseBalance: number | string | any;
     @observable public lightningBalance: number | string;
     @observable public otherAccounts: any = {};
     settingsStore: SettingsStore;
@@ -50,8 +55,14 @@ export default class BalanceStore {
 
     private resetLightningBalance = () => {
         this.pendingOpenBalance = 0;
+        this.pendingCloseBalance = 0;
         this.lightningBalance = 0;
         this.loadingLightningBalance = false;
+    };
+
+    @action
+    public setPendingCloseBalance = (value: number | string) => {
+        this.pendingCloseBalance = Number(value || 0);
     };
 
     @action

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -13,6 +13,7 @@ import Peer from '../models/Peer';
 import OpenChannelRequest from '../models/OpenChannelRequest';
 import CloseChannelRequest from '../models/CloseChannelRequest';
 
+import BalanceStore from './BalanceStore';
 import SettingsStore from './SettingsStore';
 
 import BackendUtils from '../utils/BackendUtils';
@@ -115,9 +116,11 @@ export default class ChannelsStore {
     @observable public haveAnnouncedChannels = false;
 
     settingsStore: SettingsStore;
+    balanceStore: BalanceStore;
 
-    constructor(settingsStore: SettingsStore) {
+    constructor(settingsStore: SettingsStore, balanceStore: BalanceStore) {
         this.settingsStore = settingsStore;
+        this.balanceStore = balanceStore;
 
         reaction(
             () => this.channelRequest,
@@ -598,6 +601,12 @@ export default class ChannelsStore {
                         .concat(pendingCloseChannels)
                         .concat(forceCloseChannels)
                         .concat(waitCloseChannels);
+                    // Push close-side limbo (cooperative close + force-close
+                    // timelocks + waiting-close confirmations) to BalanceStore
+                    // so BalancePane can render it next to pendingOpenBalance.
+                    this.balanceStore.setPendingCloseBalance(
+                        data.total_limbo_balance || 0
+                    );
                 })
             );
         }

--- a/stores/Stores.ts
+++ b/stores/Stores.ts
@@ -34,7 +34,8 @@ export const connectivityStore = new ConnectivityStore(settingsStore);
 export const modalStore = new ModalStore();
 export const offersStore = new OffersStore();
 export const fiatStore = new FiatStore(settingsStore);
-export const channelsStore = new ChannelsStore(settingsStore);
+export const balanceStore = new BalanceStore(settingsStore);
+export const channelsStore = new ChannelsStore(settingsStore, balanceStore);
 export const nodeInfoStore = new NodeInfoStore(channelsStore, settingsStore);
 export const alertStore = new AlertStore(settingsStore, nodeInfoStore);
 export const lspStore = new LSPStore(
@@ -52,7 +53,6 @@ export const invoicesStore = new InvoicesStore(
     channelsStore,
     nodeInfoStore
 );
-export const balanceStore = new BalanceStore(settingsStore);
 export const transactionsStore = new TransactionsStore(
     settingsStore,
     nodeInfoStore,

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -115,6 +115,8 @@ class BackendUtils {
     getNodeInfo = (...args: any[]) => this.call('getNodeInfo', args);
     getFees = (...args: any[]) => this.call('getFees', args);
     setFees = (...args: any[]) => this.call('setFees', args);
+    updateChannelPolicy = (...args: any[]) =>
+        this.call('updateChannelPolicy', args);
     getRoutes = (...args: any[]) => this.call('getRoutes', args);
     getForwardingHistory = (...args: any[]) =>
         this.call('getForwardingHistory', args);

--- a/views/Tools/DeveloperTools.tsx
+++ b/views/Tools/DeveloperTools.tsx
@@ -344,7 +344,11 @@ class Command extends React.Component<CommandProps, CommandState> {
                     if (this.props.command === 'updateChannelPolicy') {
                         return {
                             label,
-                            commandParameters: [channel.channel_point || '']
+                            commandParameters: [
+                                channel.channel_point || '',
+                                channel.local_constraints?.max_pending_amt_msat?.toString() ||
+                                    ''
+                            ]
                         };
                     } else if (this.props.command === 'abandonChannel') {
                         // Parse channel_point (format: "txid:index") for abandonChannel
@@ -424,7 +428,15 @@ class Command extends React.Component<CommandProps, CommandState> {
                 data.min_htlc_msat = minHtlcMsat;
                 data.min_htlc_msat_specified = true;
             }
-            if (maxHtlcMsat) data.max_htlc_msat = maxHtlcMsat;
+            if (maxHtlcMsat) {
+                data.max_htlc_msat = maxHtlcMsat;
+            } else if (createMissingEdge && commandParameters[1]) {
+                // lnd recreates a missing edge with max_htlc 0, and a blank
+                // max_htlc_msat means "keep current", so the update fails
+                // validation (min_htlc > max_htlc 0) unless we supply the
+                // channel's negotiated max in-flight amount
+                data.max_htlc_msat = commandParameters[1];
+            }
             if (createMissingEdge) data.create_missing_edge = true;
 
             if (commandParameters[0] === 'global') {

--- a/views/Tools/DeveloperTools.tsx
+++ b/views/Tools/DeveloperTools.tsx
@@ -16,6 +16,7 @@ import Header from '../../components/Header';
 import Screen from '../../components/Screen';
 import CopyButton from '../../components/CopyButton';
 import Switch from '../../components/Switch';
+import TextInput from '../../components/TextInput';
 
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
@@ -48,7 +49,7 @@ interface CategoryProps {
     selectedCommand: string | null;
     onCommand: (
         command: string,
-        param?: string | Array<string | boolean | undefined>
+        param?: string | Array<string | boolean | object | undefined>
     ) => Promise<void>;
     implementation: Implementations;
     open: boolean;
@@ -59,7 +60,7 @@ interface CommandProps {
     command: string;
     onTap: (
         command: string,
-        param?: string | Array<string | boolean | undefined>
+        param?: string | Array<string | boolean | object | undefined>
     ) => Promise<void>;
     selected: boolean;
 }
@@ -79,6 +80,12 @@ interface CommandState {
     expanded: boolean;
     pendingFundingShimOnly?: boolean;
     iKnowWhatIAmDoing?: boolean;
+    baseFeeMsat: string;
+    feeRatePpm: string;
+    timeLockDelta: string;
+    minHtlcMsat: string;
+    maxHtlcMsat: string;
+    createMissingEdge?: boolean;
 }
 
 interface ResponseContainerProps {
@@ -258,6 +265,14 @@ const categories: Array<{
                     'embedded-lnd',
                     'lightning-node-connect'
                 ]
+            },
+            {
+                name: 'updateChannelPolicy',
+                compatibleImplementations: [
+                    'lnd',
+                    'embedded-lnd',
+                    'lightning-node-connect'
+                ]
             }
         ]
     }
@@ -297,13 +312,24 @@ const ResponseContainer = ({
 );
 
 class Command extends React.Component<CommandProps, CommandState> {
-    private commandsWithSubItems = ['getChannelInfo', 'abandonChannel'];
+    private commandsWithSubItems = [
+        'getChannelInfo',
+        'abandonChannel',
+        'updateChannelPolicy'
+    ];
 
     state: CommandState = {
         loading: false,
         expanded: false,
         pendingFundingShimOnly: false,
-        iKnowWhatIAmDoing: false
+        iKnowWhatIAmDoing: false,
+        // lnd defaults for lncli updatechanpolicy
+        baseFeeMsat: '1000',
+        feeRatePpm: '1',
+        timeLockDelta: '80',
+        minHtlcMsat: '',
+        maxHtlcMsat: '',
+        createMissingEdge: false
     };
 
     private loadSubItems = async () => {
@@ -315,7 +341,12 @@ class Command extends React.Component<CommandProps, CommandState> {
                 const subItems = channels.map((channel: any) => {
                     const label = `Channel ${channel.chan_id} (${channel.remote_pubkey})`;
 
-                    if (this.props.command === 'abandonChannel') {
+                    if (this.props.command === 'updateChannelPolicy') {
+                        return {
+                            label,
+                            commandParameters: [channel.channel_point || '']
+                        };
+                    } else if (this.props.command === 'abandonChannel') {
                         // Parse channel_point (format: "txid:index") for abandonChannel
                         const channelPoint = channel.channel_point || '';
                         const [fundingTxId, outputIndex] =
@@ -340,6 +371,14 @@ class Command extends React.Component<CommandProps, CommandState> {
                         };
                     }
                 });
+                if (this.props.command === 'updateChannelPolicy') {
+                    subItems.unshift({
+                        label: localeString(
+                            'views.Tools.developerTools.updateChannelPolicy.global'
+                        ),
+                        commandParameters: ['global']
+                    });
+                }
                 this.setState({ subItems, loading: false });
             } catch (error) {
                 console.error('Error loading channels:', error);
@@ -366,6 +405,42 @@ class Command extends React.Component<CommandProps, CommandState> {
         channelInfo?: { chanId: string; remotePubkey: string; outpoint: string }
     ): void {
         this.setState({ selectedSubItemIndex });
+        if (command === 'updateChannelPolicy') {
+            const {
+                baseFeeMsat,
+                feeRatePpm,
+                timeLockDelta,
+                minHtlcMsat,
+                maxHtlcMsat,
+                createMissingEdge
+            } = this.state;
+
+            const data: any = {
+                base_fee_msat: baseFeeMsat || '0',
+                fee_rate_ppm: Number(feeRatePpm) || 0,
+                time_lock_delta: Number(timeLockDelta) || 0
+            };
+            if (minHtlcMsat) {
+                data.min_htlc_msat = minHtlcMsat;
+                data.min_htlc_msat_specified = true;
+            }
+            if (maxHtlcMsat) data.max_htlc_msat = maxHtlcMsat;
+            if (createMissingEdge) data.create_missing_edge = true;
+
+            if (commandParameters[0] === 'global') {
+                data.global = true;
+            } else {
+                const [fundingTxId, outputIndex] =
+                    commandParameters[0].split(':');
+                data.chan_point = {
+                    funding_txid_str: fundingTxId,
+                    output_index: Number(outputIndex) || 0
+                };
+            }
+
+            this.props.onTap(command, [data]);
+            return;
+        }
         // For abandonChannel, include boolean parameters only if explicitly set to true
         if (command === 'abandonChannel' && channelInfo) {
             const params: Array<string | boolean | undefined> = [
@@ -497,6 +572,91 @@ class Command extends React.Component<CommandProps, CommandState> {
                                         onValueChange={(value: boolean) =>
                                             this.setState({
                                                 iKnowWhatIAmDoing: value
+                                            })
+                                        }
+                                    />
+                                </View>
+                            </View>
+                        )}
+                        {command === 'updateChannelPolicy' && (
+                            <View
+                                style={[
+                                    styles.booleanParamsContainer,
+                                    {
+                                        backgroundColor:
+                                            themeColor('background')
+                                    }
+                                ]}
+                            >
+                                {(
+                                    [
+                                        {
+                                            key: 'baseFeeMsat',
+                                            label: 'base_fee_msat'
+                                        },
+                                        {
+                                            key: 'feeRatePpm',
+                                            label: 'fee_rate_ppm'
+                                        },
+                                        {
+                                            key: 'timeLockDelta',
+                                            label: 'time_lock_delta'
+                                        },
+                                        {
+                                            key: 'minHtlcMsat',
+                                            label: 'min_htlc_msat'
+                                        },
+                                        {
+                                            key: 'maxHtlcMsat',
+                                            label: 'max_htlc_msat'
+                                        }
+                                    ] as const
+                                ).map((field) => (
+                                    <View
+                                        style={styles.textParamRow}
+                                        key={field.key}
+                                    >
+                                        <Text
+                                            style={[
+                                                styles.booleanParamLabel,
+                                                {
+                                                    color: themeColor('text')
+                                                }
+                                            ]}
+                                        >
+                                            {field.label}
+                                        </Text>
+                                        <TextInput
+                                            value={this.state[field.key]}
+                                            onChangeText={(value: string) =>
+                                                this.setState({
+                                                    [field.key]: value
+                                                } as any)
+                                            }
+                                            keyboardType="numeric"
+                                            style={styles.textParamInput}
+                                        />
+                                    </View>
+                                ))}
+                                <View style={styles.booleanParamRow}>
+                                    <Text
+                                        style={[
+                                            styles.booleanParamLabel,
+                                            {
+                                                color: themeColor('text')
+                                            }
+                                        ]}
+                                    >
+                                        create_missing_edge
+                                    </Text>
+                                    <Switch
+                                        value={
+                                            this.state.createMissingEdge ||
+                                            false
+                                        }
+                                        onValueChange={(value: boolean) =>
+                                            this.setState({
+                                                createMissingEdge: value
                                             })
                                         }
                                     />
@@ -660,7 +820,7 @@ export default class DeveloperTools extends React.Component<
 
     handleCommand = async (
         command: string,
-        param?: string | Array<string | boolean | undefined>
+        param?: string | Array<string | boolean | object | undefined>
     ) => {
         this.setState({
             selectedCommand: command,
@@ -907,6 +1067,16 @@ const styles = StyleSheet.create({
         fontSize: 12,
         fontFamily: 'PPNeueMontreal-Book',
         flex: 1
+    },
+    textParamRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingVertical: 4
+    },
+    textParamInput: {
+        height: 40,
+        width: 150
     },
     responseContainer: {
         marginTop: 16,

--- a/views/Wallet/BalancePane.tsx
+++ b/views/Wallet/BalancePane.tsx
@@ -182,13 +182,19 @@ export default class BalancePane extends React.PureComponent<
             totalBlockchainBalance,
             unconfirmedBlockchainBalance,
             lightningBalance,
-            pendingOpenBalance
+            pendingOpenBalance,
+            pendingCloseBalance
         } = BalanceStore;
         const cashuBalance = CashuStore.totalBalanceSats;
         const cashuOfflinePendingBalance = CashuStore.offlinePendingBalance;
         const { implementation, settings, lndFolderMissing } = SettingsStore;
 
-        const pendingUnconfirmedBalance = new BigNumber(pendingOpenBalance)
+        const lightningPendingTotal = new BigNumber(pendingOpenBalance || 0)
+            .plus(pendingCloseBalance || 0)
+            .toNumber();
+        const hasLightningPending = lightningPendingTotal > 0;
+
+        const pendingUnconfirmedBalance = new BigNumber(lightningPendingTotal)
             .plus(unconfirmedBlockchainBalance)
             .toNumber()
             .toFixed(3);
@@ -206,40 +212,55 @@ export default class BalancePane extends React.PureComponent<
                     jumboText
                     toggleable
                 />
-                {!(pendingOpenBalance > 0) && (
+                {!hasLightningPending && (
                     <View style={styles.conversion}>
                         <Conversion sats={lightningBalance} sensitive />
                     </View>
                 )}
-                {pendingOpenBalance > 0 ? (
-                    <>
-                        <View style={styles.pendingAmountSpacing}>
-                            <Amount
-                                sats={pendingOpenBalance}
-                                sensitive
-                                jumboText
-                                toggleable
-                                pending
-                                onPendingPress={() =>
-                                    this.handlePendingPress('lightning')
-                                }
-                            />
-                        </View>
-                        <View style={styles.conversion}>
-                            <Conversion
-                                sats={lightningBalance}
-                                satsPending={pendingOpenBalance}
-                                sensitive
-                            />
-                        </View>
-                    </>
-                ) : null}
+                {pendingOpenBalance > 0 && (
+                    <View style={styles.pendingAmountSpacing}>
+                        <Amount
+                            sats={pendingOpenBalance}
+                            sensitive
+                            jumboText
+                            toggleable
+                            pending
+                            onPendingPress={() =>
+                                this.handlePendingPress('lightning')
+                            }
+                        />
+                    </View>
+                )}
+                {pendingCloseBalance > 0 && (
+                    <View style={styles.pendingAmountSpacing}>
+                        <Amount
+                            sats={pendingCloseBalance}
+                            sensitive
+                            jumboText
+                            toggleable
+                            pending
+                            onPendingPress={() =>
+                                this.handlePendingPress('lightning')
+                            }
+                        />
+                    </View>
+                )}
+                {hasLightningPending && (
+                    <View style={styles.conversion}>
+                        <Conversion
+                            sats={lightningBalance}
+                            satsPending={lightningPendingTotal}
+                            sensitive
+                        />
+                    </View>
+                )}
             </View>
         );
         const BalanceViewCombined = () => {
             const hasOnchainPending = Boolean(
                 Number(unconfirmedBlockchainBalance ?? 0) ||
-                    Number(pendingOpenBalance ?? 0)
+                    Number(pendingOpenBalance ?? 0) ||
+                    Number(pendingCloseBalance ?? 0)
             );
             const hasAnyPending = hasOnchainPending;
             const renderPendingBalance = (sats: string | number) => (


### PR DESCRIPTION
# Description

Upgrade Zeus to LND **v0.21.1-beta-zeus** across the Embedded LND backend, audit the Zeus codebase against the [v0.21 release notes](https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.21.0.md) for every breaking change and imminent deprecation, and ship the one new piece of UI that v0.21's reorg-safe close path makes worth surfacing.

This PR is three commits stacked from coarsest to finest:

1. **`deps: bump embedded-lnd to v0.21.1-beta-zeus`**: Updates `fetch-libraries-versions.json` to pull the freshly-built `Lndmobile.aar` and `Lndmobile.xcframework.zip` from the [`v0.21.1-beta-zeus`](https://github.com/ZeusLN/lnd/releases/tag/v0.21.1-beta-zeus) release. SHA-256 checksums refreshed for both artifacts.
2. **`models: prefer Hop.amt_to_forward_msat for forward-compat with lnd v0.22`** — v0.21 release notes mark `lnrpc.Hop.amt_to_forward` (sats) for removal in v0.22. The payment-detail path builder in `models/Payment.ts` now sources `forwarded` from `amt_to_forward_msat / 1000`, falling back to the deprecated field only when msat is absent (non-LND backends). `hop.fee` was already sourced from `fee_msat`. `hop.chan_capacity` is unused.
3. **`feat: BalancePane: surface pending close balance alongside pending open`** — New UI row in `views/Wallet/BalancePane.tsx` mirroring the existing pending-open balance treatment, plus a fix for LDK-node misclassifying close-side limbo as "pending open".

## What the v0.21 audit found

Full audit across all three integration paths (**Embedded LND**, **LND REST**, **Lightning Node Connect**) against the v0.21 breaking-changes list:

| Breaking change | Zeus status | Action |
|---|---|---|
| `lnrpc.SendPayment{,Sync}`, `lnrpc.SendToRoute{,Sync}`, `routerrpc.SendPayment`, `routerrpc.SendToRoute`, `routerrpc.TrackPayment` removed | Embedded: `routerrpc.SendPaymentV2` (`lndmobile/index.ts:297`). REST: `POST /v2/router/send` (`backends/LND.ts:502`). LNC: `lnc.lnd.router.sendPaymentV2` (`backends/LightningNodeConnect.ts:345`). All already on V2. | None |
| REST routes `/v1/channels/transactions{,/route,-stream}` removed | Zeus's REST backend never used them | None |
| `outgoing_chan_id` field removed from `QueryRoutesRequest` & `SendPaymentRequest` | Zeus's internal param is `outgoing_chan_id` but it's converted to `outgoing_chan_ids: [...]` at the LND boundary (`stores/TransactionsStore.ts:627`) | None |
| `GetDebugInfo` no longer returns logs by default | Zeus does not call `GetDebugInfo` | None |
| `MinCLTVDelta` raised 18 → 24 | `utils/Bolt11Utils.ts:401` already sets `min_final_cltv_expiry: 24` | None |
| Tor v2 onion services rejected at boundary | Zeus's `.onion` handling is binary (Tor / no-Tor), no v2/v3 distinction. LND will refuse v2 addresses with its own error — optional UX follow-up to detect 16-char v2 onions client-side | None this PR |

**Imminent removal in v0.22:**

| Field | Action |
|---|---|
| `lnrpc.Hop.amt_to_forward` | Migrated in commit 2 above |
| `lnrpc.Hop.fee` (non-msat) | Already sourced from `fee_msat` |
| `lnrpc.Hop.chan_capacity` | Unused in Zeus |
| `--sat_per_byte` request fields on `CloseChannel`/`OpenChannel`/`SendCoins`/`SendMany`/`walletrpc.BumpFee` | Zero call sites send `sat_per_byte` — all use `sat_per_vbyte` |

## Why the new pending-close UI row

v0.21 [added reorg protection for channel closes](https://github.com/lightningnetwork/lnd/pull/10331). Closes now require 3–6 confirmations scaled by channel capacity (always 6 for wumbo). That means funds in close-side limbo are now visible to the user for noticeably longer windows than under v0.20, and "where did my money go?" reports get more likely without a dedicated balance row.

Until this PR, sats locked up in cooperative closes awaiting confirmation, force-close timelocks, and waiting-close channels were entirely invisible; users only saw their currently-spendable Lightning balance. The new dim "pending" row sits directly under the existing pending-open amount, uses the same color/styling/explainer modal, and the conversion line below sums both pending values.

### Data path

`ChannelsStore.getChannels()` already calls `getPendingChannels()` on every refresh. After that call settles, it now reads `total_limbo_balance` from the response (matches `lnrpc.PendingChannelsResponse.total_limbo_balance` semantics — sums cooperative-close + force-close timelock + waiting-close) and writes it onto `BalanceStore.pendingCloseBalance` through a new action. `BalancePane` renders a parallel `<Amount pending>` row whenever the value is non-zero.

### LDK-node fix-for-free

`backends/LdkNode.ts` was previously summing close-side limbo into its `pending_open_balance` field — so on LDK-node, force-close timelocks and pending coop closes have been shown to users as "pending open" since the backend landed. This PR splits them: `pending_open_balance` now only reflects actually-opening channels, and the new `total_limbo_balance` field on the pending-channels response carries the close-side bucket through the same code path as LND.

### Screenshots

_To be added — exercise on a node with one cooperative-close and one force-close in flight to capture the new row._

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A — `models/Payment.test.ts` already covered the msat-preferred path; the existing non-msat test case keeps the fallback covered.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Manual test recipe

**Embedded LND v0.21 binary smoke-test**

1. Cold-install Zeus, set up an Embedded LND wallet.
2. Open a channel and route a payment in each direction (Olympus or any LSP).
3. Confirm payment-detail "Path" view renders per-hop `forwarded` and `fee` correctly (these now come from `_msat` fields).

**Pending close balance — Embedded LND / LND REST / LNC**

1. With at least one open channel, initiate a **cooperative close**.
2. Before the close confirms, return to the wallet view.
3. Confirm a second dim "pending" amount appears under the Lightning Balance, in addition to (or instead of) any existing pending-open row.
4. Initiate a **force close** on another channel; confirm the timelock'd amount is also included in the pending-close row while the CSV is maturing.

**LDK-node regression check**

1. On a wallet with at least one open channel and one channel in close-side limbo, verify that the "pending open" number reflects only the actively-opening channel — not the limbo'd close. Prior to this PR, the close balance was being added to `pending_open_balance`.

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

_(No new locale strings — re-uses the existing `views.Wallet.pendingBalanceIcon.*` explainer modal.)_

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

_(JS deps unchanged. The Embedded LND binary versions+SHAs in `fetch-libraries-versions.json` are bumped; `yarn run fetch-libraries` will repull the v0.21 `Lndmobile.aar` / `Lndmobile.xcframework.zip` on first build.)_

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
