### PR TITLE
enhancement: AmountKeypad: support pasting amount from clipboard

### DIFF
--- a/components/PinPad.tsx
+++ b/components/PinPad.tsx
@@ -50,6 +50,13 @@ export default function PinPad({
     const [pinValueLength, setPinValueLength] = useState(0);
 
     React.useEffect(() => {
+        // For PIN entry we clear the value when the app is backgrounded so the
+        // PIN isn't visible in the OS task-switcher snapshot. Amount input has
+        // no such security concern, and clearing it on backgrounding loses
+        // typed values when the user briefly switches apps (e.g. to check an
+        // amount from another app).
+        if (amount) return;
+
         const subscription = AppState.addEventListener(
             'change',
             (nextAppState) => {
@@ -61,7 +68,7 @@ export default function PinPad({
         );
 
         return () => subscription.remove();
-    }, []);
+    }, [amount]);
 
     const bigKeypadButtons =
         settingsStore.settings &&

--- a/utils/KeypadUtils.test.ts
+++ b/utils/KeypadUtils.test.ts
@@ -2,7 +2,8 @@ import {
     getDecimalLimit,
     validateKeypadInput,
     getAmountFontSize,
-    deleteLastCharacter
+    deleteLastCharacter,
+    parseClipboardAmount
 } from './KeypadUtils';
 
 // Mock stores
@@ -11,7 +12,16 @@ const createMockFiatStore = (decimalPlaces?: number) => ({
         .fn()
         .mockReturnValue(
             decimalPlaces !== undefined ? { decimalPlaces } : undefined
-        )
+        ),
+    getSymbol: jest.fn().mockReturnValue({ separatorSwap: false })
+});
+
+const createMockFiatStoreWithSwap = (
+    decimalPlaces: number = 2,
+    separatorSwap: boolean = true
+) => ({
+    symbolLookup: jest.fn().mockReturnValue({ decimalPlaces }),
+    getSymbol: jest.fn().mockReturnValue({ separatorSwap })
 });
 
 const createMockSettingsStore = (fiat: string = 'USD') => ({
@@ -469,6 +479,226 @@ describe('KeypadUtils', () => {
                     40
                 );
             });
+        });
+    });
+
+    describe('parseClipboardAmount', () => {
+        const settingsStore = createMockSettingsStore();
+
+        it('returns null for empty input', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    '',
+                    'sats',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBeNull();
+        });
+
+        it('parses a plain integer', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    '12345',
+                    'sats',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBe('12345');
+        });
+
+        it('strips US-style thousands separators', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    '1,234,567',
+                    'sats',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBe('1234567');
+        });
+
+        it('strips currency symbols and whitespace', () => {
+            const fiatStore = createMockFiatStore(2);
+            expect(
+                parseClipboardAmount(
+                    '$ 19.99',
+                    'fiat',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBe('19.99');
+        });
+
+        it('strips unit suffix labels', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    '50000 sats',
+                    'sats',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBe('50000');
+        });
+
+        it('strips the active fiat currency code', () => {
+            const fiatStore = createMockFiatStore(2);
+            expect(
+                parseClipboardAmount(
+                    '100 USD',
+                    'fiat',
+                    fiatStore as any,
+                    createMockSettingsStore('USD') as any
+                )
+            ).toBe('100');
+        });
+
+        it('rejects non-active fiat currency codes', () => {
+            const fiatStore = createMockFiatStore(2);
+            expect(
+                parseClipboardAmount(
+                    '50 EUR',
+                    'fiat',
+                    fiatStore as any,
+                    createMockSettingsStore('USD') as any
+                )
+            ).toBeNull();
+        });
+
+        it('honours comma decimal separator for fiat with separatorSwap', () => {
+            const fiatStore = createMockFiatStoreWithSwap(2, true);
+            expect(
+                parseClipboardAmount(
+                    '1.234,56',
+                    'fiat',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBe('1234.56');
+        });
+
+        it('truncates excess decimal places to unit limit', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    '0.123456789',
+                    'BTC',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBe('0.12345678');
+        });
+
+        it('truncates excess decimal places for sats', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    '5.123456',
+                    'sats',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBe('5.123');
+        });
+
+        it('drops decimals entirely for zero-decimal fiat (JPY)', () => {
+            const fiatStore = createMockFiatStore(0);
+            expect(
+                parseClipboardAmount(
+                    '500.99',
+                    'fiat',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBe('500');
+        });
+
+        it('rejects amounts exceeding BTC integer length', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    '123456789',
+                    'BTC',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBeNull();
+        });
+
+        it('rejects amounts exceeding sats max supply', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    '2100000000000001',
+                    'sats',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBeNull();
+        });
+
+        it('rejects BOLT11 invoices', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    'lnbc1500u1p3xnpsapp5q...',
+                    'sats',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBeNull();
+        });
+
+        it('rejects on-chain addresses', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+                    'sats',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBeNull();
+        });
+
+        it('rejects non-numeric garbage', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    'hello world',
+                    'sats',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBeNull();
+        });
+
+        it('normalizes leading zeros', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    '0000123',
+                    'sats',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBe('123');
+        });
+
+        it('handles bare decimal like ".5"', () => {
+            const fiatStore = createMockFiatStore();
+            expect(
+                parseClipboardAmount(
+                    '.5',
+                    'BTC',
+                    fiatStore as any,
+                    settingsStore as any
+                )
+            ).toBe('0.5');
         });
     });
 

--- a/utils/KeypadUtils.ts
+++ b/utils/KeypadUtils.ts
@@ -279,3 +279,88 @@ export const deleteLastCharacter = (amount: string): string => {
     }
     return amount.substring(0, amount.length - 1);
 };
+
+/**
+ * Parses a free-form clipboard string into a keypad-compatible amount in the
+ * given unit. Strips currency symbols, unit suffixes ("sats", "BTC", ...) and
+ * thousands separators, honours the decimal separator implied by the active
+ * currency (e.g. "1.234,56" for EUR), truncates excess decimal places, and
+ * enforces the same integer-length and capacity caps as keypad entry.
+ *
+ * Returns null when the clipboard does not contain a usable numeric amount.
+ */
+export const parseClipboardAmount = (
+    clipboardValue: string,
+    units: Units | string,
+    fiatStore: FiatStore,
+    settingsStore: SettingsStore
+): string | null => {
+    if (!clipboardValue) return null;
+
+    // Reject clipboard content that obviously isn't a number — e.g. BOLT11
+    // invoices, on-chain addresses, or BIP-21 URIs would otherwise have their
+    // alphabetic chars stripped and the leftover digits parsed as an amount.
+    // Strip recognised unit/currency labels first so "100 USD" or "50000 sats"
+    // pass the alphabetic-content check.
+    let withoutUnitLabels = clipboardValue.replace(
+        /sats?|satoshis?|btc|bitcoin|msats?/gi,
+        ''
+    );
+    const activeFiat = settingsStore?.settings?.fiat;
+    if (activeFiat) {
+        withoutUnitLabels = withoutUnitLabels.replace(
+            new RegExp(`\\b${activeFiat}\\b`, 'gi'),
+            ''
+        );
+    }
+    if (/[a-z]{2,}/i.test(withoutUnitLabels)) return null;
+
+    const useCommaAsDecimal =
+        units === 'fiat' && !!fiatStore.getSymbol().separatorSwap;
+
+    let cleaned = clipboardValue.trim();
+    if (useCommaAsDecimal) {
+        cleaned = cleaned.replace(/\./g, '').replace(/,/g, '.');
+    } else {
+        cleaned = cleaned.replace(/,/g, '');
+    }
+    cleaned = cleaned.replace(/[^0-9.]/g, '');
+
+    const firstDot = cleaned.indexOf('.');
+    if (firstDot !== -1) {
+        cleaned =
+            cleaned.substring(0, firstDot + 1) +
+            cleaned.substring(firstDot + 1).replace(/\./g, '');
+    }
+
+    if (!cleaned || cleaned === '.') return null;
+
+    const parts = cleaned.split('.');
+    let intPart = parts[0].replace(/^0+/, '') || '0';
+    let decPart: string | undefined = parts[1];
+
+    const decimalLimit = getDecimalLimit(units, fiatStore, settingsStore);
+    if (decPart !== undefined) {
+        if (decimalLimit === 0) {
+            decPart = undefined;
+        } else if (decimalLimit !== null && decPart.length > decimalLimit) {
+            decPart = decPart.substring(0, decimalLimit);
+        }
+    }
+
+    if (units === 'BTC' && intPart.length > 8) return null;
+    if (units === 'sats' && intPart.length > 12) return null;
+    if (units === 'fiat' && intPart.length > 10) return null;
+
+    const finalAmount =
+        decPart !== undefined && decPart !== ''
+            ? `${intPart}.${decPart}`
+            : intPart;
+
+    const bn = new BigNumber(finalAmount);
+    if (bn.isNaN()) return null;
+    if (units === 'BTC' && bn.gt(21000000)) return null;
+    if (units === 'sats' && bn.gt(2100000000000000)) return null;
+
+    return finalAmount;
+};

--- a/views/AmountKeypad.tsx
+++ b/views/AmountKeypad.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Animated, View, StyleSheet } from 'react-native';
+import { Animated, TouchableOpacity, View, StyleSheet } from 'react-native';
 import { inject, observer } from 'mobx-react';
+import Clipboard from '@react-native-clipboard/clipboard';
 import { Route } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
@@ -22,12 +23,15 @@ import {
     validateKeypadInput,
     getAmountFontSize,
     deleteLastCharacter,
+    parseClipboardAmount,
     resetKeypadTextAnimation,
     resetAllKeypadAnimations,
     startKeypadInvalidInputAnimation
 } from '../utils/KeypadUtils';
 import { getDecimalPlaceholder } from '../utils/UnitsUtils';
 import { localeString } from '../utils/LocaleUtils';
+
+import ClipboardSVG from '../assets/images/SVG/Clipboard.svg';
 
 interface AmountKeypadProps {
     navigation: NativeStackNavigationProp<any, any>;
@@ -172,6 +176,26 @@ export default class AmountKeypad extends React.Component<
         this.clearValue();
     };
 
+    handlePaste = async () => {
+        const { FiatStore, SettingsStore } = this.props;
+        const clipboardValue = await Clipboard.getString();
+        const parsed = parseClipboardAmount(
+            clipboardValue,
+            this.getEffectiveUnits(),
+            FiatStore!,
+            SettingsStore!
+        );
+
+        if (parsed === null) {
+            this.startShake();
+            return;
+        }
+
+        resetKeypadTextAnimation(this.textAnimation, this.animationRefs);
+        this.amountInput = parsed;
+        this.setState({ amount: parsed });
+    };
+
     getAmountFontSize = () => {
         const { amount } = this.state;
         const units = this.getEffectiveUnits();
@@ -187,6 +211,20 @@ export default class AmountKeypad extends React.Component<
 
         const fontSize = this.getAmountFontSize();
 
+        const PasteButton = (
+            <TouchableOpacity
+                onPress={this.handlePaste}
+                accessibilityLabel={localeString('general.paste')}
+                hitSlop={10}
+            >
+                <ClipboardSVG
+                    fill={themeColor('text')}
+                    width="24"
+                    height="30"
+                />
+            </TouchableOpacity>
+        );
+
         return (
             <Screen>
                 <Header
@@ -198,6 +236,7 @@ export default class AmountKeypad extends React.Component<
                             fontFamily: 'PPNeueMontreal-Book'
                         }
                     }}
+                    rightComponent={PasteButton}
                     navigation={navigation}
                 />
 


### PR DESCRIPTION
# Description

Relates to issue: [**#4190**](https://github.com/ZeusLN/zeus/issues/4190)

Improves the invoice amount entry UX in two ways:

1. **Paste amount from clipboard.** A clipboard icon is added to the top-right of the amount keypad. Tapping it reads the clipboard, parses out a numeric amount, and sets it as the current value. The parser strips currency symbols (`$`, `€`, `₿`, …), unit suffix labels (`sats`, `BTC`, `bitcoin`, `msats`, …), and whitespace; honours both period-decimal (US-style `1,234.56`) and comma-decimal (EU-style `1.234,56`) formats based on the active fiat's `separatorSwap` setting; truncates excess decimal places to the unit's limit; and respects the existing integer-length / 21M BTC / 2.1Q sats caps. BOLT11 invoices, on-chain addresses, and other strings containing runs of alphabetic characters are rejected outright (would otherwise have their digits parsed as an amount). Invalid clipboard content triggers the existing red/shake animation.

2. **Preserve typed amount across app backgrounding.** Previously, `PinPad` cleared its value whenever the app went to the background — sensible for PIN entry (the value would otherwise be visible in the OS task-switcher snapshot) but actively harmful for amount entry. The `AppState` listener is now scoped to non-amount mode only, so the typed amount survives a quick app switch (e.g. checking an amount from a screenshot in another app).

This pull request is categorized as a:

- [x] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

16 new unit tests for `parseClipboardAmount` in `utils/KeypadUtils.test.ts` cover: plain integers, US/EU thousands separators, currency-symbol stripping, unit-suffix stripping, decimal truncation per unit, zero-decimal fiat (JPY), integer-length overflow, sats capacity overflow, BOLT11/on-chain-address rejection, non-numeric garbage, leading-zero normalization, and bare `.5` → `0.5` handling. Full suite (990 tests) passes.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

The paste button reuses the existing `general.paste` string ("Paste from clipboard") as its accessibility label, so no new locale entries are introduced.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
