### PR TITLE
refactor: Receive: deduplicate componentDidMount/render locals

### DIFF
--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -80,6 +80,8 @@ import {
     verifyMessageWithAddr as verifyMsgWithAddr
 } from '../lndmobile/wallet';
 
+import { toLnrpcAddressTypeNum } from '../utils/LndUtils';
+
 export default class EmbeddedLND extends LND {
     openChannelListener: any;
 
@@ -123,7 +125,10 @@ export default class EmbeddedLND extends LND {
         reversed?: boolean;
     }) => await listPayments(params);
     getNewAddress = async (data: any) =>
-        await newAddress(data.type, data.account);
+        await newAddress(
+            toLnrpcAddressTypeNum(data?.type) as any,
+            data?.account
+        );
     getNewChangeAddress = async (data: any) =>
         await newChangeAddress(data.type, data.account);
     openChannelSync = async (data: OpenChannelRequest) =>

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -9,6 +9,7 @@ import OpenChannelRequest from './../models/OpenChannelRequest';
 import Base64Utils from './../utils/Base64Utils';
 import VersionUtils from './../utils/VersionUtils';
 import { localeString } from './../utils/LocaleUtils';
+import { toLnrpcAddressType } from './../utils/LndUtils';
 import { Hash as sha256Hash } from 'fast-sha256';
 import BigNumber from 'bignumber.js';
 
@@ -371,7 +372,13 @@ export default class LND {
             }`
         );
 
-    getNewAddress = (data: any) => this.getRequest('/v1/newaddress', data);
+    getNewAddress = (data: any) => {
+        const params: any = { ...data };
+        const type = toLnrpcAddressType(params.type);
+        if (type !== undefined) params.type = type;
+        else delete params.type;
+        return this.getRequest('/v1/newaddress', params);
+    };
     getNewChangeAddress = (data: any) =>
         this.postRequest('/v2/wallet/address/next', data);
     openChannelSync = (data: OpenChannelRequest) => {

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -10,19 +10,11 @@ import OpenChannelRequest from '../models/OpenChannelRequest';
 
 import Base64Utils from '../utils/Base64Utils';
 import { snakeize } from '../utils/DataFormatUtils';
+import { toLnrpcAddressType } from '../utils/LndUtils';
 import VersionUtils from '../utils/VersionUtils';
 
 import { Hash as sha256Hash } from 'fast-sha256';
 import BigNumber from 'bignumber.js';
-
-const ADDRESS_TYPES = [
-    'WITNESS_PUBKEY_HASH',
-    'NESTED_PUBKEY_HASH',
-    'UNUSED_WITNESS_PUBKEY_HASH',
-    'UNUSED_NESTED_PUBKEY_HASH',
-    'TAPROOT_PUBKEY',
-    'UNUSED_TAPROOT_PUBKEY'
-];
 
 const NEXT_ADDR_MAP: any = {
     WITNESS_PUBKEY_HASH: 0,
@@ -220,7 +212,7 @@ export default class LightningNodeConnect {
     getNewAddress = async (data: any) =>
         await this.lnc.lnd.lightning
             .newAddress({
-                type: ADDRESS_TYPES[data.type] || data.type,
+                type: toLnrpcAddressType(data.type),
                 account: data.account || 'default'
             })
             .then((data: walletrpc.AddrRequest) => snakeize(data));

--- a/utils/LndUtils.test.ts
+++ b/utils/LndUtils.test.ts
@@ -1,0 +1,103 @@
+import { toLnrpcAddressType, toLnrpcAddressTypeNum } from './LndUtils';
+
+describe('LndUtils', () => {
+    describe('toLnrpcAddressType', () => {
+        it('returns the lnrpc enum name for numeric-string input from the picker / settings', () => {
+            expect(toLnrpcAddressType('0')).toEqual('WITNESS_PUBKEY_HASH');
+            expect(toLnrpcAddressType('1')).toEqual('NESTED_PUBKEY_HASH');
+            expect(toLnrpcAddressType('2')).toEqual(
+                'UNUSED_WITNESS_PUBKEY_HASH'
+            );
+            expect(toLnrpcAddressType('3')).toEqual(
+                'UNUSED_NESTED_PUBKEY_HASH'
+            );
+            expect(toLnrpcAddressType('4')).toEqual('TAPROOT_PUBKEY');
+            expect(toLnrpcAddressType('5')).toEqual('UNUSED_TAPROOT_PUBKEY');
+        });
+
+        it('accepts numeric input as well as numeric strings', () => {
+            expect(toLnrpcAddressType(0)).toEqual('WITNESS_PUBKEY_HASH');
+            expect(toLnrpcAddressType(1)).toEqual('NESTED_PUBKEY_HASH');
+            expect(toLnrpcAddressType(4)).toEqual('TAPROOT_PUBKEY');
+        });
+
+        it('maps walletrpc enum names returned by ListAccounts to the lnrpc equivalent', () => {
+            // lnrpc has no hybrid variant; nested-segwit p2sh-p2wkh is the
+            // closest equivalent the receiver sees.
+            expect(toLnrpcAddressType('NESTED_WITNESS_PUBKEY_HASH')).toEqual(
+                'NESTED_PUBKEY_HASH'
+            );
+            expect(
+                toLnrpcAddressType('HYBRID_NESTED_WITNESS_PUBKEY_HASH')
+            ).toEqual('NESTED_PUBKEY_HASH');
+        });
+
+        it('passes lnrpc enum names through unchanged', () => {
+            expect(toLnrpcAddressType('WITNESS_PUBKEY_HASH')).toEqual(
+                'WITNESS_PUBKEY_HASH'
+            );
+            expect(toLnrpcAddressType('NESTED_PUBKEY_HASH')).toEqual(
+                'NESTED_PUBKEY_HASH'
+            );
+            expect(toLnrpcAddressType('TAPROOT_PUBKEY')).toEqual(
+                'TAPROOT_PUBKEY'
+            );
+        });
+
+        it('returns undefined for null / undefined input so the backend default kicks in', () => {
+            expect(toLnrpcAddressType(undefined)).toBeUndefined();
+            expect(toLnrpcAddressType(null)).toBeUndefined();
+        });
+
+        it('passes unrecognised values through verbatim rather than swallowing them', () => {
+            // Lets callers decide how to handle (LND surfaces a clear
+            // "not a valid value" error rather than silently picking '0').
+            expect(toLnrpcAddressType('SOMETHING_NEW')).toEqual(
+                'SOMETHING_NEW'
+            );
+        });
+    });
+
+    describe('toLnrpcAddressTypeNum', () => {
+        it('returns the lnrpc numeric AddressType for numeric-string input', () => {
+            expect(toLnrpcAddressTypeNum('0')).toEqual(0);
+            expect(toLnrpcAddressTypeNum('1')).toEqual(1);
+            expect(toLnrpcAddressTypeNum('2')).toEqual(2);
+            expect(toLnrpcAddressTypeNum('3')).toEqual(3);
+            expect(toLnrpcAddressTypeNum('4')).toEqual(4);
+            expect(toLnrpcAddressTypeNum('5')).toEqual(5);
+        });
+
+        it('returns the lnrpc numeric AddressType for lnrpc enum names', () => {
+            expect(toLnrpcAddressTypeNum('WITNESS_PUBKEY_HASH')).toEqual(0);
+            expect(toLnrpcAddressTypeNum('NESTED_PUBKEY_HASH')).toEqual(1);
+            expect(toLnrpcAddressTypeNum('TAPROOT_PUBKEY')).toEqual(4);
+        });
+
+        it('returns the lnrpc numeric AddressType for walletrpc enum names', () => {
+            expect(toLnrpcAddressTypeNum('NESTED_WITNESS_PUBKEY_HASH')).toEqual(
+                1
+            );
+            expect(
+                toLnrpcAddressTypeNum('HYBRID_NESTED_WITNESS_PUBKEY_HASH')
+            ).toEqual(1);
+        });
+
+        it('returns undefined for null / undefined input', () => {
+            expect(toLnrpcAddressTypeNum(undefined)).toBeUndefined();
+            expect(toLnrpcAddressTypeNum(null)).toBeUndefined();
+        });
+
+        it('returns undefined for unrecognised non-numeric strings', () => {
+            // protobufjs would silently encode garbage as 0 — better to
+            // fall through to the backend default.
+            expect(toLnrpcAddressTypeNum('SOMETHING_NEW')).toBeUndefined();
+        });
+
+        it('accepts numeric input directly', () => {
+            expect(toLnrpcAddressTypeNum(0)).toEqual(0);
+            expect(toLnrpcAddressTypeNum(1)).toEqual(1);
+            expect(toLnrpcAddressTypeNum(4)).toEqual(4);
+        });
+    });
+});

--- a/utils/LndUtils.ts
+++ b/utils/LndUtils.ts
@@ -1,0 +1,55 @@
+// LND's lnrpc.NewAddress endpoint expects the AddressType enum by name.
+// Address types reach the backend in three forms:
+//
+// 1. The numeric strings used by the address-type picker / settings ('0',
+//    '1', '4') — LND REST's grpc-gateway silently treats these as the
+//    default (WITNESS_PUBKEY_HASH = native segwit) unless converted.
+// 2. The lnrpc enum names (already correct).
+// 3. The walletrpc enum names returned by ListAccounts and forwarded by
+//    OnChainAddresses → Receive: NESTED_WITNESS_PUBKEY_HASH and
+//    HYBRID_NESTED_WITNESS_PUBKEY_HASH. lnrpc.NewAddress has no hybrid
+//    variant; the resulting address is still a nested-segwit p2sh-p2wkh,
+//    which is the visible part the receiver cares about.
+const LNRPC_NEW_ADDRESS_TYPE_NAMES: { [key: string]: string } = {
+    '0': 'WITNESS_PUBKEY_HASH',
+    '1': 'NESTED_PUBKEY_HASH',
+    '2': 'UNUSED_WITNESS_PUBKEY_HASH',
+    '3': 'UNUSED_NESTED_PUBKEY_HASH',
+    '4': 'TAPROOT_PUBKEY',
+    '5': 'UNUSED_TAPROOT_PUBKEY',
+    NESTED_WITNESS_PUBKEY_HASH: 'NESTED_PUBKEY_HASH',
+    HYBRID_NESTED_WITNESS_PUBKEY_HASH: 'NESTED_PUBKEY_HASH'
+};
+
+export const toLnrpcAddressType = (
+    value: string | number | undefined | null
+): string | undefined => {
+    if (value == null) return undefined;
+    const key = String(value);
+    return LNRPC_NEW_ADDRESS_TYPE_NAMES[key] ?? key;
+};
+
+// Numeric form of the lnrpc enum, for the embedded LND backend.
+// protobufjs's NewAddressRequest encoder writes the `type` field via
+// `writer.int32(...)`, which does numeric coercion — enum-name strings
+// like 'NESTED_PUBKEY_HASH' become NaN and get serialized as 0
+// (= WITNESS_PUBKEY_HASH). Always send a number.
+const LNRPC_ADDRESS_TYPE_NUMS: { [key: string]: number } = {
+    WITNESS_PUBKEY_HASH: 0,
+    NESTED_PUBKEY_HASH: 1,
+    UNUSED_WITNESS_PUBKEY_HASH: 2,
+    UNUSED_NESTED_PUBKEY_HASH: 3,
+    TAPROOT_PUBKEY: 4,
+    UNUSED_TAPROOT_PUBKEY: 5
+};
+
+export const toLnrpcAddressTypeNum = (
+    value: string | number | undefined | null
+): number | undefined => {
+    const name = toLnrpcAddressType(value);
+    if (name == null) return undefined;
+    if (LNRPC_ADDRESS_TYPE_NUMS[name] !== undefined)
+        return LNRPC_ADDRESS_TYPE_NUMS[name];
+    const num = Number(name);
+    return Number.isInteger(num) ? num : undefined;
+};

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -278,6 +278,14 @@ export default class Receive extends React.Component<
         );
     };
 
+    private getAddressType = (): string => {
+        const { route, SettingsStore } = this.props;
+        const { settings } = SettingsStore;
+        return (
+            route.params?.addressType || settings?.invoices?.addressType || '0'
+        );
+    };
+
     async componentDidMount() {
         const {
             InvoicesStore,
@@ -327,7 +335,7 @@ export default class Receive extends React.Component<
             false;
 
         this.setState({
-            addressType: settings?.invoices?.addressType || '0',
+            addressType: this.getAddressType(),
             expirationIndex,
             memo: settings?.invoices?.memo || '',
             receiverName: settings?.invoices?.receiverName || '',
@@ -371,8 +379,7 @@ export default class Receive extends React.Component<
             this.setState({ selectedIndex: this.getDefaultIndex() });
         }
 
-        const addressType =
-            route.params?.addressType || settings?.invoices?.addressType || '0';
+        const addressType = this.getAddressType();
 
         // POS
         const memo = route.params?.memo ?? this.state.memo;

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -254,6 +254,22 @@ export default class Receive extends React.Component<
         return defaultInvoiceType === DefaultInvoiceType.Lightning ? 1 : 0;
     };
 
+    private getReceiveModeFlags = (): {
+        lnOnly: boolean;
+        onChainOnly: boolean;
+    } => {
+        const { route, SettingsStore } = this.props;
+        const { posStatus, settings } = SettingsStore;
+        const lnOnly =
+            (settings &&
+                posStatus === 'active' &&
+                settings.pos?.confirmationPreference === 'lnOnly') ||
+            !!route.params?.forceLn ||
+            !BackendUtils.supportsOnchainReceiving();
+        const onChainOnly = !!route.params?.forceOnChain;
+        return { lnOnly, onChainOnly };
+    };
+
     async componentDidMount() {
         const {
             InvoicesStore,
@@ -263,7 +279,7 @@ export default class Receive extends React.Component<
             route
         } = this.props;
         const { reset } = InvoicesStore;
-        const { getSettings, posStatus } = SettingsStore;
+        const { getSettings } = SettingsStore;
         const { status, lightningAddressHandle } = LightningAddressStore;
 
         const settings = await getSettings();
@@ -318,16 +334,7 @@ export default class Receive extends React.Component<
             flowLspNotConfigured
         });
 
-        const lnOnly =
-            (settings &&
-                posStatus &&
-                posStatus === 'active' &&
-                settings.pos &&
-                settings.pos.confirmationPreference &&
-                settings.pos.confirmationPreference === 'lnOnly') ||
-            route.params?.forceLn ||
-            !BackendUtils.supportsOnchainReceiving();
-        const onChainOnly = route.params?.forceOnChain;
+        const { lnOnly, onChainOnly } = this.getReceiveModeFlags();
 
         reset();
 
@@ -1289,16 +1296,7 @@ export default class Receive extends React.Component<
             settings?.invoices?.defaultInvoiceType !==
             DefaultInvoiceType.Unified;
 
-        const lnOnly =
-            (settings &&
-                posStatus &&
-                posStatus === 'active' &&
-                settings.pos &&
-                settings.pos.confirmationPreference &&
-                settings.pos.confirmationPreference === 'lnOnly') ||
-            route.params?.forceLn ||
-            !BackendUtils.supportsOnchainReceiving();
-        const onChainOnly = route.params?.forceOnChain;
+        const { lnOnly, onChainOnly } = this.getReceiveModeFlags();
 
         const lnurl = route.params?.lnurlParams;
 

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -270,6 +270,14 @@ export default class Receive extends React.Component<
         return { lnOnly, onChainOnly };
     };
 
+    private getSkipOnchain = (): boolean => {
+        const { settings } = this.props.SettingsStore;
+        return (
+            settings?.invoices?.defaultInvoiceType !==
+            DefaultInvoiceType.Unified
+        );
+    };
+
     async componentDidMount() {
         const {
             InvoicesStore,
@@ -553,15 +561,12 @@ export default class Receive extends React.Component<
         addressType?: string,
         lspIsActive?: boolean
     ) => {
-        const { InvoicesStore, PosStore, SettingsStore } = this.props;
+        const { InvoicesStore, PosStore } = this.props;
         const { receiverName, orderId, orderTip, exchangeRate } = this.state;
         // Use passed lspIsActive parameter, fall back to state if not provided
         const effectiveLspIsActive = lspIsActive ?? this.state.lspIsActive;
         const { createUnifiedInvoice } = InvoicesStore;
-        const { settings } = SettingsStore;
-        const skipOnchain =
-            settings?.invoices?.defaultInvoiceType !==
-            DefaultInvoiceType.Unified;
+        const skipOnchain = this.getSkipOnchain();
 
         // POS invoice reuse logic
         const checkExistingInvoice = async () => {
@@ -682,14 +687,11 @@ export default class Receive extends React.Component<
     };
 
     validateAddress = (text: string) => {
-        const { navigation, InvoicesStore, SettingsStore, route } = this.props;
+        const { navigation, InvoicesStore, route } = this.props;
         const { lspIsActive, receiverName } = this.state;
         const { createUnifiedInvoice } = InvoicesStore;
-        const { settings } = SettingsStore;
         const satAmount = getSatAmount(route.params?.amount);
-        const skipOnchain =
-            settings?.invoices?.defaultInvoiceType !==
-            DefaultInvoiceType.Unified;
+        const skipOnchain = this.getSkipOnchain();
 
         handleAnything(text, satAmount.toString())
             .then((response) => {
@@ -1292,9 +1294,7 @@ export default class Receive extends React.Component<
         const showCustomPreimageField =
             settings?.invoices?.showCustomPreimageField;
 
-        const skipOnchain =
-            settings?.invoices?.defaultInvoiceType !==
-            DefaultInvoiceType.Unified;
+        const skipOnchain = this.getSkipOnchain();
 
         const { lnOnly, onChainOnly } = this.getReceiveModeFlags();
 


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-4193**](https://github.com/ZeusLN/zeus/issues/4193)

Deduplicates several locals that were redefined identically (or near-identically) across `componentDidMount`, `render`, `autoGenerateInvoice`, and `validateAddress` in `views/Receive.tsx`. Surfaced during review of #4192 (Gemini flagged the `lnOnly` duplicate, which predates that PR).

Three small refactors, one commit each, all no-behavior-change except where called out:

1. **`getReceiveModeFlags()`** — returns `{ lnOnly, onChainOnly }`. Replaces two copies (componentDidMount + render).
2. **`getSkipOnchain()`** — replaces three copies of `settings?.invoices?.defaultInvoiceType !== DefaultInvoiceType.Unified` (in `autoGenerateInvoice`, `validateAddress`, and `render`).
3. **`getAddressType()`** — returns `route.params?.addressType || settings?.invoices?.addressType || '0'`. Used at both the initial `setState` in `componentDidMount` and the per-action local that seeds `autoGenerate*` calls.

### Behavior change in (3)

Previously the `route.params?.addressType` override only applied to the immediate auto-generation in `componentDidMount`; the initial `setState` seeded `state.addressType` from settings alone, so the picker and any subsequent re-generations silently snapped back to the settings default. Both sites now share `getAddressType()`, so navigating to Receive from `OnChainAddresses` with an `addressType` in params is now reflected in state as well. This looks like a missed update when the route override was originally added (the `autoGenerate*` callers already accounted for it; only the persisted state didn't).

No behavior change in (1) or (2).

### Address-type translation fix (LND backends)

Reviewing (3) surfaced a separate pre-existing bug: the address-type picker was silently generating native segwit on every LND backend regardless of what the user picked, and the `OnChainAddresses` → `Receive` flow for `NESTED_WITNESS_PUBKEY_HASH` / `HYBRID_NESTED_WITNESS_PUBKEY_HASH` accounts produced the wrong type or errored outright.

Three different forms reach the backend — numeric strings from the picker / settings (`'0'` / `'1'` / `'4'`), lnrpc enum names, and walletrpc enum names returned by `ListAccounts` — and each transport wants something different:

- **LND REST** — grpc-gateway parses the `AddressType` query param by name. `?type=1` is silently treated as `WITNESS_PUBKEY_HASH`.
- **LNC** — same; the LNC client expects the lnrpc enum name.
- **Embedded LND** — protobufjs writes the enum via `writer.int32(...)`, which numeric-coerces string enum names to `NaN` and serializes them as `0`. Needs the numeric form.

Added `utils/LndUtils.ts` (with unit tests) exposing `toLnrpcAddressType` (name form) and `toLnrpcAddressTypeNum` (numeric form). `LND`, `LightningNodeConnect`, and `EmbeddedLND` `getNewAddress` calls now route through whichever helper their transport needs, and `HYBRID_NESTED_WITNESS_PUBKEY_HASH` is mapped to `NESTED_PUBKEY_HASH` (lnrpc has no hybrid variant; the resulting nested-segwit p2sh-p2wkh is what the receiver sees).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND

Remote
- [x] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding