### PR TITLE
fix(lnurl): decode percent-encoded characters in LNURL pay memo (#1717)

### DIFF
--- a/views/LnurlPay/Metadata.tsx
+++ b/views/LnurlPay/Metadata.tsx
@@ -20,9 +20,21 @@ export default class LnurlPayMetadata extends React.Component<LnurlPayMetadataPr
         } catch (err) {
             keypairs = [];
         }
-        const text: string = keypairs
+        const rawText: string = keypairs
             .filter(([typ]: any) => typ === 'text/plain')
             .map(([, content]: any) => content)[0];
+
+        // Some LNURL pay servers percent-encode the description (e.g. spaces as
+        // %20). Decode it for display, falling back to the raw value if it isn't
+        // valid percent-encoding (e.g. a literal "%").
+        let text: string = rawText;
+        if (rawText) {
+            try {
+                text = decodeURI(rawText);
+            } catch {
+                text = rawText;
+            }
+        }
 
         const image: string = keypairs
             .filter(([typ]: any) => typ.slice(0, 6) === 'image/')


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-#1717**

Some LNURL-pay servers percent-encode the `text/plain` description in their
metadata (e.g. a space is sent as `%20`). ZEUS rendered that raw string verbatim,
so the memo showed up as `Pay%20to%20Alice` instead of `Pay to Alice` on the
LNURL pay screen.

This PR decodes the `text/plain` metadata for display:

- Read the raw `text/plain` value into `rawText`.
- Run it through `decodeURI(...)` for display.
- Fall back to the raw value if decoding throws — this keeps memos that contain a
  bare `%` (invalid percent-encoding) rendering safely instead of crashing.

```ts
let text: string = rawText;
if (rawText) {
    try {
        text = decodeURI(rawText);
    } catch {
        text = rawText;
    }
}
```

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
