### PR TITLE
ui: Receive: highlight 0-conf fee when channel setup required

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -186,6 +186,8 @@ const LOCKED_EXPIRY = '1';
 const LOCKED_TIME_PERIOD = 'Hours';
 const LOCKED_EXPIRY_SECONDS = '3600';
 
+const LSP_MIN_CHANNEL_OPEN_FEE_SATS = 1000;
+
 @inject(
     'ChannelsStore',
     'InvoicesStore',
@@ -1266,7 +1268,8 @@ export default class Receive extends React.Component<
 
         const { zeroConfFee, showLspSettings } = LSPStore;
         const requiresChannelSetup =
-            zeroConfFee && new BigNumber(zeroConfFee).gt(2);
+            zeroConfFee &&
+            new BigNumber(zeroConfFee).gte(LSP_MIN_CHANNEL_OPEN_FEE_SATS);
 
         const {
             createUnifiedInvoice,
@@ -1895,7 +1898,9 @@ export default class Receive extends React.Component<
                                                 navigation.navigate(
                                                     new BigNumber(
                                                         zeroConfFee
-                                                    ).gt(1000)
+                                                    ).gte(
+                                                        LSP_MIN_CHANNEL_OPEN_FEE_SATS
+                                                    )
                                                         ? 'LspExplanationFees'
                                                         : 'LspExplanationRouting'
                                                 )
@@ -1933,7 +1938,9 @@ export default class Receive extends React.Component<
                                                     {localeString(
                                                         new BigNumber(
                                                             zeroConfFee
-                                                        ).gt(1000)
+                                                        ).gte(
+                                                            LSP_MIN_CHANNEL_OPEN_FEE_SATS
+                                                        )
                                                             ? selectedIndex ===
                                                               0
                                                                 ? 'views.Receive.lspExplainerUnified'

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -1265,6 +1265,8 @@ export default class Receive extends React.Component<
         } = this.state;
 
         const { zeroConfFee, showLspSettings } = LSPStore;
+        const requiresChannelSetup =
+            zeroConfFee && new BigNumber(zeroConfFee).gt(2);
 
         const {
             createUnifiedInvoice,
@@ -1903,6 +1905,12 @@ export default class Receive extends React.Component<
                                                 style={{
                                                     backgroundColor:
                                                         themeColor('secondary'),
+                                                    borderColor:
+                                                        requiresChannelSetup
+                                                            ? themeColor(
+                                                                  'highlight'
+                                                              )
+                                                            : undefined,
                                                     borderRadius: 10,
                                                     top: 10,
                                                     margin: 10,
@@ -1915,7 +1923,9 @@ export default class Receive extends React.Component<
                                                         fontFamily:
                                                             'PPNeueMontreal-Medium',
                                                         color: themeColor(
-                                                            'text'
+                                                            requiresChannelSetup
+                                                                ? 'highlight'
+                                                                : 'text'
                                                         ),
                                                         marginBottom: 5
                                                     }}


### PR DESCRIPTION
# Description

Highlights the LSP modal border and prompt text when a channel open is required. Standard wrapped invoice fees will be displayed as before.

Default theme

|Before|After|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-25 at 18 48 09" src="https://github.com/user-attachments/assets/adb2a40c-35cd-461a-85a7-e91cdc9b68e6" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-25 at 18 48 18" src="https://github.com/user-attachments/assets/b5dccb7b-8abc-48e4-aa81-59b629db5b4c" />|

Deep Purple theme

|Before|After|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-25 at 18 47 45" src="https://github.com/user-attachments/assets/20948d25-4c7d-47fa-8e77-ecb12a34111f" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-25 at 18 47 32" src="https://github.com/user-attachments/assets/a7abf868-4e22-4fae-a225-d91c474b6dc9" />|

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
