### PR TITLE
fix: Receive: treat backends without on-chain support as lightning-only

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -325,7 +325,8 @@ export default class Receive extends React.Component<
                 settings.pos &&
                 settings.pos.confirmationPreference &&
                 settings.pos.confirmationPreference === 'lnOnly') ||
-            route.params?.forceLn;
+            route.params?.forceLn ||
+            !BackendUtils.supportsOnchainReceiving();
         const onChainOnly = route.params?.forceOnChain;
 
         reset();
@@ -1295,7 +1296,8 @@ export default class Receive extends React.Component<
                 settings.pos &&
                 settings.pos.confirmationPreference &&
                 settings.pos.confirmationPreference === 'lnOnly') ||
-            route.params?.forceLn;
+            route.params?.forceLn ||
+            !BackendUtils.supportsOnchainReceiving();
         const onChainOnly = route.params?.forceOnChain;
 
         const lnurl = route.params?.lnurlParams;


### PR DESCRIPTION
# Description

On the Receive view, the "Advanced" toggle (which expands the unified/lightning/on-chain tab switcher) was showing for backends that don't support on-chain receiving — including Nostr Wallet Connect and LND Hub. Tapping it would reveal an on-chain tab that the backend can't service.

This fix folds `!BackendUtils.supportsOnchainReceiving()` into the existing `lnOnly` variable so backends without on-chain support are treated the same as a POS `lnOnly` configuration: the initial tab is forced to lightning, the tab switcher is hidden, and the "Advanced" toggle disappears (unless NFC is independently applicable).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [x] Nostr Wallet Connect
- [x] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
