### PR TITLE
fix: SyncStore: fallback block height APIs with timeout

### DIFF
--- a/stores/SyncStore.ts
+++ b/stores/SyncStore.ts
@@ -11,6 +11,21 @@ import NodeInfo from '../models/NodeInfo';
 import ConnectivityStore from './ConnectivityStore';
 import SettingsStore from './SettingsStore';
 
+const BLOCK_HEIGHT_APIS: Record<string, string[]> = {
+    mainnet: [
+        'https://mempool.space/api/blocks/tip/height',
+        'https://blockstream.info/api/blocks/tip/height',
+        'https://mempool.emzy.de/api/blocks/tip/height'
+    ],
+    testnet: [
+        'https://mempool.space/testnet/api/blocks/tip/height',
+        'https://blockstream.info/testnet/api/blocks/tip/height'
+    ],
+    testnet4: ['https://mempool.space/testnet4/api/blocks/tip/height']
+};
+
+const BLOCK_HEIGHT_API_TIMEOUT_MS = 5000;
+
 export default class SyncStore {
     @observable public isSyncing: boolean = false;
     @observable public isRecovering: boolean = false;
@@ -83,8 +98,8 @@ export default class SyncStore {
         if (this.currentBlockHeight !== nodeInfo?.block_height) {
             this.currentBlockHeight = nodeInfo?.block_height || 0;
 
-            // if current block exceeds or equals best block height, query mempool for new tip
-            // if mempool call fails, set best block height to current height, then proceed
+            // if current block exceeds or equals best block height, fetch chain tip
+            // if all explorers fail, set best block height to current height, then proceed
             if (this.currentBlockHeight >= this.bestBlockHeight) {
                 await this.getBestBlockHeight();
                 if (this.error) this.bestBlockHeight = this.currentBlockHeight;
@@ -113,37 +128,46 @@ export default class SyncStore {
             (this.bestBlockHeight ?? 0) - this.currentBlockHeight;
     };
 
-    private getBestBlockHeight = async () => {
-        await new Promise((resolve, reject) => {
-            ReactNativeBlobUtil.fetch(
-                'get',
-                `https://mempool.space/${
-                    this.settingsStore.embeddedLndNetwork === 'Testnet'
-                        ? 'testnet/'
-                        : ''
-                }api/blocks/tip/height`
-            )
-                .then(async (response: any) => {
-                    const status = response.info().status;
-                    if (status == 200) {
-                        this.bestBlockHeight = Number.parseInt(response.json());
-                        if (
-                            typeof this.bestBlockHeight === 'number' &&
-                            this.currentBlockHeight
-                        ) {
-                            this.updateProgress();
-                        }
-                        resolve(this.bestBlockHeight);
-                    } else {
-                        this.error = true;
-                        reject();
-                    }
-                })
-                .catch(() => {
-                    this.error = true;
-                    reject();
+    private getBestBlockHeight = async (): Promise<void> => {
+        const urls =
+            BLOCK_HEIGHT_APIS[this.getNetwork()] ?? BLOCK_HEIGHT_APIS.mainnet;
+
+        for (const url of urls) {
+            try {
+                const height = await new Promise<number>((resolve, reject) => {
+                    const timeout = setTimeout(
+                        () => reject(new Error('timeout')),
+                        BLOCK_HEIGHT_API_TIMEOUT_MS
+                    );
+
+                    ReactNativeBlobUtil.fetch('get', url)
+                        .then((response: any) => {
+                            clearTimeout(timeout);
+                            if (response.info().status === 200) {
+                                const h = Number.parseInt(response.json(), 10);
+                                if (h > 0) resolve(h);
+                                else reject();
+                            } else {
+                                reject();
+                            }
+                        })
+                        .catch((err) => {
+                            clearTimeout(timeout);
+                            reject(err);
+                        });
                 });
-        });
+                this.bestBlockHeight = height;
+                this.error = false;
+                if (this.currentBlockHeight) {
+                    this.updateProgress();
+                }
+                return;
+            } catch {
+                // try next explorer
+            }
+        }
+
+        this.error = true;
     };
 
     @action
@@ -156,9 +180,8 @@ export default class SyncStore {
         // Fetch best block height, retrying until successful
         while (!this.bestBlockHeight) {
             if (!this.isSyncing) return;
-            try {
-                await this.getBestBlockHeight();
-            } catch {
+            await this.getBestBlockHeight();
+            if (!this.bestBlockHeight) {
                 await sleep(3000);
             }
         }
@@ -180,16 +203,16 @@ export default class SyncStore {
             await sleep(2000);
             this.getNodeInfo().then(() => this.setSyncInfo());
 
-            // only query Mempool instance every 30 seconds
-            const queryMempool = i === 14;
-            if (queryMempool) {
+            // refresh chain tip every 30 seconds
+            const queryTip = i === 14;
+            if (queryTip) {
                 i = 0;
             } else {
                 i++;
             }
 
-            if (queryMempool) {
-                this.getBestBlockHeight().catch(() => {});
+            if (queryTip) {
+                this.getBestBlockHeight();
             }
         }
     };

--- a/stores/SyncStore.ts
+++ b/stores/SyncStore.ts
@@ -94,25 +94,32 @@ export default class SyncStore {
 
     private setSyncInfo = async () => {
         const nodeInfo = this.nodeInfo;
+        const blockHeight = nodeInfo?.block_height;
 
-        if (this.currentBlockHeight !== nodeInfo?.block_height) {
-            this.currentBlockHeight = nodeInfo?.block_height || 0;
+        if (this.currentBlockHeight !== blockHeight) {
+            let needsTipFetch = false;
+            runInAction(() => {
+                this.currentBlockHeight = blockHeight || 0;
+                needsTipFetch = this.currentBlockHeight >= this.bestBlockHeight;
+            });
 
-            // if current block exceeds or equals best block height, fetch chain tip
-            // if all explorers fail, set best block height to current height, then proceed
-            if (this.currentBlockHeight >= this.bestBlockHeight) {
+            if (needsTipFetch) {
                 await this.getBestBlockHeight();
-                if (this.error) this.bestBlockHeight = this.currentBlockHeight;
             }
 
-            this.updateProgress();
+            runInAction(() => {
+                if (needsTipFetch && this.error) {
+                    this.bestBlockHeight = this.currentBlockHeight;
+                }
+                this.updateProgress();
+            });
         }
 
-        if (nodeInfo?.synced_to_chain || this.numBlocksUntilSynced <= 0) {
-            this.isSyncing = false;
-        }
-
-        return;
+        runInAction(() => {
+            if (nodeInfo?.synced_to_chain || this.numBlocksUntilSynced <= 0) {
+                this.isSyncing = false;
+            }
+        });
     };
 
     private getNodeInfo = () =>
@@ -156,18 +163,22 @@ export default class SyncStore {
                             reject(err);
                         });
                 });
-                this.bestBlockHeight = height;
-                this.error = false;
-                if (this.currentBlockHeight) {
-                    this.updateProgress();
-                }
+                runInAction(() => {
+                    this.bestBlockHeight = height;
+                    this.error = false;
+                    if (this.currentBlockHeight) {
+                        this.updateProgress();
+                    }
+                });
                 return;
             } catch {
                 // try next explorer
             }
         }
 
-        this.error = true;
+        runInAction(() => {
+            this.error = true;
+        });
     };
 
     @action


### PR DESCRIPTION
## Summary

Fixes embedded LND sync UI getting stuck showing `isSyncing: true` even when the node is already caught up and internet is available.

Sync progress depends on fetching the chain tip (`bestBlockHeight`) from an external Esplora-compatible API. Previously this only hit `mempool.space`, which could hang on rate limits or fail entirely — leaving `bestBlockHeight` stale and `numBlocksUntilSynced > 0` indefinitely.

## Problem

- Sync state used a single `mempool.space` endpoint for chain tip height
- Rate-limited or slow mempool responses could block sync progress indefinitely
- `isSyncing` stayed true, disabling wallet actions and showing a misleading sync banner

## Solution

- Add fallback block height APIs with ordered retry
- Add a 5s timeout per request (same as `ConnectivityStore`) so slow endpoints don't block fallbacks
- 
## Changes

**`stores/SyncStore.ts`**

| Network | Fallback order |
|---|---|
| Mainnet | mempool.space → blockstream.info → mempool.emzy.de |
| Testnet | mempool.space → blockstream.info |
| Testnet4 | mempool.space |

- `getBestBlockHeight()` tries each URL in order until one succeeds
- On total failure: sets `this.error = true` and returns (no throw)
- `setSyncInfo` unchanged: if `this.error`, sets `bestBlockHeight = currentBlockHeight` so sync can complete
- Initial sync loop retries on `!this.bestBlockHeight` instead of try/catch

## Test plan

- [ ] Start embedded LND wallet on mainnet — sync banner clears when node is caught up
- [ ] Verify sync banner clears when node reports `synced_to_chain.`
- [ ] Repeat on testnet
- [ ] Confirm wallet actions (send/receive) are not blocked after sync completes
- [ ] Confirm sync UI still shows progress while node is genuinely behind chain tip

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
