### PR TITLE
fix(tor): honor certVerification for LND/CLN REST over Tor (#4178)

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -70,7 +70,12 @@ export default class CLNRest {
                     url,
                     method as RequestMethod,
                     JSON.stringify(data),
-                    headers
+                    headers,
+                    // Tor v3 .onion authenticates the endpoint at the
+                    // protocol layer, and the upstream daemon's self-signed
+                    // cert can't match an .onion hostname, so TLS validation
+                    // here is always redundant.
+                    true
                 ).then((response: any) => {
                     calls.delete(id);
                     return response;

--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -15,7 +15,11 @@ import {
 } from './CoreLightningRequestHandler';
 import { localeString } from '../utils/LocaleUtils';
 import ReactNativeBlobUtil from 'react-native-blob-util';
-import { doTorRequest, RequestMethod } from '../utils/TorUtils';
+import {
+    doTorRequest,
+    isOnionHttpsUrl,
+    RequestMethod
+} from '../utils/TorUtils';
 
 const calls = new Map<string, Promise<any>>();
 
@@ -71,11 +75,12 @@ export default class CLNRest {
                     method as RequestMethod,
                     JSON.stringify(data),
                     headers,
-                    // Tor v3 .onion authenticates the endpoint at the
-                    // protocol layer, and the upstream daemon's self-signed
-                    // cert can't match an .onion hostname, so TLS validation
-                    // here is always redundant.
-                    true
+                    // .onion-over-Tor: bypass TLS validation (the .onion
+                    // address authenticates at the Tor layer, upstream
+                    // self-signed certs can't match anyway).
+                    // Clearnet-over-Tor: keep strict TLS because exit
+                    // nodes can MITM.
+                    isOnionHttpsUrl(url)
                 ).then((response: any) => {
                     calls.delete(id);
                     return response;

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -1,6 +1,10 @@
 import ReactNativeBlobUtil from 'react-native-blob-util';
 import { settingsStore, nodeInfoStore } from '../stores/Stores';
-import { doTorRequest, RequestMethod } from '../utils/TorUtils';
+import {
+    doTorRequest,
+    isOnionHttpsUrl,
+    RequestMethod
+} from '../utils/TorUtils';
 import OpenChannelRequest from './../models/OpenChannelRequest';
 import Base64Utils from './../utils/Base64Utils';
 import VersionUtils from './../utils/VersionUtils';
@@ -48,11 +52,12 @@ export default class LND {
                     method as RequestMethod,
                     JSON.stringify(data),
                     headers,
-                    // Tor v3 .onion authenticates the endpoint at the
-                    // protocol layer, and the upstream daemon's self-signed
-                    // cert can't match an .onion hostname, so TLS validation
-                    // here is always redundant.
-                    true
+                    // .onion-over-Tor: bypass TLS validation (the .onion
+                    // address authenticates at the Tor layer, upstream
+                    // self-signed certs can't match anyway).
+                    // Clearnet-over-Tor: keep strict TLS because exit
+                    // nodes can MITM.
+                    isOnionHttpsUrl(url)
                 ).then((response: any) => {
                     calls.delete(id);
                     return response;

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -47,7 +47,12 @@ export default class LND {
                     url,
                     method as RequestMethod,
                     JSON.stringify(data),
-                    headers
+                    headers,
+                    // Tor v3 .onion authenticates the endpoint at the
+                    // protocol layer, and the upstream daemon's self-signed
+                    // cert can't match an .onion hostname, so TLS validation
+                    // here is always redundant.
+                    true
                 ).then((response: any) => {
                     calls.delete(id);
                     return response;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2044,7 +2044,7 @@ PODS:
     - React-utils (= 0.85.3)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.85.3)
-  - ReactNativeNitroTor (0.5.3):
+  - ReactNativeNitroTor (0.6.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2956,7 +2956,7 @@ SPEC CHECKSUMS:
   ReactCodegen: c8f81e6c6f762dcf442a6203a1fb58f7dafc8014
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
   ReactNativeDependencies: 3b1913a9f473170b145a700f1d50f32e575cb0b3
-  ReactNativeNitroTor: c208c7d0faff06e22124c8e01c311f4697e51e73
+  ReactNativeNitroTor: 3a55374c5816550e4b24f65e9380a5e315797899
   RNCAsyncStorage: 2ad919e88b8bc2cd80e8697ce66d04d006743283
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
   RNCPicker: d74667bdfc08ed389a2a277d95b8faf2349290a9

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "react-native-svg": "15.15.5",
     "react-native-svg-transformer": "1.5.3",
     "react-native-system-navigation-bar": "2.8.0",
-    "react-native-nitro-tor": "0.5.3",
+    "react-native-nitro-tor": "0.6.0",
     "react-native-udp": "4.1.7",
     "react-native-view-shot": "5.1.0",
     "react-native-vision-camera": "4.7.3",

--- a/utils/TorUtils.test.ts
+++ b/utils/TorUtils.test.ts
@@ -1,0 +1,100 @@
+jest.mock('react-native-nitro-tor', () => ({
+    RnTor: {
+        startTorIfNotRunning: jest.fn(),
+        shutdownService: jest.fn(),
+        httpGet: jest.fn(),
+        httpPost: jest.fn(),
+        httpDelete: jest.fn()
+    }
+}));
+
+jest.mock('react-native-fs', () => ({
+    DocumentDirectoryPath: '/tmp'
+}));
+
+import { isOnionHttpsUrl } from './TorUtils';
+
+describe('TorUtils', () => {
+    describe('isOnionHttpsUrl', () => {
+        it('returns true for an HTTPS v3 .onion URL', () => {
+            expect(
+                isOnionHttpsUrl(
+                    'https://hnmvv3bxny3chob3ytfai5m5j3356qplcf26hel63fs6c3adlbu56lad.onion/v1/getinfo'
+                )
+            ).toBe(true);
+        });
+
+        it('returns true regardless of port', () => {
+            expect(
+                isOnionHttpsUrl(
+                    'https://hnmvv3bxny3chob3ytfai5m5j3356qplcf26hel63fs6c3adlbu56lad.onion:8443/v1/getinfo'
+                )
+            ).toBe(true);
+        });
+
+        it('returns true for a multi-label .onion hostname', () => {
+            expect(isOnionHttpsUrl('https://api.xyz.onion/v1/getinfo')).toBe(
+                true
+            );
+        });
+
+        it('returns true even when the hostname is mixed case', () => {
+            expect(isOnionHttpsUrl('https://XYZ.ONION/v1/getinfo')).toBe(true);
+        });
+
+        it('returns false for an HTTP .onion URL (no TLS to bypass)', () => {
+            expect(isOnionHttpsUrl('http://xyz.onion/v1/getinfo')).toBe(false);
+        });
+
+        it('returns false for a clearnet HTTPS URL', () => {
+            expect(isOnionHttpsUrl('https://example.com/v1/getinfo')).toBe(
+                false
+            );
+        });
+
+        it('returns false when .onion appears in the path', () => {
+            expect(
+                isOnionHttpsUrl('https://example.com/xyz.onion/v1/getinfo')
+            ).toBe(false);
+        });
+
+        it('returns false when .onion appears in a query string', () => {
+            expect(isOnionHttpsUrl('https://example.com/?host=xyz.onion')).toBe(
+                false
+            );
+        });
+
+        it('returns false when .onion appears in a fragment', () => {
+            expect(isOnionHttpsUrl('https://example.com/#xyz.onion')).toBe(
+                false
+            );
+        });
+
+        it('returns false for hostnames that merely contain "onion"', () => {
+            expect(isOnionHttpsUrl('https://onion-router.example.com/')).toBe(
+                false
+            );
+        });
+
+        it('returns false for a hostname where .onion is a non-trailing label', () => {
+            expect(isOnionHttpsUrl('https://xyz.onion.evil.com/')).toBe(false);
+        });
+
+        it('returns false for a hostname suffixed with .onion-like text', () => {
+            expect(isOnionHttpsUrl('https://foo.onionspoof.com/')).toBe(false);
+        });
+
+        it('returns false for unrelated schemes pointing at .onion', () => {
+            expect(isOnionHttpsUrl('ws://xyz.onion/socket')).toBe(false);
+            expect(isOnionHttpsUrl('wss://xyz.onion/socket')).toBe(false);
+            expect(isOnionHttpsUrl('ftp://xyz.onion/file')).toBe(false);
+        });
+
+        it('returns false for invalid / unparseable URLs', () => {
+            expect(isOnionHttpsUrl('')).toBe(false);
+            expect(isOnionHttpsUrl('not a url')).toBe(false);
+            expect(isOnionHttpsUrl('xyz.onion')).toBe(false); // no scheme
+            expect(isOnionHttpsUrl('://xyz.onion')).toBe(false);
+        });
+    });
+});

--- a/utils/TorUtils.ts
+++ b/utils/TorUtils.ts
@@ -19,6 +19,27 @@ const headersToString = (headers?: any): string => {
     return JSON.stringify(headers);
 };
 
+// Whether a URL targets a Tor v3 hidden service over HTTPS. For such
+// endpoints the .onion address itself authenticates the peer at the
+// Tor protocol layer, so TLS hostname/CA validation against the
+// upstream daemon's (typically self-signed) cert is redundant and
+// can be safely bypassed.
+//
+// Returns false for clearnet hosts routed via Tor — TLS validation
+// there still matters because exit nodes can MITM. Returns false on
+// any URL that won't parse, so the caller defaults to strict TLS.
+const isOnionHttpsUrl = (url: string): boolean => {
+    try {
+        const u = new URL(url);
+        return (
+            u.protocol === 'https:' &&
+            u.hostname.toLowerCase().endsWith('.onion')
+        );
+    } catch {
+        return false;
+    }
+};
+
 let startPromise: Promise<void> | null = null;
 
 const ensureTorStarted = (): Promise<void> => {
@@ -51,6 +72,18 @@ const doTorRequest = async (
     await ensureTorStarted();
     const headerStr = headersToString(headers);
 
+    // Defense in depth: only honor trustInvalidCerts for HTTPS .onion
+    // URLs. If a caller passes true for a clearnet URL we drop it on
+    // the floor and warn, so that exit-node MITM defenses stay in
+    // place even if a future call site forgets to gate the param.
+    const effectiveTrustInvalidCerts =
+        trustInvalidCerts && isOnionHttpsUrl(url);
+    if (trustInvalidCerts && !effectiveTrustInvalidCerts) {
+        console.warn(
+            `doTorRequest: ignoring trust_invalid_certs=true for non-.onion URL (${url}) — clearnet-over-Tor must validate TLS to defend against exit-node MITM`
+        );
+    }
+
     let response;
     switch (method) {
         case RequestMethod.GET:
@@ -58,7 +91,7 @@ const doTorRequest = async (
                 url,
                 headers: headerStr,
                 timeout_ms: REQUEST_TIMEOUT_MS,
-                trust_invalid_certs: trustInvalidCerts
+                trust_invalid_certs: effectiveTrustInvalidCerts
             });
             break;
         case RequestMethod.POST:
@@ -67,7 +100,7 @@ const doTorRequest = async (
                 body: data || '',
                 headers: headerStr,
                 timeout_ms: REQUEST_TIMEOUT_MS,
-                trust_invalid_certs: trustInvalidCerts
+                trust_invalid_certs: effectiveTrustInvalidCerts
             });
             break;
         case RequestMethod.DELETE:
@@ -75,7 +108,7 @@ const doTorRequest = async (
                 url,
                 headers: headerStr,
                 timeout_ms: REQUEST_TIMEOUT_MS,
-                trust_invalid_certs: trustInvalidCerts
+                trust_invalid_certs: effectiveTrustInvalidCerts
             });
             break;
         default:
@@ -116,4 +149,4 @@ const restartTor = async () => {
     await ensureTorStarted();
 };
 
-export { doTorRequest, restartTor, RequestMethod };
+export { doTorRequest, restartTor, isOnionHttpsUrl, RequestMethod };

--- a/utils/TorUtils.ts
+++ b/utils/TorUtils.ts
@@ -45,7 +45,8 @@ const doTorRequest = async (
     url: string,
     method: RequestMethod,
     data?: string,
-    headers?: any
+    headers?: any,
+    trustInvalidCerts: boolean = false
 ) => {
     await ensureTorStarted();
     const headerStr = headersToString(headers);
@@ -56,7 +57,8 @@ const doTorRequest = async (
             response = await RnTor.httpGet({
                 url,
                 headers: headerStr,
-                timeout_ms: REQUEST_TIMEOUT_MS
+                timeout_ms: REQUEST_TIMEOUT_MS,
+                trust_invalid_certs: trustInvalidCerts
             });
             break;
         case RequestMethod.POST:
@@ -64,14 +66,16 @@ const doTorRequest = async (
                 url,
                 body: data || '',
                 headers: headerStr,
-                timeout_ms: REQUEST_TIMEOUT_MS
+                timeout_ms: REQUEST_TIMEOUT_MS,
+                trust_invalid_certs: trustInvalidCerts
             });
             break;
         case RequestMethod.DELETE:
             response = await RnTor.httpDelete({
                 url,
                 headers: headerStr,
-                timeout_ms: REQUEST_TIMEOUT_MS
+                timeout_ms: REQUEST_TIMEOUT_MS,
+                trust_invalid_certs: trustInvalidCerts
             });
             break;
         default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9217,10 +9217,10 @@ react-native-nfc-manager@3.17.2:
   resolved "https://registry.yarnpkg.com/react-native-nfc-manager/-/react-native-nfc-manager-3.17.2.tgz#81924946b7fe381bbf85bfb16af90cb05cac4944"
   integrity sha512-0NryP/Iw2hzw4MVH5KCngoRerNUrnRok6VfLrlFcFZRKyTQ7KTgpsdDxCB6cR33qYNyEDrWGBayfAI+ym5gt8Q==
 
-react-native-nitro-tor@0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/react-native-nitro-tor/-/react-native-nitro-tor-0.5.3.tgz#f4b57dff15230e7f83bc3a72a7ec42bd5dd5c870"
-  integrity sha512-GHCgxrotKz+EaT3mF5dvepWtmx0MaVxYaeteYZUWYKAkLBhfXwPIWpGDWAu9ugwLYfoMNZ3b2Iuy1Sn+aaGenw==
+react-native-nitro-tor@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-nitro-tor/-/react-native-nitro-tor-0.6.0.tgz#30ab0ab07ce71f1147fe91ddf2da4e79095a3ab8"
+  integrity sha512-ul9KNC7NDMbNWp89MF5Epp+75ajI63DjZJakt/LaVmYQYoI5AqM7ae9Oaiy+LqAvqh1WmPcwWct4v8H9GHqyXg==
   dependencies:
     craby-modules "^0.1.0-rc.5"
 


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-4178**

Before v13.1.0 the Tor path always trusted self-signed certificates because the old `react-native-tor` library defaulted `trustSSL=true`. `react-native-nitro-tor` 0.5.3 had no such knob — TLS validation was strict, so users connecting to their own LND/CLN node over a hidden service (default LND REST + self-signed cert setup) regressed on upgrade.

This PR:

- Plumbs a `trust_invalid_certs` field through `doTorRequest` and hardcodes it to `true` on the Tor branch in `backends/LND.ts` and `backends/CLNRest.ts`.
- The `certVerification` setting is intentionally ignored over Tor: the `.onion` address authenticates the endpoint at the Tor protocol layer, and the upstream daemon's self-signed cert can never match an `.onion` hostname, so TLS validation here is a category error. The wallet config UI already hides the `certVerification` toggle when Tor is enabled, so this matches the user-visible model.
- The other `doTorRequest` callers (`utils/handleAnything.ts`, `stores/SettingsStore.ts`, `components/LayerBalances/LightningSwipeableRow.tsx`) keep the strict default — they talk to public third-party services (lnurl resolution, Olympus, Zeus servers), not user-owned nodes.

### Upstream changes

Schema/Rust support landed upstream in:
- niteshbalusu11/tor-rust-sdk#4
- niteshbalusu11/react-native-nitro-tor#10

This PR picks up the matching `react-native-nitro-tor` **0.6.0** release.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [x] Contributors will need to run \`yarn\` after this PR is merged in
- [x] 3rd party dependencies have been modified:
    * verify that \`package.json\` and \`yarn.lock\` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding