### PR TITLE
ui: Receive: prevent input field flash on initial load via initialLoad state

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -587,6 +587,10 @@ export default class Receive extends React.Component<
         const { createUnifiedInvoice } = InvoicesStore;
         const skipOnchain = this.getSkipOnchain();
 
+        // Set synchronously so componentDidMount's initialLoad flip sees
+        // creatingInvoice=true before the checkExistingInvoice microtask runs.
+        InvoicesStore.creatingInvoice = true;
+
         // POS invoice reuse logic
         const checkExistingInvoice = async () => {
             if (orderId) {
@@ -617,7 +621,10 @@ export default class Receive extends React.Component<
         };
 
         checkExistingInvoice().then((canReuseInvoice) => {
-            if (canReuseInvoice) return;
+            if (canReuseInvoice) {
+                InvoicesStore.creatingInvoice = false;
+                return;
+            }
 
             createUnifiedInvoice({
                 memo: effectiveLspIsActive

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -144,6 +144,7 @@ interface ReceiveProps {
 }
 
 interface ReceiveState {
+    initialLoad: boolean;
     selectedIndex: number;
     expirationIndex: ExpirationPreset | null;
     addressType: string;
@@ -208,6 +209,7 @@ export default class Receive extends React.Component<
     constructor(props: ReceiveProps) {
         super(props);
         this.state = {
+            initialLoad: true,
             selectedIndex: props.route.params?.selectedIndex ?? 0,
             expirationIndex: 1,
             addressType: '0',
@@ -469,6 +471,10 @@ export default class Receive extends React.Component<
         } else if (autoGenerateOnChain) {
             this.autoGenerateOnChainAddress(account, addressType);
         }
+
+        this.setState({
+            initialLoad: false
+        });
 
         if (Platform.OS !== 'android') {
             return;
@@ -1300,7 +1306,10 @@ export default class Receive extends React.Component<
         } = InvoicesStore;
         const { implementation, posStatus, settings, updateSettings } =
             SettingsStore;
-        const loading = SettingsStore.loading || InvoicesStore.loading;
+        const loading =
+            SettingsStore.loading ||
+            InvoicesStore.loading ||
+            this.state.initialLoad;
         const address = onChainAddress;
         const { lightningAddress } = LightningAddressStore;
         const lightningAddressLoading = LightningAddressStore.loading;
@@ -2309,6 +2318,7 @@ export default class Receive extends React.Component<
                                 )}
                                 {!haveInvoice &&
                                     !creatingInvoice &&
+                                    !loading &&
                                     route.params?.selectedIndex !== 2 && (
                                         <>
                                             {BackendUtils.supportsFlowLSP() &&


### PR DESCRIPTION
# Description

Prevents the memo/amount input fields from briefly flashing on the Receive view when navigating from the Wallet keypad's Request button. Adds an `initialLoad` state flag that's true on mount and flipped to false at the end of `componentDidMount`, then folds it into the existing `loading` computed value so the input section stays hidden until auto-generation has had a chance to set `creatingInvoice`.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [x] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS Transfix page and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
