### PR TITLE
fix(utxo-picker): restore UTXO labels and keep Set button above gesture bar

### DIFF
--- a/components/UTXOPicker.tsx
+++ b/components/UTXOPicker.tsx
@@ -8,7 +8,9 @@ import {
     Text,
     TouchableOpacity
 } from 'react-native';
+import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
 import { inject, observer } from 'mobx-react';
+import { reaction } from 'mobx';
 
 import AccountFilter from '../components/AccountFilter';
 import Amount from './Amount';
@@ -45,6 +47,7 @@ interface UTXOPickerState {
 
 const DEFAULT_TITLE = localeString('components.UTXOPicker.defaultTitle');
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+const FOOTER_PADDING_BOTTOM = 12;
 
 @inject('UTXOsStore')
 @observer
@@ -53,6 +56,7 @@ export default class UTXOPicker extends React.Component<
     UTXOPickerState
 > {
     private _isMounted = false;
+    private reactionDisposer: (() => void) | null = null;
 
     state: UTXOPickerState = {
         utxosSelected: [],
@@ -75,20 +79,23 @@ export default class UTXOPicker extends React.Component<
         if (BackendUtils.supportsAccounts()) {
             listAccounts();
         }
-    }
 
-    componentDidUpdate(prevProps: UTXOPickerProps) {
-        const { UTXOsStore } = this.props;
-        const prev = prevProps.UTXOsStore;
-        const utxosChanged = prev.utxos !== UTXOsStore.utxos;
-        const finishedLoading = prev.loading && !UTXOsStore.loading;
-        if (!UTXOsStore.loading && (utxosChanged || finishedLoading)) {
-            void this.loadLabels();
-        }
+        // The injected UTXOsStore is a singleton, so prevProps comparisons in
+        // componentDidUpdate never detect a change. Observe the utxos list via
+        // a MobX reaction so labels reload whenever the UTXO set changes.
+        this.reactionDisposer = reaction(
+            () => UTXOsStore.utxos.slice(),
+            () => {
+                void this.loadLabels();
+            },
+            { fireImmediately: true }
+        );
     }
 
     componentWillUnmount() {
         this._isMounted = false;
+        this.reactionDisposer?.();
+        this.reactionDisposer = null;
     }
 
     private async loadLabels() {
@@ -279,7 +286,11 @@ export default class UTXOPicker extends React.Component<
                     <Text
                         style={[
                             styles.utxoLabel,
-                            { color: themeColor('secondaryText') }
+                            {
+                                color: selected
+                                    ? themeColor('highlight')
+                                    : themeColor('secondaryText')
+                            }
                         ]}
                     >
                         {`${localeString('general.label')}: ${message}`}
@@ -454,46 +465,61 @@ export default class UTXOPicker extends React.Component<
                             )}
                         </View>
 
-                        <View style={styles.footer}>
-                            <View style={styles.footerButton}>
-                                <Button
-                                    title={localeString(
-                                        'components.UTXOPicker.modal.set'
-                                    )}
-                                    disabled={
-                                        loading ||
-                                        utxos.length === 0 ||
-                                        utxosSelected.length === 0
-                                    }
-                                    onPress={() => {
-                                        const {
-                                            utxosSelected,
-                                            selectedBalance
-                                        } = this.state;
-                                        this.setState({
-                                            showUtxoModal: false,
-                                            clearedDraftInModal: false,
-                                            utxosSet: utxosSelected,
-                                            setBalance: selectedBalance
-                                        });
+                        <SafeAreaInsetsContext.Consumer>
+                            {(insets) => (
+                                <View
+                                    style={[
+                                        styles.footer,
+                                        {
+                                            paddingBottom:
+                                                FOOTER_PADDING_BOTTOM +
+                                                (insets?.bottom || 0)
+                                        }
+                                    ]}
+                                >
+                                    <View style={styles.footerButton}>
+                                        <Button
+                                            title={localeString(
+                                                'components.UTXOPicker.modal.set'
+                                            )}
+                                            disabled={
+                                                loading ||
+                                                utxos.length === 0 ||
+                                                utxosSelected.length === 0
+                                            }
+                                            onPress={() => {
+                                                const {
+                                                    utxosSelected,
+                                                    selectedBalance
+                                                } = this.state;
+                                                this.setState({
+                                                    showUtxoModal: false,
+                                                    clearedDraftInModal: false,
+                                                    utxosSet: utxosSelected,
+                                                    setBalance: selectedBalance
+                                                });
 
-                                        onValueChange(
-                                            utxosSelected,
-                                            selectedBalance,
-                                            account
-                                        );
-                                    }}
-                                />
-                            </View>
+                                                onValueChange(
+                                                    utxosSelected,
+                                                    selectedBalance,
+                                                    account
+                                                );
+                                            }}
+                                        />
+                                    </View>
 
-                            <View style={styles.footerButton}>
-                                <Button
-                                    title={localeString('general.cancel')}
-                                    onPress={this.closePicker}
-                                    secondary
-                                />
-                            </View>
-                        </View>
+                                    <View style={styles.footerButton}>
+                                        <Button
+                                            title={localeString(
+                                                'general.cancel'
+                                            )}
+                                            onPress={this.closePicker}
+                                            secondary
+                                        />
+                                    </View>
+                                </View>
+                            )}
+                        </SafeAreaInsetsContext.Consumer>
                     </View>
                 </ModalBox>
 
@@ -679,7 +705,7 @@ const styles = StyleSheet.create({
     },
     footer: {
         paddingTop: 8,
-        paddingBottom: 12
+        paddingBottom: FOOTER_PADDING_BOTTOM
     },
     footerButton: {
         paddingTop: 10,


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-4201**](https://github.com/ZeusLN/zeus/issues/4201)

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

<img width="450" alt="Screenshot_1782557397" src="https://github.com/user-attachments/assets/58622a34-aad9-4907-8bc3-8bbc57d288e1" />


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
