### PR TITLE
fix: Lightning address: gate by backend support across Receive and Wallet

### DIFF
--- a/components/WalletHeader.tsx
+++ b/components/WalletHeader.tsx
@@ -636,6 +636,7 @@ export default class WalletHeader extends React.Component<
                             <MenuBadge navigation={navigation} />
                             {!isChannelMigrating &&
                                 !connecting &&
+                                BackendUtils.supportsLightningAddress() &&
                                 paid &&
                                 paid.length > 0 && (
                                     <TouchableOpacity

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -260,6 +260,8 @@ class BackendUtils {
         return this.isLNDBased() || this.call('supportsDevTools');
     };
     supportsCashuWallet = () => this.call('supportsCashuWallet');
+    supportsLightningAddress = () =>
+        this.supportsCustomPreimages() || this.supportsCashuWallet();
     supportsNestedSegWit = () => this.call('supportsNestedSegWit');
     supportsSettingInvoiceExpiration = () =>
         this.call('supportsSettingInvoiceExpiration');

--- a/views/Cashu/ReceiveEcash.tsx
+++ b/views/Cashu/ReceiveEcash.tsx
@@ -51,6 +51,7 @@ import UnitsStore from '../../stores/UnitsStore';
 
 import CashuInvoice from '../../models/CashuInvoice';
 
+import BackendUtils from '../../utils/BackendUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { scanNfcTag } from '../../utils/NFCUtils';
 import { themeColor } from '../../utils/ThemeUtils';
@@ -149,7 +150,11 @@ export default class ReceiveEcash extends React.Component<
 
         const settings = await getSettings();
 
-        if (settings?.lightningAddress?.enabled && !lightningAddressHandle) {
+        if (
+            settings?.lightningAddress?.enabled &&
+            !lightningAddressHandle &&
+            BackendUtils.supportsLightningAddress()
+        ) {
             status();
         }
 

--- a/views/Menu.tsx
+++ b/views/Menu.tsx
@@ -525,8 +525,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
                         )}
 
                     {selectedNode &&
-                        (BackendUtils.supportsCustomPreimages() ||
-                            BackendUtils.supportsCashuWallet()) &&
+                        BackendUtils.supportsLightningAddress() &&
                         !NodeInfoStore.testnet &&
                         !isChannelMigrating && (
                             <View

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -1448,7 +1448,7 @@ export default class Receive extends React.Component<
         );
 
         const buttons: any =
-            BackendUtils.supportsCustomPreimages() && !NodeInfoStore.testnet
+            BackendUtils.supportsLightningAddress() && !NodeInfoStore.testnet
                 ? [
                       { element: unifiedButton },
                       { element: lightningButton },

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -268,7 +268,11 @@ export default class Receive extends React.Component<
 
         const settings = await getSettings();
 
-        if (settings?.lightningAddress?.enabled && !lightningAddressHandle) {
+        if (
+            settings?.lightningAddress?.enabled &&
+            !lightningAddressHandle &&
+            BackendUtils.supportsLightningAddress()
+        ) {
             status();
         }
 

--- a/views/Settings/NostrWalletConnect/NWCSettings.tsx
+++ b/views/Settings/NostrWalletConnect/NWCSettings.tsx
@@ -584,57 +584,58 @@ export default class NWCSettings extends React.Component<
                                 </View>
                             )}
 
-                        {settings.lightningAddress?.enabled && (
-                            <View style={{ marginTop: 20 }}>
-                                <View style={{ flexDirection: 'row' }}>
-                                    <View
-                                        style={{
-                                            flex: 1,
-                                            justifyContent: 'center'
-                                        }}
-                                    >
-                                        <Text
+                        {settings.lightningAddress?.enabled &&
+                            BackendUtils.supportsLightningAddress() && (
+                                <View style={{ marginTop: 20 }}>
+                                    <View style={{ flexDirection: 'row' }}>
+                                        <View
                                             style={{
-                                                color: themeColor('text'),
-                                                fontSize: 17
+                                                flex: 1,
+                                                justifyContent: 'center'
                                             }}
                                         >
-                                            {localeString(
-                                                'views.Settings.NostrWalletConnect.nwcIncludeLud16InUrl'
-                                            )}
-                                        </Text>
+                                            <Text
+                                                style={{
+                                                    color: themeColor('text'),
+                                                    fontSize: 17
+                                                }}
+                                            >
+                                                {localeString(
+                                                    'views.Settings.NostrWalletConnect.nwcIncludeLud16InUrl'
+                                                )}
+                                            </Text>
+                                        </View>
+                                        <View
+                                            style={{
+                                                alignSelf: 'center'
+                                            }}
+                                        >
+                                            <Switch
+                                                value={lud16Enabled}
+                                                onValueChange={
+                                                    this.toggleLud16Enabled
+                                                }
+                                                disabled={
+                                                    SettingsStore.settingsUpdateInProgress ||
+                                                    loading
+                                                }
+                                            />
+                                        </View>
                                     </View>
-                                    <View
+                                    <Text
                                         style={{
-                                            alignSelf: 'center'
+                                            color: themeColor('secondaryText'),
+                                            fontSize: 14,
+                                            marginTop: 8,
+                                            lineHeight: 20
                                         }}
                                     >
-                                        <Switch
-                                            value={lud16Enabled}
-                                            onValueChange={
-                                                this.toggleLud16Enabled
-                                            }
-                                            disabled={
-                                                SettingsStore.settingsUpdateInProgress ||
-                                                loading
-                                            }
-                                        />
-                                    </View>
+                                        {localeString(
+                                            'views.Settings.NostrWalletConnect.nwcIncludeLud16InUrlDescription'
+                                        )}
+                                    </Text>
                                 </View>
-                                <Text
-                                    style={{
-                                        color: themeColor('secondaryText'),
-                                        fontSize: 14,
-                                        marginTop: 8,
-                                        lineHeight: 20
-                                    }}
-                                >
-                                    {localeString(
-                                        'views.Settings.NostrWalletConnect.nwcIncludeLud16InUrlDescription'
-                                    )}
-                                </Text>
-                            </View>
-                        )}
+                            )}
                         {Platform.OS === 'android' && (
                             <View style={{ marginTop: 20 }}>
                                 <View style={{ flexDirection: 'row' }}>

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1242,7 +1242,8 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             settings?.ecash?.enableCashu &&
             !lightningAddress.enabled &&
             (settings?.ecash?.initialMintUrls?.length ?? 0) > 0 &&
-            !NodeInfoStore.testnet
+            !NodeInfoStore.testnet &&
+            BackendUtils.supportsCashuWallet()
         ) {
             try {
                 const mintUrl = settings.ecash.initialMintUrls![0];

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1198,7 +1198,11 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             }
         }
 
-        if (lightningAddress.enabled && !NodeInfoStore.testnet) {
+        if (
+            lightningAddress.enabled &&
+            !NodeInfoStore.testnet &&
+            BackendUtils.supportsLightningAddress()
+        ) {
             if (connecting) {
                 try {
                     await LightningAddressStore.status();


### PR DESCRIPTION
# Description

Fixes a `Pubkey not defined` error surfaced when opening the Receive screen on a backend that can't host a Lightning Address (LndHub, NWC, CLNRest) while `settings.lightningAddress.enabled` is `true` from a prior session on a capable backend.

The error came from `LightningAddressStore.status()` posting `pubkey: undefined` to `zeuspay.com/api/lnurl/auth`, because those backends don't implement `getMyNodeInfo` and have no way to receive Lightning Address payments anyway.

This PR introduces `BackendUtils.supportsLightningAddress()` — derived from `supportsCustomPreimages() || supportsCashuWallet()`, which is the existing semantic for "I have somewhere to receive these payments" already used by the Menu gate at `views/Menu.tsx:527-529`.

Changes:
- Add `BackendUtils.supportsLightningAddress()`.
- Gate the `LightningAddressStore.status()` calls in `views/Receive.tsx`, `views/Cashu/ReceiveEcash.tsx`, and `views/Wallet/Wallet.tsx` on the new method.
- Replace the Receive screen's Lightning Address tab gate (previously `supportsCustomPreimages()`) with `supportsLightningAddress()`, so LdkNode users — who can use the Cashu mode of Lightning Address — now see the tab. This also brings the Receive tab gate in line with the Menu gate.

Backend matrix:

| Backend | customPreimages | cashuWallet | supportsLightningAddress |
|---|---|---|---|
| LND | true | false | true |
| LNC | true | false | true |
| EmbeddedLND | true | true | true |
| LdkNode | false | true | true |
| CLNRest | false | false | false |
| LndHub | false | false | false |
| NWC | false | false | false |

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
