### PR TITLE
fix: poll status for free LSPS1/LSPS7 orders

### DIFF
--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -1575,7 +1575,9 @@ export default class LdkNode {
 
         return {
             order_id: response.orderId,
-            order_state: response.orderState,
+            // ldk-node returns lowercase order states ('created' | 'completed' |
+            // 'failed'); normalize to the uppercase LSPOrderState the app uses.
+            order_state: response.orderState?.toUpperCase(),
             channel_extension_expiry_blocks:
                 response.channelExtensionExpiryBlocks,
             new_channel_expiry_block: response.newChannelExpiryBlock,
@@ -1613,7 +1615,9 @@ export default class LdkNode {
 
         return {
             order_id: response.orderId,
-            order_state: response.orderState,
+            // ldk-node returns lowercase order states ('created' | 'completed' |
+            // 'failed'); normalize to the uppercase LSPOrderState the app uses.
+            order_state: response.orderState?.toUpperCase(),
             channel_extension_expiry_blocks:
                 response.channelExtensionExpiryBlocks,
             new_channel_expiry_block: response.newChannelExpiryBlock,

--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -9,6 +9,8 @@ import NodeInfoStore from './NodeInfoStore';
 import lndMobile from '../lndmobile/LndMobileInjection';
 const { index, channel } = lndMobile;
 
+import { LSPOrderState, LSPService } from '../models/LSP';
+
 import BackendUtils from '../utils/BackendUtils';
 import Base64Utils from '../utils/Base64Utils';
 import { getClientInfo } from '../utils/ClientInfoUtils';
@@ -27,6 +29,8 @@ const JSON_RPC_VERSION = '2.0';
 // Upper bound for how long a custom-message get_order round trip may take before
 // the caller stops waiting. Resolves early as soon as the response arrives.
 const CUSTOM_MESSAGE_RESPONSE_TIMEOUT_MS = 7000;
+
+const FREE_ORDER_POLL_INTERVAL_MS = 5000;
 
 export default class LSPStore {
     @observable public info: any = {};
@@ -63,6 +67,14 @@ export default class LSPStore {
     // await the round trip instead of racing a fixed delay.
     private getOrderResponseResolver: (() => void) | null = null;
     private getExtensionOrderResponseResolver: (() => void) | null = null;
+
+    // Free orders have no payment step, so they never pass through the LSPPaymentAwait polling screen.
+    // Without this poll the post-creation view would stay on the
+    // "opening now…" message forever, even after the channel open fails.
+    // Poll get_order until the order reaches a terminal state, then mirror the result
+    // into the create-order response so the view reflects the real outcome.
+    private freeOrderPollTimer: ReturnType<typeof setTimeout> | null = null;
+    private freeOrderPollId: string | null = null;
 
     settingsStore: SettingsStore;
     channelsStore: ChannelsStore;
@@ -123,6 +135,7 @@ export default class LSPStore {
 
     @action
     public resetLSPS1Data = () => {
+        this.stopFreeOrderStatusPolling();
         this.createOrderResponse = {};
         this.getInfoData = {};
         this.loadingLSPS1 = false;
@@ -132,6 +145,7 @@ export default class LSPStore {
 
     @action
     public resetLSPS7Data = () => {
+        this.stopFreeOrderStatusPolling();
         this.createExtensionOrderResponse = {};
         this.loadingLSPS7 = false;
         this.error = false;
@@ -140,6 +154,7 @@ export default class LSPStore {
 
     @action
     public clearLSPS7Order = () => {
+        this.stopFreeOrderStatusPolling();
         this.createExtensionOrderResponse = {};
     };
 
@@ -1298,6 +1313,84 @@ export default class LSPStore {
                     settle();
                 });
         });
+    };
+
+    public startFreeOrderStatusPolling = (
+        orderId: string,
+        service: LSPService
+    ) => {
+        if (this.freeOrderPollId === orderId) return;
+        this.stopFreeOrderStatusPolling();
+        this.freeOrderPollId = orderId;
+        this.pollFreeOrderStatus(orderId, service);
+    };
+
+    public stopFreeOrderStatusPolling = () => {
+        this.freeOrderPollId = null;
+        if (this.freeOrderPollTimer) {
+            clearTimeout(this.freeOrderPollTimer);
+            this.freeOrderPollTimer = null;
+        }
+    };
+
+    private pollFreeOrderStatus = async (
+        orderId: string,
+        service: LSPService
+    ) => {
+        if (this.freeOrderPollId !== orderId) return;
+
+        try {
+            if (service === LSPService.LSPS7) {
+                await this.lsps7GetOrderCustomMessage(
+                    orderId,
+                    this.getLSPSPubkey()
+                );
+            } else if (BackendUtils.supportsLSPS1native()) {
+                await this.lsps1GetOrderNative(orderId);
+            } else if (BackendUtils.supportsLSPS1rest()) {
+                await this.lsps1GetOrderREST(orderId, this.getLSPS1Rest());
+            } else if (BackendUtils.supportsLSPScustomMessage()) {
+                await this.lsps1GetOrderCustomMessage(
+                    orderId,
+                    this.getLSPSPubkey()
+                );
+            } else {
+                return;
+            }
+
+            if (this.freeOrderPollId !== orderId) return;
+
+            const response =
+                service === LSPService.LSPS7
+                    ? this.getExtensionOrderResponse
+                    : this.getOrderResponse;
+            if (response && Object.keys(response).length > 0) {
+                const result = response?.result || response;
+                if (
+                    result?.order_state === LSPOrderState.COMPLETED ||
+                    result?.order_state === LSPOrderState.FAILED
+                ) {
+                    runInAction(() => {
+                        if (service === LSPService.LSPS7) {
+                            this.createExtensionOrderResponse = response;
+                        } else {
+                            this.createOrderResponse = response;
+                        }
+                    });
+                    this.updateOrderInStorage(response);
+                    this.stopFreeOrderStatusPolling();
+                    return;
+                }
+            }
+        } catch (error) {
+            console.error('LSPStore: free order poll error', error);
+        }
+
+        if (this.freeOrderPollId !== orderId) return;
+        this.freeOrderPollTimer = setTimeout(
+            () => this.pollFreeOrderStatus(orderId, service),
+            FREE_ORDER_POLL_INTERVAL_MS
+        );
     };
 
     public updateOrderInStorage(order: any) {

--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -75,6 +75,9 @@ export default class LSPStore {
     // into the create-order response so the view reflects the real outcome.
     private freeOrderPollTimer: ReturnType<typeof setTimeout> | null = null;
     private freeOrderPollId: string | null = null;
+    // Incremented on every start/stop so an in-flight poll that resumes after an
+    // await can tell whether its session is still the active one.
+    private freeOrderPollSessionId = 0;
 
     settingsStore: SettingsStore;
     channelsStore: ChannelsStore;
@@ -1322,11 +1325,13 @@ export default class LSPStore {
         if (this.freeOrderPollId === orderId) return;
         this.stopFreeOrderStatusPolling();
         this.freeOrderPollId = orderId;
-        this.pollFreeOrderStatus(orderId, service);
+        const sessionId = ++this.freeOrderPollSessionId;
+        this.pollFreeOrderStatus(orderId, service, sessionId);
     };
 
     public stopFreeOrderStatusPolling = () => {
         this.freeOrderPollId = null;
+        this.freeOrderPollSessionId++;
         if (this.freeOrderPollTimer) {
             clearTimeout(this.freeOrderPollTimer);
             this.freeOrderPollTimer = null;
@@ -1335,9 +1340,10 @@ export default class LSPStore {
 
     private pollFreeOrderStatus = async (
         orderId: string,
-        service: LSPService
+        service: LSPService,
+        sessionId: number
     ) => {
-        if (this.freeOrderPollId !== orderId) return;
+        if (this.freeOrderPollSessionId !== sessionId) return;
 
         try {
             if (service === LSPService.LSPS7) {
@@ -1345,8 +1351,6 @@ export default class LSPStore {
                     orderId,
                     this.getLSPSPubkey()
                 );
-            } else if (BackendUtils.supportsLSPS1native()) {
-                await this.lsps1GetOrderNative(orderId);
             } else if (BackendUtils.supportsLSPS1rest()) {
                 await this.lsps1GetOrderREST(orderId, this.getLSPS1Rest());
             } else if (BackendUtils.supportsLSPScustomMessage()) {
@@ -1358,7 +1362,7 @@ export default class LSPStore {
                 return;
             }
 
-            if (this.freeOrderPollId !== orderId) return;
+            if (this.freeOrderPollSessionId !== sessionId) return;
 
             const response =
                 service === LSPService.LSPS7
@@ -1386,9 +1390,9 @@ export default class LSPStore {
             console.error('LSPStore: free order poll error', error);
         }
 
-        if (this.freeOrderPollId !== orderId) return;
+        if (this.freeOrderPollSessionId !== sessionId) return;
         this.freeOrderPollTimer = setTimeout(
-            () => this.pollFreeOrderStatus(orderId, service),
+            () => this.pollFreeOrderStatus(orderId, service, sessionId),
             FREE_ORDER_POLL_INTERVAL_MS
         );
     };

--- a/views/LSPS1/index.tsx
+++ b/views/LSPS1/index.tsx
@@ -196,10 +196,15 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
             isOrderFree(result?.payment)
         ) {
             this.lastSavedOrderId = orderId;
-            LSPStore.saveOrderToHistory(createOrderResponse, 'LSPS1');
-            LSPStore.startFreeOrderStatusPolling(orderId, LSPService.LSPS1);
+            this.handleFreeOrderCreated(orderId);
         }
     }
+
+    private handleFreeOrderCreated = (orderId: string) => {
+        const { LSPStore } = this.props;
+        LSPStore.saveOrderToHistory(LSPStore.createOrderResponse, 'LSPS1');
+        LSPStore.startFreeOrderStatusPolling(orderId, LSPService.LSPS1);
+    };
 
     subscribeToCustomMessages() {
         if (

--- a/views/LSPS1/index.tsx
+++ b/views/LSPS1/index.tsx
@@ -197,6 +197,7 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
         ) {
             this.lastSavedOrderId = orderId;
             LSPStore.saveOrderToHistory(createOrderResponse, 'LSPS1');
+            LSPStore.startFreeOrderStatusPolling(orderId, LSPService.LSPS1);
         }
     }
 

--- a/views/LSPS7/index.tsx
+++ b/views/LSPS7/index.tsx
@@ -108,6 +108,10 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
         });
     }
 
+    componentWillUnmount() {
+        this.props.LSPStore.stopFreeOrderStatusPolling();
+    }
+
     componentDidUpdate(_prevProps: LSPS7Props) {
         const { LSPStore } = this.props;
         const { createExtensionOrderResponse } = LSPStore;
@@ -123,6 +127,7 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
         ) {
             this.lastSavedOrderId = orderId;
             LSPStore.saveOrderToHistory(createExtensionOrderResponse, 'LSPS7');
+            LSPStore.startFreeOrderStatusPolling(orderId, LSPService.LSPS7);
         }
     }
 

--- a/views/LSPS7/index.tsx
+++ b/views/LSPS7/index.tsx
@@ -126,10 +126,18 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
             isOrderFree(result?.payment)
         ) {
             this.lastSavedOrderId = orderId;
-            LSPStore.saveOrderToHistory(createExtensionOrderResponse, 'LSPS7');
-            LSPStore.startFreeOrderStatusPolling(orderId, LSPService.LSPS7);
+            this.handleFreeOrderCreated(orderId);
         }
     }
+
+    private handleFreeOrderCreated = (orderId: string) => {
+        const { LSPStore } = this.props;
+        LSPStore.saveOrderToHistory(
+            LSPStore.createExtensionOrderResponse,
+            'LSPS7'
+        );
+        LSPStore.startFreeOrderStatusPolling(orderId, LSPService.LSPS7);
+    };
 
     updateExpirationIndex = (expirationIndex: number) => {
         if (expirationIndex === 0) {


### PR DESCRIPTION
# Description

**Issue:** Free LSPS1/LSPS7 orders showed "Free channel — opening now…" forever even after the channel open failed.

**Reason:** Free orders skip the payment screen that re-checks status, so the view stayed stuck on the original "CREATED" state.

**Fix:** After a free order is created, poll `get_order` every 5s until it's done (completed/failed), then update the view with the real result.

Also fixed:
- LDK Node returns LSPS7 order states in lowercase, which never matched what the app checks: normalized them so status is detected correctly.


This pull request is categorized as a:

- [ ] New feature
- [X] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [X] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [X] LDK Node
- [] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
