### PR TITLE
docs: add Claude Code skill library under .claude/skills

### DIFF
--- a/.claude/skills/zeus-architecture-contract/SKILL.md
+++ b/.claude/skills/zeus-architecture-contract/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: zeus-architecture-contract
+description: "Load when you need to understand WHY Zeus is structured the way it is before changing it: app boot/connection sequence (App.tsx vs views/Wallet/Wallet.tsx fetchData, fetchLock, connecting), the stores/Stores.ts singleton DI graph, MobX 5 decorators and @inject/@observer, utils/BackendUtils.ts dispatch and the call()-returns-false invariant, supports*() capability gating vs implementation branching, EmbeddedLND/LndHub inheritance fallthrough, NavigationService/popTo navigation contract, New Architecture (Fabric) constraints, and the catalog of known weak points. Symptoms/triggers: 'false.then is not a function' crashes, a backend method that silently does nothing, a feature appearing on a backend that cannot support it, infinite 'connecting' spinner, reconnect re-entrancy, embedded node hitting a REST URL, navigation going forward instead of back, 'where does the app actually connect to the node', 'where do I add a new store/backend method'."
+---
+
+# Zeus Architecture Contract
+
+The load-bearing design decisions of the Zeus wallet, why they exist, and what
+breaks when you violate them. Zeus is a React Native (RN) app written in
+TypeScript that speaks to 7 different Lightning Network backends. Almost every
+recurring crash class in this repo comes from violating one of the invariants
+below.
+
+Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha, RN 0.85.3).
+
+## When to use / When NOT to use
+
+USE this skill when you are:
+
+- Tracing app startup, node connection, reconnect, or the infinite-loading class of bugs.
+- Adding/renaming a method on a backend, adding a store, or wiring a new view to stores.
+- Deciding how to gate a feature per backend (`supports*` vs `implementation`).
+- Debugging `.then of false` / silent no-op backend calls.
+- Writing navigation code (imperative nav, back-navigation, typing).
+
+Do NOT use this skill for — load the sibling instead:
+
+| Need | Sibling skill |
+|---|---|
+| Per-backend quirks, the full 7-backend capability matrix, adding an RPC end-to-end | zeus-backends-and-capabilities |
+| Keychain contract, `zeus-settings-v2` blob, migrations, iCloud rules | zeus-storage-and-migrations |
+| Settings axes, defaults, add-a-setting checklist | zeus-config-and-flags |
+| Recreating the dev environment, postinstall chain, native binaries | zeus-build-and-env |
+| Symptom→triage tables for live debugging | zeus-debugging-playbook |
+| Historical incidents in narrative form (root cause chains) | zeus-failure-archaeology |
+| The change-gating rules (what needs maintainer sign-off) | zeus-change-control |
+| The node-lifecycle-races active campaign | zeus-node-lifecycle-campaign |
+
+## Glossary (jargon used below, defined once)
+
+| Term | Meaning |
+|---|---|
+| Backend / implementation | One of 7 ways Zeus talks to a Lightning node. The active one is the string `settingsStore.implementation`: `embedded-lnd`, `ldk-node`, `lnd`, `lightning-node-connect`, `cln-rest`, `lndhub`, `nostr-wallet-connect` (default `lnd`). |
+| LND / CLN | The two major Lightning node implementations (Go / C). Zeus talks to remote LND over its REST proxy; to CLN via the `cln-rest` plugin. |
+| Embedded LND / LDK Node | Node software running *inside* the phone app: LND compiled via gomobile, or LDK Node via a Rust FFI. Both are "local wallets". |
+| LNC | Lightning Node Connect — encrypted tunnel (mailbox protocol) to a remote LND, via the vendored `lnc-rn` module. |
+| LNDHub / NWC | Custodial-ish account protocols: LNDHub is an accounts API on top of LND; NWC (Nostr Wallet Connect, NIP-47) controls a wallet over Nostr relays. |
+| Macaroon | LND's bearer-token credential format, sent as a hex header on REST calls. |
+| Store (MobX) | An observable state container class. Zeus uses MobX 5 (`mobx` 5.15.3, `mobx-react` 6.1.4) with legacy decorators (`@observable`, `@action`), enabled by `experimentalDecorators` in tsconfig.json. |
+| Class component / `@inject` / `@observer` | Zeus views are React class components (not hooks). `@inject('SettingsStore', ...)` injects store singletons as props (PascalCase names); `@observer` re-renders on observable change. |
+| Native stack | `@react-navigation/native-stack` — screen navigation backed by native OS containers (vs the JS-based `@react-navigation/stack`, which Zeus does not use). |
+| New Architecture / Fabric | RN's rewritten rendering system (Fabric) + TurboModules. ON in Zeus. Stricter than the legacy bridge about layout/animation misuse. |
+| DI (dependency injection) | Passing a component's dependencies in from outside. Zeus does it manually: constructor arguments in `stores/Stores.ts`, no framework. |
+
+---
+
+## 1. Boot sequence — where the app ACTUALLY connects
+
+Statement: `App.tsx` renders shell + navigator only. All node connection logic
+lives in `views/Wallet/Wallet.tsx` and re-runs on every Wallet-screen focus.
+
+The chain:
+
+1. `index.js` — polyfills (TextEncoder, URL, random values), wires `protobufjs` to use `Long`, imports `shim.js` (generated by rn-nodeify), registers `App`.
+2. `App.tsx` (~1823 lines) — mobx-react `<Provider>` passing all 30 store singletons as PascalCase props, wrapping ONE flat `createNativeStackNavigator()` (`const Stack = createNativeStackNavigator()`) with ~209 `Stack.Screen` entries, `headerShown: false`. There is no `initialRouteName`: `Wallet` is the initial route because it is the FIRST `Stack.Screen`. ~220 `@ts-ignore` lines in App.tsx suppress Screen typing (see §5).
+3. `views/Wallet/Wallet.tsx` (~1901 lines) — `handleFocus` / `handleAppStateChange(active)` trigger `getSettingsAndNavigate()` (with an in-flight guard flag so focus events don't stack).
+4. `getSettingsAndNavigate()` — awaits `SettingsStore.getSettings()` (which also waits on Tor bootstrap), checks channel-migration lock, lockscreen/POS state, then either navigates (Lockscreen / Wallets / IntroSplash) or calls `fetchData()`.
+5. `fetchData()` — the real connect. Guarded by two SettingsStore observables:
+   - `connecting` — `@observable public connecting = true` (initialized true so first boot takes the full-connect path).
+   - `fetchLock` — `@observable public fetchLock = false`; first line of substance is `if (fetchLock) return; SettingsStore.fetchLock = true;`.
+
+What `fetchData` does when `connecting` is true — resets 11 stores before touching the network:
+`AlertStore, NodeInfoStore, BalanceStore, ChannelsStore, TransactionsStore, SyncStore, LightningAddressStore, LSPStore, ChannelBackupStore, UTXOsStore, CashuStore` all `.reset()`, plus `ContactStore.loadContacts()` and `NotesStore.loadNoteKeys()`. `LnurlPayStore.reset()` runs unconditionally (even when not `connecting`).
+
+Then it branches per implementation:
+
+| Implementation | Connect path in fetchData |
+|---|---|
+| `ldk-node` | stop previous instance → `startLdkNodeWallet(...)` (esplora/RGS/scorer/VSS config, LSPS1, trusted 0-conf peers) → later `waitForLdkNodeReady()` → getNodeInfo → getCombinedBalance → `getChannelsWithPolling()` |
+| `embedded-lnd` | `stopLnd()` (if already started) → `initializeLnd()` → optional express graph sync → `startLnd()` → `waitForRpcReady()` → getNodeInfo → listAccounts → getCombinedBalance → `getChannelsWithPolling()`; a 60 s timeout raises a "startup slow" alert; transient RPC errors retry with exponential backoff |
+| `lndhub` | `login({ login: username, password })` → lightning balance |
+| `lightning-node-connect` | `connect()` → `BackendUtils.checkPerms()` → getNodeInfo → balances → channels |
+| `nostr-wallet-connect` | `connectNWC()` → lightning balance |
+| default (`lnd`, `cln-rest`) | REST: getNodeInfo → listAccounts (if supported) → getCombinedBalance → getChannels |
+
+Post-connect (all backends): lightning-address status + auto-accept, Cashu
+auto-address creation, swap fees, Flow LSP init (`LSPStore.getLSPInfo()`,
+`subscribeCustomMessages()`, `initChannelAcceptor()`), NWC service init, then
+`SettingsStore.fetchLock = false` and `setConnectingStatus(false)`.
+
+Why: connection must re-run on focus (app resume, wallet switch) but never
+twice in parallel — parallel runs double-start embedded nodes and corrupt
+store state mid-reset.
+
+What breaks if violated: the UNSAFE-lifecycle refactor `fdad118ed` (2025-10-24)
+disturbed this flow and shipped an infinite-loading regression, fixed three
+weeks later by `93227029e` (the fix commit cites the offending hash in its
+subject). This flow is the #1 maintainer-flagged live problem area
+(node-lifecycle races) — see zeus-node-lifecycle-campaign before touching it.
+
+Known sharp edge (verified in source): many early-`return` error paths inside
+`fetchData` exit WITHOUT clearing `fetchLock`. `fetchLock` is released only at
+the natural end of `fetchData`, or as a side effect of
+`SettingsStore.setConnectingStatus(true)` (which also calls
+`BackendUtils.clearCachedCalls()` and resets error state). So a failed connect
+can leave the lock held until the next explicit reconnect. Do not "fix" this
+casually — it is entangled with the lifecycle-races campaign.
+
+## 2. Stores — composition root, singletons, DI order
+
+Statement: `stores/Stores.ts` is the single composition root. It creates 30
+module-level singletons with manual constructor DI. Declaration order matters.
+
+- `settingsStore = new SettingsStore()` is first — it is the root dependency nearly everything else takes.
+- Dependencies are plain constructor args, e.g. `nodeInfoStore = new NodeInfoStore(channelsStore, settingsStore)`. The biggest consumer is `NostrWalletConnectStore` (10 deps, declared last).
+- A store can only depend on stores declared ABOVE it in the file. Adding a store: declare it after all its deps, export it, and add it as a PascalCase prop on the `<Provider>` in App.tsx (prop name = injection name).
+- Views: class components with `@inject('PascalCaseName', ...)` + `@observer` (~197 `@observer` uses under views/). Injected prop names match the Provider prop names exactly — a typo'd inject name yields `undefined` at runtime, not a compile error.
+- Non-React code (backends, utils, services) does NOT use inject — it imports singletons directly: `import { settingsStore } from '../stores/Stores'`.
+
+Why: no DI framework keeps the graph explicit and debuggable; module-level
+singletons let non-React code (backend classes, NavigationService consumers,
+push handlers) reach state without a React context.
+
+The circular-import hazard — and why it currently works:
+
+```
+stores/Stores.ts → stores/SettingsStore.ts → utils/BackendUtils.ts
+      ↑                                              ↓
+backends/LND.ts  ←———————————————————————————— (imports LND et al.)
+```
+
+`backends/LND.ts` imports `{ settingsStore, nodeInfoStore }` from
+`stores/Stores`, while `stores/SettingsStore.ts` imports `BackendUtils`, which
+imports the backend classes. This cycle does not explode because every cyclic
+reference is used only INSIDE method bodies at call time, never during module
+evaluation: `new LND()` / `new BackendUtils()` touch no store, and store
+constructors call no backend. What breaks if violated: reference
+`settingsStore` (or any store) at module scope or in a backend constructor and
+you get `undefined` imports or a require-cycle crash at startup, possibly only
+on one platform. Keep cyclic usage lazy.
+
+MobX 5 constraint: the codebase uses MobX 5.15.3 decorator syntax
+(`@observable`/`@action` on class fields). Do not introduce MobX 6 idioms
+(`makeObservable`/`makeAutoObservable`) piecemeal — mixed modes silently stop
+observing. tsconfig has `strictPropertyInitialization: false` specifically to
+tolerate decorated store fields.
+
+## 3. Backend dispatch — THE central invariant
+
+Statement: `utils/BackendUtils.ts` (~308 lines) pre-instantiates all 7 backend
+classes in its constructor and dispatches every call on
+`settingsStore.implementation` via `getClass()` (unknown value falls back to
+`this.lnd`).
+
+INVARIANT: `call()` returns `false` SYNCHRONOUSLY for a missing method. It
+never throws.
+
+Why: this doubles as the capability mechanism — callers can cheaply probe
+"does the active backend have X" without try/catch, and `supports*()` flags
+are themselves dispatched through `call()` (missing flag ⇒ `false` ⇒ feature
+hidden, which is the safe default).
+
+The dispatcher code and the full consequence catalog (`false.then` crash
+class, silent no-op on typos, the two-touch rule for adding an RPC, the
+`payLightningInvoiceStreaming` dead dispatch) are owned by
+**zeus-backends-and-capabilities §1** — read that before touching dispatch.
+The design rule that matters here: always gate with the matching `supports*()`
+before awaiting a dispatched method (see §8 for the dead-dispatch weak point).
+
+Side behavior worth knowing: for `ldk-node`, `call()` wraps rejections with
+`parseLdkNodeError` to normalize Rust FFI error strings — error-shape handling
+lives in the dispatcher, not the backend class.
+
+### The supports*() gating invariant
+
+Statement: views gate feature AVAILABILITY only via `BackendUtils.supports*()`
+methods (~55 of them, e.g. `supportsKeysend`, `supportsCashuWallet` — see
+zeus-backends-and-capabilities for the authoritative counting command),
+never by comparing `implementation` strings.
+
+Why: 7 backends × every feature is unmaintainable as string checks; missing
+capability gates are historically the top cross-backend crash source (a
+feature renders on a backend that lacks the method → `false.then` crash or
+nonsense UI).
+
+Sanctioned exceptions — `implementation` branching IS used for
+transport/lifecycle mechanics, where the question is "HOW do I talk to this
+backend", not "does it have the feature":
+
+- Connection lifecycle: the per-implementation branches in `views/Wallet/Wallet.tsx fetchData()` (§1).
+- Keysend function selection + payment-result handling: `stores/TransactionsStore.ts sendPayment` picks `sendKeysend` vs `payLightningInvoice` by implementation, returns the raw promise for `lightning-node-connect` but routes others through `handlePayment`/`handlePaymentError`, and sets per-implementation request fields (`max_fee_percent` for cln-rest, `timeout_seconds` for LND-based/cln-rest/ldk-node).
+- Invoice-creation/subscription wiring: `views/Receive.tsx` selects the payment-detection mechanism per implementation (embedded-lnd vs LNC vs ldk-node vs REST polling etc.).
+
+Other scattered `implementation ===` checks exist in views (grep shows ~100
+occurrences across ~30 files beyond the sanctioned Wallet.tsx/Receive.tsx
+sites); treat them as debt to contain, not a pattern to extend. New feature
+gates must be `supports*`.
+
+Related version-gating caveat: LND-family flags additionally version-gate via
+`LND.supports(minVersion)`, which reads `nodeInfoStore.nodeInfo.version` —
+this is EMPTY until `getNodeInfo` resolves, so version-gated `supports*`
+answers are unreliable during early connect. Don't cache them pre-connect.
+
+## 4. Inheritance leak hazard — EmbeddedLND / LndHub extend LND
+
+Statement: there is no abstract backend base class. `backends/LND.ts` (~942
+lines, REST via react-native-blob-util + WebSocket streams, in-flight request
+dedup cache, Tor routing) is the de facto base. `EmbeddedLND` and `LndHub`
+`extends LND`; `CLNRest`, `LdkNode`, `LightningNodeConnect`,
+`NostrWalletConnect` are standalone duck-typed classes.
+
+Why (historical): embedded LND and LNDHub genuinely share LND's data shapes
+and many helpers, so extension was cheap. The price:
+
+HAZARD: any method NOT overridden in the subclass falls through to LND's REST
+implementation — a network call against `settingsStore.host`, which for an
+embedded node is meaningless (there is no REST host) and for LNDHub is the
+wrong API. Verified fallthrough surface today: `getFees`, `setFees`,
+`getForwardingHistory`, `subscribeInvoice`, `subscribeTransactions`,
+`initChanAcceptor` exist only on `LND` among {LND, EmbeddedLND, LndHub}.
+EmbeddedLND's own subscription methods are commented out with
+`// TODO rewrite subscription logic` (backends/EmbeddedLND.ts), and
+`stores/LSPStore.ts` works around the broken `initChanAcceptor` inheritance by
+calling the native `lndmobile` `channel.channelAcceptor()` API directly
+instead of going through BackendUtils.
+
+Same hazard, capability edition: `LndHub` overrides ~45 `supports*` flags
+(43 of them to `false`) but does NOT override `supportsChannelFundMax`, so it inherits `true`
+from `LND` (`supportsChannelFundMax = () => true`) — a custodial account
+"supporting" max-funding a channel it cannot open. This is the canonical
+example: when adding ANY method or `supports*` flag to `LND`, immediately ask
+"is this correct for EmbeddedLND and LndHub?" and override in both if not.
+
+What breaks if violated: silent wrong-network calls (embedded node issuing
+REST requests to a stale/absent host), or features rendered on backends that
+cannot execute them.
+
+## 5. Navigation contract
+
+Statement:
+
+- One flat native-stack navigator (App.tsx). No nested navigators for the main flow.
+- Imperative navigation from OUTSIDE React (push handlers, deep links, services) goes through `NavigationService.ts`: `setTopLevelNavigator` (wired from App.tsx's `NavigationContainer` ref), `navigate`, `navigateWhenReady` (retries 50 × 100 ms until the container is ready), `getRouteStack`.
+- Back-navigation uses `navigation.popTo('Screen')`, NOT `navigation.navigate('Screen')`. Why: after the react-navigation 6→7 upgrade, `navigate` to an existing route can PUSH a duplicate instead of popping back, corrupting the stack. What breaks: the regression class fixed in PR #2192 (`7abc7a971`, "fix-navigation-upgrade-regressions") — broken back-nav and node-picture selection. ~79 `popTo` call sites exist under views/ today.
+- Types: use `NativeStackNavigationProp` from `@react-navigation/native-stack` (7.12.0) — never `StackNavigationProp` from `@react-navigation/stack`, which is not the navigator Zeus uses.
+- Known debt, stated plainly: ~220 `@ts-ignore` lines in App.tsx (278 repo-wide excluding zeus_modules) paper over Screen/route typing. There is no typed route-param map. Zeus suppresses with `@ts-ignore` (ban-ts-comment is off), never `eslint-disable`. Don't try to drive-by-fix the typing debt inside a feature PR.
+
+## 6. Persistence boundary (summary — details in zeus-storage-and-migrations)
+
+Everything durable and secret goes through ONE wrapper: `storage/index.ts`, a
+react-native-keychain facade with key prefix `zeus:` and `cloudSync: false` on
+every call. Contract quirks you must know even when not doing storage work:
+`getItem` returns `false` (not `null`) when a key is unset, and writing an
+empty string is converted to a delete. All wallet configs and secrets live in
+one JSON blob under key `zeus-settings-v2`, owned by `stores/SettingsStore.ts`.
+Anything touching that blob, keychain keys, or migrations is a GATED change
+(maintainer sign-off + migration plan — see zeus-change-control). For the
+migration recipes, iCloud rules, and the three-registries rule for new keys,
+load zeus-storage-and-migrations.
+
+## 7. New Architecture (Fabric) is ON
+
+Statement: RN New Architecture has been enabled since the RN 0.74.2 → 0.83.1
+jump, commit `d13ebc2cd` ("deps: React Native upgrade: 0.74.2 -> 0.83.1").
+Verified today: `android/gradle.properties` has `newArchEnabled=true`; iOS has
+no opt-out in the Podfile (New Architecture is the RN 0.85 default). Current
+RN: 0.85.3.
+
+Why it's a contract: Fabric is stricter than the legacy renderer. Forbidden /
+crash-prone patterns:
+
+- Legacy `Animated` usage that mutated layout outside the declarative flow — WalletHeader crashed on Fabric and was fixed in `f08bfc7c5` ("fix WalletHeader animation crashes on New Architecture").
+- Layout assumptions the old renderer tolerated — the keypad Fabric crash required a baseline-layout restructure, `2c55e4f89` (#4163).
+
+What breaks if violated: hard native crashes, often only in release builds or
+on one platform. Any pre-2026 RN snippet (Stack Overflow, old Zeus code) that
+manipulates Animated values or measures layout imperatively must be treated as
+suspect. Fuller incident chains: zeus-failure-archaeology.
+
+## 8. Known weak points — stated plainly
+
+These are acknowledged, open, and NOT invitations for drive-by fixes (payment
+paths and storage are change-controlled; several are entangled with active
+campaigns). Cite them; don't silently "clean them up".
+
+| Weak point | Location (verified) | Status |
+|---|---|---|
+| Zero test coverage for stores/, views/, components/, backends/ | 0 `*.test.ts*` files in those trees; all 49 test files live in utils/, models/, lndmobile/, plus `check-styles.test.ts` at the repo root | Open. No safety net for architecture-level changes; see zeus-validation-and-qa |
+| `thread.run()` instead of `thread.start()` in the LND sync worker (runs the "thread" synchronously on the caller) | `android/app/src/main/java/com/zeus/LndMobileScheduledSyncWorker.java`, `FIXME(hsjoberg)` comment: "this is really wrong" (Looper.prepare crash blocked the correct form) | Open, Blixt-inherited |
+| `unbindLndMobileService` acknowledged broken | `lndmobile/LndMobile.d.ts`: `// TODO(hsjoberg): function looks broken`; Java side parks a Promise in `requests` that the unbind path never resolves | Open |
+| EmbeddedLND subscription methods disabled | `backends/EmbeddedLND.ts`: `subscribeInvoice`/`subscribeTransactions` commented out under `// TODO rewrite subscription logic`; un-overridden methods fall through to REST (§4) | Open; LSPStore bypasses via native `lndmobile` |
+| `payLightningInvoiceStreaming` dead dispatch | Declared only in `utils/BackendUtils.ts`; no backend implements it; always returns `false` | Open question (vestigial vs planned — unresolved) |
+| `readLndLog` stub returns `['']` | `lndmobile/index.ts`, marked `TODO remove` | Open |
+| LNC permissions hard-coded to `true` | `backends/LightningNodeConnect.ts checkPerms`: "ZEUS-3642: we are temporarily returning all perms as true until resolved" (github issue #3642) | Open — perm-derived `supports*` on LNC is untrustworthy; read-only pairings show send UI |
+| WebSocket streams bypass Tor | `backends/LND.ts wsReq` constructs `new WebSocket(url, ...)` directly — no `doTorRequest`/SOCKS path, unlike `restReq` which routes through Tor when enabled | Open privacy gap |
+| LNURL params unfetchable from `.onion` in some flows | `// TODO handle fetching of params with internal Tor` at 3 call sites: `utils/handleAnything.ts`, `components/LayerBalances/LightningSwipeableRow.tsx`, `components/LayerBalances/EcashSwipeableRow.tsx` | Open |
+| `fetchLock` not released on early-return error paths in `fetchData` | `views/Wallet/Wallet.tsx` (§1); only cleared at fetchData end or by `setConnectingStatus(true)` | Open, part of node-lifecycle races — see zeus-node-lifecycle-campaign |
+
+## Invariants quick card
+
+| # | Invariant | Breaks as |
+|---|---|---|
+| 1 | Connection logic lives in Wallet.tsx `fetchData`, guarded by `fetchLock` + `connecting`; never run it in parallel | Infinite loading (`fdad118ed` → fixed `93227029e`), double node start |
+| 2 | Stores are constructed once in stores/Stores.ts, deps declared above dependents; cyclic refs only used lazily | `undefined` singleton / require-cycle startup crash |
+| 3 | `BackendUtils.call()` returns `false` for missing methods — gate with `supports*()` before awaiting | `TypeError: .then is not a function`; silent no-ops on typos |
+| 4 | Feature availability gated ONLY by `supports*()`; `implementation` branching reserved for lifecycle/transport mechanics | Cross-backend crashes (historically the top source) |
+| 5 | Every method/flag added to `LND` must be audited for EmbeddedLND + LndHub overrides | Meaningless REST calls from embedded node; LndHub `supportsChannelFundMax` gap |
+| 6 | Back-navigation uses `popTo`, imperative nav uses NavigationService, types use `NativeStackNavigationProp` | Duplicate-screen stacks (PR #2192, `7abc7a971`) |
+| 7 | All persistence through `storage/index.ts` / `zeus-settings-v2`; storage changes are gated | Data loss; see zeus-storage-and-migrations + zeus-change-control |
+| 8 | New Architecture is ON — no legacy Animated/layout patterns | Fabric native crashes (`f08bfc7c5`, `2c55e4f89`) |
+
+## Provenance and maintenance
+
+Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha). All
+paths repo-relative. Line counts, screen counts, and `@ts-ignore` totals are
+approximate by nature and drift with every release — re-verify before citing.
+
+One-line re-verification commands (all read-only):
+
+| Fact | Command |
+|---|---|
+| RN / mobx / navigation versions | `grep -nE '"react-native"|"mobx"|"mobx-react"|"@react-navigation/native-stack"' package.json` |
+| 30 store singletons + DI order | `grep -c '^export const' stores/Stores.ts` and read the file top-to-bottom |
+| Provider props match store names | `sed -n '/<Provider/,/>/p' App.tsx` |
+| Wallet is first (initial) screen; screen count | `grep -n 'Stack.Screen' App.tsx \| head -3` ; `grep -c 'Stack.Screen' App.tsx` |
+| `call()` returns false for missing methods | `grep -n -A3 'call = (funcName' utils/BackendUtils.ts` |
+| 7-way dispatch + default lnd | `grep -n -A20 'getClass = ' utils/BackendUtils.ts` |
+| `payLightningInvoiceStreaming` still dead | `grep -rn payLightningInvoiceStreaming --include='*.ts*' . \| grep -v node_modules \| grep -v zeus_modules` (only BackendUtils.ts hits ⇒ still dead) |
+| EmbeddedLND/LndHub still extend LND | `grep -n 'extends' backends/*.ts` |
+| LndHub `supportsChannelFundMax` gap | `grep -n supportsChannelFundMax backends/LndHub.ts backends/LND.ts` (no LndHub hit ⇒ gap persists) |
+| EmbeddedLND subscriptions still disabled | `grep -n -A3 'TODO rewrite subscription logic' backends/EmbeddedLND.ts` |
+| `fetchLock` / `connecting` guards | `grep -n 'fetchLock\|@observable public connecting' stores/SettingsStore.ts views/Wallet/Wallet.tsx` |
+| fetchData reset list | `sed -n '/if (connecting) {/,/CashuStore.reset/p' views/Wallet/Wallet.tsx \| head -25` |
+| NavigationService API | `cat NavigationService.ts` |
+| popTo usage level | `grep -rn 'popTo(' views \| wc -l` |
+| `@ts-ignore` debt | `grep -c '@ts-ignore' App.tsx` |
+| New Arch ON | `grep -n newArchEnabled android/gradle.properties` ; `git log --oneline -1 d13ebc2cd` |
+| thread.run() hack | `grep -n -B4 'thread.run()' android/app/src/main/java/com/zeus/LndMobileScheduledSyncWorker.java` |
+| unbind broken TODO | `grep -n 'looks broken' lndmobile/LndMobile.d.ts` |
+| LNC perms hardcoded | `grep -n -A3 'ZEUS-3642' backends/LightningNodeConnect.ts` |
+| WS-bypasses-Tor | `grep -n 'new WebSocket' backends/LND.ts` (constructed directly, no Tor branch) |
+| onion LNURL TODOs (3 sites) | `grep -rn 'TODO handle fetching of params with internal Tor' utils components` |
+| Zero store/view/backend tests | `find stores views components backends -name '*.test.ts*' \| wc -l` (expect 0) |
+| Incident hashes | `git log --oneline -1 <hash>` for `fdad118ed`, `93227029e`, `7abc7a971`, `f08bfc7c5`, `2c55e4f89`, `d13ebc2cd`, `7ed901a10`, `d416052cd` |

--- a/.claude/skills/zeus-backends-and-capabilities/SKILL.md
+++ b/.claude/skills/zeus-backends-and-capabilities/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: zeus-backends-and-capabilities
+description: Load when working across Zeus's 7 Lightning backends (lnd, embedded-lnd, ldk-node, lightning-node-connect, cln-rest, lndhub, nostr-wallet-connect) - adding a new RPC or feature to backends/ or utils/BackendUtils.ts, adding or checking a supports* capability flag, gating a view on backend support, debugging "works on LND but crashes on CLN/NWC/LndHub", ".then is not a function" / "false.then" crashes, features silently doing nothing on one backend, payment success reported despite timeout, LNC showing send UI on read-only pairings, CLN invoice/payment lists missing entries, LDK Node channel-open or payment result handling, stale Tor request errors, or filling in the PR-template backend testing matrix.
+---
+
+# Zeus Backends and Capabilities
+
+Zeus is one wallet UI in front of 7 interchangeable Lightning node backends. This skill covers: what the 7 backends are, how per-call dispatch works, how the `supports*` capability system gates every feature, each backend's sharp edges, and the exact checklist for adding a new RPC or feature across the matrix.
+
+Glossary of terms used once and reused throughout:
+
+- **Lightning**: Bitcoin's layer-2 payment-channel network. A **channel** is a 2-party on-chain-funded balance that lets the parties pay each other off-chain instantly.
+- **LND, CLN (Core Lightning), LDK Node**: three independent Lightning node implementations. Zeus can drive all of them.
+- **Macaroon**: LND's bearer auth token (a hex blob granting RPC permissions). **Rune**: CLN's equivalent. **Pairing phrase**: Lightning Node Connect's one-time connection secret. **NWC URL**: a `nostr+walletconnect://` connection string.
+- **BOLT11**: standard Lightning invoice format. **BOLT12**: newer reusable "offers" format. **Keysend**: spontaneous payment to a pubkey without an invoice. **MPP/AMP**: multi-part / atomic multi-path payments (splitting one payment across routes). **LSP**: Lightning Service Provider (sells inbound channels); **LSPS0/1/7** are LSP protocol specs. **Cashu**: Chaumian ecash protocol. **Watchtower**: third party that punishes channel cheating while you're offline. **PSBT**: partially signed Bitcoin transaction.
+- **gomobile**: Go-to-mobile bindings (how LND runs on-device). **uniffi**: Mozilla's Rust-to-mobile FFI generator (how LDK Node and Cashu run on-device). **REST**: plain HTTPS JSON calls.
+
+## When to use / When NOT to use
+
+Use this skill when you are:
+- adding/changing anything in `backends/` or `utils/BackendUtils.ts`
+- adding a feature that must work (or deliberately not work) on more than one backend
+- debugging behavior that differs between backends
+- deciding which `supports*` flag to gate a view on
+
+Do NOT use this skill for:
+- boot/connect sequence, store wiring, `Wallet.tsx fetchData()` — see **zeus-architecture-contract**
+- running the app, connecting to Polar/regtest nodes, release ops — see **zeus-run-and-operate**
+- Lightning protocol theory (BOLT11 internals, LSPS message formats, Cashu NUTs) — see **zeus-lightning-reference**
+- settings axes and per-node config fields — see **zeus-config-and-flags**
+- keychain/settings-blob persistence — see **zeus-storage-and-migrations**
+- symptom-driven triage of app-wide bugs — see **zeus-debugging-playbook**
+- PR/commit/review process — see **zeus-change-control**
+
+## 1) The dispatch mechanism (read this first)
+
+`utils/BackendUtils.ts` pre-instantiates ALL 7 backend classes in its constructor and dispatches every call at runtime based on `settingsStore.implementation` (`getClass()` switch; default case returns the `lnd` instance). The implementation key is one of the 7 string values of the `Implementations` type in `stores/SettingsStore.ts`.
+
+The core dispatcher:
+
+```ts
+call = (funcName: string, args?: any) => {
+    const cls: any = this.getClass();
+    // return false if function is not defined in backend, as a fallback
+    if (!cls[funcName]) return false;
+    const result = cls[funcName].apply(cls, args);
+    // ldk-node only: rejected promises get .catch(parseLdkNodeError) attached
+    ...
+};
+```
+
+**THE FOOTGUN, memorize it:** if the active backend does not define `funcName`, `call()` returns `false` *synchronously* — not a rejected Promise, not an exception. Consequences:
+
+1. `BackendUtils.someMethod().then(...)` crashes with `TypeError: ... .then is not a function` on backends that lack the method. Always gate with the matching `supports*` flag before calling.
+2. A typo'd method name (backend class says `getRcoveryInfo`, wrapper says `getRecoveryInfo`) silently no-ops as `false` forever. There is no abstract base class or interface to catch this at compile time.
+3. This same mechanism IS the capability system: `supportsX()` flags are dispatched through `call()` too, so a backend that simply omits a flag reads as `false` (e.g. `supportsLSPS1native` is only defined on `LdkNode` — every other backend returns `false` by omission; `supportsWatchtowerClient` is not defined on `CLNRest`, so CLN reads `false` by omission).
+
+Known dead dispatch (as of 2026-07-06): `payLightningInvoiceStreaming` is declared in `utils/BackendUtils.ts` but implemented by NO backend — it always returns `false`. Do not model new code on it.
+
+Also in the dispatcher, not the backend class: when `implementation === 'ldk-node'`, `call()` attaches a `.catch` that normalizes raw uniffi error strings (Android `org.lightningdevkit.ldknode.NodeException.X: msg`, iOS `X(message: "msg")`) into clean messages via `parseLdkNodeError` in `utils/ErrorUtils.ts`. If you bypass `BackendUtils` and call the `LdkNode` class directly, you get raw FFI error strings.
+
+There is no abstract base: `backends/LND.ts` is the *implicit* base class. `EmbeddedLND` and `LndHub` **extend** it (inheriting REST methods and flags — see section 5); `CLNRest`, `LdkNode`, `LightningNodeConnect`, `NostrWalletConnect` are standalone classes that duck-type the same method names.
+
+## 2) The 7-backend inventory
+
+All files under `backends/`. Auth material lives per-node in the settings blob (see zeus-config-and-flags).
+
+| Implementation key | Class (file) | Runs | Transport | Auth material |
+|---|---|---|---|---|
+| `lnd` (default) | `LND` (`backends/LND.ts`) | remote | REST via `react-native-blob-util`; WebSocket for streams (`wsReq`, `openChannelStream`, `initChanAcceptor`, `subscribeCustomMessages`); optional Tor routing via `utils/TorUtils.doTorRequest` | macaroon (hex, `Grpc-Metadata-macaroon` header) |
+| `embedded-lnd` | `EmbeddedLND` (`backends/EmbeddedLND.ts`) **extends LND** | on-device | gomobile `Lndmobile` via `lndmobile/LndMobileInjection` (Messenger-IPC service on Android) | seed / wallet password (node is local) |
+| `ldk-node` | `LdkNode` (`backends/LdkNode.ts`) | on-device | uniffi FFI via `ldknode/LdkNodeInjection` (Rust ldk-node, ZeusLN fork) | BIP-39 mnemonic (also derives VSS remote-state auth) |
+| `lightning-node-connect` | `LightningNodeConnect` (`backends/LightningNodeConnect.ts`) | remote | native LNC module (`NativeModules.LncModule` inside vendored `zeus_modules/@lightninglabs/lnc-rn`) — gRPC tunneled through an LNC mailbox server (`mailbox.terminal.lightning.today:443`, `lnc.zeusln.app:443`, or custom; `LNC_MAILBOX_KEYS` in `stores/SettingsStore.ts`) | pairing phrase (+ creds cached by `backends/LNC/credentialStore.ts`) |
+| `cln-rest` | `CLNRest` (`backends/CLNRest.ts`) | remote | REST (all calls are POST, incl. reads) + response reshaping in `backends/CoreLightningRequestHandler.ts`; invoices/payments via raw SQL to `/v1/sql` | rune (`Rune` header) |
+| `lndhub` | `LndHub` (`backends/LndHub.ts`) **extends LND** | remote custodial | REST against `lndhubUrl` (`/auth`, `/gettxs`, `/balance`, `/addinvoice`, `/payinvoice`, ...) | login/password → Bearer `accessToken` (overrides `getHeaders`) |
+| `nostr-wallet-connect` | `NostrWalletConnect` (`backends/NostrWalletConnect.ts`) | remote custodial-ish | `NostrWebLNProvider` from `@getalby/sdk` (NIP-47 over Nostr relays) | `nostrWalletConnectUrl` |
+
+Zeus is also an NWC *service* (wallet side) — that lives in `stores/NostrWalletConnectStore.ts`, not in this backend, which is the *client* side.
+
+`BackendUtils.isLocalWallet()` returns true for `embedded-lnd` and `ldk-node` only (checks `implementation`, not a flag — one of the sanctioned implementation checks).
+
+## 3) The capability system
+
+### How supports* works
+
+Every feature surface in views/stores must be gated by a `supports*()` call on `BackendUtils`, which dispatches to the active backend class. Flags are plain methods returning booleans (a few return Promise-shaped values; treat truthiness only). There are ~55 flags — get the authoritative current list with:
+
+```bash
+grep -n "supports\w*\s*=\s*()" backends/LND.ts        # implicit base
+grep -n "    supports" utils/BackendUtils.ts           # dispatcher wrappers
+```
+
+**Invariant (top historical cross-backend crash source when violated):** views never branch on `settingsStore.implementation` for *features* — only on `supports*()`. The sanctioned exceptions that DO branch on implementation:
+- connection lifecycle in `views/Wallet/Wallet.tsx` (per-backend connect flows)
+- payment function selection and result handling in `stores/TransactionsStore.ts` (`sendPayment`: keysend goes through `sendKeysend` for `cln-rest`/`embedded-lnd`/`ldk-node` but through `payLightningInvoice` for LND REST; LNC results are returned raw to the caller instead of `.then(handlePayment)`; embedded-lnd statuses decoded through `lnrpc.Payment.PaymentStatus` enums)
+- the embedded-lnd channel acceptor in `stores/LSPStore.ts initChannelAcceptor` (see section 4)
+- `BackendUtils.isLocalWallet()`
+
+### Version gating (LND family)
+
+`LND.supports(minVersion, eosVersion?)` (also on `LightningNodeConnect`) compares `nodeInfoStore.nodeInfo.version` using `utils/VersionUtils.isSupportedVersion`. `CLNRest.supports` additionally accepts `minApiVersion` checked against `nodeInfo.api_version`.
+
+**Trap:** `nodeInfoStore.nodeInfo` initializes to `{}` and is reset on disconnect, and `isSupportedVersion(undefined, ...)` parses the missing version as `0.0.0`. So every version-gated flag returns **false until `getMyNodeInfo` has resolved** during connect. Version-gated flags read at boot (before node info lands) are pessimistically false, then flip to true — code that caches a flag value at construction time will be wrong. Read flags lazily at render/call time.
+
+Version-gated flags (all verified in `backends/LND.ts` at c5fd094fb; `EmbeddedLND`/`LightningNodeConnect` mirror most):
+
+| Flag | Min LND version |
+|---|---|
+| `supportsMPP` | v0.10.0 |
+| `supportsHopPicking` | v0.11.0 |
+| `supportsCoinControl` | v0.12.0 |
+| `supportsAMP`, `supportsAccounts` (LND only; EmbeddedLND hardcodes true) | v0.13.0 |
+| `supportsTaproot` | v0.15.0 |
+| `supportsChannelCoinControl`, `supportsSimpleTaprootChannels` | v0.17.0 |
+| `supportInboundFees`, `supportsAddressesWithDerivationPaths` | v0.18.0 |
+| `supportsOnchainSendMax`, `supportsBolt11BlindedRoutes` | v0.18.3 |
+| `supportsForwardingHistoryChannelFilter` (dispatcher-level composite in `utils/BackendUtils.ts`, takes `nodeInfoVersion` argument) | v0.20.0 |
+
+### Composite flags (computed in the dispatcher, not backend classes)
+
+- `supportsLightningAddress = supportsCustomPreimages() || supportsCashuWallet()` — ZEUS Pay lightning addresses need either hodl-preimage support or an embedded Cashu wallet.
+- `supportsDevTools = isLNDBased() || call('supportsDevTools')` — so the LND family gets dev tools implicitly; `CLNRest` and `LndHub` opt in with an explicit flag; `ldk-node` and `nostr-wallet-connect` get **false** (neither LND-based nor flag-defining).
+
+### Capability matrix for major features
+
+Verified flag-by-flag against the six backend files at c5fd094fb (2026-07-06). "vX.Y" means version-gated as above. LNC "perm" flags are all effectively **true** — see the ZEUS-3642 quirk in section 4.
+
+| Feature (flag) | lnd | embedded-lnd | lnc | cln-rest | ldk-node | lndhub | nwc |
+|---|---|---|---|---|---|---|---|
+| Lightning sends (`supportsLightningSends`) | Y | Y | perm | Y | Y | Y* | Y |
+| On-chain send/receive (`supportsOnchainSends`/`Receiving`) | Y | Y | perm | Y | Y | N / URL-dependent* | N |
+| Keysend (`supportsKeysend`) | Y | Y | Y | Y | Y | N | N |
+| MPP (`supportsMPP`) | v0.10 | v0.10 | v0.10 | N | Y | N | N |
+| AMP (`supportsAMP`) | v0.13 | v0.13 | v0.13 | N | N | N | N |
+| Channel management (`supportsChannelManagement`) | Y | Y | perm | Y | Y | N | N |
+| Force close (`supportsForceClose`) | Y | Y | Y | N | Y | N | N |
+| Pending channels (`supportsPendingChannels`) | Y | Y | Y | N | Y | N | N |
+| Coin control (`supportsCoinControl`) | v0.12 | v0.12 | perm | Y | Y | N | N |
+| Watchtower client (`supportsWatchtowerClient`) | Y | Y | Y | N (by omission) | N | N | N |
+| Cashu embedded wallet (`supportsCashuWallet`) | N | **Y** | N | N | **Y** | N | N |
+| BOLT12 offers (`supportsOffers`) | N | N | N | **Y** | **Y** | N | N |
+| Listing offers (`supportsListingOffers`) | N | N | N | **Y** | N (LDK can't store/list offers; its `listOffers` returns `{offers: []}`) | N | N |
+| BOLT12 address (`supportsBolt12Address`) | N | N | N | **Y** | N | N | N |
+| Withdrawal requests (`supportsWithdrawalRequests`) | N | N | N | **Y** | **Y** | N | N |
+| Custom preimages (`supportsCustomPreimages`) | Y | Y | Y | N | N | N | N |
+| Lightning address (composite) | Y | Y | Y | N | Y (via Cashu) | N | N |
+| Flow LSP (`supportsFlowLSP`) | Y | Y | N | N | Y | N | N |
+| LSPS1 REST (`supportsLSPS1rest`) | Y | N | Y | Y | Y | N | N |
+| LSPS custom message (`supportsLSPScustomMessage`) | Y | Y | Y | N | N | N | N |
+| LSPS1/7 native (`supportsLSPS1native`/`supportsLSPS7native`, LdkNode-only flags) | N | N | N | N | N / **Y** | N | N |
+| Routing/forwarding (`supportsRouting`) | Y | N | perm | Y | N | N | N |
+| Forwarding history (`supportsForwardingHistory`) | Y | N | Y | Y | N | N | N |
+| Circular rebalancing (`supportsCircularRebalancing`) | Y | Y | Y | Y | N | N | N |
+| Fee bumping / CPFP (`supportsBumpFee`) | Y | Y | Y | N | N | N | N |
+| Message signing (`supportsMessageSigning`) | Y | Y | perm | Y | Y | N | N |
+| Sweep (`supportsSweep`) | Y | Y | Y | Y | N | N | N |
+| Dev tools (composite) | Y | Y | Y | Y | N | Y | N |
+| Set invoice expiry (`supportsSettingInvoiceExpiration`) | Y | Y | Y | Y | Y | N | N |
+| NWC service (`supportsNostrWalletConnectService`) | Y | Y | Y | Y | Y | Y | N |
+| `requiresVerifyPubkey` (verifyMessage needs pubkey arg) | N | N | N | N | **Y** | N (inherited) | n/a |
+
+\* LndHub URL-dependent: `supportsOnchainReceiving` is false for known custodial hosts (Alby, lntxbot, LNBits `/lndhub/ext/`, LNbank); `supportsLightningSends` is false for LNBits invoice-only credentials (`username === 'invoice'`). Read `backends/LndHub.ts` before assuming.
+
+Do NOT trust this table for a new feature decision without re-grepping — flags change. One command rebuilds any row:
+
+```bash
+grep -n "supportsOffers" backends/*.ts
+```
+
+## 4) Per-backend quirks (each one has cost real debugging time)
+
+**LND (REST)**
+- `payLightningInvoice` races the actual `/v2/router/send` call against a forced timeout that **resolves** (not rejects) with `{ payment_error: localeString('views.SendingLightning.paymentTimedOut') }` (a locale-dependent "Payment timed out…" message — don't match the string literally) — timeout errors arrive *success-shaped*. `TransactionsStore.handlePayment` must (and does) check `result.payment_error`; new callers must too.
+- In-flight request dedup: a module-level `calls` Map keyed by `url+body` returns the same promise for identical concurrent requests. **On the Tor branch, `calls.delete(id)` only happens in `.then`** — a rejected Tor request stays cached, so identical retries replay the stale rejection until `clearCachedCalls()` runs (it is wired into `SettingsStore.setConnectingStatus(true)` on reconnect). Same pattern duplicated in `CLNRest.ts`.
+- TLS: cert verification is OFF unless the node's `certVerification` setting is on (`trusty: !certVerification` in blob-util). Tor requests bypass TLS validation only for HTTPS `.onion` URLs (see zeus-failure-archaeology FA-5 for the incident that set this rule). WebSocket streaming endpoints bypass Tor entirely.
+- Streaming/subscription endpoints use raw `WebSocket` with `wss://` rewritten URLs, not blob-util.
+
+**EmbeddedLND** (extends LND — inheritance hazards in section 5)
+- Subscription methods are commented out at the backend layer (`// TODO rewrite subscription logic` near the bottom of `backends/EmbeddedLND.ts`) — `subscribeInvoice`/`subscribeTransactions`/`initChanAcceptor` fall through to LND's REST/WebSocket implementations, which point at `settingsStore.host` — meaningless for an on-device node. `stores/LSPStore.ts initChannelAcceptor` works around this by branching on `implementation === 'embedded-lnd'` and calling `lndmobile` `channel.channelAcceptor()` + `LndMobileEventEmitter` directly.
+- `getFees`/`setFees`/`getForwardingHistory` also not overridden (commented "N/A") — same REST fall-through; guarded only because `supportsForwardingHistory` is false (fees screens are LND-family gated; embedded inherits `getFees` exposure — be careful surfacing anything that calls them).
+- Extra methods not in the base: `getRecoveryInfo`, `rescan`.
+
+**LightningNodeConnect (LNC)**
+- `checkPerms()` is **hard-coded to set all perms true** (ZEUS-3642 workaround, github.com/ZeusLN/zeus/issues/3642; the real `lnc.hasPerms` calls are commented out in `backends/LightningNodeConnect.ts`). Every perm-derived flag (`supportsLightningSends`, `supportsOnchainSends`, `supportsChannelManagement`, `supportsAccounts`, `supportsRouting`, `supportsMessageSigning`, ...) therefore reads true — read-only pairings still show send UI and fail at call time. Do not build new features assuming LNC perms are meaningful.
+- `payLightningInvoice` returns lnc-rn's streaming call object, not a settled result — `TransactionsStore.sendPayment` special-cases LNC by returning it to the caller instead of `.then(handlePayment)`.
+- Responses are camelCase protobuf objects converted with `snakeize()` per call; forget it and field names silently mismatch the LND-REST-shaped models.
+- lnc-rn is vendored in `zeus_modules/` and imported by relative path — never `yarn add` it (see zeus-build-and-env).
+
+**CLNRest**
+- Invoice and payment lists come from **raw SQL** POSTed to `/v1/sql` against CLN's internal `invoices`/`sendpays` tables — filtered to `status = 'paid'` (invoices). The invoices query defaults to `LIMIT 150`, but callers can override via `getInvoices({ limit })`; the payments query is hardcoded to `limit 150`. Unpaid/expired invoices don't appear, payment histories truncate at 150, and **any CLN schema change breaks Zeus silently**. Treat `/v1/sql` queries as version-coupled code.
+- Every call is a POST, including reads (`/v1/getinfo`, `/v1/listfunds`, ...). Raw responses are reshaped into LND-ish shapes by `backends/CoreLightningRequestHandler.ts` (balances, peers, closed channels) — new CLN RPCs usually need a transform there.
+- `closeChannel` force-close is expressed as `unilateraltimeout: 2` (seconds) on `/v1/close`; `urlParams[0]` is the CLN channel/peer id, NOT a funding txid.
+- Circular rebalancing uses CLN-only askrene methods (`askReneCreateLayer`/`askReneUpdateChannel`/`askReneRemoveLayer`, `sendPay`/`waitSendPay`) that exist on no other backend.
+- Shares LND's dedup-cache-retains-rejections Tor trap (module-level `calls` map, own `clearCachedCalls`).
+
+**LdkNode**
+- No request/response protocol at all — direct uniffi FFI calls. Payment completion is **poll-based**: `awaitPaymentCompletion` polls `listPayments()` at 1 Hz for `timeout_seconds + 5` attempts, capturing failure reasons from a parallel event subscription; `payLightningInvoice`, `sendKeysend`, and `fetchInvoiceFromOffer` all block on it and then return a synthetic `{status: 'SUCCEEDED'}` LND-shaped result.
+- `openChannelSync` waits up to 60s for a `channelPending`/`channelClosed` event, then **resolves optimistically** with just `{user_channel_id}` (no funding txid) on timeout — callers cannot assume `funding_txid_str` exists.
+- Errors are normalized by `parseLdkNodeError` **in `BackendUtils.call`**, not in the class — direct class usage yields raw FFI strings.
+- `closeChannel` takes LND-format urlParams but internally looks up the channel by funding txid to find `userChannelId`/`counterpartyNodeId`.
+- Runs its own JS event loop (`startEventLoop` polling `nextEvent()`); node start/stop lifecycle races are a live problem — see **zeus-node-lifecycle-campaign** before touching start/stop paths.
+- `requiresVerifyPubkey() === true`: its `verifyMessage` needs an explicit `pubkey` argument (LDK can't recover the signer).
+- BOLT12: can create/pay offers and do refund-based withdrawal requests, but cannot list or truly disable offers (`listOffers` returns empty, `disableOffer` is a no-op).
+
+**LndHub**
+- Thin custodial API; everything channel/on-chain is flagged off (with the URL-dependent exceptions in the matrix footnote). Inherits LND's REST plumbing: `request()` uses `host || lndhubUrl` and `macaroonHex || accessToken`, with `getHeaders` overridden to Bearer auth.
+- Known inheritance gaps (unfixed as of 2026-07-06): `supportsChannelFundMax` and `supportsAddressMessageSigning` are NOT overridden and inherit `true` from LND. This is the canonical example of the extends-LND hazard.
+- `lnurlAuth` signs differently per `lndHubLnAuthMode` setting ('Alby' default vs 'BlueWallet').
+
+**NostrWalletConnect**
+- Smallest surface: balance, list transactions (split into invoices/payments by `type`), make invoice, pay invoice, lookup invoice. Everything else flagged false.
+- `createInvoice` backfills `payment_hash` by decoding the returned bolt11 with `Bolt11Utils` (NWC only returns `paymentRequest`).
+- Flag typo lives here: `supportsLSPS1customMessage` (dispatcher calls `supportsLSPScustomMessage`) — harmless because omission already means false, but don't copy it.
+- `decodePaymentRequest` (like LndHub's) is done client-side via `Bolt11Utils.decode`, so decoded fields are Zeus's hand-rolled decoder output, not node output.
+
+### Call signatures are NOT portable across backends
+
+Capability flags make a feature *available*; they do not make the *arguments* uniform. The dispatcher passes `...args` through verbatim. Live examples (verified at c5fd094fb):
+
+- `getRoutes`: LND/EmbeddedLND/LNC take positional `urlParams` (`[pubkey, amt]`); **CLNRest takes a single object** `{source, destination, amount_msat, layers?, maxfee_msat?, final_cltv?}` (askrene `/v1/getroutes`). LdkNode/LndHub/NWC don't implement it.
+- `closeChannel`: all take `urlParams` arrays, but element meaning differs — LND-family: `[funding_txid, output_index, force, sat_per_vbyte, delivery_address]`; CLNRest: `[channel_id, force→unilateraltimeout]`; LdkNode: LND format but resolves internally.
+- `createInvoice`: field names differ (`value_msat` vs `amount_msat` vs `amt`); each backend adapts internally, but only for the fields it knows about — new invoice fields must be threaded through every implementation.
+
+When adding a cross-backend call, define ONE canonical argument shape at the call site and adapt inside each backend class — never make views build per-backend arguments.
+
+## 5) THE RECIPE: adding a new RPC / feature end-to-end
+
+Checklist (do every step; the dispatch design gives you zero compile-time safety):
+
+1. **Implement the method on each backend** in `backends/` — or deliberately omit it (omission = feature absent, `call()` returns `false`). For each of the 7, decide: native support / emulation / omit. Match the method name EXACTLY across classes and wrapper.
+2. **Add the dispatcher wrapper** in `utils/BackendUtils.ts`:
+   ```ts
+   myNewCall = (...args: any[]) => this.call('myNewCall', args);
+   ```
+   String must match the class method name character-for-character (typo = permanent silent `false`).
+3. **Add a `supports*` flag** to every backend class (explicit `true`/`false`/version-gate on each standalone class: `LND`, `CLNRest`, `LdkNode`, `LightningNodeConnect`, `NostrWalletConnect`), plus a wrapper `supportsMyFeature = () => this.call('supportsMyFeature');` in `utils/BackendUtils.ts`. Relying on omission-as-false works but explicit flags are the observed convention.
+4. **Run the inheritance-override checklist** (below) for `EmbeddedLND` and `LndHub`.
+5. **Gate every view/store call site** with `BackendUtils.supportsMyFeature()` — never with `settingsStore.implementation`, and never call the method unguarded (remember: `false.then` crashes). Missing gates are the top historical cross-backend crash source.
+6. **Version-gate if needed**: inside LND-family flags use `this.supports('vX.Y.Z')`; remember it reads false until node info resolves.
+7. **Keep the argument contract canonical** at call sites; adapt shapes inside each backend class (section 4).
+8. **Fill in the PR-template backend matrix** (`.github/PULL_REQUEST_TEMPLATE.md` — never delete it): check each of the 7 node types you actually tested (On-device: LDK Node, Embedded LND; Remote: LND REST, LNC, CLNRest, NWC, LndHub) with node/API versions. Test at minimum every backend whose flag you set to `true`. Manual iOS+Android testing by the author is mandatory regardless of CI (see zeus-change-control).
+9. If the feature emits errors on ldk-node, confirm they read cleanly through `parseLdkNodeError`; extend `utils/ErrorUtils.ts` mappings if a new NodeException variant appears.
+
+### Inheritance-override checklist (EmbeddedLND / LndHub)
+
+Whenever you add a method OR flag to `backends/LND.ts`, `EmbeddedLND` and `LndHub` inherit it silently. For each addition ask:
+
+- **EmbeddedLND**: the inherited implementation is a REST/WebSocket call against `settingsStore.host` — meaningless for an on-device node. Override with an `lndmobile` implementation, or ensure the corresponding flag is `false` on EmbeddedLND so nothing reaches it. (Existing debt: `getFees`/`setFees`/subscriptions fall through today.)
+- **LndHub**: the inherited implementation would hit `lndhubUrl` with LND REST routes that don't exist there, and inherited `true` flags advertise features a custodial account lacks. Override the flag to `false` explicitly. (Existing bugs of this class: `supportsChannelFundMax` and `supportsAddressMessageSigning` inherit `true`.)
+
+Quick audit command — flags defined on LND but missing from a subclass:
+
+```bash
+comm -23 <(grep -o "supports\w*" backends/LND.ts | sort -u) \
+         <(grep -o "supports\w*" backends/LndHub.ts | sort -u)
+```
+
+(The bare `supports` line in the output is LND's version-gate helper, not a flag — ignore it. Run 2026-07-06, this prints exactly `supportsAddressMessageSigning` and `supportsChannelFundMax`: the two open gaps above.)
+
+## 6) Testing each backend cheaply
+
+Full environment setup and node connection walkthroughs live in **zeus-run-and-operate**; this is the per-backend minimum:
+
+| Backend | Cheapest test rig |
+|---|---|
+| `lnd` (REST) | [Polar](https://github.com/jamaljsr/polar) regtest LND node (CONTRIBUTING.md recommends Polar); connect with REST host/port + hex admin macaroon |
+| `cln-rest` | Polar Core Lightning node with the clnrest plugin; connect with a rune |
+| `embedded-lnd` | create an on-device wallet in the app (emulator works); network choice per zeus-config-and-flags |
+| `ldk-node` | create an on-device LDK wallet in the app |
+| `lightning-node-connect` | requires a node running litd (Lightning Terminal) for a pairing phrase — the most expensive rig; test last |
+| `lndhub` | any LNDHub-compatible account (e.g. an LNBits instance's LNDHub extension) |
+| `nostr-wallet-connect` | any NWC connection string (e.g. Alby, or Zeus's own NWC service from a second device/wallet) |
+
+Android emulator gotcha: emulator host rule — see **zeus-run-and-operate** §2 (the owner of the `10.0.2.2` fact).
+
+Backend-difference triage shortcut: if a feature works on `lnd` but not backend X, check in order (1) X's `supports*` flag, (2) whether X defines the method at all (silent `false`), (3) argument-shape mismatch (section 4), (4) X-specific quirk (section 4).
+
+## Provenance and maintenance
+
+All facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha) by reading `backends/*.ts`, `utils/BackendUtils.ts`, `utils/VersionUtils.ts`, `utils/ErrorUtils.ts`, `stores/TransactionsStore.ts`, `stores/LSPStore.ts`, `stores/NodeInfoStore.ts`, `stores/SettingsStore.ts`, CONTRIBUTING.md, and `.github/PULL_REQUEST_TEMPLATE.md`. No build/run commands were executed for this skill; Polar/litd rig suggestions are verified by source/docs read, not executed.
+
+Re-verification one-liners for volatile facts:
+
+| Fact | Re-verify with |
+|---|---|
+| 7 implementation keys + default `lnd` | `grep -n "Implementations" stores/SettingsStore.ts; grep -n "default:" utils/BackendUtils.ts` |
+| `call()` returns `false` on missing method; ldk-node error normalization | `sed -n '55,74p' utils/BackendUtils.ts` |
+| Any flag's per-backend values | `grep -n "<flagName>" backends/*.ts` |
+| Composite flags (`supportsLightningAddress`, `supportsDevTools`) | `grep -n "supportsLightningAddress\|supportsDevTools" utils/BackendUtils.ts` |
+| LND version gates table | `grep -n "this.supports('v" backends/LND.ts` |
+| Version reads 0.0.0 before node info | `grep -n "nodeInfo: NodeInfo" stores/NodeInfoStore.ts; sed -n '17,28p' utils/VersionUtils.ts` |
+| LNC perms hardcoded (ZEUS-3642) | `grep -n "ZEUS-3642" backends/LightningNodeConnect.ts` |
+| CLN raw SQL, paid-only, LIMIT 150 | `grep -n "v1/sql\|LIMIT" backends/CLNRest.ts` |
+| LDK poll loop + optimistic open | `grep -n "awaitPaymentCompletion\|CHANNEL_OPEN_TIMEOUT" backends/LdkNode.ts` |
+| LND timeout resolves success-shaped | `grep -n "payment_error" backends/LND.ts` |
+| Tor dedup cache retains rejections; cleared on reconnect | `grep -n "calls.delete" backends/LND.ts backends/CLNRest.ts; grep -rn "clearCachedCalls" stores/SettingsStore.ts` |
+| LndHub inheritance gaps still open | the `comm -23` audit command in section 5 |
+| `payLightningInvoiceStreaming` still dead | `grep -rn "payLightningInvoiceStreaming" backends/ utils/` |
+| EmbeddedLND subscription TODO / LSPStore workaround | `grep -n "TODO rewrite subscription" backends/EmbeddedLND.ts; grep -n "channelAcceptor()" stores/LSPStore.ts` |
+| PR template backend matrix | `grep -n "LDK Node\|LndHub" .github/PULL_REQUEST_TEMPLATE.md` |
+| LNC mailbox servers | `grep -n "LNC_MAILBOX_KEYS" -A 9 stores/SettingsStore.ts` |
+| Emulator host `10.0.2.2`, Polar recommendation | `grep -n "10.0.2.2\|polar" -i CONTRIBUTING.md` |

--- a/.claude/skills/zeus-build-and-env/SKILL.md
+++ b/.claude/skills/zeus-build-and-env/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: zeus-build-and-env
+description: Load when setting up the Zeus dev environment from scratch, running yarn install / postinstall, or debugging build/toolchain failures. Triggers - "yarn install fails", "postinstall error", missing Lndmobile.aar / Lndmobile.xcframework / LDKNodeFFI / cdkFFI / zeusRestoreFFI, "checksum failed", fetch-libraries.sh, rn-nodeify, shim.js, pod install / CocoaPods errors, Gradle / Kotlin / NDK / minSdk questions, Xcode framework-not-found, autolinking / native module not found, MainApplication.kt package registration, zeus_modules / lnc-rn vendoring, uniffi binding version mismatch, gen-proto, Hermes or New Architecture build crashes.
+---
+
+# Zeus: Build and Environment
+
+Zeus is a React Native (RN) Bitcoin/Lightning mobile wallet. This skill is the runbook for recreating the development environment from nothing, understanding the postinstall chain that assembles the native layer, and avoiding the traps that break builds.
+
+Jargon quick-reference (terms used below):
+- **LND**: Lightning Network Daemon — a Lightning node implementation. Zeus embeds a mobile build of it ("embedded LND") compiled with **gomobile** (Go-to-mobile compiler) into `Lndmobile.aar` (Android archive) / `Lndmobile.xcframework` (iOS multi-arch framework bundle).
+- **LNC**: Lightning Node Connect — Lightning Labs' encrypted-tunnel protocol for reaching a remote LND node. Shares the same Lndmobile binary.
+- **LDK Node**: a self-contained Lightning node library from the Lightning Dev Kit project; second embedded-node option. Rust, exposed via **uniffi** (Mozilla's Rust FFI binding generator that emits matching Kotlin/Swift wrapper source).
+- **CDK**: Cashu Dev Kit — Rust library for Cashu ecash wallets, also uniffi-based.
+- **Hermes**: Meta's JS engine for RN (enabled here). **New Architecture / Fabric**: RN's rewritten native rendering/bridge layer (enabled here).
+- **CocoaPods / pod**: iOS dependency manager; `pod install` generates the Xcode workspace's dependency project.
+
+## When to use / When NOT to use
+
+Use this skill when you need to: install dependencies, understand or debug the postinstall chain, fix missing/failing native binaries, wire a new native module, or bring up a dev build on Android/iOS.
+
+Do NOT use it for:
+- Running the app day-to-day, connecting nodes, releases and reproducible builds (`build.sh`, Docker, APK signing) → **zeus-run-and-operate**
+- `yarn verify` / jest / CI check anatomy, adding tests, `transformIgnorePatterns` details → **zeus-validation-and-qa**
+- Runtime bugs once the app builds and boots → **zeus-debugging-playbook**
+- Adding dependencies (requires maintainer discussion first), commit/PR rules → **zeus-change-control**
+- Backend/RPC code structure → **zeus-backends-and-capabilities**; architecture rationale → **zeus-architecture-contract**
+
+## 1) Prerequisites (verified 2026-07-06, master `c5fd094fb`, v13.1.3-alpha)
+
+| Requirement | Value | Source of truth |
+|---|---|---|
+| Node.js | `>= 22.11.0` (package.json `engines`); CI uses Node `24.x` — prefer 24.x LTS to match CI | `package.json`, `.github/workflows/*.yml` |
+| Package manager | Yarn classic (v1) — `yarn.lock` is "yarn lockfile v1"; CI runs `yarn install --frozen-lockfile` | `yarn.lock`, workflows |
+| React Native | 0.85.3, New Architecture ON, Hermes ON | `package.json`, `android/gradle.properties` |
+| Android | minSdk 28, compileSdk 36, targetSdk 36, buildTools 36.0.0, Kotlin 2.1.20, NDK 28.0.13004108, Gradle 9.3.1 | `android/build.gradle`, `android/gradle/wrapper/gradle-wrapper.properties` |
+| iOS | Xcode (current version per RN 0.85 requirements — repo does not pin one), CocoaPods `>= 1.13` excluding 1.15.0/1.15.1, Ruby `>= 2.6.10` | `ios/Podfile`, `Gemfile` |
+| Shell tools for fetch-libraries.sh | `curl`, `unzip`, `python3`, `sha256sum` (present on modern macOS at /sbin and on Linux) | `fetch-libraries.sh` |
+| Docker | ONLY for reproducible release builds — not needed for dev (see zeus-run-and-operate) | `build.sh` |
+
+There is no `.nvmrc`, no `.ruby-version`, no `.yarnrc`. CONTRIBUTING.md says "Node.js (LTS version)" — the hard floor is the `engines` field.
+
+## 2) The postinstall chain (order matters)
+
+`yarn install` triggers (`package.json` scripts.postinstall):
+
+```
+node patches/index.mjs && rn-nodeify --install crypto,stream,dgram --hack && yarn run fetch-libraries && pod-install
+```
+
+Run each step manually if you need to re-do part of it. Skipping the chain leaves unpatched node_modules, missing shims, and missing native binaries — the app will fail to compile or crash at boot.
+
+### Step 1 — `node patches/index.mjs` (patch node_modules in place)
+
+Four patches, each idempotent, each rewriting files inside `node_modules/` (so they must re-run after every install):
+
+| Patch file | What it does | What breaks if skipped |
+|---|---|---|
+| `patches/patch-jcenter.mjs` | Replaces removed `jcenter()` Maven repo with `mavenCentral()` in `react-native-hce` and `react-native-securerandom` build.gradle files (jcenter was removed in Gradle 9) | Android Gradle sync fails resolving those two libraries |
+| `patches/patch-native-event-emitter.mjs` | In RN's `NativeEventEmitter.js`, downgrades the iOS null-module `invariant()` throw to a `console.warn` (RN 0.83+ throws for deprecated modules loaded during React Refresh) | iOS dev builds crash/red-screen on refresh |
+| `patches/patch-react-native-notifications.mjs` | Fully rewrites `FcmToken.java` in react-native-notifications — the upstream library uses `ReactInstanceManager`, unsupported in New Architecture bridgeless mode | Android push-token handling fails to compile / crashes under New Arch |
+| `patches/patch-noble-hashes.mjs` | Adds `./crypto.js` to every `@noble/hashes` package.json `exports` map so Metro can resolve deep imports | Metro bundler "module not found" for @noble/hashes/crypto.js |
+
+### Step 2 — `rn-nodeify --install crypto,stream,dgram --hack` (Node core-module shims)
+
+rn-nodeify makes Node.js core modules (crypto, stream, dgram) usable in React Native. It **regenerates**:
+- the `react-native` and `browser` alias maps at the bottom of `package.json` (crypto → react-native-crypto, stream → stream-browserify, dgram → react-native-udp, `tls: false`, readable-stream aliases)
+- `shim.js` at the repo root (global Buffer/process polyfills), imported by `index.js`
+
+**Trap: hand edits to those alias maps or to `shim.js` are clobbered on the next `yarn install`.** If skipped: Metro fails to resolve `crypto`/`stream` imports and the app crashes at JS boot.
+
+### Step 3 — `yarn run fetch-libraries` = `bash fetch-libraries.sh` (native binaries)
+
+Downloads the pre-built native binaries that are gitignored (see `.gitignore` lines for `Lndmobile.aar`, `Lndmobile.xcframework`, `cashudevkit.aar`, `cdkFFI.xcframework`, `zeus-cashu-restore.aar`, `zeusRestoreFFI.xcframework`, `jniLibs/`, `LDKNodeFFI.xcframework`). All versions and SHA256 hashes live in **`fetch-libraries-versions.json`** — when bumping a binary, change version AND sha256 there, never inside the script.
+
+Versions pinned at time of writing:
+
+| Artifact | Version | Android destination | iOS destination |
+|---|---|---|---|
+| embedded LND (`ZeusLN/lnd` release) | `v0.20.1-beta-zeus.1` | `android/lndmobile/Lndmobile.aar` | unzipped to `ios/LncMobile/Lndmobile.xcframework` (yes, **Lnc**Mobile — see §4) |
+| LDK Node (`ZeusLN/ldk-node` release) | `v0.7.0-zeus-pathfinder-config` | `.so` files unzipped into `android/app/src/main/jniLibs/<abi>/libldk_node.so` | `ios/LdkNodeMobile/LDKNodeFFI.xcframework` |
+| CDK (`cashubtc/cdk-kotlin` / `cdk-swift` releases) | `0.14.2` | `android/cdk/cashudevkit.aar` | `ios/Cdk/cdkFFI.xcframework` |
+| zeus-cashu-restore (`ZeusLN/zeus-cashu-restore` release) | `0.1.0` | `android/zeus-restore/zeus-cashu-restore.aar` | `ios/ZeusRestore/zeusRestoreFFI.xcframework` |
+
+Behavior and caveats (all verified by reading the script):
+- **SHA256 enforcement**: embedded-LND and LDK Node downloads hard-fail (`exit 1`) on checksum mismatch, always.
+- **Empty-hash skip caveat**: for `cdk` and `zeus-cashu-restore` ONLY, the checksum check is wrapped in `[ -n "$SHA256" ]` — if the hash field in `fetch-libraries-versions.json` is an empty string, verification is **skipped** and the script just prints the downloaded file's hash. All four hash fields are currently non-empty; never blank one to "fix" a checksum failure.
+- **Unchecked binding-source downloads**: the script also `curl`s uniffi **source** bindings with NO checksum: `ios/CashuDevKit/CashuDevKit.swift` (from cdk-swift tag), `ios/CashuDevKit/zeus_cashu_restore.swift` and `android/app/src/main/java/uniffi/zeus_cashu_restore/zeus_cashu_restore.kt` (from zeus-cashu-restore tag). Known supply-chain gap — labeled open, not planned-fixed.
+- **`jq()` is not jq**: the script defines a shell function literally named `jq()` that is a `python3 -c` one-liner reading the versions JSON. Don't grep-conclude the repo depends on the jq binary.
+- **Error noise is normal**: the script has no `set -e`; on a fresh clone you will see `sha256sum: ... No such file or directory` and failed `rm` messages before each download, and on re-runs `mkdir: ios/LndMobileLibZipFile: File exists` (the directory doesn't exist on a truly fresh clone — its contents are gitignored). Only an explicit "checksum failed" + exit 1 is a real failure.
+- If skipped: Android fails at Gradle time (missing `.aar`/`.so`); iOS fails at Xcode link time ("framework 'Lndmobile' not found" etc.).
+
+### Step 4 — `pod-install` (iOS pods)
+
+The `pod-install` npm package runs CocoaPods for `ios/`. On non-macOS it prints "CocoaPods is only supported on darwin" and exits gracefully (this is why `yarn install` passes on ubuntu CI). Note `react-native.config.js` sets `automaticPodsInstallation: false`, so the RN CLI will NOT install pods for you — only this postinstall step (or a manual `cd ios && pod install`) does. If skipped: `zeus.xcworkspace` fails to build with missing-pod errors.
+
+## 3) Vendoring rules (`zeus_modules/`)
+
+`zeus_modules/` holds vendored (checked-in) packages: `@lightninglabs/lnc-core`, `@lightninglabs/lnc-rn`, `@remobile/react-native-qrcode-local-image`, `bc-bech32`, `bc-ur`, `ur`, `noble_ecc.ts`.
+
+- `@lightninglabs/lnc-core` IS in `package.json` dependencies via `"file:zeus_modules/@lightninglabs/lnc-core"`.
+- `@lightninglabs/lnc-rn` is NOT in `package.json` at all. It is vendored **with its own committed `node_modules/` and `yarn.lock`** and imported by relative path (`backends/LightningNodeConnect.ts`: `import LNC from '../zeus_modules/@lightninglabs/lnc-rn'`). **Never `yarn add` lnc-rn** — you would get a second, unpatched copy and break the LNC backend.
+- `zeus_modules` is excluded from all tooling: `tsconfig.json` `exclude` (along with `node_modules`, `android`, `ios`), `eslint.config.js` ignores, and `.prettierignore`. Code inside it is not held to repo lint/format/type standards; don't "fix" it in a normal PR.
+
+## 4) Native-layer wiring
+
+### Android
+
+- App source root: `android/app/src/main/java/` with THREE package trees: `com/zeus/` (bulk of modules — note `MainApplication.kt` lives here even though its declared package is `app.zeusln.zeus`; it also holds `cashudevkit/`, declared package `app.zeusln.zeus.cashudevkit` — another dir/package mismatch), `app/zeusln/zeus/` (LdkNode, StealthMode, ZipUtils), and `org/lightningdevkit/ldknode/` + `uniffi/zeus_cashu_restore/` (uniffi bindings). The `com/zeus/lnc-rn/` directory name contains a hyphen (nonstandard Java layout) — it is correct, don't "fix" it.
+- **Manual native-package registration**: `android/app/src/main/java/com/zeus/MainApplication.kt` manually `add(...)`s 10 packages that RN autolinking cannot discover (they are app-local, not npm packages): `MobileToolsPackage`, `LndMobilePackage`, `LndMobileToolsPackage`, `LndMobileScheduledSyncPackage`, `LncPackage`, `NostrConnectPackage`, `StealthModePackage`, `CashuDevKitPackage`, `LdkNodePackage`, `ZipUtilsPackage`. **A new app-local native module must be added here or `NativeModules.YourModule` is null at runtime.**
+- Binary consumption (`android/app/build.gradle` + `android/build.gradle`): `Lndmobile.aar` via the `:lndmobile` subproject and a `flatDir` repo; CDK and restore AARs via `implementation files("../cdk/cashudevkit.aar")` / `files("../zeus-restore/zeus-cashu-restore.aar")`; LDK Node via raw `.so` files in `jniLibs/` plus the **checked-in** Kotlin binding `android/app/src/main/java/org/lightningdevkit/ldknode/ldk_node.kt`.
+- Release APKs are split per ABI with `versionCodeOverride = versionCode * 1000 + {1..4}` — release mechanics belong to **zeus-run-and-operate**.
+
+### iOS
+
+- Workspace: `ios/zeus.xcworkspace` (always open the workspace, not the .xcodeproj — pods live in a companion project).
+- **One `Lndmobile.xcframework`, shared by two modules, in a misleading directory**: fetch-libraries.sh unzips it to `ios/LncMobile/` (NOT `ios/LndMobile/`). The embedded-LND Swift layer (`ios/LndMobile/Lnd.swift`, `LndMobile.swift`: `import Lndmobile`) and the LNC layer (`ios/LncMobile/LncModule.mm`, which #imports the header straight out of the xcframework) both link against it; `zeus.xcodeproj` references it at path `LncMobile/Lndmobile.xcframework`.
+- **Podfile post_install** appends to every pod's `FRAMEWORK_SEARCH_PATHS`: `"$(SRCROOT)/Cdk"`, `"$(SRCROOT)/ZeusRestore"`, `"$(SRCROOT)/LncMobile"`, and floors `IPHONEOS_DEPLOYMENT_TARGET` at 13.4. Local podspecs `ios/CashuDevKit.podspec` and `ios/ZeusCashuRestore.podspec` are consumed as `pod 'CashuDevKit', :path => '.'` / `pod 'ZeusCashuRestore', :path => '.'`.
+- Other frameworks: `ios/LdkNodeMobile/LDKNodeFFI.xcframework` (with **checked-in** binding `ios/LdkNodeMobile/LDKNode.swift`), `ios/Cdk/cdkFFI.xcframework`, `ios/ZeusRestore/zeusRestoreFFI.xcframework`; downloaded Swift bindings land in `ios/CashuDevKit/`.
+
+### uniffi binding version-match rule
+
+uniffi generates wrapper source (Kotlin/Swift) whose function/type checksums must match the compiled Rust library. In Zeus the two halves arrive by different routes:
+- **Checked into git** (must be updated by hand when the binary version bumps): `ldk_node.kt`, `LDKNode.swift`.
+- **Downloaded by fetch-libraries.sh pinned to the same version tag as the binary** (auto-matching): `CashuDevKit.swift`, `zeus_cashu_restore.swift`, `zeus_cashu_restore.kt`.
+
+If binding source and binary versions diverge you get runtime symbol/checksum errors (uniffi aborts on API-checksum mismatch), not compile errors. When bumping `ldk-node` in `fetch-libraries-versions.json`, regenerate/replace the two checked-in binding files from the same release.
+
+### TypeScript wrapper layers (where JS meets native)
+
+| Dir | Role |
+|---|---|
+| `lndmobile/` | TS API over the embedded-LND native modules (Blixt-derived); protobuf encode/decode per RPC |
+| `ldknode/` | TS API over `NativeModules.LdkNodeModule` (uniffi LDK Node) |
+| `cashu-cdk/` | TS API over the CDK native module |
+| `zeus_modules/@lightninglabs/lnc-rn` | vendored LNC RN client |
+
+### Tor
+
+Tor support is `react-native-nitro-tor` **0.6.0** (normal npm dependency, autolinked; used via `import { RnTor } from 'react-native-nitro-tor'` in `utils/TorUtils.ts`). The old `react-native-tor` ZeusLN fork is **retired** — replaced in PR #3971 (commit `a58b4cefc`, merge `c512ea687`). Ignore any older notes about building/patching the Sifir react-native-tor fork; there is nothing to build.
+
+## 5) Known traps
+
+1. **Android emulator localhost**: emulator host rule — see **zeus-run-and-operate** §2 (the owner of the `10.0.2.2` fact).
+2. **Proto changes**: `proto/lightning.js` + `proto/lightning.d.ts` are generated artifacts (checked in). After editing any `proto/**/*.proto`, run `yarn gen-proto` (pbjs/pbts from protobufjs-cli) and commit the regenerated pair.
+3. **Stale Android build state**: `yarn android:clean` removes `android/app/.cxx`, `android/build`, then runs `gradlew clean`. Use it after NDK/Gradle/RN version changes or C++ codegen weirdness. `yarn gradlew <task>` is the repo shortcut for arbitrary Gradle tasks.
+4. **New ESM dependency breaks jest** ("Unexpected token 'export'"): extend the jest `transformIgnorePatterns` whitelist in `package.json` — full anatomy in **zeus-validation-and-qa**.
+5. **Hermes + New Architecture are ON** (`android/gradle.properties`: `hermesEnabled=true`, `newArchEnabled=true`; New Arch since RN 0.83.1 upgrade, commit `d13ebc2cd`). Consequences: pre-2026 Animated/layout patterns can crash Fabric, and Hermes regexes need input length caps — details and incident hashes in **zeus-failure-archaeology** / **zeus-debugging-playbook**.
+6. **Never hand-edit** the `react-native`/`browser` alias maps in `package.json` or `shim.js` — rn-nodeify regenerates them (§2 step 2).
+7. **`pod install` didn't run automatically from the RN CLI**: expected — `automaticPodsInstallation: false` in `react-native.config.js`; run `npx pod-install` or `cd ios && pod install`.
+8. **Checksum failure on a binary**: means the release asset changed or the download was corrupted. Delete the cached artifact (paths in §2 step 3 table) and re-run `yarn fetch-libraries`. Do NOT blank the hash in `fetch-libraries-versions.json` (empty-hash skip caveat).
+9. **`gradle.properties` sets `org.gradle.parallel=false`** — a reproducible-build requirement; don't flip it for speed in a PR.
+10. **New npm dependencies require maintainer discussion first** (CONTRIBUTING.md) — see **zeus-change-control** before adding anything.
+
+## 6) From-scratch bring-up checklists
+
+Build/run steps below are labeled **[source-read]** = verified by reading package.json/CONTRIBUTING/README/CI usage, not executed in this session; everything else was executed read-only.
+
+### Common (both platforms)
+
+1. Install Node ≥ 22.11 (24.x recommended to match CI) and Yarn classic: `npm i -g yarn`. [source-read]
+2. Set up the React Native environment per the RN "Building Projects with Native Code" guide for your target platform (README, "Starting development").
+3. `git clone https://github.com/ZeusLN/zeus.git && cd zeus`
+4. `yarn` — runs install + the full postinstall chain of §2. Requires network access to GitHub releases; expect harmless first-run noise from fetch-libraries.sh. [source-read]
+5. Sanity-check the toolchain-free gates: `yarn tsc` and `yarn test` should pass on a clean master checkout. [source-read; full gate anatomy in zeus-validation-and-qa]
+
+### Android
+
+6. Install Android Studio with SDK Platform 36, build-tools 36.0.0, NDK 28.0.13004108 (Gradle will prompt/fetch NDK if missing). [source-read]
+7. Start an emulator, or enable USB debugging on a device and confirm `adb devices` lists it.
+8. Terminal A: `yarn start` (Metro bundler — RN's JS dev server).
+9. Terminal B: `yarn android` (= `react-native run-android`): builds debug APK, installs, launches. [source-read]
+10. Verify: app boots to the Wallet screen. To connect a node running on your machine, use host `10.0.2.2`.
+11. If the build fails on missing `.aar`/`.so`: re-run `yarn fetch-libraries`; on C++/codegen residue: `yarn android:clean`.
+
+### iOS (macOS only)
+
+6. Install Xcode + command line tools; `sudo gem install cocoapods` or `bundle install` (Gemfile pins cocoapods ≥ 1.13, != 1.15.0/1.15.1). [source-read]
+7. Pods were installed by postinstall; if not, `cd ios && pod install && cd ..`.
+8. Terminal A: `yarn start`.
+9. Either `yarn ios` (= `react-native run-ios`) or open `ios/zeus.xcworkspace` in Xcode, select the `zeus` scheme + a simulator, hit Run. [source-read]
+10. Verify: app boots to the Wallet screen; simulator can use `127.0.0.1` for local nodes (no 10.0.2.2 remap needed — that trap is Android-emulator-specific).
+11. If linking fails with "framework not found" for Lndmobile/cdkFFI/zeusRestoreFFI/LDKNodeFFI: re-run `yarn fetch-libraries` then `pod install` (search paths come from the Podfile post_install, §4).
+
+## Provenance and maintenance
+
+Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha) by direct file reads and read-only commands in this repo. Build/run commands not executed are labeled [source-read] above.
+
+Re-verification one-liners for every volatile fact:
+
+| Fact | Re-verify with |
+|---|---|
+| Node engines floor | `node -e "console.log(require('./package.json').engines.node)"` |
+| CI Node version | `grep -h node-version .github/workflows/*.yml` |
+| RN / key dep versions | `node -e "const p=require('./package.json');console.log(p.dependencies['react-native'],p.dependencies['react-native-nitro-tor'],p.devDependencies['pod-install'],p.devDependencies['rn-nodeify'])"` |
+| Postinstall chain | `node -e "console.log(require('./package.json').scripts.postinstall)"` |
+| Patch list | `ls patches/` and read `patches/index.mjs` |
+| Native binary versions + hashes | `cat fetch-libraries-versions.json` |
+| Empty-hash skip + unchecked binding downloads | `grep -n -e 'if \[ -n' -e BINDINGS_URL fetch-libraries.sh` |
+| Android SDK/Kotlin/NDK | `sed -n '1,10p' android/build.gradle` |
+| Gradle version | `grep distributionUrl android/gradle/wrapper/gradle-wrapper.properties` |
+| Hermes / New Arch / parallel | `grep -n -e newArchEnabled -e hermesEnabled -e org.gradle.parallel android/gradle.properties` |
+| Manually registered packages | `grep -n 'add(' android/app/src/main/java/com/zeus/MainApplication.kt` |
+| Podfile search paths / pods | `grep -n -e FRAMEWORK_SEARCH_PATHS -e "pod '" ios/Podfile` |
+| xcframework location | `grep -n 'LncMobile/Lndmobile.xcframework' ios/zeus.xcodeproj/project.pbxproj` |
+| lnc-rn not in package.json | `grep -c lnc-rn package.json` (expect 0); `grep -n lnc-rn backends/LightningNodeConnect.ts` |
+| Tooling excludes zeus_modules | `grep -n zeus_modules tsconfig.json eslint.config.js .prettierignore` |
+| Checked-in vs downloaded uniffi bindings | `git ls-files -- '*ldk_node.kt' '*LDKNode.swift' '*zeus_cashu_restore*' '*CashuDevKit.swift'` (only the first two are tracked) |
+| Emulator host rule | `grep -n 10.0.2.2 CONTRIBUTING.md` |
+| CocoaPods constraint | `grep cocoapods Gemfile` |
+| nitro-tor migration commit | `git log --oneline --all --grep=nitro-tor` |
+| New Arch upgrade commit | `git log --oneline -1 d13ebc2cd` |

--- a/.claude/skills/zeus-change-control/SKILL.md
+++ b/.claude/skills/zeus-change-control/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: zeus-change-control
+description: How changes get classified, gated, reviewed, and merged in Zeus. Load BEFORE writing a commit message, opening/filling a PR, reviewing a PR, deciding whether a change needs maintainer sign-off, adding a dependency, editing locale files, or editing docs. Triggers/symptoms - "can I refactor this payment code", "which CI checks run on PRs", "how do I format my commit", "PR template", "ACK/tACK/NACK meaning", "why was my locale/de.json PR rejected", "do I need approval to touch keychain/settings storage", "first PR to Zeus", "revert policy", "version bump commit", "license/PGP key questions".
+---
+
+# Zeus Change Control
+
+How to get a change into Zeus (a React Native Bitcoin/Lightning wallet) without losing user funds, corrupting user data, or getting your PR closed. Zeus moves money; process rules here exist because each one was paid for by a real incident.
+
+Glossary used throughout (defined once):
+
+- **PR** — GitHub pull request. **CI** — continuous integration; the automated checks GitHub runs on every PR.
+- **Lightning** — Bitcoin's payment-channel network; Zeus is a wallet for it. **LND / CLN** — the two major Lightning node implementations Zeus talks to. **Macaroon** — LND's bearer-token auth credential (a secret; leaking one can drain a node).
+- **Keychain** — the OS-level secure credential store (iOS Keychain / Android Keystore) where Zeus persists ALL wallet secrets in one JSON blob under key `zeus-settings-v2`.
+- **Squash / fixup** — git operations that fold review-fix commits into the original commit before merge.
+- **Backend** — one of the 7 node implementations Zeus can drive (embedded LND, LDK Node, remote LND REST, Lightning Node Connect, CLNRest, LndHub, Nostr Wallet Connect).
+
+## When to use / When NOT to use
+
+USE this skill for: change classification and approval gates, commit-message style, PR template and review process, CI-check expectations, dependency policy, locale rules, revert policy, docs/license/signing house rules.
+
+Do NOT use this skill for — go to the sibling instead:
+
+| Need | Sibling skill |
+|---|---|
+| HOW to write a storage migration, keychain contract details | zeus-storage-and-migrations |
+| yarn verify internals, jest traps, check-styles.test.ts trick, how to add tests | zeus-validation-and-qa |
+| zeus_modules vendoring mechanics, postinstall chain, native builds | zeus-build-and-env |
+| Full incident narratives with evidence chains | zeus-failure-archaeology |
+| Backend capability matrix, adding an RPC | zeus-backends-and-capabilities |
+| Release operations, reproducible builds in practice | zeus-run-and-operate |
+| Adding a settings axis (defaults, options) | zeus-config-and-flags |
+
+Authoritative in-repo documents this skill summarizes (read them for full text; nothing here overrides them): `CONTRIBUTING.md`, `CODE_REVIEW.md`, `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## 1. The four maintainer non-negotiables (UNWRITTEN rules)
+
+These four rules are **maintainer-stated (2026-07-06) and appear in NO repo document**. They bind anyway. Each has a paid-for rationale.
+
+### Rule 1 — Storage/keychain changes are gated
+
+Anything touching the `zeus-settings-v2` blob, keychain keys, `storage/index.ts`, or migrations (`utils/MigrationUtils.ts`, `stores/SettingsStore.ts` persistence paths) requires **maintainer sign-off plus a written migration plan, always** — before you write code. Never route around this by "just changing the format".
+
+- WHY: every wallet's seed, macaroon, and PIN live in one keychain JSON blob. A bad write or migration bricks wallets or leaks seeds; there is no server-side undo.
+- INCIDENTS: the iCloud keychain saga — PR #3307 (merged as `5f533bb12`, 2025-11-10) was reverted the **same day** (`7d8678457`, via revert PR #3354); the proper fix took two more PRs (merges `e808fd71a` + `ed161541a`, 2025-12-01) and STILL left stale iCloud-synced wallet copies on new devices, requiring a third migration (`46f2bac00`, 2026-01-14). Separately, a settings migration passed a `JSON.stringify`'d object to `setSettings`, corrupting MobX observables — issue #4150, fixed by `7ed901a10` (2026-06-09). Recipes and the safety protocol: **zeus-storage-and-migrations**; full narratives: **zeus-failure-archaeology**.
+
+### Rule 2 — Revert-first near releases
+
+A regression found during release testing gets **reverted the same day**, never forward-fixed under pressure. If your merged change is implicated, expect a `revert-<PR#>-<branch>` PR with an empty body; don't argue for a hotfix, re-land properly later.
+
+- WHY: forward-fixes under release pressure ship untested code into a funds-handling app.
+- INCIDENTS: NWC txlist fix #3432 merged and reverted (#3444) on the same day, 2025-12-15 (`28bc50f5e`); iCloud #3307 reverted same day 2025-11-10; sat-rounding #1568 (2023-08-04) reverted next day by #1587; app-lock-timeout #1679 reverted by #1773 (2023-10).
+- Practical consequence: before trusting any merged fix as final, check `git log --grep='revert-<PR#>'`.
+
+### Rule 3 — No refactors of payment paths
+
+Changes to send/receive/payment-handling code (`views/Send.tsx`, `views/PaymentRequest.tsx`, `stores/TransactionsStore.ts`, `backends/*`, `utils/BackendUtils.ts` dispatch) must be **minimal diffs**. No drive-by refactoring, renaming, or "cleanup" inside a funds-touching change.
+
+- WHY: stores, views, components, and backends have **zero automated test coverage** — only `utils/`, `models/`, and `lndmobile/` have tests (plus the root `check-styles.test.ts`; see zeus-validation-and-qa). A refactor there is reviewed and safety-netted by human eyeballs alone, across 7 backends.
+- INCIDENT (refactors bite even outside payment code): `fdad118ed` (2025-10-24), a "replace UNSAFE React lifecycle methods" refactor, caused an infinite-loading regression fixed only 3 weeks later by `93227029e` (2025-11-12, which cites the offending hash in its subject).
+
+### Rule 4 — Manual two-platform testing is mandatory
+
+No merge without hands-on testing by the author on **both iOS and Android**, regardless of green CI.
+
+- WHY: PR CI runs only unit tests, lint, formatting, and type-check on Linux (Section 5) — it never builds or launches the mobile app. Rendering, native modules, and navigation differ per platform; CI green proves almost nothing about runtime behavior. CONTRIBUTING.md says "when possible"; the maintainer standard is stricter: do it.
+- The PR template's platform and backend checkboxes (Section 3) are how you attest to this.
+
+## 2. Change classification and gates
+
+Classify every change before starting. When a change spans classes, the strictest gate applies.
+
+| Class | What counts | Gate before coding | Gate before merge |
+|---|---|---|---|
+| **Funds-touching** | Sending/receiving payments, invoice creation/decoding, channel open/close, fee logic, seed/key handling: `views/Send.tsx`, `views/PaymentRequest.tsx`, `stores/TransactionsStore.ts`, `backends/*`, `utils/BackendUtils.ts`, swap/Cashu/NWC payment flows | Open an issue / discuss approach first (CONTRIBUTING "Share Early, Share Often") | Minimal diff (Rule 3); manual test on iOS + Android (Rule 4); test on every backend the code path can reach, recorded in the PR template matrix; regression test if it's a bug fix |
+| **Storage-touching** | `zeus-settings-v2` blob shape, any keychain key, `storage/index.ts`, migrations, changed defaults for existing users | **Maintainer sign-off + migration plan, always** (Rule 1) | Migration follows the gated pattern in zeus-storage-and-migrations; manual test on both platforms including upgrade-from-previous-version |
+| **UI-only** | Screens/components with no store-shape or payment-logic change | None beyond checking for an existing issue/PR | Manual test on **both** platforms (CONTRIBUTING is explicit: rendering differs); screenshots/video in the PR; theme check (styling violations fail the Lint CI job — see zeus-validation-and-qa); new user-facing strings go in `locales/en.json` only (Section 7) |
+| **Docs-only** | `README.md`, `CONTRIBUTING.md`, `CODE_REVIEW.md`, `docs/*` | None | `docs:` commit prefix; no drive-by doc edits inside code PRs — known stale text (e.g. the PR template "Transfix" typo) is fixed via dedicated docs commits, not opportunistically |
+| **Dependency** | Any `package.json` addition/major bump | **Discuss with maintainers first** (Section 6) | PR template third-party-deps section filled; verify `yarn.lock` updated and both platforms still build |
+| **Locales** | Translation strings | — | Only `locales/en.json` (Section 7) |
+
+## 3. PR process
+
+### The template is sacred
+
+`.github/PULL_REQUEST_TEMPLATE.md` — **never delete or replace it**; fill in every section (CONTRIBUTING.md states this explicitly). Its required sections, as of 2026-07-06:
+
+1. **Description** — issue reference (`ZEUS-0000` placeholder), description + screenshots.
+2. **Category checkboxes** — new feature / bug fix / code refactor / configuration change / locales update / quality assurance / other.
+3. **Checklist** — you ran `yarn run tsc`, `yarn run lint`, `yarn run prettier`, `yarn run test` (i.e. everything `yarn verify` runs).
+4. **Testing** — did you add unit tests for modified utility files (options: "No, I'm a fool" / Yes / N/A).
+5. **Platform matrix** — Android and iOS checkboxes, with OS version and phone model/VM. This is where Rule 4 is attested.
+6. **Backend testing matrix** — which of the 7 node types you tested against, with node/API versions: On-device: LDK Node, Embedded LND; Remote: LND (REST), LND (Lightning Node Connect), Core Lightning (CLNRest), Nostr Wallet Connect, LndHub.
+7. **Locales** — new translatable text flagged; acknowledgment that translations happen on Transifex, not in-repo. (The template's "Transfix" spelling is a known typo — leave it.)
+8. **Third-party dependencies** — whether contributors must re-run `yarn`, whether `package.json`/`yarn.lock` changed, both-platform install verified.
+9. **Other** — README or onboarding updates needed?
+
+### First-time contributors: proof of work
+
+Per CONTRIBUTING.md: first-time contributors submitting features or UI changes **must attach screenshot or video evidence** that the change works, directly in the PR description. PRs without it are closed within 24 hours; repeat offenders are blocked. Also: no trivial typo/whitespace first PRs; issue assignment is team-only — just comment that you've started.
+
+### Review vocabulary (Bitcoin-Core style, defined in CODE_REVIEW.md)
+
+| Term | Meaning |
+|---|---|
+| `ACK` | Full approval: code reviewed AND changes tested. Usually cites the commit hash: `ACK 3a4b5c6` |
+| `tACK` | Tested the changes, but no full code review |
+| `cACK` | Concept ACK — agree with the approach, didn't review the implementation |
+| `NACK` | Recommend against merging; must include detailed reasoning |
+| `Nitpick/nit` | Minor, non-blocking suggestion |
+
+### Review flow
+
+- Fetch a PR locally: `git fetch origin pull/<N>/head:pr-<N>` then `git checkout pr-<N>` (from CODE_REVIEW.md).
+- During review, push **fixup commits** (easy to re-review); **squash before merge**. Rebase on master; no merge commits in the branch.
+- Merge requirements (CONTRIBUTING.md): all CI checks pass, ≥1 maintainer approval, no unresolved conversations, up to date with base.
+- Review checklist highlights (full list in CODE_REVIEW.md): no sensitive data (keys, macaroons, seeds) logged or exposed; inputs validated on payment paths; no potential fund-loss scenarios; no unnecessary `any` types; works across themes/locales/font sizes; commits atomic. Separately, CONTRIBUTING.md ("Test Coverage") requires that bug fixes include a test that would have caught the bug.
+
+## 4. Commit style
+
+CONTRIBUTING.md prescribes `component:` prefixes (`views:`, `stores:`, `backends:`, `utils:`, `build:`, `docs:`, `tests:`) — that is the written rule and this skill does not override it. Master history additionally shows conventional-commit-ish prefixes being accepted in practice (122 of the last 200 commit subjects at `c5fd094fb` use them; most of the rest are merge commits), so either observed style is tolerated in review — but absent a maintainer statement authorizing otherwise, default to the CONTRIBUTING.md component prefixes. Real examples from `git log`:
+
+```
+fix(migrations): pass object to setSettings to avoid MobX observable corruption (#4150)
+fix(utxo-picker): restore UTXO labels and keep Set button above gesture bar
+ui: Receive: prevent input field flash on initial load via initialLoad state
+refactor: Receive: extract skipOnchain into helper
+docs: fix NWC service link in README (#4179)
+chore(deps): bump concurrent-ruby from 1.3.3 to 1.3.7
+```
+
+Rules:
+
+- Subject ≤ ~50 chars where possible; body wrapped at 72, explaining problem + why this approach (CONTRIBUTING.md).
+- Atomic commits; each should ideally pass `yarn verify` independently.
+- Version bumps are exactly `Version bump: vX.Y.Z[-alpha|-beta1]` (e.g. `Version bump: v13.1.3-alpha`) — maintainer-only.
+- **NO AI co-author lines** (`Co-Authored-By: Claude ...` or similar) in any commit — maintainer rule, stated 2026-07-06, not in any doc.
+- Branch names: `feature/...`, `fix/...`, `refactor/...`.
+- When citing hashes in commit messages or discussions, use first-parent master hashes: `git log --all` contains duplicated/grafted merge hashes (e.g. PR #3444 appears as both `28bc50f5e` and `f47ef1acf`).
+
+## 5. CI reality: green PR = exactly 4 checks
+
+Verified in `.github/workflows/` at `c5fd094fb`: exactly four workflows trigger on `pull_request` —
+
+| Check name | Workflow file | Runs |
+|---|---|---|
+| Test | `test.yml` | `yarn run test` (jest) |
+| Lint | `lint.yml` | `yarn run lint` (eslint + the styles test) |
+| Prettier | `prettier.yml` | `yarn run prettier` (format check) |
+| Typescript Check | `tsc.yml` | `yarn run tsc` |
+
+All four = `yarn verify` locally (`package.json`: `concurrently "yarn test" "yarn prettier" "yarn tsc" "yarn lint"`). Run `yarn verify` before every push. Details of each job's traps (check-styles trick, Prettier pinned at 2.4.1, jest transform whitelist): **zeus-validation-and-qa**.
+
+What PR CI does **NOT** do: no mobile build, no dependency scan — `build-android.yml` and `dependency-scan.yml` are `workflow_dispatch`-only (manually triggered); `telegram.yml` is a push/release notifier, not a check. This is exactly why Rule 4 (manual two-platform testing) exists.
+
+CI runs on ubuntu-latest, Node 24.x, `yarn install --frozen-lockfile`.
+
+## 6. Dependency policy
+
+- **Discuss before adding** any new library (CONTRIBUTING.md "Discuss new dependencies"): there may be an existing in-repo solution or a preferred alternative, and every dependency is supply-chain surface in a funds-handling app.
+- Zeus vendors some packages under `zeus_modules/` (some via `file:` refs, some imported by relative path and deliberately NOT in `package.json`). Never `yarn add` something that lives there. Mechanics: **zeus-build-and-env**.
+- If a PR modifies dependencies: tick the PR-template third-party section, confirm `package.json` + `yarn.lock` are consistent, and verify install on both iOS and Android.
+
+## 7. Locales
+
+- **Only `locales/en.json` may be edited in-repo.** The other 33 locale files (34 total in `locales/` as of 2026-07-06) are managed through Transifex (https://explore.transifex.com/ZeusLN/zeus/) and must never be modified directly — such PRs get rejected.
+- All user-facing strings must go through the localization system; no hardcoded UI text.
+- Want to translate? Request a language role on Transifex, not a PR.
+
+## 8. Docs house rules
+
+- **In-repo docs inventory**: `README.md` (project overview, feature list, integration guides), `CONTRIBUTING.md` (contribution process — source of truth for everything in Sections 2–4 here), `CODE_REVIEW.md` (review process and vocabulary), `docs/Bounties.md` (bounty program; reportedly partially stale — check open bounties against the issue tracker before relying on it), `docs/RemoteConnections.md` (node-connection guides), `docs/ReproducibleBuilds.md` (Android-only reproducible builds).
+- **External user docs of record**: https://docs.zeusln.app/ — README links there for all user-facing feature documentation. User-behavior changes may need updates there (out-of-repo), plus README/onboarding per the PR template's "Other" section.
+- **License**: AGPLv3 (see `LICENSE`). All contributions must be AGPLv3-compatible; submitting a PR is agreement to that (CONTRIBUTING.md).
+- **Signing**: all releases and all maintainer commits since 2021-10-20 are PGP-signed with key `AAC48DE8AB8DEE84` (full fingerprint `96C225207F2137E278C31CF7AAC48DE8AB8DEE84`, Zeus LN <zeusln@tutanota.com>); public key in `PGP.txt` (README.md "Release + Commit Verification" section). Contributors are not required to sign.
+- Writing style for docs changes: match existing docs; `docs:` commit prefix; don't bundle doc fixes into code PRs.
+
+## Pre-PR checklist (condensed)
+
+1. Classified the change (Section 2)? Storage-touching → maintainer sign-off FIRST. Funds-touching → minimal diff, discussed first.
+2. `yarn verify` green locally.
+3. Manually tested on iOS AND Android (Rule 4); backends exercised and recorded.
+4. New strings in `locales/en.json` only; no other locale files touched.
+5. Commits: CONTRIBUTING.md component-prefix style (conventional-commit-ish prefixes are tolerated in practice), atomic, no AI co-author lines, rebased on master.
+6. PR template fully filled in — not deleted; screenshots for UI changes (mandatory for first-timers).
+7. If a dependency changed: was it discussed first?
+
+## Provenance and maintenance
+
+Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha). Maintainer-stated rules (Section 1, no-AI-co-author) confirmed verbally 2026-07-06 — they appear in no repo document; everything else was verified by reading the cited files or running the commands below.
+
+Re-verify volatile facts:
+
+| Fact | Command |
+|---|---|
+| HEAD / version | `git log -1 --format='%h %s'` |
+| PR CI = exactly 4 workflows | `grep -l 'pull_request:' .github/workflows/*.yml` (expect lint, prettier, test, tsc) |
+| build/scan not in PR CI | `grep -A2 '^on:' .github/workflows/build-android.yml .github/workflows/dependency-scan.yml` (expect `workflow_dispatch`) |
+| `yarn verify` composition | `grep '"verify"' package.json` |
+| CI Node version | `grep node-version .github/workflows/test.yml` (24.x as of 2026-07-06) |
+| PR template sections | `cat .github/PULL_REQUEST_TEMPLATE.md` |
+| Locale file count / en-only rule | `ls locales \| wc -l` (34); CONTRIBUTING.md "Internationalization" |
+| Proof-of-work rule | CONTRIBUTING.md "Proof of Work for First-Time Contributors" |
+| ACK vocabulary | CODE_REVIEW.md "Review Approval Terminology" |
+| Commit-style drift | `git log --format='%s' -200 \| grep -Ec '^(fix\|ui\|refactor\|feat\|chore\|docs)[:(]'` |
+| Version-bump format | `git log --format='%s' --grep='Version bump' -5` |
+| Incident hashes | `git log -1 --format='%h %ad %s' --date=short <hash>` for `5f533bb12`, `7d8678457`, `7ed901a10`, `46f2bac00`, `e808fd71a`, `ed161541a`, `fdad118ed`, `93227029e`, `28bc50f5e` |
+| Revert-of-a-PR check | `git log --first-parent --grep='revert-<PR#>'` |
+| PGP key | `gpg --show-keys PGP.txt`; README.md "Release + Commit Verification" |
+| License | `grep -m1 'GNU AFFERO' LICENSE` |
+| Docs inventory | `ls docs/` |

--- a/.claude/skills/zeus-config-and-flags/SKILL.md
+++ b/.claude/skills/zeus-config-and-flags/SKILL.md
@@ -1,0 +1,354 @@
+---
+name: zeus-config-and-flags
+description: Catalog of every Zeus configuration axis and the add-a-setting checklist. Load when you need to add/change/remove a user setting or flag, find where a setting lives (settings blob key, per-node vs global, nested group vs top-level), look up a default value (theme, routing fee, LSP/swap/esplora/RGS/VSS URLs, neutrino peers, invoice expiry), change a default for existing users, work in views/Settings/* or stores/SettingsStore.ts, or answer "why does a fresh install behave differently from a migrated one" (bimodalPathfinding, showMillisatoshiAmounts). Keywords: settings, defaults, updateSettings, zeus-settings-v2, certVerification, enableLSP, DropdownSetting, feature flag, deprecated setting, MOD_KEY, per-node config, embeddedLndNetwork, ldkNetwork, mutinynet.
+---
+
+# Zeus Config and Flags
+
+Every user-facing configuration axis in Zeus: where it lives, its options, its default, and the exact checklist for adding or changing a setting. Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha). Defaults drift — re-verify with the commands in the final section before relying on any specific value.
+
+## When to use / When NOT to use
+
+USE this skill when you are:
+- Adding a new setting/flag, or changing an existing one (checklist below is mandatory).
+- Looking up any default value or the full option list for a settings axis.
+- Deciding whether config belongs per-node (`settings.nodes[]`) or global.
+- Debugging "my setting change wiped other settings" (shallow-merge trap) or "fresh installs behave differently from upgraded installs" (new-vs-migrated divergence).
+
+Do NOT use this skill for:
+- The keychain storage contract, the `zeus-settings-v2` blob mechanics, migration recipes, or iCloud rules → **zeus-storage-and-migrations** (that skill owns the storage layer; this one owns the catalog of what is stored).
+- Which backends support which features (`supports*()` gating) → **zeus-backends-and-capabilities**.
+- The change-approval process for storage-format changes → **zeus-change-control**. Anything that changes what is persisted (new keys, changed defaults for existing users, removed fields) requires maintainer sign-off plus a migration plan — never route around that.
+- Boot sequence / how settings are loaded at startup → **zeus-architecture-contract**.
+
+## Glossary (terms used below, defined once)
+
+| Term | Meaning |
+|---|---|
+| settings blob | One JSON object holding almost all config AND all wallet secrets, persisted in the device keychain under key `zeus-settings-v2` (see zeus-storage-and-migrations for the contract) |
+| keychain | OS secure credential store (iOS Keychain / Android Keystore), accessed via `storage/index.ts` |
+| AsyncStorage | React Native's plain, unencrypted key-value store — non-sensitive UI flags only |
+| macaroon | LND's bearer-token credential (hex-encoded here) authorizing REST API calls |
+| rune | Core Lightning's equivalent bearer-token credential |
+| LNC | Lightning Node Connect — LND remote-control protocol using a human-readable "pairing phrase" and a relay ("mailbox") server |
+| NWC | Nostr Wallet Connect (NIP-47) — wallet control over the Nostr protocol via a `nostr+walletconnect://` URL |
+| embedded node | A Lightning node running inside the app: `embedded-lnd` (LND compiled via gomobile) or `ldk-node` (LDK Node via Rust FFI) |
+| LSP | Lightning Service Provider — sells inbound channels. "Flow" is Olympus's zero-conf JIT-channel API; LSPS1/LSPS7 are standardized channel-purchase specs |
+| esplora | Blockstream-style HTTP block-explorer API used by LDK Node for chain data |
+| RGS | Rapid Gossip Sync — pre-digested Lightning network-graph snapshots for LDK |
+| VSS | Versioned Storage Service — remote encrypted storage for LDK channel state |
+| neutrino | LND's light-client chain backend (BIP157/158); "peers" are the btcd nodes it syncs from |
+| EGS / speedloader | Express Graph Sync — pre-baked graph download for embedded LND |
+| mutinynet | A custom signet (test network with 30s blocks) run by Mutiny; LDK treats it as `signet` |
+| Cashu / ecash | Chaumian ecash tokens issued by "mints"; Zeus embeds a Cashu wallet on embedded backends |
+| POS | Point of Sale mode (merchant checkout UI), standalone or Square-integrated |
+| zero-conf | Accepting a channel/payment before on-chain confirmation |
+| MOD_KEY migration | One-shot settings mutation flagged by a key in legacy EncryptedStorage so it runs exactly once per install (recipe owned by zeus-storage-and-migrations) |
+
+## 1) Where config lives
+
+| Location | Key(s) | What | Defined in |
+|---|---|---|---|
+| Keychain blob | `zeus-settings-v2` (`STORAGE_KEY`) | Everything in the `Settings` interface: all groups below + `nodes[]` + secrets (PINs, seeds, macaroons) | `stores/SettingsStore.ts` |
+| Keychain, separate | `zeus-units-v2` (`UNIT_KEY`) | Display units; default `'sats'` | `stores/UnitsStore.ts` |
+| Keychain, separate | `zeus-favorite-currencies` (`FAVORITE_CURRENCIES_KEY`) | Starred fiat currencies (JSON array) | `stores/SettingsStore.ts` |
+| Keychain, separate | `zeus-currency-codes` (`CURRENCY_CODES_KEY`) | Cached currency-code list | `stores/SettingsStore.ts` |
+| Keychain, separate | `zeus-activity-filters-v2` (`ACTIVITY_FILTERS_KEY`) | Activity-list filters | `stores/ActivityStore.ts` |
+| AsyncStorage | `persistentServicesEnabled` | Embedded-LND persistent background services (Android) | `views/Settings/EmbeddedNode/Advanced.tsx`, `views/PendingHTLCs.tsx` |
+| AsyncStorage | `persistentLdkNodeServicesEnabled` | LDK Node persistent background services | `views/Settings/EmbeddedNode/index.tsx` (`PERSISTENT_LDK_KEY`) |
+| AsyncStorage | `persistentNWCServicesEnabled` (`NWC_PERSISTENT_SERVICE_ENABLED`) | NWC wallet-service persistence | `stores/NostrWalletConnectStore.ts` |
+
+Rules of thumb:
+- Secrets and anything financial → the blob (keychain). Non-sensitive UI-only flags → AsyncStorage. Never put new data in legacy `react-native-encrypted-storage` (migration flags only).
+- Any NEW persisted keychain key must be registered in three registries (`utils/DataClearUtils.ts` STORAGE_KEYS, `utils/KeychainRecoveryUtils.ts` OTHER_KEYS, `MigrationUtils.keychainCloudSyncMigration` migrationKeys) or it leaks on wallet clear/recovery — full recipe in **zeus-storage-and-migrations**.
+
+Critical load semantics (verified in `SettingsStore.getSettings`): when a stored blob exists, `this.settings = parsedSettings` REPLACES the entire inline-default object. There is NO deep merge of defaults into stored blobs. Consequence: a newly added field is `undefined` for every existing user until they touch its UI control — every consumer must tolerate that (`settings?.group?.field ?? fallback`, or `||` fallbacks like `getLspConfigForNetwork` uses).
+
+## 2) Per-node axes — `settings.nodes[]` + `settings.selectedNode`
+
+Each wallet is a `Node` object (interface in `stores/SettingsStore.ts`). `selectedNode` is the array index of the active wallet. On load/switch, `updateNodeProperties` copies the selected node's fields onto flat observables (`this.host`, `this.implementation`, ...) that the rest of the app reads.
+
+| Field | Applies to | Notes |
+|---|---|---|
+| `implementation` | all | One of 7: `'embedded-lnd' \| 'ldk-node' \| 'lnd' \| 'lightning-node-connect' \| 'cln-rest' \| 'lndhub' \| 'nostr-wallet-connect'`. Falls back to `'lnd'` when unset. Picker labels in `INTERFACE_KEYS` |
+| `host`, `port`, `url` | remote REST | Node endpoint |
+| `macaroonHex` | lnd | LND REST credential |
+| `rune` | cln-rest | CLN credential |
+| `accessKey` | lndhub | LNDHub access key |
+| `certVerification` | remote REST | **Default `false`** (UI initial state and `updateNodeProperties` fallback). SECURITY: `false` → `trusty: !certVerification` in `backends/LND.ts`, i.e. TLS certificate validation is DISABLED by default for remote node connections (accepted because self-signed node certs are the norm). Turning it on requires installing the node's cert (`views/Settings/CertInstallInstructions.tsx`). The separate Tor `.onion` TLS rule is owned by zeus-backends-and-capabilities |
+| `enableTor` | remote | Route requests through Tor |
+| `pairingPhrase`, `mailboxServer`, `customMailboxServer` | lightning-node-connect | Mailbox options in `LNC_MAILBOX_KEYS` (`mailbox.terminal.lightning.today:443` \| `lnc.zeusln.app:443` \| custom) |
+| `nostrWalletConnectUrl` | nostr-wallet-connect | The NWC pairing URL (note the field name — it is NOT `nwcUrl`) |
+| `seedPhrase`, `walletPassword`, `adminMacaroon` | embedded-lnd | Wallet secrets, plaintext in the blob |
+| `embeddedLndNetwork` | embedded-lnd | Stored values are CAPITALIZED `'Mainnet'`/`'Testnet'` (code compares `=== 'Mainnet'`), while the creation picker uses lowercase `EMBEDDED_NODE_NETWORK_KEYS` values — a real casing trap. Mutinynet is filtered OUT of the picker for new embedded-lnd wallets (`WalletConfiguration.tsx` filters `k.value !== 'mutinynet'`) |
+| `lndDir` | embedded-lnd | Per-wallet data dir; new wallets get a uuid, absent → falls back to `'lnd'` |
+| `isSqlite` | embedded-lnd | Database backend: `false` = Bolt DB (default, `?? false`), `true` = SQLite. Picker: "bolt"/"sqlite" in WalletConfiguration |
+| `ldkNetwork` | ldk-node | Picker shows all of `mainnet \| testnet \| mutinynet` (lowercase). `mutinynet` maps to LDK network `signet` via `getNetworkType` in `utils/LdkNodeUtils.ts`. The `SupportedNetwork` type also includes `'signet'` and `'regtest'` but neither has UI exposure (types-only, as of 2026-07-06) |
+| `ldkNodeDir`, `ldkMnemonic`, `ldkPassphrase` | ldk-node | Data dir (`ldk-node/<uuid>`) + wallet secrets |
+| `ldkEsploraServer` | ldk-node | Default per network via `getDefaultEsploraServer` — mainnet `https://electrs.zeusln.com` |
+| `ldkRgsServer` | ldk-node | Mainnet default `https://rgs.zeusln.com/snapshot`, testnet `https://rapidsync.lightningdevkit.org/testnet/snapshot`, none for signet/mutinynet |
+| `ldkScorerUrl` | ldk-node | Default `https://scores.zeusln.com/latest.bin` (`DEFAULT_SCORER_URL`) |
+| `ldkVssServer` | ldk-node | Default `https://vss.zeusln.com/vss` (`DEFAULT_VSS_SERVER`) |
+| `nickname`, `photo`, `dismissCustodialWarning` | all | Cosmetics + custodial-warning dismissal |
+
+Quirks:
+- LNDHub credentials (`username`, `password`, `lndhubUrl`) are read by `updateNodeProperties` via an `any` cast but are NOT declared on the `Node` interface — grep for them before assuming the interface is complete.
+- Remote nodes have NO network field; network is detected from `getinfo` at connect time. Only embedded wallets choose a network.
+- Per-node editing UI: `views/Settings/WalletConfiguration.tsx` (single 3000+ line view handling all 7 implementations); wallet list: `views/Settings/Wallets.tsx`.
+
+## 3) Global settings catalog
+
+All defaults below are the inline initializer of `@observable settings: Settings` in `stores/SettingsStore.ts` (currently starting near line 1467 — search `@observable settings: Settings =`). "Nested" groups are replaced wholesale by `updateSettings` (see checklist); "flat" keys sit at the blob top level.
+
+### Top-level scalars (flat)
+
+| Axis | Options | Default | UI | Stability |
+|---|---|---|---|---|
+| `pin`, `passphrase`, `duressPin`, `duressPassphrase` | strings | unset | `views/Settings/SetPin.tsx`, `SetPassword.tsx`, `SetDuressPin.tsx`, `SetDuressPassword.tsx` | production — stored PLAINTEXT in the blob (keychain is the security boundary; do not "fix" by hashing without maintainer sign-off) |
+| `scramblePin` | bool | `true` | `views/Settings/Security.tsx` | production |
+| `loginBackground` | bool | `false` | Security.tsx | production |
+| `isBiometryEnabled` / `supportedBiometryType` | bool / detected enum | `false` / `undefined` | Security.tsx | production |
+| `authenticationAttempts` | number | unset | incremented by `views/Lockscreen.tsx` on failed login | internal counter, not a user toggle |
+| `fiatEnabled` | bool | `true` | `views/Settings/Currency.tsx` | production |
+| `fiat` | 101 entries in `CURRENCY_KEYS` (99 fiat currencies plus XAU/XAG; one commented-out KWD entry inflates a naive `grep -c "key:"` to 102 — count with `grep -c '^        key:'`) | `'USD'` (`DEFAULT_FIAT`) | Currency.tsx / SelectCurrency.tsx | production |
+| `fiatRatesSource` | `'Zeus' \| 'Yadio'` (`FIAT_RATES_SOURCE_KEYS`) | `'Zeus'` | Currency.tsx | production |
+| `locale` | 33 ISO codes in `LOCALE_KEYS` | unset → English. NOTE: exported `DEFAULT_LOCALE = 'English'` is a STALE pre-ISO-migration constant; do not copy it | `views/Settings/Language.tsx` | production |
+| `selectNodeOnStartup` | bool | `false` | surfaced in `views/Settings/Display.tsx` | production |
+| `lndHubLnAuthMode` | `'BlueWallet' \| 'Alby'` (`LNDHUB_AUTH_MODES`) | unset; `views/LnurlAuth.tsx` state defaults to `'Alby'` | LnurlAuth.tsx | production |
+| `justDeletedWallet` | bool | unset | internal flag consumed by `views/Settings/Wallets.tsx` | internal |
+
+### `privacy` (nested) — UI: `views/Settings/Privacy.tsx`, `views/Settings/StealthMode.tsx`
+
+| Axis | Options | Default |
+|---|---|---|
+| `defaultBlockExplorer` | `mempool.space \| blockstream.info \| Custom` (`BLOCK_EXPLORER_KEYS`) + `customBlockExplorer` | `'mempool.space'` |
+| `clipboard` | bool (auto-detect clipboard contents) | `true` |
+| `lurkerMode` | bool (hide balances; `SettingsStore.toggleLurker` reveals for 3s then re-hides) | `false` |
+| `enableMempoolRates` | bool (fetch fee rates from mempool.space) | `true` |
+| `stealthMode` | bool — Android only (activity-alias app disguises) | `false` |
+| `stealthApp` | `'zeus' \| 'calculator' \| 'vpn' \| 'qrscanner' \| 'notepad'` | `'calculator'` |
+| `stealthPinLength` | number of unlock taps | `5` |
+| `stealthVpnCountry` / `stealthVpnServer` | strings (VPN-disguise unlock combo) | `'Switzerland'` / `'Geneva'` |
+
+### `display` (nested) — UI: `views/Settings/Display.tsx`
+
+| Axis | Options | Default |
+|---|---|---|
+| `theme` | 23 themes in `THEME_KEYS` | `'kyriaki'` (`DEFAULT_THEME`) |
+| `defaultView` | `'Keypad' \| 'Balance'` (`DEFAULT_VIEW_KEYS`) | `'Keypad'` |
+| `displayNickname` | bool | `false` |
+| `bigKeypadButtons` | bool | `false` |
+| `showAllDecimalPlaces` | bool | `false` |
+| `removeDecimalSpaces` | bool | `false` |
+| `showMillisatoshiAmounts` | bool | `false` fresh — but `true` for legacy-migrated users (MOD_KEY `millisat_amounts`); see §5 |
+
+### `payments` (nested) — UI: `views/Settings/PaymentsSettings.tsx`
+
+| Axis | Options | Default |
+|---|---|---|
+| `defaultFeeMethod` | `'fixed' \| 'percent'` | `'fixed'` — DEPRECATED (see §4) |
+| `defaultFeePercentage` | string percent | `'5.0'` — the 5% routing-fee limit. Companion rule (verified `utils/FeeUtils.ts`): amounts ≤ 1000 sats allow up to 100% fee (`calculateDefaultRoutingFee`) |
+| `defaultFeeFixed` | string sats | `'1000'` |
+| `timeoutSeconds` | string | `'60'` |
+| `preferredMempoolRate` | `fastestFee \| halfHourFee \| hourFee \| minimumFee` (`MEMPOOL_RATES_KEYS`) | `'fastestFee'` |
+| `slideToPayThreshold` | number sats — payments above it require slide-to-confirm | `10000` (`DEFAULT_SLIDE_TO_PAY_THRESHOLD`) |
+| `enableDonations` / `defaultDonationPercentage` | bool / number | `false` / `5` |
+
+### `invoices` (nested) — UI: `views/Settings/InvoicesSettings.tsx`
+
+| Axis | Options | Default |
+|---|---|---|
+| `addressType` | on-chain address type code | `'0'` |
+| `memo`, `receiverName` | strings | `''` |
+| `expiry` + `timePeriod` + `expirySeconds` | display value + `TIME_PERIOD_KEYS` unit + canonical seconds | `'1'` / `'Hours'` / `'3600'`. This TRIPLET must stay mutually consistent — `MigrationUtils.migrateInvoiceExpiryDisplay` repairs drift on both load paths ("3600 hours" bug, #4149). Never update one field alone |
+| `routeHints` | bool | `false` |
+| `ampInvoice` | bool (AMP = LND's Atomic Multi-Path invoices) | `false` |
+| `blindedPaths` | bool (receiver-privacy routes) | `false` |
+| `showCustomPreimageField` | bool | `false` |
+| `displayAmountOnInvoice` | bool | `false` — DEPRECATED |
+| `defaultInvoiceType` | `'unified' \| 'lightning'` (`DEFAULT_INVOICE_TYPE_KEYS`) | `'lightning'` |
+
+### `channels` (nested) — UI: `views/Settings/ChannelsSettings.tsx`
+
+| Axis | Options | Default |
+|---|---|---|
+| `min_confs` | number (confirmations for funding inputs) | `1` |
+| `privateChannel` | bool (unannounced channel) | `true` |
+| `scidAlias` | bool (short-channel-id alias, needed for private-channel invoices) | `true` |
+| `simpleTaprootChannel` | bool (experimental taproot channel type) | `false` |
+
+### Embedded-node group — FLAT top-level keys — UI: `views/Settings/EmbeddedNode/*`
+
+| Axis | Options | Default |
+|---|---|---|
+| `automaticDisasterRecoveryBackup` | bool (channel-backup upload) | `true` |
+| `expressGraphSync` | bool (EGS download) | `false` |
+| `resetExpressGraphSyncOnStartup` | bool | `false` |
+| `bimodalPathfinding` | bool (LND bimodal payment-probability model) | `true` fresh — but forced `false` for legacy-migrated users (MOD_KEY `bimodal-bug-9085`, lnd issue #9085); see §5 |
+| `graphSyncPromptNeverAsk` / `graphSyncPromptIgnoreOnce` | bool | `false` / `false` |
+| `dontAllowOtherPeers` | bool (restrict neutrino to listed peers) | `false` |
+| `neutrinoPeersMainnet` | string[] | `DEFAULT_NEUTRINO_PEERS_MAINNET` (5 peers: `btcd1.lnolymp.us`, `btcd2.lnolymp.us`, `btcd-mainnet.lightning.computer`, `node.eldamar.icu`, `noad.sathoarder.com`); regional alternates in `SECONDARY_NEUTRINO_PEERS_MAINNET` |
+| `neutrinoPeersTestnet` | string[] | 3 peers (`testnet.lnolymp.us`, `btcd-testnet.lightning.computer`, `testnet.blixtwallet.com`) |
+| `zeroConfPeers` | string[] pubkeys allowed to open zero-conf channels | `[]` |
+| `rescan`, `compactDb`, `recovery` | bool one-shot startup flags | `false` |
+| `initialLoad` | bool | `true` |
+| `embeddedTor` | bool (run embedded LND over Tor) | `false` |
+| `feeEstimator` + `customFeeEstimator` | `FEE_ESTIMATOR_KEYS` (lightning.computer \| strike.me \| Custom) | `https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json` (`DEFAULT_FEE_ESTIMATOR`) |
+| `speedloader` + `customSpeedloader` | `SPEEDLOADER_KEYS` (ZEUS \| Blixt \| Custom) | `https://egs.lnze.us/` (`DEFAULT_SPEEDLOADER`) |
+
+### LSP group — FLAT top-level keys — UI: `views/Settings/LSP.tsx`, `views/Settings/LSPServicesList.tsx`
+
+Per-network TRIPLETS (mainnet/testnet/mutinynet). The canonical resolver is `getLspConfigForNetwork(settings, network)` in `stores/SettingsStore.ts` — it accepts a network string or NodeInfo-style flags, and treats `'signet'` as testnet. Always use it; never read the triplet fields directly.
+
+| Axis | Default |
+|---|---|
+| `enableLSP` | `true` |
+| `lspMainnet` / `lspTestnet` / `lspMutinynet` (Olympus Flow hosts) | `https://0conf.lnolymp.us` / `https://testnet-0conf.lnolymp.us` / `https://mutinynet-flow.lnolymp.us` |
+| `lspAccessKey` | `''` |
+| `requestSimpleTaproot` | `true` |
+| `lsps1RestMainnet` / `...Testnet` / `...Mutinynet` | `https://lsps1.lnolymp.us` / `https://testnet-lsps1.lnolymp.us` / `https://mutinynet-lsps1.lnolymp.us` |
+| `lsps1PubkeyMainnet` / `...Testnet` / `...Mutinynet` | Olympus node pubkeys (see `DEFAULT_LSPS1_PUBKEY_*` consts) |
+| `lsps1HostMainnet` / `...Testnet` / `...Mutinynet` | `45.79.192.236:9735` / `139.144.22.237:9735` / `45.79.201.241:9735` |
+| `lsps1Token` | `''` |
+| `lsps1ShowPurchaseButton` | unset — DEPRECATED |
+
+### `swaps` (nested) — UI: `views/Swaps/Settings.tsx` (note: under views/Swaps/, not views/Settings/)
+
+| Axis | Options | Default |
+|---|---|---|
+| `hostMainnet` | `SWAP_HOST_KEYS_MAINNET`: ZEUS (`https://swaps.zeuslsp.com/api/v2`), Boltz, SwapMarket, Eldamar Swaps, Custom | ZEUS host (`DEFAULT_SWAP_HOST_MAINNET`) |
+| `hostTestnet` | `SWAP_HOST_KEYS_TESTNET`: ZEUS, Boltz, Custom | `https://testnet-swaps.zeuslsp.com/api/v2` |
+| `customHost` | string | `''` |
+| `proEnabled` | bool — unlocks `pro: true` hosts (Boltz mainnet, Custom) | `false` |
+
+### `lightningAddress` (nested) — UI: `views/LightningAddress/LightningAddressSettings.tsx` (+ Cashu/NWC variants under `views/Cashu/LightningAddress/`, `views/LightningAddress/NWCAddressSettings.tsx`)
+
+| Axis | Options | Default |
+|---|---|---|
+| `enabled` | bool (ZEUS Pay address) | `false` |
+| `automaticallyAccept` | bool | `true` |
+| `automaticallyAcceptAttestationLevel` | `0 \| 1 \| 2` (`AUTOMATIC_ATTESTATION_KEYS`: disabled / success only / success+not-found) | `2` |
+| `automaticallyRequestOlympusChannels` | bool | `false` — DEPRECATED |
+| `routeHints` | bool | `false` |
+| `allowComments` | bool | `true` |
+| `zapReceiptsEnabled` | bool (Nostr zap receipts) | `true` |
+| `nostrPrivateKey` | string | `''` |
+| `nostrRelays` | string[] | `DEFAULT_NOSTR_RELAYS` (8 relays; the older 3-relay list survives as `DEFAULT_NOSTR_RELAYS_2023` for migration) |
+| `notifications` | `0 \| 1 \| 2` (`NOTIFICATIONS_PREF_KEYS`: disabled / push / nostr) | `0` |
+| `mintUrl` | string (Cashu-type address mint) | `''` |
+| `posEnabled` | bool — ZEUS Pay+ web POS | `false` (newer, treat as experimental) |
+
+### `bolt12Address` (nested) — UI: `views/Settings/Bolt12Address.tsx`
+
+Single axis: `localPart` (string, default `''`) — username for a BOLT12 offer-based address (CLN/LDK backends).
+
+### `ecash` (nested) — UI: `views/Settings/EcashSettings.tsx`
+
+| Axis | Options | Default |
+|---|---|---|
+| `enableCashu` | bool | `false` |
+| `enableMultiMint` | bool (NUT-15 multi-mint payments) | `false` |
+| `automaticallySweep` | bool (sweep ecash to LN balance) | `false` |
+| `sweepThresholdSats` | number | `10000` |
+| `initialMintUrls` | string[] | unset (optional) |
+
+Cashu is only available on embedded backends — gating rules live in **zeus-backends-and-capabilities**.
+
+### `pos` (nested) — UI: `views/Settings/PointOfSale.tsx`
+
+| Axis | Options | Default |
+|---|---|---|
+| `posEnabled` | `'disabled' \| 'square' \| 'standalone'` (`PosEnabled` enum / `POS_ENABLED_KEYS`) | `'disabled'` |
+| `squareEnabled` | bool | `false` — DEPRECATED (migrated into `posEnabled`) |
+| `squareAccessToken` / `squareLocationId` / `squareDevMode` | Square API config | `''` / `''` / `false` |
+| `merchantName`, `taxPercentage` | strings | `''` |
+| `confirmationPreference` | `'0conf' \| '1conf' \| 'lnOnly'` (`POS_CONF_PREF_KEYS`) | `'lnOnly'` |
+| `disableTips` | bool | `false` |
+| `showKeypad` | bool | `true` |
+| `enablePrinter` | bool | `false` |
+| `defaultView` | `'Products' \| 'POS Keypad'` (`DEFAULT_VIEW_KEYS_POS`) | `'Products'` |
+
+### `networking` (nested) — UI: `views/Settings/Networking.tsx`
+
+Single axis: `disableOfflineCheck` (bool, default `false`) — skips the connectivity probe before requests.
+
+### Not a setting: developer mode
+
+There is NO developer-mode toggle. Developer tools are gated purely by `supportsDevTools()` in `utils/BackendUtils.ts` (`isLNDBased() || this.call('supportsDevTools')` — LND-based backends, plus any backend that implements `supportsDevTools`, currently LndHub and CLNRest). Don't invent a settings flag for it.
+
+## 4) Deprecated-but-retained flags
+
+All five are marked `// deprecated` in `stores/SettingsStore.ts` and MUST stay in the type + defaults:
+
+| Flag | Group | Why it can't be casually deleted |
+|---|---|---|
+| `defaultFeeMethod` | payments | Still read as a fallback by `views/Settings/PaymentsSettings.tsx` (`feeLimitMethod`); present in every existing blob |
+| `displayAmountOnInvoice` | invoices | Present in existing blobs; type removal breaks migration code paths |
+| `squareEnabled` | pos | `MigrationUtils.legacySettingsMigrations` still reads it to migrate old installs to `posEnabled` (and its test fixtures reference it) |
+| `automaticallyRequestOlympusChannels` | lightningAddress | Still explicitly written `false` by `stores/LightningAddressStore.ts` and `utils/MigrationUtils.ts` |
+| `lsps1ShowPurchaseButton` | LSP (flat) | Present in existing blobs; optional field |
+
+General rule: removing a persisted field is a storage-format change. Old blobs keep the field forever; migration code and its tests reference it; and TypeScript on those paths breaks if the type disappears. Removal requires the gated process in **zeus-change-control** plus a migration plan per **zeus-storage-and-migrations**.
+
+## 5) New-vs-migrated divergences (document yours if you create one)
+
+Because MOD_KEY migrations in `MigrationUtils.legacySettingsMigrations` run only for users upgrading from the legacy `zeus-settings` blob, some settings intentionally differ between fresh installs and migrated installs:
+
+| Setting | Fresh install | Legacy-migrated | Cause |
+|---|---|---|---|
+| `bimodalPathfinding` | `true` (inline default) | `false` | MOD_KEY `bimodal-bug-9085` disables it for existing users while lnd issue #9085 stands |
+| `display.showMillisatoshiAmounts` | `false` (inline default) | `true` | MOD_KEY `millisat_amounts` opted existing users in |
+
+If your change creates such a divergence, it must be stated in the PR description and added to this table.
+
+## 6) ADD-A-SETTING CHECKLIST
+
+Follow every step; skipping any one has caused real bugs (data loss via shallow merge, "3600 hours" display corruption, leaked keys).
+
+1. **Choose the home.**
+   - Per-wallet behavior → new field on the `Node` interface (`stores/SettingsStore.ts`).
+   - Global, thematically grouped → the matching nested group interface (`PrivacySettings`, `PaymentsSettings`, ...).
+   - Global, embedded-node/LSP-style → flat top-level key on `Settings`.
+   - Non-sensitive UI-only flag that shouldn't live in the secrets blob → AsyncStorage (see §1 examples).
+2. **Type it** in `stores/SettingsStore.ts`. Prefer optional (`field?:`) — existing blobs won't have it (see §1 load semantics).
+3. **Add the inline default** in the `@observable settings: Settings = {...}` initializer (search for it; near line 1467 as of 2026-07-06). Remember this default only applies before a stored blob loads — every reader still needs a fallback for `undefined`.
+4. **If it's an enumerated axis**, add an exported `*_KEYS` array (key/value/translateKey objects) next to the other pickers so DropdownSetting UIs and tests can consume it.
+5. **Build the UI** in the matching `views/Settings/*.tsx` (or per-node in `WalletConfiguration.tsx`). When persisting, use the shallow-merge-safe pattern — `SettingsStore.updateSettings` merges ONLY the top level, so nested groups are replaced wholesale:
+   ```ts
+   await updateSettings({
+       payments: {
+           ...settings.payments, // MANDATORY spread — omitting it silently
+           myNewField: value     // destroys every sibling payments setting
+       }
+   });
+   ```
+   Flat top-level keys (`updateSettings({ enableLSP: false })`) are safe without a spread.
+6. **Locale strings**: add English copy to `locales/en.json` ONLY (the other 33 locale files are Transifex-managed — rule owned by **zeus-change-control**). Reference via `localeString('views.Settings.<...>')`.
+7. **Changing an existing default for existing users?** That is a storage-format change: write a one-shot MOD_KEY migration (recipe, ordering, and `setSettings`-with-a-real-object rules in **zeus-storage-and-migrations**) and note that it must run on the modern `zeus-settings-v2` load path (like `migrateRgsDefaultToZeus`), not only inside `legacySettingsMigrations`. Maintainer sign-off required.
+8. **Creating a fresh-vs-migrated divergence?** Document it (§5).
+9. **New separate keychain key** (not in the blob)? Register it in the three registries (§1) — recipe in **zeus-storage-and-migrations**.
+10. **Verify**: `yarn verify` (test + prettier + tsc + lint) and fill in the PR template's backend-testing matrix — details in **zeus-validation-and-qa** / **zeus-change-control**.
+
+## Provenance and maintenance
+
+Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha) by reading `stores/SettingsStore.ts`, `utils/MigrationUtils.ts`, `utils/LdkNodeUtils.ts`, `utils/FeeUtils.ts`, `utils/BackendUtils.ts`, `backends/LND.ts`, `stores/UnitsStore.ts`, `stores/ActivityStore.ts`, `stores/NostrWalletConnectStore.ts`, and `views/Settings/*`. Defaults are volatile — re-verify before citing:
+
+| Volatile fact | Re-verification command |
+|---|---|
+| Inline defaults block location + every default value | `grep -n '@observable settings: Settings' stores/SettingsStore.ts` then read the initializer |
+| Blob key / out-of-blob keys | `grep -rn "STORAGE_KEY\|UNIT_KEY\|FAVORITE_CURRENCIES_KEY\|CURRENCY_CODES_KEY\|ACTIVITY_FILTERS_KEY = " stores/` |
+| AsyncStorage flag names | `grep -rn "persistentServicesEnabled\|persistentLdkNodeServicesEnabled\|persistentNWCServicesEnabled" stores views` |
+| 7 implementations + picker labels | `grep -n "Implementations =" -A 8 stores/SettingsStore.ts && grep -n "INTERFACE_KEYS" -A 12 stores/SettingsStore.ts` |
+| certVerification default + TLS implication | `grep -n "certVerification: false" views/Settings/WalletConfiguration.tsx && grep -n "trusty" backends/LND.ts` |
+| Theme count + default | `sed -n '/THEME_KEYS/,/^];/p' stores/SettingsStore.ts \| grep -c "key:"` and `grep -n "DEFAULT_THEME" stores/SettingsStore.ts` |
+| Locale count | `sed -n '/LOCALE_KEYS = /,/^];/p' stores/SettingsStore.ts \| grep -c "key:"` and `ls locales/*.json \| wc -l` |
+| Routing-fee default + ≤1000-sat rule | `grep -n "defaultFeePercentage\|DEFAULT_ROUTING_FEE_PERCENT" stores/SettingsStore.ts utils/FeeUtils.ts` |
+| LSP/LSPS1 triplets + signet→testnet | `grep -n "DEFAULT_LSP\|DEFAULT_LSPS1\|signet" stores/SettingsStore.ts` |
+| Swap hosts | `grep -n "SWAP_HOST_KEYS\|DEFAULT_SWAP_HOST" stores/SettingsStore.ts` |
+| LDK server defaults + mutinynet→signet | `grep -n "DEFAULT_VSS_SERVER\|DEFAULT_SCORER_URL\|rgs.zeusln\|electrs.zeusln\|case 'mutinynet'" utils/LdkNodeUtils.ts` |
+| Neutrino peer lists | `grep -n "DEFAULT_NEUTRINO_PEERS" -A 8 stores/SettingsStore.ts` |
+| Deprecated flags still present | `grep -n "deprecated" stores/SettingsStore.ts` |
+| MOD_KEY list (divergences) | `grep -n "MOD_KEY" utils/MigrationUtils.ts` |
+| Mutinynet filtered from embedded-lnd picker | `grep -n "mutinynet" views/Settings/WalletConfiguration.tsx` |
+| embeddedLndNetwork capitalization | `grep -rn "embeddedLndNetwork === 'Mainnet'" views/ \| head -3` |
+| No dev-mode toggle | `grep -n "supportsDevTools" utils/BackendUtils.ts` |

--- a/.claude/skills/zeus-debugging-playbook/SKILL.md
+++ b/.claude/skills/zeus-debugging-playbook/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: zeus-debugging-playbook
+description: Load when debugging a Zeus failure - a feature silently does nothing, "TypeError x.then is not a function", settings vanished after update, app stuck on "connecting"/infinite loading, CI Lint or Prettier fails though local eslint passes, Jest "unexpected token" on a new dependency, crash in Animated/layout code after RN upgrade, Hermes RangeError/regex stack overflow, identical error repeats on every retry over Tor, "payment timed out" shown as success, back navigation lands on wrong screen, embedded LND won't start or crashes on restart, keychain/settings weirdness on a new device, gRPC stream write reports success but nothing happens, or node start/stop/delete race crashes. Gives a symptom-to-triage table with discriminating experiments and known trap references.
+---
+
+# Zeus Debugging Playbook
+
+Symptom → triage for Zeus's recurring failure modes. Each row names the first thing to check, the likely cause, the fix pattern, and (where one exists) the commit that proves the story. Deep incident narratives live in **zeus-failure-archaeology** — this skill gives you the fast path.
+
+## When to use / When NOT to use
+
+**Use this skill when** something is broken and you need to find out why: a runtime misbehavior, a CI failure you can't reproduce locally, a crash, a hang, a silently-no-op feature.
+
+**Do NOT use this skill for:**
+
+| Need | Go to sibling skill |
+|---|---|
+| Setting up the dev environment, postinstall/build failures | zeus-build-and-env |
+| Running the app, connecting to a node, releases | zeus-run-and-operate |
+| How to capture logs / measure / inspect state (tooling recipes) | zeus-diagnostics-and-tooling |
+| Full incident histories with root-cause narratives | zeus-failure-archaeology |
+| Backend capability matrix, per-backend quirks, adding an RPC | zeus-backends-and-capabilities |
+| Keychain contract, settings blob, migration recipes | zeus-storage-and-migrations |
+| The node-lifecycle-races live problem (embedded LND / LDK Node start-stop-delete) | zeus-node-lifecycle-campaign |
+| What counts as test evidence, `yarn verify` anatomy, adding tests | zeus-validation-and-qa |
+| Formal race/migration/dispatch analysis methods | zeus-proof-and-analysis-toolkit |
+
+## Jargon in one line each
+
+- **Backend / implementation**: Zeus talks to 7 kinds of Lightning nodes (`embedded-lnd`, `ldk-node`, `lnd`, `lightning-node-connect`, `cln-rest`, `lndhub`, `nostr-wallet-connect`). The active one is the string `settingsStore.implementation`.
+- **BackendUtils dispatch**: `utils/BackendUtils.ts` routes every node call to the active backend class in `backends/`. If the class lacks the method, `call()` **returns `false` synchronously** — it does not throw.
+- **`supports*()` flags**: per-backend capability methods (e.g. `supportsMessageSigning()`); views must gate features on these, never on the implementation string.
+- **MobX store**: an observable state singleton in `stores/` (e.g. `SettingsStore`); views react to its fields.
+- **Keychain**: iOS/Android secure credential storage; Zeus persists nearly everything there via `storage/index.ts`, including the whole settings blob.
+- **Hermes**: the JavaScript engine React Native uses in Zeus; it has a shallow native stack, so heavy regex backtracking overflows it.
+- **Fabric / New Architecture**: React Native's rewritten rendering layer, ON in Zeus since RN 0.83.1 (commit `d13ebc2cd`); it is stricter about Animated/layout usage than the old renderer.
+- **Tor**: anonymity network; Zeus can route node REST calls through it (`enableTor` per node).
+- **Embedded LND**: a full LND Lightning node compiled to a mobile library (gomobile) running inside the app; **LDK Node** is the same idea built on the Lightning Dev Kit (Rust, uniffi FFI).
+- **Macaroon**: LND's bearer auth token, sent as a header on REST calls.
+- **gRPC streaming**: long-lived request channels used by the embedded-LND native layer (Blixt-derived code in `android/app/src/main/java/com/zeus/` and `ios/LndMobile/`).
+
+## Before you debug — 4 questions
+
+1. **Which backend?** Most "bugs" are missing capability gates. Reproduce on (or at least reason about) the specific `implementation`. A feature working on `lnd` and dead on `lndhub` is a gating issue, not a logic issue.
+2. **Which platform?** The embedded-LND native layer is separate code per platform (`LndMobileService.java` vs `ios/LndMobile/Lnd.swift`); NWC background services, stealth mode, and keychain-iCloud behavior are platform-specific.
+3. **Fresh install or upgrade?** One-shot migrations (the MOD_KEY blocks in `utils/MigrationUtils.ts`) only run once per install. Upgrade-only bugs live there — a fresh install will never reproduce them. See zeus-storage-and-migrations.
+4. **Tor on or off?** Tor changes the request path (dedup-cache retention, TLS rules, WebSocket bypass). Toggle it as a discriminating experiment.
+
+Also remember: `stores/`, `views/`, `components/`, and `backends/` have **zero test coverage** (tests exist only for `utils/`, `models/`, `lndmobile/`) — a green `yarn test` proves nothing about a store bug. See zeus-validation-and-qa.
+
+## Triage table
+
+| # | Symptom | First check | Likely cause | Fix pattern |
+|---|---|---|---|---|
+| 1 | Feature silently does nothing on some backend | `grep -n 'theMethod' backends/<ActiveBackend>.ts` | `BackendUtils.call()` returned `false` (method missing on backend), or the view lacks a `supports*` gate | Gate the view with the right `supports*()`; implement or wrap the method (zeus-backends-and-capabilities) |
+| 2 | `TypeError: ... .then is not a function` / `.then of false` | Same as #1 | Same root cause: code awaited/`.then`ed the `false` that `call()` returns for a missing method | Same as #1; log `typeof result` at the call site to confirm |
+| 3 | User settings vanished after an update | The `updateSettings({...})` call that shipped in the update | `SettingsStore.updateSettings` is a **shallow top-level merge** — passing a partial nested group replaces the whole group | Spread the existing group: `updateSettings({ payments: { ...settings.payments, newField } })` (zeus-config-and-flags for the axes) |
+| 4 | App stuck on "connecting" / infinite loading | `fetchLock` and `connecting` values in `views/Wallet/Wallet.tsx` | Re-entrancy guard never released, or a lifecycle refactor changed when `getSettingsAndNavigate()` runs | Ensure every exit path releases `fetchLock`; incident `fdad118ed` → fixed by `93227029e` |
+| 5 | CI **Lint** job fails though `eslint .` passes locally | `yarn lint` locally (not bare eslint) | `yarn lint` = `eslint . && yarn run test check-styles.test.ts --testPathIgnorePatterns=` — the second half bans `themeColor()` inside static `StyleSheet.create` in any `.tsx` | Move the themed color out of the static stylesheet (inline style or style function) |
+| 6 | Prettier check fails with a reformat that looks wrong | `npx prettier --version` → must print `2.4.1` | You formatted with a global/modern prettier; repo pins `prettier@2.4.1` (tabWidth 4, singleQuote, trailingComma none) | Re-format with the repo-local binary: `yarn prettier --write <file>` |
+| 7 | Jest: `SyntaxError: Unexpected token` on a new dependency | `transformIgnorePatterns` in `package.json` (jest block) | New ESM dep isn't in the transform whitelist, so Babel skips it | Add the package name inside the `node_modules/(?!(...))` group |
+| 8 | Crash in Animated/layout code after an RN upgrade | Was the pattern written pre-New-Architecture? | Fabric (ON since `d13ebc2cd`, RN 0.83.1) rejects patterns the old renderer tolerated | Restructure per `f08bfc7c5` (WalletHeader Animated) and `2c55e4f89` (keypad baseline layout) |
+| 9 | Hermes `RangeError` / stack overflow on string matching | Input length at the regex call site | Hermes regex backtracking overflows on long inputs | Length-cap before matching, like `MERCHANT_QR_MAX_LEN = 500` in `utils/handleAnything.ts` (`5c451839d`) |
+| 10 | Identical error repeats on every retry (Tor node) | The `calls` Map in `backends/LND.ts` / `backends/CLNRest.ts` | Tor branch of `restReq` deletes the dedup-cache entry only in `.then` — a **rejected** promise stays cached and is replayed | Retries work after reconnect: `setConnectingStatus(true)` calls `BackendUtils.clearCachedCalls()`. Real fix: delete cache entry on rejection too (`backends/*` is funds-touching — minimal diff, discuss first; see zeus-change-control) |
+| 11 | "payment timed out" but payment shows as success (or is handled as one) | `result.payment_error` on the resolved value | LND REST `payLightningInvoice` races a timer that **resolves** with `{ payment_error: localeString('views.SendingLightning.paymentTimedOut') }` (a locale-dependent "Payment timed out…" message) — errors arrive success-shaped | Always check `payment_error` on resolved LND payment results; never treat resolution as success |
+| 12 | Back navigation lands on the wrong screen / stale params | Does the code call `navigation.navigate()` to go "back"? | react-navigation 7: `navigate` pushes/reuses unpredictably | Use `navigation.popTo('Screen', params)` (PR #2192, merge `7abc7a971`); type with `NativeStackNavigationProp` |
+| 13 | Embedded LND won't start / crashes on restart | Which DB backend: `isSqlite` per node → `db.backend=sqlite\|bolt` in `utils/LndMobileUtils.ts` | SQLite/Bolt DB-backend saga; restart crash fixed in `3e04e6bf2` (#4013) | Read the real logs first — see "Getting embedded-LND logs" below |
+| 14 | Keychain/settings weirdness on a new device (old wallets appear, wrong data) | Did the data come from iCloud keychain sync? | Orphaned pre-migration keychain entries are retained **by design** (`deleteFromOldKeychain` is a deliberate no-op); iCloud-synced copies caused the 2025–26 saga | Do NOT "fix" storage yourself — storage changes are gated. Go to zeus-storage-and-migrations |
+| 15 | gRPC stream write "succeeded" but nothing happened (embedded LND) | `LndMobileService.java:279` and `ios/LndMobile/Lnd.swift:334` | Android swallows the send exception (`catch (Throwable) { /* TODO */ }`) and reports success anyway; iOS `try write?.send(bytes)` may not throw on failure (TODO: BOOL return) | Don't trust stream-write callbacks in the Blixt-derived layer; verify the effect via a read call |
+| 16 | Crash during wallet start/stop/delete/switch (Tokio panic, native crash) | Sequence of node lifecycle calls | Node lifecycle races — the hardest live problem | Go to zeus-node-lifecycle-campaign; ref fixes `d416052cd`, `0e2b89164` |
+
+## Discriminating experiments (rows that need more than one line)
+
+### Rows 1–2: missing backend method vs missing gate
+
+`BackendUtils.call()` in `utils/BackendUtils.ts` returns `false` synchronously for a method the active backend lacks — the dispatcher code and full consequence catalog are owned by **zeus-backends-and-capabilities §1**. Discriminate in three steps:
+
+```sh
+# 1. Is the method on the active backend class? (LND is the implicit base;
+#    EmbeddedLND and LndHub extend it — check the parent too)
+grep -n 'theMethod' backends/LndHub.ts backends/LND.ts
+
+# 2. Is there a dispatch wrapper at all? (a typo'd name silently no-ops)
+grep -n 'theMethod' utils/BackendUtils.ts
+
+# 3. At runtime: log what came back
+console.log(typeof result, result); // "boolean false" => missing method
+```
+
+Known dead dispatch as of 2026-07-06: `payLightningInvoiceStreaming` is declared in `utils/BackendUtils.ts` but implemented by **no** backend — it always returns `false`. Inheritance leaks (un-overridden LND REST methods firing on EmbeddedLND) are in zeus-backends-and-capabilities.
+
+### Row 3: shallow-merge settings loss
+
+`stores/SettingsStore.ts` `updateSettings` does `{ ...existingSettings, ...newSetting }` — top level only. `updateSettings({ privacy: { lurkerMode: true } })` erases every other `privacy` field for the user. Discriminating experiment: diff the settings blob before/after the call (see zeus-diagnostics-and-tooling for inspecting it). If a nested group shrank, you found it. Repair for already-shipped damage requires a migration — zeus-storage-and-migrations, and note storage changes are maintainer-gated (zeus-change-control).
+
+### Row 4: stuck connecting
+
+`views/Wallet/Wallet.tsx` `fetchData()` opens with:
+
+```ts
+if (fetchLock) return;
+SettingsStore.fetchLock = true;
+```
+
+and `SettingsStore.connecting` initializes `true`. `getSettingsAndNavigate()` runs on Wallet-screen focus only for initial load, POS exit, or an explicit settings refresh (`this.state.initialLoad || SettingsStore.posWasEnabled || SettingsStore.triggerSettingsRefresh`), and is skipped while the in-flight `_navigating` guard flag is set. If any code path between lock-set and lock-release throws unhandled or early-returns, the app hangs on the loading state forever — and because focus events won't re-trigger the call outside those three conditions, nothing retries it. `SettingsStore.setConnectingStatus(true)` clears `fetchLock` and the request cache — that's why "go to settings and back" sometimes unsticks it (a diagnostic signal, not a fix). Trap story: the UNSAFE-lifecycle refactor `fdad118ed` caused exactly this; `93227029e` fixed it three weeks later. Deep narrative: zeus-failure-archaeology.
+
+### Rows 5–7: CI failures that lie about their cause
+
+Green PR = 4 checks (Test, Lint, Prettier, Typescript Check) = `yarn verify`. Anatomy and jest traps are owned by zeus-validation-and-qa; the three that masquerade as something else:
+
+- **Lint** runs a jest test: `check-styles.test.ts` (repo root) is excluded from `yarn test` via `testPathIgnorePatterns` and re-included by `yarn lint` with `--testPathIgnorePatterns=`. Failure text lists the offending `.tsx` files.
+- **Prettier/Lint double failure**: prettier violations also fail ESLint (`prettier/prettier` is an `error` rule in `eslint.config.js`). Fix formatting once, both clear.
+- **Test** on a new dep: extend the `transformIgnorePatterns` whitelist in `package.json`; current members include `react-native`, `@react-native`, `react-native-blob-util`, `nostr-tools`, `@noble`, `@scure`, `uuid`, etc.
+
+### Row 10: Tor request dedup cache retains rejections
+
+Both `backends/LND.ts` and `backends/CLNRest.ts` keep a module-level `const calls = new Map<string, Promise<any>>()` keyed by `url + JSON.stringify(body)`. The non-Tor branch deletes the entry on both success and failure (a `.catch` on the raced promise). The Tor branch deletes only in `.then`:
+
+```ts
+doTorRequest(...).then((response: any) => {
+    calls.delete(id);   // no .catch — a rejection stays cached
+    return response;
+})
+```
+
+Discriminating experiment: same request, Tor off → retry gets a fresh attempt; Tor on → retry replays the identical rejection instantly (suspiciously fast failure = cached). Cache is cleared on reconnect (`SettingsStore.setConnectingStatus(true)` → `BackendUtils.clearCachedCalls()`).
+
+### Row 13: embedded LND startup — and getting real logs
+
+`lndmobile/index.ts` `readLndLog` is a stub (`return [''];`, marked `TODO remove`) — do not build diagnostics on it. The actual log path is what `views/Settings/EmbeddedNode/LNDLogs.tsx` does: `NativeModules.LndMobileTools.tailLog(...)` plus the `'lndlog'` event listener. In-app: the embedded node settings expose the LND Logs screen. Full log-capture recipes: zeus-diagnostics-and-tooling. The DB backend is chosen per node (`isSqlite` → `db.backend=sqlite|bolt` written into lnd.conf by `utils/LndMobileUtils.ts`); the SQLite/Bolt history (`ef4a42112` → `3c6f4175e` → `d475ef2b4` → `3e04e6bf2`) is chronicled in zeus-failure-archaeology.
+
+### Row 15: stream-write success is unverifiable
+
+`android/app/src/main/java/com/zeus/LndMobileService.java` (line 279 as of 2026-07-06):
+
+```java
+try {
+  s.send(payload);
+} catch (Throwable error) {
+  // TODO(hsjoberg): Handle errors
+}
+// ...then unconditionally reports MSG_GRPC_STREAM_WRITE_RESULT
+```
+
+`ios/LndMobile/Lnd.swift` (line 334): `try write?.send(bytes) // TODO(hsjoberg): Figure out whether send returns a BOOL?` — thrown errors are forwarded, but a `false`-returning send would still call back success. Verification pattern: after any stream write you care about, confirm the effect with an independent read RPC.
+
+## Grep hygiene
+
+When searching the repo for debt markers, symbols, or error strings, exclude generated and vendored code or you'll drown in noise:
+
+```sh
+grep -rn "TODO" . \
+  --include='*.ts' --include='*.tsx' \
+  --exclude-dir=node_modules --exclude-dir=zeus_modules \
+  --exclude-dir=proto --exclude-dir=android --exclude-dir=ios
+```
+
+- `ios/LdkNodeMobile/LDKNode.swift` and `android/app/src/main/java/org/lightningdevkit/ldknode/ldk_node.kt` are **uniffi-generated** bindings (18 TODO hits each as of 2026-07-06) — never "fix" them by hand.
+- `proto/lightning.js` is generated protobuf output.
+- `zeus_modules/` is vendored (lnc-rn has its own `node_modules` inside it).
+- `utils/AddressUtils.test.ts` contains `XXX` inside a base64 PSBT fixture (~line 923) — a false positive for placeholder hunts.
+- `fetch-libraries.sh` defines a shell function literally named `jq()` (it's python3) — misleading grep target.
+
+## Provenance and maintenance
+
+Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha) by reading the cited files and running the commands below. All cited commit hashes verified as ancestors of that commit via `git merge-base --is-ancestor <hash> HEAD`.
+
+Re-verification one-liners for volatile facts:
+
+| Fact | Re-verify with |
+|---|---|
+| `call()` returns `false` for missing method | `grep -n 'return false' utils/BackendUtils.ts` |
+| `payLightningInvoiceStreaming` still unimplemented | `grep -rn payLightningInvoiceStreaming backends/` (expect no hits) |
+| `updateSettings` still shallow merge | `grep -n -A6 'public updateSettings' stores/SettingsStore.ts` |
+| `fetchLock` guard in Wallet.tsx | `grep -n 'fetchLock' views/Wallet/Wallet.tsx` |
+| `yarn lint` includes check-styles | `grep -n '"lint"' package.json` |
+| Prettier pin 2.4.1 | `grep -n '"prettier"' package.json` |
+| Jest transform whitelist members | `grep -n -A2 transformIgnorePatterns package.json` |
+| Merchant-QR 500-char cap | `grep -n MERCHANT_QR_MAX_LEN utils/handleAnything.ts` |
+| Tor dedup cache deletes only in `.then` | `grep -n -A16 'useTor === true' backends/LND.ts backends/CLNRest.ts` |
+| Cache cleared on reconnect | `grep -n clearCachedCalls stores/SettingsStore.ts` |
+| Timeout resolves with `payment_error` | `grep -n -B2 -A6 forcedTimeout backends/LND.ts` |
+| `readLndLog` still a stub | `grep -n -A3 'export const readLndLog' lndmobile/index.ts` |
+| Android stream-write swallow | `grep -n -A3 's.send(payload)' android/app/src/main/java/com/zeus/LndMobileService.java` |
+| iOS stream-write BOOL doubt | `grep -n 'returns a BOOL' ios/LndMobile/Lnd.swift` |
+| Incident hashes still resolve | `git log --oneline -1 <hash>` for `fdad118ed 93227029e f08bfc7c5 2c55e4f89 7abc7a971 d416052cd 0e2b89164 d13ebc2cd 3e04e6bf2 5c451839d` |
+| No tests for stores/views/components/backends | `find stores views components backends -name '*.test.*'` (expect empty) |

--- a/.claude/skills/zeus-diagnostics-and-tooling/SKILL.md
+++ b/.claude/skills/zeus-diagnostics-and-tooling/SKILL.md
@@ -1,0 +1,546 @@
+---
+name: zeus-diagnostics-and-tooling
+description: How to MEASURE Zeus instead of eyeballing it — find and tail logs (embedded LND lnd.log paths on Android/iOS, LDK Node ldk_node.log, adb logcat tags, Metro/Xcode consoles), use in-app diagnostics (Developer Tools view, Keychain Recovery scanner, log viewers), inspect network traffic (REST/WebSocket/Tor paths, TLS caveats), grep the codebase without generated-file noise, and run the shipped scripts (find-debt.sh, capability-matrix.sh, list-settings-defaults.sh). Load this when you need to answer "where are the logs?", "why is the node stuck syncing/connecting?", "which backend supports feature X?" (measured, not guessed), "how do I see the app's HTTP requests?", or when a grep is drowning in uniffi/protobuf bindings.
+---
+
+# Zeus Diagnostics and Tooling
+
+Zeus is a React Native (RN) Bitcoin/Lightning wallet supporting 7 node
+backends. This skill is the measurement toolbox: where every log lives, how
+to read it, and runnable scripts that extract ground truth from the code
+instead of from stale docs.
+
+## When to use / When NOT to use
+
+Use this skill when you need to:
+- Find or tail node logs (embedded LND, LDK Node) on device, emulator, or in-app.
+- Watch native-layer behavior via `adb logcat` / Xcode console.
+- Inspect what the app sends over the network (REST, WebSocket, Tor).
+- Query the live capability matrix, settings defaults, or debt markers.
+- Interpret a log: is this node healthy, syncing, or wedged?
+
+Use a sibling skill instead for:
+- Symptom → root-cause triage flowcharts: **zeus-debugging-playbook** (this skill tells you how to observe; that one tells you what the observation means for known failure classes).
+- What `yarn verify` runs and how to add tests: **zeus-validation-and-qa**.
+- Backend quirks and the add-an-RPC recipe: **zeus-backends-and-capabilities** (this skill only ships the script that *prints* the matrix).
+- Keychain/storage semantics and migration safety: **zeus-storage-and-migrations** (the Keychain Recovery tool is described here only as a diagnostic; never change storage behavior without that skill's gated process).
+- Building the dev environment / running the app / connecting Polar nodes: **zeus-build-and-env** and **zeus-run-and-operate**.
+- Formal race/dispatch analysis techniques: **zeus-proof-and-analysis-toolkit**.
+
+## Vocabulary (defined once)
+
+| Term | Meaning here |
+|---|---|
+| Backend / implementation | One of 7 node-connection strategies selected per wallet: `embedded-lnd`, `ldk-node`, `lnd` (remote REST), `lightning-node-connect` (LNC), `cln-rest`, `lndhub`, `nostr-wallet-connect` (NWC). Dispatch lives in `utils/BackendUtils.ts`. |
+| Embedded LND | A full LND Lightning node compiled to a mobile library (gomobile) running *inside* the app process tree. |
+| LDK Node | An alternative embedded node built on the Lightning Dev Kit, integrated via uniffi (Rust→Kotlin/Swift FFI bindings). |
+| Neutrino | LND's light-client chain backend (BIP-157/158 compact block filters); embedded LND uses it instead of a full bitcoind. |
+| Metro | React Native's JS bundler/dev server (`yarn start`). In dev, all JS `console.*` output appears in the Metro terminal. |
+| logcat | Android's system log stream, read with `adb logcat`. Native (Java/Kotlin) `Log.d/i/e` calls land here, filtered by TAG. |
+| uniffi bindings | Machine-generated Kotlin/Swift glue code for Rust libraries — huge files you must exclude from greps. |
+| Tor | Anonymity network; Zeus routes REST calls through it per-node via `react-native-nitro-tor` (0.6.0 as of 2026-07-06). |
+
+## 1) Log access per node type
+
+### Summary table
+
+| Node type | Node's own log | In-app viewer | Off-device access |
+|---|---|---|---|
+| embedded-lnd | `lnd.log` (paths below), `debuglevel=info` hardcoded | Settings → Embedded node → "LND Logs" (`views/Settings/EmbeddedNode/LNDLogs.tsx`, tail 100 + live follow, Copy button) | `adb shell run-as` (debug builds) / simulator container |
+| ldk-node | `ldk_node.log` in the node dir, `LogLevel.DEBUG` hardcoded | Settings → Embedded node → "LDK Node Logs" (`views/Settings/EmbeddedNode/LDKLogs.tsx`) | same |
+| lnd / cln-rest / lndhub (remote) | on the remote server, not the phone | — (use Developer Tools for RPC probes) | server-side (e.g. Polar, below) |
+| lightning-node-connect | on the litd server | — | server-side |
+| nostr-wallet-connect | remote wallet service | — | relay/service side |
+| App itself (JS layer) | `console.*` | — | Metro terminal (dev), `ReactNativeJS` logcat tag (Android), Xcode console (iOS) |
+
+### Embedded LND log file paths (verified in native code)
+
+Android (`android/app/src/main/java/com/zeus/LndMobileTools.java`, `tailLog`/`observeLndLogFile`):
+
+- Legacy first wallet (`lndDir == 'lnd'`): `<filesDir>/logs/bitcoin/<network>/lnd.log`
+- Every other wallet (uuid dir): `<filesDir>/<lndDir>/logs/bitcoin/<network>/lnd.log`
+
+where `<filesDir>` = `/data/user/0/app.zeusln.zeus/files` and `<network>` is
+`mainnet` or `testnet`. Note the asymmetry: the legacy `'lnd'` wallet lives at
+the files-dir *root*, not in a `lnd/` subfolder.
+
+iOS (`ios/LndMobile/LndMobileTools.swift`, `tailLog`): always
+`<Application Support>/<lndDir>/logs/bitcoin/<network>/lnd.log` — the `lndDir`
+subfolder is used even for `'lnd'` (unlike Android).
+
+`lndDir` per wallet: `stores/SettingsStore.ts` sets `this.lndDir =
+node.lndDir || 'lnd'`; new wallets get `uuidv4()` dirs
+(`views/Settings/WalletConfiguration.tsx`). To map uuid → wallet, use Tools →
+"Export/Import Wallet Configurations".
+
+Verbosity: `writeLndConfig` in `utils/LndMobileUtils.ts` hardcodes
+`debuglevel=info` in the generated lnd.conf. For a local debugging session you
+may bump it to `debug` there (dev-only; never commit).
+
+**Trap — `readLndLog` is a stub.** `lndmobile/index.ts` `readLndLog` returns
+`['']` with a `TODO remove` comment. Do not build tooling on it; the real
+mechanisms are `NativeModules.LndMobileTools.tailLog(numberOfLines, lndDir,
+network)` and `observeLndLogFile(lndDir, network)` which emits `lndlog`
+device events (used by both the LNDLogs view and `SyncStore` rescan tracking).
+
+Pulling the file off a device (debug builds only — `run-as` requires
+`android:debuggable`):
+
+```bash
+# legacy 'lnd' wallet on mainnet:
+adb shell "run-as app.zeusln.zeus tail -n 200 files/logs/bitcoin/mainnet/lnd.log"
+# list wallet dirs to find uuid dirs:
+adb shell "run-as app.zeusln.zeus ls files/"
+```
+
+iOS simulator:
+
+```bash
+APP=$(xcrun simctl get_app_container booted com.zeusln.zeus data)
+find "$APP/Library/Application Support" -name lnd.log
+```
+
+(`com.zeusln.zeus` = iOS bundle id; Android applicationId is
+`app.zeusln.zeus` — they differ.)
+
+### LDK Node logs
+
+- Path: `<DocumentDirectoryPath>/ldk-node/<ldkNodeDir-uuid>/ldk_node.log`.
+  The storage dir comes from `utils/LdkNodeUtils.ts`
+  `getLdkNodeStoragePath(nodeDir)`; `ldkNodeDir` is a `uuidv4()` per wallet.
+  On Android `DocumentDirectoryPath` = `/data/user/0/app.zeusln.zeus/files`;
+  on iOS it is the app sandbox `Documents/` folder.
+- Log level: `LogLevel.DEBUG` / `.debug`, hardcoded at
+  `builder.setFilesystemLogger(...)` in
+  `android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt` and
+  `ios/LdkNodeMobile/LdkNodeModule.swift`. Not user-configurable.
+- In-app: `views/Settings/EmbeddedNode/LDKLogs.tsx` calls
+  `NativeModules.LdkNodeModule.tailLdkNodeLog(100)` and subscribes to
+  `ldklog` events from `observeLdkNodeLogFile()` (backed by
+  `LogFileObserver.kt` / `LogFileObserver.swift`).
+- The native module ALSO logs its own lifecycle to logcat under tag
+  `LdkNodeModule` (e.g. `[timing] FFI buildWithDualStore completed in Nms`) —
+  often more useful than ldk_node.log for start/stop races.
+
+### adb logcat — verified filter tags
+
+All tags below appear in the checked-in native sources
+(`git grep -n 'TAG = "' android/app/src/main/java` to re-verify — with one
+exception: `LdkNodeModule` has no `TAG` constant and uses inline
+`Log.d("LdkNodeModule", ...)` literals; re-verify that one with
+`git grep -n '"LdkNodeModule"' android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt`):
+
+| Tag | Source | What you see |
+|---|---|---|
+| `ReactNativeJS` | RN runtime (standard) | all JS `console.*` on device |
+| `LndMobileService` | `com/zeus/LndMobileService.java` | embedded LND process/IPC lifecycle |
+| `LndMobile` | `com/zeus/LndMobile.java` | RN↔LND bridge module |
+| `LndMobileTools` | `com/zeus/LndMobileTools.java` | log observation, chain tools |
+| `LndScheduledSyncWorker` | `com/zeus/LndMobileScheduledSyncWorker.java` | background sync worker |
+| `LndMobileScheduledSync` | `com/zeus/LndMobileScheduledSync.java` | sync scheduling |
+| `LdkNodeModule` | `app/zeusln/zeus/LdkNodeModule.kt` | LDK Node build/start/stop, VSS, timing |
+| `LdkNodeService` | `app/zeusln/zeus/LdkNodeService.kt` | LDK foreground service |
+| `NostrConnectService` / `NostrConnectModule` | `com/zeus/NostrConnect*.java` | NWC background service |
+| `CashuDevKitModule` | `com/zeus/cashudevkit/CashuDevKitModule.kt` | Cashu FFI |
+| `MainActivity` | `com/zeus/MainActivity.kt` | activity lifecycle, intents |
+| `MobileTools` | `com/zeus/MobileTools.java` | misc native tools |
+| `StealthMode` | `app/zeusln/zeus/StealthMode.java` | icon-disguise switching |
+
+Copy-paste starters:
+
+```bash
+# Embedded LND session:
+adb logcat -s LndMobileService:* LndMobile:* LndMobileTools:* ReactNativeJS:*
+# LDK Node session (start/stop/delete races):
+adb logcat -s LdkNodeModule:* LdkNodeService:* ReactNativeJS:*
+# NWC background service:
+adb logcat -s NostrConnectService:* NostrConnectModule:* ReactNativeJS:*
+```
+
+### iOS console & Metro
+
+- Xcode: run the `zeus` scheme (`ios/zeus.xcworkspace`) — the debug console
+  shows both native `NSLog`/`os_log` and JS console output.
+- Console.app: filter by process `zeus` on a connected device (release-ish
+  builds where Xcode isn't attached). Standard macOS tooling.
+- Metro: `yarn start` (script = `react-native start`, verified in
+  package.json). All dev-mode JS logs appear there. Press `j` in the Metro
+  terminal to open React Native DevTools (network + console + profiler) —
+  standard RN ≥0.76 tooling, not Zeus-specific.
+- JS-side embedded-LND logging goes through `lndmobile/log.ts`: a tiny
+  wrapper that prefixes `console.*` output with a tag, e.g. lines starting
+  `utils/LndMobileUtils.ts: ...` (see `const log = Log('utils/LndMobileUtils.ts')`).
+  Grep Metro/logcat output for that prefix during embedded-LND triage.
+
+## 2) In-app diagnostics
+
+### Developer Tools view
+
+- File: `views/Tools/DeveloperTools.tsx`; route `DeveloperTools`; reached via
+  Menu → Tools ("Developers" row).
+- Gating: shown when `BackendUtils.supportsDevTools()` is true, which is
+  `isLNDBased() || call('supportsDevTools')` (`utils/BackendUtils.ts`).
+  Measured availability (2026-07-06):
+  - **Available**: `lnd`, `embedded-lnd`, `lightning-node-connect`
+    (`isLNDBased = true`), plus `cln-rest` and `lndhub` (declare
+    `supportsDevTools = () => true`).
+  - **Not available**: `ldk-node`, `nostr-wallet-connect`.
+  - There is NO developer-mode setting; gating is purely capability-based.
+- Contents: 18 raw RPC probes in 4 accordions (General, Lightning, On-chain,
+  Channels): `getMyNodeInfo`, `getNetworkInfo`, `getLightningBalance`,
+  `getInvoices`, `getPayments`, `getBlockchainBalance`, `getTransactions`,
+  `getUTXOs`, `getNewAddress`, `listAccounts`, `listAddresses`,
+  `getChannels`, `getPendingChannels`, `getClosedChannels`, `getChannelInfo`,
+  `getFees`, `getForwardingHistory`, `abandonChannel`. Each command carries a
+  `compatibleImplementations` allowlist, so what you see varies per backend.
+  Responses render as copyable JSON — this is the fastest way to see exactly
+  what a backend returns without adding temporary logging.
+- Danger rail: `abandonChannel` (drops a channel without an on-chain close;
+  can burn funds) requires an "I know what I am doing" switch AND a native
+  confirm dialog. Do not script around it.
+
+### Keychain Recovery tool
+
+- File: `views/Tools/NodeConfigExportImport.tsx` ("Export/Import Wallet
+  Configurations" in Tools), backed by `utils/KeychainRecoveryUtils.ts`.
+- The "Recover Lost Configurations" flow scans four sources for orphaned
+  data: `current`, `unprefixed-local`, `unprefixed-cloud` (old
+  iCloud-synchronizable keychain entries), and `encrypted-storage` (legacy
+  `zeus-settings` blob). It exists because pre-migration keychain copies are
+  deliberately never deleted — see **zeus-storage-and-migrations** for the
+  whole saga and the rules before touching any of this.
+- As a *diagnostic*, a scan tells you which storage generation a user's data
+  is in — run it (read-only until the user restores) before hypothesizing
+  about "lost wallets".
+- Same view's Export flow is also the sanctioned way to inspect a device's
+  wallet configuration set (per-wallet `lndDir`/`ldkNodeDir` uuids included).
+
+### Activity / store inspection
+
+- Tools → "Activity export" (`views/Tools/ActivityExport.tsx`) dumps
+  invoices/payments/transactions to CSV — use it to diff what the app
+  *thinks* happened against node truth (Developer Tools `getPayments` etc.).
+- Sync observability is a store, not a screen: `stores/SyncStore.ts` polls
+  `getMyNodeInfo` every 2s while syncing, compares `block_height` against a
+  mempool.space tip (refetched every ~30s), and flips `isSyncing` off on
+  `synced_to_chain`. Rescans are tracked by parsing lnd.log lines matching
+  `/Rescanned through block.*\(height (\d+)\)/` via the `lndlog` event stream.
+- MobX stores are module singletons (`stores/Stores.ts`); in a dev build you
+  can inspect them from the React Native DevTools console via imports in
+  scope of any breakpoint. No Reactotron/Flipper integration is configured
+  (verified: no such deps in package.json).
+
+## 3) Network debugging
+
+### How requests flow (verified in `backends/LND.ts` + `utils/TorUtils.ts`)
+
+```
+view → BackendUtils.<method> → call(funcName) → active backend class
+   REST (clearnet):   ReactNativeBlobUtil.config({ trusty: !certVerification }).fetch(...)
+   REST (Tor):        doTorRequest(...)  [react-native-nitro-tor]
+   Streaming:         wsReq(...) → new WebSocket(wss://host:port/route?method=...)
+   Embedded backends: no network at this layer (gomobile IPC / uniffi FFI)
+```
+
+Facts you need before reaching for a proxy:
+
+1. **TLS verification is OFF by default for remote REST.** `restReq`'s
+   `certVerification` parameter defaults to `false`, and blob-util is called
+   with `trusty: !certVerification` — i.e. invalid/self-signed certs are
+   accepted unless the user enabled "Certificate Verification" on the node
+   config. Consequence: a MITM proxy (mitmproxy, Charles, Proxyman) can
+   intercept remote-node REST traffic *without installing its CA cert*, as
+   long as certVerification is off and you route the emulator/device through
+   the proxy (Android emulator: `-http-proxy`; iOS simulator honors macOS
+   system proxy). There is no cert pinning anywhere in the REST path.
+2. **WebSocket streams bypass Tor entirely.** `wsReq` and the other
+   `new WebSocket(...)` call sites in `backends/LND.ts` build `wss://` URLs
+   straight from host/port — even when the node has Tor enabled. When
+   debugging "subscription works but payments leak clearnet" (or vice
+   versa), remember these are two different transports.
+3. **Tor path cannot be trivially proxied.** Tor requests go through the
+   embedded nitro-tor daemon (`utils/TorUtils.ts` `doTorRequest`), not the
+   system proxy. TLS bypass on this path is scoped to HTTPS `.onion` URLs
+   only (`isOnionHttpsUrl`); clearnet-over-Tor keeps strict validation and
+   `doTorRequest` treats HTTP ≥ 300 as errors. To observe Tor traffic,
+   instrument at the far end (your node) instead.
+4. **The request-dedup cache can replay failures.** `backends/LND.ts` keeps
+   a module-level `calls` Map keyed by url+body. On the Tor branch the entry
+   is only deleted on success, so a rejected promise is returned again for
+   identical retries until `clearCachedCalls()` runs — which happens on
+   reconnect via `SettingsStore.setConnectingStatus(true)`. If "the same
+   error keeps coming back instantly with no network activity", suspect this
+   cache, not the network. (`backends/CLNRest.ts` has the same structure.)
+5. Cheap first probe: Developer Tools → `getMyNodeInfo` exercises the whole
+   REST stack with one tap; React Native DevTools' Network panel shows
+   fetch-based traffic in dev (blob-util requests may not appear there —
+   fall back to the proxy or server-side logs).
+
+### Server-side (Polar) inspection
+
+Polar (https://github.com/jamaljsr/polar) is the recommended local Lightning
+network for dev (CONTRIBUTING.md). For connecting Zeus to it, see
+**zeus-run-and-operate**. Diagnostics side (external tooling — verify
+against your Polar version):
+
+- Each Polar node is a Docker container; view logs in the Polar UI (node →
+  Logs) or `docker logs -f <container>` (containers are named per
+  network/node, e.g. `polar-n1-alice`; `docker ps` lists them).
+- lnd-side truth beats app-side guesses: watch the lnd container log while
+  reproducing a payment to see whether the failure is client (Zeus) or node.
+- LNC (`lightning-node-connect`) requires a litd (Lightning Terminal)
+  instance to pair against; its session/mailbox logs live on that server.
+  (litd-in-Polar support depends on Polar version — unverified here.)
+
+## 4) Grep hygiene
+
+Generated and vendored files will bury your signal: the two uniffi bindings
+alone are ~31k lines, `proto/lightning.js` is ~133k lines, and `zeus_modules/`
+is vendored third-party code with its own node_modules. Canonical grep:
+
+```bash
+git grep -nIw -E 'YOUR_PATTERN' -- . \
+  ':(exclude)zeus_modules' \
+  ':(exclude)proto/lightning.js' \
+  ':(exclude)proto/lightning.d.ts' \
+  ':(exclude)ios/LdkNodeMobile/LDKNode.swift' \
+  ':(exclude)android/app/src/main/java/org/lightningdevkit/ldknode/ldk_node.kt' \
+  ':(exclude)android/app/src/main/java/uniffi/zeus_cashu_restore/zeus_cashu_restore.kt' \
+  ':(exclude)ios/CashuDevKit/CashuDevKit.swift' \
+  ':(exclude)ios/CashuDevKit/zeus_cashu_restore.swift'
+```
+
+Rules of thumb:
+
+- Prefer `git grep` over `grep -r`: `node_modules/`, `ios/Pods/`, and
+  `android/app/build/` are gitignored, so git grep skips them for free
+  (verified with `git check-ignore`). Plain `grep -r` and some `rg` setups
+  will wade straight into them.
+- Use `-w`, not `\b`: this git's ERE engine (macOS) does not support `\b`
+  and **fails silently with zero matches** — a nasty way to conclude "no
+  hits". `-w` gives whole-word matching portably.
+- Known false positive: `utils/AddressUtils.test.ts` contains `XXX` inside a
+  base64 PSBT fixture (line ~923). `-w` filters it; substring searches won't.
+- `fetch-libraries.sh` defines a shell function literally named `jq()`
+  (a python3 wrapper) — a misleading hit when grepping for jq usage.
+- Config blind spots: tsconfig excludes `node_modules`, `zeus_modules`,
+  `android`, `ios`; ESLint additionally ignores `proto/`; Prettier ignores
+  ONLY `zeus_modules/` (per `.prettierignore` — so regenerated `proto/*.d.ts`
+  can still fail the Prettier CI check). Code in excluded dirs is neither
+  linted nor type-checked, so absence of CI complaints proves nothing
+  about it.
+
+## 5) Scripts
+
+All live in `.claude/skills/zeus-diagnostics-and-tooling/scripts/`, are
+executable, safe (read-only), and were run against master `c5fd094fb`.
+Run them from anywhere inside the repo; they `cd` to the git root themselves.
+
+### find-debt.sh — debt-marker census
+
+```bash
+.claude/skills/zeus-diagnostics-and-tooling/scripts/find-debt.sh            # full listing
+.claude/skills/zeus-diagnostics-and-tooling/scripts/find-debt.sh --summary  # per-file counts
+.claude/skills/zeus-diagnostics-and-tooling/scripts/find-debt.sh TODO       # single marker
+```
+
+Sample output (2026-07-06, `--summary`, top of list):
+
+```
+   5 android/app/src/main/java/com/zeus/LndMobile.java
+   4 lndmobile/wallet.ts
+   3 proto/lightning.proto
+   3 lndmobile/index.ts
+   3 android/app/src/main/java/com/zeus/LndMobileService.java
+   2 views/Wallet/Wallet.tsx
+   2 views/Activity/Activity.tsx
+   ...
+---
+total markers: 63
+```
+
+Sample detail lines:
+
+```
+android/app/src/main/java/com/zeus/LndMobile.java:71:// TODO break this class up
+android/app/src/main/java/com/zeus/LndMobile.java:350:  // TODO unbind LndMobileService?
+```
+
+Interpretation: the debt concentrates in the Blixt-derived embedded-LND
+native layer (`com/zeus/*.java`, `lndmobile/*.ts`) — expected; see
+**zeus-failure-archaeology** for which of those TODOs have bitten before.
+Standalone `HACK`/`XXX` markers: zero in hand-written code (as of the date
+above).
+
+### capability-matrix.sh — live supports* matrix
+
+```bash
+.claude/skills/zeus-diagnostics-and-tooling/scripts/capability-matrix.sh                  # all flags
+.claude/skills/zeus-diagnostics-and-tooling/scripts/capability-matrix.sh supportsOffers   # filter (regex)
+```
+
+Cell legend: `T`/`F` literal, `expr` computed (usually LND version gates like
+`this.supports('v0.13.0')`), `^T`/`^F`/`^expr` inherited from `LND.ts`
+(EmbeddedLND and LndHub extend LND — inherited `T` is the classic silent-bug
+pattern), `-` not declared anywhere → `BackendUtils.call()` returns literal
+`false`. Composite flags computed in `utils/BackendUtils.ts`
+(`supportsDevTools`, `supportsLightningAddress`,
+`supportsForwardingHistoryChannelFilter`) are listed in the script header,
+not the matrix.
+
+Sample output (2026-07-06, excerpt; 56 flags total):
+
+```
+FLAG                                      LND    eLND   LNC    LDK    CLN    Hub    NWC
+isLNDBased                                T      T      T      F      F      F      F
+supportsCashuWallet                       F      T      F      T      F      F      F
+supportsChannelFundMax                    T      T      T      T      T      ^T     F
+supportsDevTools                          -      -      -      -      T      T      -
+supportsOffers                            F      F      F      T      T      F      F
+supportsTaproot                           expr   expr   expr   T      T      F      F
+supportsWatchtowerClient                  T      T      T      F      -      F      -
+```
+
+Hand-verified against source (3 flags): `supportsCashuWallet` T only in
+`backends/EmbeddedLND.ts` and `backends/LdkNode.ts`; `supportsOffers` T only
+in `backends/LdkNode.ts` and `backends/CLNRest.ts`; `supportsChannelFundMax`
+absent from `backends/LndHub.ts` hence inherited `^T` from `backends/LND.ts`
+(the known LndHub override gap).
+
+### list-settings-defaults.sh — defaults drift review
+
+```bash
+.claude/skills/zeus-diagnostics-and-tooling/scripts/list-settings-defaults.sh            # whole block
+.claude/skills/zeus-diagnostics-and-tooling/scripts/list-settings-defaults.sh 'Fee'      # filtered
+```
+
+Prints the inline `@observable settings: Settings = { ... }` defaults object
+of `stores/SettingsStore.ts` with real line numbers (located by brace
+counting, not hardcoded lines — 147 lines spanning 1467–1613 as of
+2026-07-06). Sample:
+
+```
+1467	    @observable settings: Settings = {
+1468	        privacy: {
+1469	            defaultBlockExplorer: 'mempool.space',
+...
+1612	        selectNodeOnStartup: false
+1613	    };
+```
+
+Why it matters: these literals are what FRESH installs get; existing users
+keep old values unless a migration runs. Diff this output between two
+commits to catch silent default drift. The catalog of every axis lives in
+**zeus-config-and-flags**; the migration recipe in
+**zeus-storage-and-migrations**.
+
+## 6) Interpretation guides — healthy vs unhealthy
+
+### Embedded LND startup (the state machine Zeus itself watches)
+
+`utils/LndMobileUtils.ts` subscribes to LND's state stream and drives on
+`lnrpc.WalletState`: `NON_EXISTING → LOCKED → UNLOCKED → RPC_ACTIVE →
+SERVER_ACTIVE`. Readiness is declared at RPC_ACTIVE/SERVER_ACTIVE (after an
+RPC-ready check); the hard ceiling is `LND_READY_TIMEOUT_MS = 60000` (60s),
+after which the slow-start path triggers.
+
+Healthy session, in order:
+1. logcat `LndMobileService`: process/service start, no restarts.
+2. State log line `Current LND state: ...` advancing through the machine
+   (JS side, tag prefix `utils/LndMobileUtils.ts:` in Metro/ReactNativeJS).
+3. `lnd.log`: wallet opened/unlocked, neutrino peers connected, sync
+   progress advancing. (Exact lnd.log wording is upstream-LND behavior and
+   varies by version — treat specific phrasings as unverified here; the
+   one pattern Zeus's own code depends on is
+   `Rescanned through block ... (height N)` in `stores/SyncStore.ts`.)
+4. App: Wallet screen leaves "connecting", balances populate.
+
+Unhealthy signatures (all from `utils/LndMobileErrors.ts`, the canonical
+error-code → raw-pattern map — read it before inventing new matching):
+
+| Symptom / matched pattern | Code | Meaning |
+|---|---|---|
+| `wallet locked` | `WALLET_LOCKED` | normal right after start; app should auto-unlock — persistent means unlock failed |
+| `already started`, `already running` | `LND_ALREADY_RUNNING` | informational; a stop didn't complete before a start (lifecycle race territory — see **zeus-node-lifecycle-campaign**) |
+| `starting up`, `not yet ready` | `RPC_NOT_READY` | transient; only a problem if still there near the 60s ceiling |
+| stuck LOCKED→nothing, then timeout | `RPC_READY_TIMEOUT` / `LND_READY_TIMEOUT` | RPC never came up; check lnd.log for the real cause |
+| `no such file or directory` etc. | `LND_FOLDER_MISSING` | wallet dir gone (post-delete or dir-mapping bug) |
+| `unable to read TLS cert`, `connection refused` during stop | `STOP_LND_EXPECTED` | expected shutdown noise — NOT an error |
+
+### Neutrino sync
+
+`stores/SyncStore.ts` semantics: `numBlocksUntilSynced = bestBlockHeight −
+currentBlockHeight` where best comes from mempool.space and current from
+`getMyNodeInfo().block_height` (polled every 2s).
+
+- Healthy: `currentBlockHeight` strictly increasing between polls; gap
+  shrinking; ends with `synced_to_chain: true`.
+- Unhealthy: current height frozen across many polls with peers configured →
+  neutrino peer trouble (check `[Neutrino]` section peers in generated
+  lnd.conf, `neutrino.connect` vs `addpeer` is controlled by the
+  `dontAllowOtherPeers` setting); best height 0/erroring → the mempool.space
+  fetch failed and the store falls back to current height, which can
+  *mask* remaining sync distance.
+- Recovery (seed restore) is separate: `getRecoveryInfo` polled at 2s;
+  healthy = `progress` monotonically rising to `recovery_finished`.
+
+### LDK Node startup
+
+Healthy (logcat, tag `LdkNodeModule`): `applyBuilderSettings: Enabling
+filesystem logger` → `Building node with dual store (VSS + local): <url>` →
+`[timing] FFI buildWithDualStore completed in <N>ms` → started/running.
+Unhealthy: `[timing] FFI buildWithDualStore failed in <N>ms: <msg>`;
+JS-layer sentinels `Node not initialized` (native ref still rebuilding —
+transient by design, retried) and `LDK Node not running yet` (both defined
+in `utils/LdkNodeUtils.ts`). Repeated build attempts or a stop that never
+returns → lifecycle race; gather the logcat trace FIRST, then switch to
+**zeus-node-lifecycle-campaign**.
+
+### Remote backends (lnd REST / cln-rest / lndhub)
+
+- Healthy: Developer Tools `getMyNodeInfo` returns JSON quickly; Wallet
+  populates.
+- Error-shaped success trap: LND REST `payLightningInvoice` timeouts
+  *resolve* with `{ payment_error: localeString('views.SendingLightning.paymentTimedOut') }`
+  (a locale-dependent "Payment timed out…" message) — a "successful"
+  response that is actually a failure. Don't classify by promise
+  resolution, and don't match the string literally.
+- Instantly repeating identical error with no traffic → stale dedup-cache
+  rejection (section 3, item 4).
+- Method returns literal `false` (and `.then` crashes with "false is not a
+  function"-style errors) → the active backend simply lacks that method;
+  check the capability matrix, not the network.
+
+## Provenance and maintenance
+
+Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha) by
+reading the cited files and running every command/script in this skill
+(scripts run to completion with the sample outputs shown; adb/simulator/
+proxy commands are standard platform tooling verified by source read of the
+paths they target, not executed against a device).
+
+One-line re-verification commands for volatile facts:
+
+| Fact | Re-verify with |
+|---|---|
+| `readLndLog` still a stub | `git grep -n -A3 'readLndLog = async' lndmobile/index.ts` |
+| Android lnd.log paths | `git grep -n 'logs/bitcoin' android/app/src/main/java/com/zeus/LndMobileTools.java` |
+| iOS lnd.log path | `git grep -n 'lnd.log' ios/LndMobile/LndMobileTools.swift` |
+| lnd `debuglevel=info` | `git grep -n 'debuglevel' utils/LndMobileUtils.ts` |
+| LDK log path + DEBUG level | `git grep -n 'setFilesystemLogger' android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt ios/LdkNodeMobile/LdkNodeModule.swift` |
+| logcat TAG list | `git grep -n 'TAG = "' android/app/src/main/java` (exception: `LdkNodeModule` uses inline literals — `git grep -n '"LdkNodeModule"' android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt`) |
+| DevTools gating rule | `git grep -n -A2 'supportsDevTools' utils/BackendUtils.ts backends/` |
+| DevTools command list | `git grep -n "name: '" views/Tools/DeveloperTools.tsx` |
+| `trusty:` TLS default | `git grep -n 'trusty' backends/LND.ts` |
+| WS-bypasses-Tor | `git grep -n 'new WebSocket' backends/LND.ts` |
+| Tor onion-only bypass | `git grep -n 'isOnionHttpsUrl' utils/TorUtils.ts backends/LND.ts` |
+| nitro-tor version | `git grep -n 'react-native-nitro-tor' package.json` |
+| dedup-cache clear site | `git grep -n 'clearCachedCalls' stores/SettingsStore.ts backends/` |
+| WalletState machine + 60s timeout | `git grep -n 'LND_READY_TIMEOUT_MS\|WalletState\.' utils/LndMobileUtils.ts` |
+| Rescan log regex | `git grep -n 'Rescanned through block' stores/SyncStore.ts` |
+| defaults block location | `.claude/skills/zeus-diagnostics-and-tooling/scripts/list-settings-defaults.sh \| head -2` |
+| capability matrix | rerun `capability-matrix.sh` and spot-check any 3 flags against `backends/*.ts` |
+| app/bundle ids | `git grep -n 'applicationId' android/app/build.gradle; git grep -n 'PRODUCT_BUNDLE_IDENTIFIER = com' ios/zeus.xcodeproj/project.pbxproj` |
+
+If any script errors with "pattern changed", the source file moved under it —
+fix the script in the same change and re-paste fresh sample output here.

--- a/.claude/skills/zeus-diagnostics-and-tooling/scripts/capability-matrix.sh
+++ b/.claude/skills/zeus-diagnostics-and-tooling/scripts/capability-matrix.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# capability-matrix.sh — print the supports* capability matrix across all 7
+# Zeus backends, extracted live from backends/*.ts (never trust a stale doc).
+#
+# Usage:
+#   .claude/skills/zeus-diagnostics-and-tooling/scripts/capability-matrix.sh
+#   .claude/skills/zeus-diagnostics-and-tooling/scripts/capability-matrix.sh supportsOffers   # single flag
+#
+# Cell legend:
+#   T      -> () => true
+#   F      -> () => false
+#   expr   -> computed (usually version-gated: this.supports('vX.Y.Z'))
+#   ^T/^F/^expr -> NOT declared in this class; inherited from LND.ts
+#                  (EmbeddedLND and LndHub extend LND)
+#   -      -> not declared anywhere: BackendUtils.call() returns literal
+#             false (sync) for this backend
+#
+# Composite flags that live in utils/BackendUtils.ts, NOT in backend classes
+# (this script does not show them):
+#   supportsDevTools        = isLNDBased() || call('supportsDevTools')
+#   supportsLightningAddress = supportsCustomPreimages() || supportsCashuWallet()
+#   supportsForwardingHistoryChannelFilter = isLNDBased() && version >= v0.20.0
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+FILTER="${1:-}"
+
+# Column order: LND family first (LND, EmbeddedLND), then the rest
+FILES=(
+    backends/LND.ts
+    backends/EmbeddedLND.ts
+    backends/LightningNodeConnect.ts
+    backends/LdkNode.ts
+    backends/CLNRest.ts
+    backends/LndHub.ts
+    backends/NostrWalletConnect.ts
+)
+LABELS=(LND eLND LNC LDK CLN Hub NWC)
+# Which columns inherit from LND.ts when a flag is not declared locally:
+INHERITS=(0 1 0 0 0 1 0)
+
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+
+# Extract "file flag value" triples. Also capture isLNDBased for context.
+for f in "${FILES[@]}"; do
+    grep -nE '^\s*(supports[A-Za-z0-9_]+|supportInboundFees|isLNDBased)\s*=' "$f" \
+    | awk -v file="$f" '
+        {
+            line = $0
+            sub(/^[0-9]+:/, "", line)
+            # flag name
+            match(line, /(supports[A-Za-z0-9_]+|supportInboundFees|isLNDBased)/)
+            flag = substr(line, RSTART, RLENGTH)
+            # value
+            if (line ~ /=>[[:space:]]*true;?([[:space:]]*\/\/.*)?$/)       val = "T"
+            else if (line ~ /=>[[:space:]]*false;?([[:space:]]*\/\/.*)?$/) val = "F"
+            else                                                           val = "expr"
+            print file, flag, val
+        }'
+done > "$TMP"
+
+# All flags, sorted (skip the bare "supports" version helper — the regex
+# above already requires at least one char after "supports")
+FLAGS=$(awk '{print $2}' "$TMP" | sort -u)
+if [ -n "$FILTER" ]; then
+    FLAGS=$(printf '%s\n' "$FLAGS" | grep -iE "$FILTER" || true)
+    if [ -z "$FLAGS" ]; then
+        echo "no flag matching '$FILTER'" >&2
+        exit 1
+    fi
+fi
+
+printf '%-42s' 'FLAG'
+for l in "${LABELS[@]}"; do printf '%-7s' "$l"; done
+printf '\n'
+
+for flag in $FLAGS; do
+    printf '%-42s' "$flag"
+    i=0
+    for f in "${FILES[@]}"; do
+        val=$(awk -v f="$f" -v fl="$flag" '$1==f && $2==fl {print $3; exit}' "$TMP")
+        if [ -z "$val" ]; then
+            if [ "${INHERITS[$i]}" -eq 1 ]; then
+                inherited=$(awk -v fl="$flag" '$1=="backends/LND.ts" && $2==fl {print $3; exit}' "$TMP")
+                if [ -n "$inherited" ]; then
+                    val="^$inherited"
+                else
+                    val="-"
+                fi
+            else
+                val="-"
+            fi
+        fi
+        printf '%-7s' "$val"
+        i=$((i + 1))
+    done
+    printf '\n'
+done

--- a/.claude/skills/zeus-diagnostics-and-tooling/scripts/find-debt.sh
+++ b/.claude/skills/zeus-diagnostics-and-tooling/scripts/find-debt.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# find-debt.sh — list TODO/FIXME/HACK/XXX debt markers in HAND-WRITTEN Zeus code.
+#
+# Usage:
+#   .claude/skills/zeus-diagnostics-and-tooling/scripts/find-debt.sh            # all markers
+#   .claude/skills/zeus-diagnostics-and-tooling/scripts/find-debt.sh TODO      # one marker only
+#   .claude/skills/zeus-diagnostics-and-tooling/scripts/find-debt.sh --summary # per-file counts only
+#
+# Excludes generated/vendored code (uniffi bindings, protobuf output,
+# zeus_modules). node_modules/ios Pods/android build are gitignored and
+# skipped automatically because this uses `git grep`.
+#
+# Known false positive: utils/AddressUtils.test.ts contains "XXX" inside a
+# base64 test fixture, not a debt marker. The -w (whole-word) match below
+# already filters it out; if you loosen the pattern, expect it to reappear.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+SUMMARY=0
+PATTERN='TODO|FIXME|HACK|XXX'
+for arg in "$@"; do
+    case "$arg" in
+        --summary) SUMMARY=1 ;;
+        *) PATTERN="$arg" ;;
+    esac
+done
+
+# Generated or vendored files that are full of upstream TODOs we don't own:
+EXCLUDES=(
+    ':(exclude)zeus_modules'
+    ':(exclude)proto/lightning.js'
+    ':(exclude)proto/lightning.d.ts'
+    ':(exclude)ios/LdkNodeMobile/LDKNode.swift'
+    ':(exclude)android/app/src/main/java/org/lightningdevkit/ldknode/ldk_node.kt'
+    ':(exclude)android/app/src/main/java/uniffi/zeus_cashu_restore/zeus_cashu_restore.kt'
+    ':(exclude)ios/CashuDevKit/CashuDevKit.swift'
+    ':(exclude)ios/CashuDevKit/zeus_cashu_restore.swift'
+    ':(exclude)*.lock'
+    ':(exclude)*.svg'
+    ':(exclude)*.map'
+)
+
+# Note: -w (whole word) instead of \b — git grep's ERE on macOS does not
+# support \b, and it fails silently (zero matches, exit 1).
+if [ "$SUMMARY" -eq 1 ]; then
+    git grep -nIwE "${PATTERN}" -- . "${EXCLUDES[@]}" \
+        | cut -d: -f1 | sort | uniq -c | sort -rn
+    echo '---'
+    TOTAL=$(git grep -nIwE "${PATTERN}" -- . "${EXCLUDES[@]}" | wc -l | tr -d ' ')
+    echo "total markers: $TOTAL"
+else
+    git grep -nIwE "${PATTERN}" -- . "${EXCLUDES[@]}" \
+        | sort -t: -k1,1 -k2,2n
+fi

--- a/.claude/skills/zeus-diagnostics-and-tooling/scripts/list-settings-defaults.sh
+++ b/.claude/skills/zeus-diagnostics-and-tooling/scripts/list-settings-defaults.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# list-settings-defaults.sh — print the inline defaults object of
+# stores/SettingsStore.ts (the `@observable settings: Settings = { ... }`
+# block) with real line numbers, for drift review.
+#
+# Usage:
+#   .claude/skills/zeus-diagnostics-and-tooling/scripts/list-settings-defaults.sh          # whole block
+#   .claude/skills/zeus-diagnostics-and-tooling/scripts/list-settings-defaults.sh privacy  # one line-match filter
+#
+# Why: these inline literals ARE the defaults new users get. There is no
+# schema versioning — changing a default here only affects FRESH installs;
+# existing users need a MOD_KEY migration (see zeus-storage-and-migrations).
+# Diff this output across commits to catch silent default drift.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+FILE=stores/SettingsStore.ts
+FILTER="${1:-}"
+
+# Locate the block by brace counting from the declaration line; do not
+# hardcode line numbers — the file is >2000 lines and moves often.
+OUT=$(awk '
+    /@observable settings: Settings = \{/ { inblock = 1 }
+    inblock {
+        printf "%d\t%s\n", NR, $0
+        n = gsub(/\{/, "{")
+        m = gsub(/\}/, "}")
+        depth += n - m
+        if (started && depth == 0) exit
+        if (n > 0) started = 1
+    }
+' "$FILE")
+
+if [ -z "$OUT" ]; then
+    echo "defaults block not found in $FILE — the declaration pattern changed; update this script" >&2
+    exit 1
+fi
+
+if [ -n "$FILTER" ]; then
+    printf '%s\n' "$OUT" | grep -iE "$FILTER"
+else
+    printf '%s\n' "$OUT"
+fi

--- a/.claude/skills/zeus-failure-archaeology/SKILL.md
+++ b/.claude/skills/zeus-failure-archaeology/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: zeus-failure-archaeology
+description: Chronicle of Zeus's settled battles — every major investigation, revert, dead end, and multi-attempt saga as symptom → root cause → evidence (verified commit hashes/PRs) → status. Load BEFORE re-attempting anything that smells familiar, and whenever you hit these symptoms - stale wallet data appearing on a new iOS device / iCloud keychain leftovers; Fabric or New Architecture crashes (WalletHeader, keypad); infinite loading on app boot; settings corrupted or lost after a migration; "3600 hours" invoice expiry; Tor TLS certificate errors; navigation stack buildup or broken back-navigation; LDK Node crash on wallet deletion; embedded LND crash on restart (SQLite vs Bolt DB); Hermes regex stack overflow on QR scan; Cashu mint data shared between wallets; a merged fix that later vanished (revert). Also load before trusting any merged PR as final, before proposing a React Native or react-navigation upgrade, or when a commit hash/PR number from history needs context.
+---
+
+# Zeus Failure Archaeology
+
+The chronicle of every costly investigation in this repo: what broke, why, what fixed it (or didn't), and the receipts. Purpose: **no one re-fights a settled battle.** Before you attempt a fix that feels obvious, search this file — someone may have shipped it and reverted it already.
+
+All hashes below were verified with read-only git against master snapshot `c5fd094fb` ("Version bump: v13.1.3-alpha", 2026-07-02; no v13.1.3 tag exists yet — nearest tag is v13.1.2). Dates are commit author dates (`git log --date=short`).
+
+## When to use / When NOT to use
+
+**Use when:**
+- A bug matches a symptom in the index below — read the entry before touching code.
+- You are about to propose a fix in storage/keychain, React Native upgrades, Tor TLS, navigation, LDK Node lifecycle, or embedded LND DB config — all have prior failed attempts.
+- You need to know whether a merged fix is still live (this repo reverts fast — see MP-1).
+- You need verified hashes/PR numbers for a historical claim.
+
+**Use a sibling instead when you need:**
+- The *rules* derived from these incidents (gating, review, migration sign-off) → **zeus-change-control**
+- How storage/keychain/migrations work *today* and how to change them safely → **zeus-storage-and-migrations**
+- Live debugging of a *new* symptom (triage tables, experiments) → **zeus-debugging-playbook**
+- The currently-open node-lifecycle race campaign → **zeus-node-lifecycle-campaign**
+- Design rationale and invariants (why the architecture is shaped this way) → **zeus-architecture-contract**
+- Analysis technique (how to *prove* a race or migration is safe) → **zeus-proof-and-analysis-toolkit**
+
+## How to verify any claim in this chronicle
+
+Jargon: a **first-parent** history walk follows only the main line of merge commits, skipping the internal commits of merged branches.
+
+```bash
+# Confirm a hash exists and read its subject/date:
+git log -1 --format='%h %ad %s' --date=short <hash>
+# Confirm it is on the master lineage (run from the v13.1.3-alpha snapshot or newer):
+git merge-base --is-ancestor <hash> HEAD && echo on-master
+# Read what it changed:
+git show --stat <hash>
+```
+
+**Two traps when citing history:**
+1. `git log --all` contains grafted duplicates — the same change can appear under two hashes (verified example: revert of PR #3307 exists as both `7d8678457` on the master lineage and duplicate `1cbf4a2c8` on a side ref). Always cite the hash that passes `git merge-base --is-ancestor <hash> <master-snapshot>`.
+2. In development clones, the local `master` branch pointer can be stale or divergent from upstream. Verify ancestry against a known-good snapshot (`c5fd094fb` = the v13.1.3-alpha version-bump commit) or `origin/master`, never against a bare local `master`.
+
+## Entry format
+
+Each entry: **ID · dates · Symptom · Root cause · Evidence (hashes/PRs) · Status · Lesson** (one imperative line).
+Status values: **settled** (fixed, closed), **policy** (resolution is a standing rule, not just a patch), **open** (still live or candidate).
+
+---
+
+## FA-1 — The iCloud keychain saga (costliest failure; 3 attempts over ~3 months)
+
+**Dates:** 2025-11-10 → 2026-01-30. **Status: policy.**
+
+Background terms: the **keychain** is the OS secure credential store (accessed via react-native-keychain); on iOS, entries flagged `kSecAttrSynchronizable` are synced by **iCloud Keychain** to all of a user's devices. Zeus keeps every wallet secret (seeds, macaroons) in keychain entries, so unwanted sync means *wallet seeds silently propagate across devices*, and unwanted deletion means *funds-losing data loss*. That tension is why this took three attempts.
+
+**Timeline (all hashes verified on master lineage):**
+
+| Date | Event | Evidence |
+|---|---|---|
+| 2025-11-10 | Attempt 1 merged: "fix: exclude our storage from iCloud backup" | PR #3307, merge `5f533bb12` |
+| 2025-11-10 | **Reverted the same day** via GitHub auto-revert branch `revert-3307-...` | PR #3354, merge `d1dcb7ba7`, revert commit `7d8678457` (no explanation in commit body) |
+| 2025-12-01 | Attempt 2 (the "proper fix") merged: re-introduces `keychainCloudSyncMigration` (first added in Attempt 1 as `c6794cf85`, reverted with it) — rewrites keychain entries in place with `cloudSync: false` (same key names; no `zeus:` prefix yet) | PR #3371 merge `e808fd71a`; PR #3405 merge `ed161541a` ("Change migration Key"); refactor PR #3404 `4c3d6dc6d` |
+| 2026-01-06 | Fallout fix: "fix: lost data after updating to v0.12.0" | `2ae645824` |
+| 2026-01-14 | Attempt 3: `iCloudCleanupMigration` added — the Dec fix only *created* local copies and never deleted the old `kSecAttrSynchronizable` entries, so a user setting up a new iPhone inherited **stale wallet data from iCloud**; cleanup purges via `Keychain.resetInternetCredentials({ ..., cloudSync: true })`; commit body says "Properly closed #2915" | `46f2bac00` |
+| 2026-01-13 | Restructured: separate `iCloudCleanupMigration` function removed; cloud-synced data deleted before writing local, inside `keychainCloudSyncMigration`. Same day, `zeus:`-prefixed key namespacing added: "migration: move to new prefixed keys, added safety steps" | `bddf52507` + `318c721e7` (+ dedup refactor `f79ae68ff`) |
+| 2026-01-30 | **Final reversal of the deletion idea**: "migration: disable key deletion for now" — `deleteFromOldKeychain` becomes a deliberate no-op | `c6323fff4`; also iOS timing mitigation `35aaf8897` (500ms delays around keychain reads/writes) |
+
+**Current state (verified in source, 2026-07-06):** `utils/MigrationUtils.ts` → `migrateKey()` does read → write → verify → delete, but `deleteFromOldKeychain()` is a no-op whose comment reads "DISABLED: To prevent potential data loss during migration. Old keychain entries will remain but are harmless (orphaned data)." The old un-prefixed (and possibly iCloud-synced) entries are **retained deliberately**; the Keychain Recovery tool (`utils/KeychainRecoveryUtils.ts`, surfaced under `views/Tools/`) depends on those orphans existing. All new writes go through `storage/index.ts` with the `zeus:` prefix and `cloudSync: false` (both `setItem` and `removeItem`).
+
+**Root cause (of the whole saga):** deleting keychain data is irreversible and iCloud sync timing is unobservable, so every "clean up old entries" attempt risked destroying the only copy of a seed. The team converged on: never delete, namespace instead.
+
+**Lesson:** never delete keychain data in a migration — namespace new data (`zeus:` prefix), leave orphans, and treat any keychain deletion as a maintainer-gated change (see zeus-change-control).
+
+---
+
+## FA-2 — React Native upgrade / New Architecture saga (~19-month freeze, then Fabric fallout)
+
+**Dates:** 2024-06-13 → 2026-06-12 (fallout); ongoing platform risk. **Status: settled (0.85.3 current), policy for Animated/layout patterns.**
+
+Background terms: **React Native (RN)** is the cross-platform mobile framework; its **New Architecture** replaces the old bridge with **Fabric** (new renderer) and TurboModules; **Hermes** is RN's JavaScript engine. Layout/animation code that was tolerated by the old renderer can hard-crash under Fabric.
+
+**Timeline:**
+
+| Date | Event | Evidence |
+|---|---|---|
+| 2024-06-13 | RN 0.74.2 lands | `1c97cdd4b`, merge `e89187c68` (PR #2178) |
+| 2025 | Two upgrade attempts die as `wip` branches: `deps-react-native-0.76.9` (tip `563f8fe1f`, 2025-10-07, subject "wip") and `deps-react-native-0.78.2` (tip `e34e356a6`, 2025-10-26, "wip"); also `react-native-0.76.2` (tip `a5264a298`, 2025-03-03, "revert react-native-tor (for now)") | local branches; see MP-2 caveat |
+| 2026-01-04 | The jump: "deps: React Native upgrade: 0.74.2 -> 0.83.1" — **~19 months** after 0.74.2 — with New Architecture ON (`android/gradle.properties` `newArchEnabled=true`, verified) | `d13ebc2cd`, merged `5c678f54b` (PR #3501, 2026-01-09) |
+| 2026-02-18 | RN 0.84.0 | `bb09f99c1` |
+| 2026-03-28 | Fabric fallout 1: "fix WalletHeader animation crashes on New Architecture" | `f08bfc7c5`, merge `6baf1051c` (PR #3910) |
+| 2026-05-12 | RN 0.85.3 (current — package.json `"react-native": "0.85.3"`, verified) | `5613ec2b7` |
+| 2026-06-12 | Fabric fallout 2: "fix(keypad): prevent Fabric crash by restructuring baseline layout" | `2c55e4f89`, merge `fe15a65ef` (PR #4163) |
+
+**Root cause pattern:** the codebase accumulated 19 months of Animated/layout patterns validated only against the legacy renderer; Fabric enforces stricter invariants, so crashes surfaced screen-by-screen for months after the jump (WalletHeader at +3 months, keypad at +5 months).
+
+**Lesson:** treat any pre-2026 Animated/layout pattern as Fabric-suspect, and never let the RN version freeze again — incremental upgrades are cheaper than a 9-minor-version jump. (An `rn-v0.86.0` branch exists locally as candidate follow-up work — open, unmerged.)
+
+---
+
+## FA-3 — Settings-migration corruption cluster (stringify, missing await, expiry re-run)
+
+**Dates:** 2026-05-30 → 2026-06-22. **Status: settled + policy.**
+
+Background terms: **MobX** is the state-management library; Zeus stores keep settings as MobX *observables* (proxied objects). A **MOD_KEY migration** is Zeus's one-shot pattern: check a flag key in legacy EncryptedStorage → mutate settings → `settingsStore.setSettings(...)` → set the flag (details in zeus-storage-and-migrations).
+
+Three related failures:
+
+1. **Stringify corruption.** Symptom: settings corrupted after a migration ran. Root cause: a migration passed a `JSON.stringify`'d string to `setSettings`, which expects a real object — corrupting the MobX observable state. Fix: `7ed901a10` "fix(migrations): pass object to setSettings to avoid MobX observable corruption (#4150)" (2026-06-09; #4150 is the issue — merged via PR #4155, merge `45e9d2095`, 2026-06-22).
+2. **Un-awaited setSettings.** Root cause: MOD_KEY blocks called `setSettings` without `await`, so the flag could be set before the write landed (or interleave with other writes). Fix: `d8e648b58` "fix(migrations): await settingsStore.setSettings in all MOD_KEY blocks" (2026-05-30).
+3. **Invoice-expiry repair had to run twice.** Symptom: invoice screen displayed "3600 hours" while invoices (BOLT11 = the standard Lightning payment-request format) actually expired in one hour. First repair `26d4215ea` (2026-05-30) fixed users whose settings *had* an `expirySeconds` field. It missed pre-Feb-2024 installs, which never stored `expirySeconds`/`timePeriod` at all — so a second pass `f7b2c30a8` (merge of `a7860aa96`, 2026-06-08, subject references #4149) derives a canonical seconds value and re-runs under a **new** flag key `invoices-expiry-display-fix-v2` (verified in `utils/MigrationUtils.ts` `migrateInvoiceExpiryDisplay`).
+
+**Lesson:** in migrations, always `await settingsStore.setSettings(realObject)` — never a stringified blob — and enumerate every historical settings shape (including fields that may have never existed) before declaring a repair complete.
+
+---
+
+## FA-4 — UNSAFE-lifecycle refactor → infinite loading (3-week regression)
+
+**Dates:** 2025-10-24 → 2025-11-12. **Status: settled.**
+
+Background: React class components have deprecated `UNSAFE_componentWillMount`-style lifecycle methods; Zeus's views are class components, and its boot/connect logic re-runs on screen focus (see zeus-architecture-contract).
+
+- **Symptom:** app stuck on infinite loading at boot.
+- **Root cause:** `fdad118ed` "refactor: replacing UNSAFE React lifecycle methods" (2025-10-24) changed when boot logic ran.
+- **Fix:** `93227029e` (2025-11-12) — subject literally cites the offender: "fix: infinite loading regression fdad118ed4a72cd3824863638f668215c01c3b85".
+
+**Lesson:** lifecycle-method refactors in boot/connect paths are behavior changes, not cleanups — test the cold-start path on both platforms before merging (this repo's naming convention of citing the offending hash in the fix subject is worth copying).
+
+---
+
+## FA-5 — Tor TLS near-miss and the nitro-tor migration
+
+**Dates:** 2026-05-26 → 2026-06-20. **Status: settled + policy.**
+
+Background terms: **Tor** routes traffic through an anonymity network; a **.onion** address is a Tor hidden service (its TLS certs can't be CA-validated normally); a **TLS cert bypass** disables certificate verification. Bypassing certs for *clearnet* hosts reached over Tor exposes users to exit-node man-in-the-middle attacks.
+
+- 2026-05-27: Tor stack replaced — merge `c512ea687` (PR #3971) migrates from the retired `ZeusLN/react-native-tor` fork to `react-native-nitro-tor` (package.json pins `0.6.0`, verified).
+- 2026-05-26: hardening: `d4c8f12e1` "fix(TorUtils): treat HTTP >= 300 responses as errors".
+- 2026-06-19: **the near-miss** — `9de1742f6` "fix(tor): trust invalid certs on LND/CLN REST over Tor" trusted invalid certs *broadly* on the Tor path.
+- 2026-06-20: scoped **one day later** by `8792003ee` "fix(tor): scope TLS bypass to .onion HTTPS endpoints", merge `5a7422a4b` (PR #4186). Standing rule since: cert bypass ONLY for HTTPS .onion; clearnet-over-Tor keeps strict TLS.
+
+**Lesson:** never widen a TLS bypass beyond `.onion` HTTPS — any Tor networking change must state exactly which hosts lose cert verification.
+
+---
+
+## FA-6 — react-navigation upgrade regressions → the popTo rule
+
+**Dates:** 2024-05-05 → 2024-05-21 (recurring class since). **Status: policy.**
+
+Background: **react-navigation** manages the screen stack; `navigation.navigate(X)` *pushes* a new instance if X isn't the immediate target, while `popTo(X)` unwinds the stack back to the existing X. Using `navigate` for "go back" silently builds duplicate screens.
+
+- **Symptom:** broken back-navigation and node-picture selection after "upgrade react navigation" `3bae746ad` (2024-05-05; bumped `@react-navigation/bottom-tabs` 5.11→6.5 among others).
+- **Fix:** PR #2192 merge `7abc7a971` (2024-05-21), key commit `a54b3c91b` "use popTo instead of navigate to navigate back" — a sweep across 23 views.
+- **The class recurs:** `7830d772c` (2026-03-30) "fix: use popTo when returning from MintDiscovery to prevent navigation stack buildup"; `bc135dda7` (2026-03-11) moved navigation types to `NativeStackNavigationProp` (from `@react-navigation/native-stack` — the repo standard). Current deps: `@react-navigation/native` 7.1.28, `@react-navigation/native-stack` 7.12.0 (verified).
+
+**Lesson:** for back-navigation always use `popTo`/`popToTop`, never `navigate`, and type screens with `NativeStackNavigationProp`.
+
+---
+
+## FA-7 — LDK Node crash on wallet deletion (Tokio thread)
+
+**Dates:** 2026-03-10. **Status: settled (rule lives on).**
+
+Background terms: **LDK Node** is a Rust Lightning node embedded via FFI (foreign function interface — calling Rust from JS/native); **Tokio** is Rust's async runtime; dropping (freeing) a Tokio-owning object *from inside a Tokio worker thread* aborts the process.
+
+- **Symptom:** native crash when deleting an LDK Node wallet, and on delete-then-create sequences.
+- **Root cause:** the Node reference was released on a Tokio thread, and stop wasn't awaited before proceeding.
+- **Fix (same day, two commits):** `d416052cd` "prevent LDK Node crash on wallet deletion by releasing Node ref off Tokio thread" + `0e2b89164` "block on LDK Node stop before resolving to prevent crash on delete-then-create" (both 2026-03-10). Related later hardening (both 2026-05-17): `b54e8f138` "enhancement: LDK: wait for node readiness before fetching startup data" (added `waitForLdkNodeReady`) and `8fc9698a0` "fix(ldk-node): tolerate buildNode race during wallet startup" (added the `walletJustCreated` skip flag).
+- Lifecycle races in this area remain a live campaign → **zeus-node-lifecycle-campaign**.
+
+**Lesson:** release LDK Node references off the Tokio thread and block on stop before resolving any delete/recreate flow.
+
+---
+
+## FA-8 — Embedded LND SQLite/Bolt DB saga (4 course corrections)
+
+**Dates:** 2026-01-27 → 2026-04-23. **Status: settled.**
+
+Background terms: **embedded LND** is the LND Lightning node compiled with gomobile and run inside the app; LND stores channel/wallet state in either **Bolt DB** (bbolt, the legacy key-value store) or **SQLite**. Which backend a wallet was *created* with matters — you can't silently switch.
+
+| Date | Event | Evidence |
+|---|---|---|
+| 2026-01-27 | SQLite enabled for newly created/restored embedded wallets | `251aa1b92` |
+| 2026-03-27 | Restricted: SQLite iOS-only | `ef4a42112` |
+| 2026-03-28 | Re-enabled on Android (next day) | `3c6f4175e` |
+| 2026-04-20 | Retreat: default back to Bolt DB + explicit DB selector in Wallet Config, `[SQLite]` suffix labels | `d475ef2b4` (subject references #4002) |
+| 2026-04-23 | Final crash fix: "prevent embedded LND crash on app restart with Bolt default" — restart crashed for wallets created during the SQLite-default window once the default flipped back | `3e04e6bf2`, merge `dc2415df4` (PR #4013) |
+
+**Root cause pattern:** the DB backend default was treated as a config toggle, but it's a per-wallet persistent property (`isSqlite` per node) — flipping the default desynced existing wallets from the engine they were created with.
+
+**Lesson:** a storage-engine default is per-wallet state, not a global flag — changing it requires tracking what each existing wallet was created with.
+
+---
+
+## FA-9 — Hermes regex stack overflow on merchant QR
+
+**Dates:** 2026-06-01. **Status: settled.**
+
+- **Symptom:** app crash (Hermes engine stack overflow) when scanning/pasting long inputs that hit the merchant-QR regex matcher.
+- **Root cause:** Hermes's regex engine recurses per character class; unbounded input length → stack overflow.
+- **Fix:** `5c451839d` "fix: length-cap merchant-QR matching to avoid Hermes regex stack overflow" — `MERCHANT_QR_MAX_LEN = 500` guard, verified at `utils/handleAnything.ts` (constant + two early-return checks). The detector-chain ordering in that file is separately load-bearing → see zeus-lightning-reference (§ handleAnything universal input router).
+
+**Lesson:** length-cap every input before running non-trivial regexes under Hermes.
+
+---
+
+## FA-10 — NWC transaction-list fix: merged and reverted the same day
+
+**Dates:** 2025-12-15. **Status: settled (as a revert); the underlying bug's final resolution is not chronicled here — check current NWC code before assuming it's fixed.**
+
+Background: **NWC (Nostr Wallet Connect, NIP-47)** lets Nostr clients drive the wallet; Zeus runs an NWC wallet service.
+
+- PR #3432 "fix: lightning node transaction list bug in Nostr clients" merged `285da755a` (2025-12-15).
+- Reverted **the same day** via auto-revert branch: PR #3444, merge `28bc50f5e`, revert commit `1c8400515` — commit body empty, no recorded reason.
+
+**Lesson:** NWC store/service-shape changes get reverted fast when release testing flags them — re-read MP-1 before building on any recent NWC fix.
+
+---
+
+## FA-11 — Cashu node-dir collision: all LDK wallets shared one mint DB
+
+**Dates:** 2026-03-20 → 2026-04-08. **Status: settled.**
+
+Background: **Cashu** is a Chaumian ecash protocol; Zeus embeds the CDK (Cashu Dev Kit, Rust). Per-wallet Cashu data is namespaced by a node directory string.
+
+- **Symptom:** multiple LDK Node wallets on one device saw each other's mint data/balances.
+- **Root cause:** namespacing used the LND directory getter, which returns the literal fallback `'lnd'` for every LDK Node wallet — so all LDK wallets collided on one namespace.
+- **Fix:** `1242ce94a` (2026-03-20) "fix: Cashu: isolate mint data per LDK node using getNodeDir()" — `CashuStore.getNodeDir()` returns `ldkNodeDir || 'ldk'` for ldk-node, `lndDir || 'lnd'` otherwise (verified in `stores/CashuStore.ts`). Follow-up `35fa31fee` (2026-04-08) "use getNodeDir for cashu multimint keys". Recovery is a **copy** migration, not a move: `MigrationUtils.migrateLegacyCashuKeysToNodeDir` copies four `cashu-*` key suffixes from the legacy `lnd`-prefixed keys to node-dir keys, only when the node key is empty (verified in `utils/MigrationUtils.ts`).
+
+**Lesson:** namespace per-wallet data with `CashuStore.getNodeDir()` (never the raw lndDir getter), and migrate by copying — leave legacy keys in place (same no-delete doctrine as FA-1).
+
+---
+
+## FA-12 — Bimodal pathfinding: default diverges for new vs migrated users (upstream lnd bug)
+
+**Dates:** standing config quirk. **Status: policy (tracks upstream).**
+
+Background: **bimodal pathfinding** is an lnd payment-routing probability model (alternative to the default "apriori" estimator).
+
+- **Root cause:** upstream bug lightningnetwork/lnd#9085 made bimodal mode unsafe for users who had it enabled; rather than change the fresh-install default, Zeus force-disabled it only for existing users.
+- **Evidence (verified in source):** `stores/SettingsStore.ts` default `bimodalPathfinding: true` (fresh installs); `utils/MigrationUtils.ts` MOD_KEY7 = `'bimodal-bug-9085'` sets `bimodalPathfinding = false` for migrated users, with the lnd issue URL in a comment.
+- **Consequence:** new and upgraded installs behave differently by design. Same divergence pattern exists for `showMillisatoshiAmounts` (see zeus-config-and-flags for the full new-vs-migrated list).
+
+**Lesson:** when an upstream bug forces a behavior change, decide explicitly whether fresh installs and migrated users should diverge — and record the upstream issue number in the MOD_KEY name.
+
+---
+
+## MP-1 — Meta-pattern: the rapid revert
+
+**Status: policy** (maintainer-confirmed: regressions found in release testing get reverted, never forward-fixed under pressure).
+
+Merged ≠ final in this repo. Reverts arrive via GitHub auto-revert branches named `revert-<PR#>-<branch>`, and the revert commits carry **no explanation in the body** — the reasoning lives in out-of-repo release testing.
+
+Verified revert pairs:
+
+| Original PR (merge, date) | Revert PR (merge, date) | Gap |
+|---|---|---|
+| #3307 iCloud exclusion (`5f533bb12`, 2025-11-10) | #3354 (`d1dcb7ba7`, revert `7d8678457`, 2025-11-10) | same day |
+| #3432 NWC txlist (`285da755a`, 2025-12-15) | #3444 (`28bc50f5e`, revert `1c8400515`, 2025-12-15) | same day |
+| #1568 sat rounding (`4c0b2ad48`, 2023-08-04) | #1587 (`3d4377935`, revert `cd7b30479`, 2023-08-05) | 1 day |
+| #1679 app-lock timeout (`3c1634710`, 2023-10-10) | #1773 (`4dd71b8da`, revert `c0dc4e1f8`, 2023-10-16) | 6 days |
+
+**Before trusting any merged fix** (especially in storage/keychain/NWC territory), run:
+
+```bash
+git log --oneline --grep='revert-<PR#>'           # revert merge, if any
+git log --oneline --grep='Revert' --since=<merge-date> | head
+```
+
+**Lesson:** always check for a `revert-<PR#>` branch/merge before citing, extending, or reintroducing a merged change.
+
+---
+
+## MP-2 — The stalled-branch graveyard
+
+**Status: open** (each branch is unfinished work, not abandoned-by-decision unless noted).
+
+Caveat: these are **local branches in the primary development clone** (hundreds exist); a fresh fork won't have them. Verify with `git branch --list <name>` (or `git branch -r` against the ZeusLN remote). Counts below are commits not reachable from `c5fd094fb`.
+
+| Branch | Tip (verified) | Unmerged | What it is |
+|---|---|---|---|
+| `android-16kb-page-size` | `fa2212457`, 2025-10-10, "config: Android: 16 KB page size" | 1 | Android 16KB-page-size compliance; note `android/check_elf_alignment.sh` already exists on master but is invoked by nothing |
+| `bip-321` | `3c1210922`, 2025-08-20, "feat: BIP-321" | 1 | BIP-321 (unified bitcoin payment URIs) support |
+| `cdk-init-remote-nodes` | `62437d4c8`, 2026-05-01 | 4 | Cashu (CDK) redemption for remote-node backends |
+| `cashu-backup` | `34228aac7`, 2025-04-04 | 73 | Large stalled effort (ecash backup / ZEUS Pay-adjacent) — oldest and biggest |
+| `zeus-rgs` | `10cc63b7b`, 2026-05-12 | **0** | Fully contained in master as of `c5fd094fb` — NOT stalled, safe to ignore |
+| `deps-react-native-0.76.9` / `deps-react-native-0.78.2` / `react-native-0.76.2` | see FA-2 | 1–3 | Dead RN upgrade attempts, superseded by the 0.83.1 jump |
+| `rn-v0.86.0` | `203cb9147`, 2026-06-26 | 6 | Candidate next RN bump — open |
+
+**`backup-*` and `*-backup-*` branches** (`backup-before-rebase`, `backup-pre-squash`, `ldk-node-backup-0326-*`) are pre-rebase safety copies of work that already landed — **not** stalled work. Don't mine them for "lost" features.
+
+**Lesson:** before starting 16KB-page-size, BIP-321, remote-node Cashu, or cashu-backup work, diff the graveyard branch first — someone already broke ground.
+
+---
+
+## Lessons index (one line each)
+
+1. **FA-1:** Never delete keychain data in a migration — namespace and retain orphans.
+2. **FA-2:** Treat pre-2026 Animated/layout code as Fabric-suspect; never freeze the RN version for months.
+3. **FA-3:** `await settingsStore.setSettings(realObject)` — never stringified — and enumerate every historical settings shape.
+4. **FA-4:** Lifecycle refactors in boot paths are behavior changes; test cold start on both platforms.
+5. **FA-5:** TLS cert bypass only for HTTPS `.onion`; treat HTTP ≥ 300 over Tor as errors.
+6. **FA-6:** Use `popTo` for back-navigation and `NativeStackNavigationProp` for types.
+7. **FA-7:** Release LDK Node refs off the Tokio thread; block on stop before delete/recreate.
+8. **FA-8:** A storage-engine default is per-wallet state, not a global flag.
+9. **FA-9:** Length-cap inputs before regexing under Hermes.
+10. **FA-10/MP-1:** Check for `revert-<PR#>` before trusting any merged fix.
+11. **FA-11:** Namespace per-wallet data via `getNodeDir()`; migrate by copy, never move.
+12. **FA-12:** Record upstream issue numbers in MOD_KEY names; decide fresh-vs-migrated divergence explicitly.
+13. **MP-2:** Diff the graveyard branch before restarting stalled work.
+
+---
+
+## Provenance and maintenance
+
+Facts verified 2026-07-06 against master snapshot `c5fd094fb` (`git describe --tags` = `v13.1.2-3-gc5fd094fb`; package.json version `13.1.3-alpha`). Every hash above passed `git log -1 <hash>` and `git merge-base --is-ancestor <hash> c5fd094fb`. Dates are author dates from `git log --date=short`. Not independently verifiable from the repo: GitHub PR *bodies* (revert reasons confirmed absent only in commit bodies) and the maintainer's revert-first policy statement (2026-07-06, authoritative).
+
+Re-verification one-liners for volatile facts:
+
+| Fact | Command |
+|---|---|
+| Any cited hash exists + subject/date | `git log -1 --format='%h %ad %s' --date=short <hash>` |
+| Hash is on master lineage | `git merge-base --is-ancestor <hash> HEAD && echo ok` |
+| RN version (0.85.3 as of 2026-07) | `grep '"react-native"' package.json` |
+| New Architecture still ON | `grep newArchEnabled android/gradle.properties` |
+| nitro-tor version (0.6.0) | `grep react-native-nitro-tor package.json` |
+| Keychain deletion still disabled | `grep -n 'Skipping delete' utils/MigrationUtils.ts` |
+| Orphan-retention comment intact | `grep -n 'DISABLED' utils/MigrationUtils.ts` |
+| `zeus:`-prefix + `cloudSync: false` writes | `grep -n 'cloudSync' storage/index.ts` |
+| Merchant-QR length cap (500) | `grep -n MERCHANT_QR_MAX_LEN utils/handleAnything.ts` |
+| Bimodal default (true) + migration off-switch | `grep -n bimodalPathfinding stores/SettingsStore.ts utils/MigrationUtils.ts` |
+| Cashu node-dir logic | `grep -n -A6 'getNodeDir = ' stores/CashuStore.ts` |
+| Expiry-repair MOD key (`...-fix-v2`) | `grep -n 'invoices-expiry-display-fix' utils/MigrationUtils.ts` |
+| New reverts since this was written | `git log --oneline --grep='revert-' --since=2026-07-06` |
+| Graveyard branch still unmerged | `git log --oneline HEAD..<branch> \| wc -l` |
+| react-navigation major (7.x) | `grep '@react-navigation/native' package.json` |
+
+If any command's output disagrees with an entry, the repo wins — update the entry and re-stamp this section.

--- a/.claude/skills/zeus-lightning-reference/SKILL.md
+++ b/.claude/skills/zeus-lightning-reference/SKILL.md
@@ -1,0 +1,475 @@
+---
+name: zeus-lightning-reference
+description: Bitcoin/Lightning/ecash domain theory AS IMPLEMENTED IN ZEUS, for readers who may know React Native but zero Lightning (or vice versa). Load when working on or reading code that touches - BOLT11 invoice decoding (utils/Bolt11Utils.ts), payments (MPP/AMP/keysend, TLV records, routing fee limits), LNURL pay/withdraw/auth/channel or lightning addresses, ZEUS Pay / Zaplocker / nostr attestations, LSP flows (Olympus Flow 2.0, jit_bolt11 wrapping, LSPS0/1/7, 0-conf channel acceptance), Cashu/ecash (CDK FFI, multimint melts, token extraction), Nostr Wallet Connect (NIP-47, service and client roles), Boltz-protocol swaps, on-chain (address types, taproot, PSBT, coin control, CPFP bump retry, mempool.space fees), the universal input router utils/handleAnything.ts and its detector ordering, CLINK/noffer, or watchtowers. Also load when confused by terms like HTLC, preimage, hodl invoice, JIT channel, melt quote, submarine swap, or keysend while reading Zeus code.
+---
+
+# Zeus Lightning & Ecash Domain Reference
+
+Protocol knowledge tied to the exact Zeus file that implements it, plus the Zeus-specific
+twist on each protocol. Every claim below was verified against the code at the commit in
+"Provenance and maintenance". Paths are repo-relative.
+
+## When to use / When NOT to use
+
+**Use this skill when** you need to understand WHAT a protocol does and HOW Zeus implements
+it: decoding invoices, payment flows, LNURL, ZEUS Pay, LSPs, Cashu, NWC, swaps, on-chain,
+or the input router.
+
+**Do NOT use this skill for:**
+
+| Need | Use instead |
+| --- | --- |
+| Which of the 7 backends supports feature X; per-backend RPC quirks; adding an RPC | `zeus-backends-and-capabilities` |
+| Settings defaults, config axes, add-a-setting checklist | `zeus-config-and-flags` |
+| Keychain keys, storage blob, migrations (e.g. Cashu per-node namespacing details) | `zeus-storage-and-migrations` |
+| Boot sequence, stores DI, dispatch design rationale | `zeus-architecture-contract` |
+| Symptom-driven debugging, past incident history | `zeus-debugging-playbook` / `zeus-failure-archaeology` |
+| PR/commit/review rules, what changes are gated | `zeus-change-control` |
+
+One rule from change control that this skill must echo because everything here is
+funds-touching: **send/receive/payment-handling code takes minimal diffs only — no
+drive-by refactoring.** See `zeus-change-control` for the full policy.
+
+## 1. Lightning in three paragraphs (just enough to read this codebase)
+
+**Channels and HTLCs.** The Lightning Network is a payment layer on top of Bitcoin. Two
+nodes lock bitcoin into a shared 2-of-2 on-chain output called a **channel**; they then pay
+each other instantly by exchanging signed balance updates off-chain. Multi-hop payments are
+forwarded through chains of channels using **HTLCs** (Hashed Time-Locked Contracts): each
+hop's payment is locked to the SHA-256 hash of a secret (the **preimage**); revealing the
+preimage settles every hop atomically. A **hodl invoice** is one where the receiver
+deliberately delays revealing the preimage — the payment hangs "in-flight" until released
+(ZEUS Pay's Zaplocker scheme, section 5, is built on this). **0-conf** channels are usable
+before their funding transaction confirms — safe only when you trust the channel opener,
+which is why Zeus only auto-accepts 0-conf from its LSP (section 6).
+
+**Invoices and routing.** A **BOLT11 invoice** (a `lnbc...` bech32 string) encodes amount,
+payment hash, expiry, destination and a signature (section 2). **BOLT12 "offers"**
+(`lno1...`) are reusable payment codes; Zeus supports them on the cln-rest and ldk-node
+backends. Payment senders find a route themselves and pay **routing fees** to intermediate
+hops; wallets set a fee cap per payment (section 3). **MPP** (multi-path payments) split
+one payment across several routes; **AMP** (atomic multi-path) is LND's variant that also
+works without an invoice. **Keysend** is a spontaneous payment (no invoice) where the sender
+generates the preimage and ships it inside the payment's **TLV** (type-length-value) custom
+records.
+
+**LSPs and the rest.** An **LSP** (Lightning Service Provider) sells inbound channel
+capacity, including **JIT** (just-in-time) channels opened at the moment a payment arrives
+(fee deducted from the received amount). **LNURL** is a family of HTTP-based UX protocols
+(pay/withdraw/auth/channel) layered on Lightning; a **lightning address**
+(`user@domain.com`) is LNURL-pay behind an email-like name. **Ecash (Cashu)** is a
+custodial-but-blinded token system: a **mint** holds sats and issues bearer tokens
+(**proofs**) it cannot link to you; **melting** a token converts it back into a Lightning
+payment. **NWC** (Nostr Wallet Connect, NIP-47) lets apps drive a wallet remotely over the
+Nostr relay network. **Submarine swaps** move funds between on-chain and Lightning through
+a swap provider (Boltz protocol): submarine = on-chain in, Lightning out; reverse = Lightning
+in, on-chain out.
+
+## 2. BOLT11 invoices — `utils/Bolt11Utils.ts`
+
+Zeus does NOT use a stock bolt11 npm decoder; it has a hand-rolled one (based on
+light-bolt11-decoder) with two load-bearing performance features:
+
+1. **LRU cache** (`CACHE_LIMIT = 256`), keyed by the lowercased payment request. The
+   Activity list decodes the same invoices repeatedly; the cache collapses that. Cache hits
+   return **the same object instance** to every caller.
+2. **Lazy self-replacing getters** for `destination`, `payeeNodeKey`, `signature`,
+   `recoveryFlag`. Recovering the payee node key from the invoice signature is an
+   ECDSA public-key recovery via `@noble/secp256k1` (~5–20 ms per call on a phone — the
+   comment in the file says so). `decode()` defers it: those four fields are installed as
+   `Object.defineProperty` getters that run recovery on first access, then replace
+   themselves with plain values. Callers that only read `payment_hash` / `description` /
+   `expiry` / `timestamp` pay zero crypto cost. If the invoice carries an explicit payee
+   tag (tag 19), `destination`/`payeeNodeKey` are set eagerly from it and the getters are
+   skipped.
+
+**Consequences — the rules:**
+
+- **Never naively serialize or spread a decoded invoice** (`JSON.stringify(decoded)`,
+  `{...decoded}`). The lazy getters are enumerable, so both operations force the expensive
+  secp256k1 recovery immediately — for every cached invoice you touch — defeating the
+  entire design. Read individual fields instead.
+- **Never mutate the returned object.** It is shared cache state; your mutation poisons
+  every future `decode()` of that invoice.
+- `decode()` throws on non-`ln` strings — callers gate with
+  `AddressUtils.isValidLightningPaymentRequest` first (see `utils/handleAnything.ts`).
+- Amount fields: `satoshis` (number|null), `millisatoshis` (string|null), plus
+  Zeus-convention `num_satoshis` / `num_msat` (strings, `'0'` when absent).
+
+The interface is `DecodedBolt11` in the same file. Tests: `utils/Bolt11Utils.test.ts`.
+
+## 3. Paying: MPP, AMP, keysend, fee limits
+
+Payment dispatch lives in `stores/TransactionsStore.ts` (`sendPayment` →
+`sendPaymentInternal`); the send UI is `views/PaymentRequest.tsx`.
+
+### MPP vs AMP and their version gates
+
+- `supportsMPP()` and `supportsAMP()` are per-backend capability flags (see
+  `zeus-backends-and-capabilities` for the doctrine). On the LND family
+  (`backends/LND.ts`, `backends/EmbeddedLND.ts`, `backends/LightningNodeConnect.ts`)
+  they are node-version-gated: MPP requires LND ≥ v0.10.0, AMP requires LND ≥ v0.13.0.
+  `backends/LdkNode.ts`: MPP true, AMP false. CLNRest, LndHub, NostrWalletConnect: both false.
+- AMP is also **forced on** when the invoice's feature bit 30 is `is_required`
+  (`views/PaymentRequest.tsx`, `lockAtomicMultiPathPayment`). Enabling AMP sets
+  `no_inflight_updates = true`. Tor also sets `no_inflight_updates = true` ("Tor can't
+  handle streaming updates").
+
+### The `max_parts` quirk (verify before relying on defaults)
+
+- `TransactionsStore.sendPaymentInternal`: `data.max_parts = max_parts ? max_parts : '1'`
+  — the **store default is `'1'`** (single path) for any caller that doesn't pass it.
+- `views/PaymentRequest.tsx` `triggerPayment`:
+  `max_parts: enableMultiPathPayment ? maxParts : '16'` with state default
+  `maxParts: '16'` — the **main send screen always passes `'16'`**, whether or not the
+  MPP toggle is on. So payments from PaymentRequest allow 16 shards; payments from other
+  call sites (e.g. programmatic sends) allow 1.
+- `sendPaymentSilently` has `if (max_parts) { data.max_parts = max_parts || '16'; }` —
+  the `|| '16'` branch is unreachable (dead fallback); if the caller omits `max_parts`
+  the field is simply not set.
+
+### Keysend
+
+Constants at the top of `stores/TransactionsStore.ts`:
+
+| TLV record type | Content | Encoding in Zeus |
+| --- | --- | --- |
+| `5482373484` | payment preimage (sender-generated) | random bytes → base64 (`preimage.toString('base64')`) |
+| `34349334` | optional text message | UTF-8 → hex → base64 (`Base64Utils.hexToBase64(Base64Utils.utf8ToHex(message))`) |
+
+Plus: `data.dest = Base64Utils.hexToBase64(pubkey)` and
+`data.last_hop_pubkey = Base64Utils.hexToBase64(...)` — **LND REST wants raw bytes
+base64-encoded, not hex strings**; forgetting the conversion is a classic bug.
+`payment_hash` is `hexToBase64(sha256(preimage))`.
+
+Function selection is one of the few sanctioned `implementation` branches (see
+`zeus-architecture-contract`): `cln-rest` / `embedded-lnd` / `ldk-node` with a pubkey go
+through `BackendUtils.sendKeysend`; everything else — including remote LND REST, which has
+no dedicated keysend endpoint — goes through `BackendUtils.payLightningInvoice` carrying
+`dest_custom_records`.
+
+### Routing fee conventions — `utils/FeeUtils.ts`
+
+`calculateDefaultRoutingFee(amount)`:
+
+- amount > 1000 sats → fee cap = 5% (`DEFAULT_ROUTING_FEE_PERCENT = 0.05`), rounded.
+- amount ≤ 1000 sats → fee cap = the amount itself (i.e. 100%; tiny payments routinely
+  need proportionally huge fees).
+
+`views/PaymentRequest.tsx` passes `max_fee_percent` (default `'5.0'`) for cln-rest, which
+takes a percent instead of a sat limit; the store only forwards `max_fee_percent` when
+`implementation === 'cln-rest'`.
+
+## 4. LNURL family and lightning addresses
+
+Zeus uses the `js-lnurl` package (`getParams`, `findlnurl`, `decodelnurl` — imported in
+`utils/handleAnything.ts`; version pinned in `package.json`). LNURL flows are routed by
+the input router (section 11) to one of four screens based on `params.tag`:
+
+| tag | Meaning | Zeus screen |
+| --- | --- | --- |
+| `payRequest` (LNURL-pay / LUD-06) | server gives min/max, you request an invoice from its callback | `views/LnurlPay/` (or `ChoosePaymentMethod` when ecash is enabled) |
+| `withdrawRequest` (LNURL-withdraw) | server offers sats; you submit YOUR invoice to its callback | `views/Receive.tsx` with `lnurlParams` |
+| `channelRequest` (LNURL-channel) | server opens a channel to you | `views/LnurlChannel.tsx` |
+| `login` (LNURL-auth) | key-based login challenge | `views/LnurlAuth.tsx`, gated by `supportsLnurlAuth()` |
+
+**Lightning address (LUD-16)** resolution is inline in `handleAnything.ts`: split
+`user@domain`, fetch `https://<domain>/.well-known/lnurlp/<user>` (plain `http://` for
+`.onion`). Per LUD-16 the domain is always lowercased and the username normally is too —
+**except for `cryptoqr.net` addresses**, whose usernames are URL-encoded merchant payloads
+where hex-digit casing matters server-side (`isCryptoQR` check; covered by
+`utils/handleAnything.test.ts`). Before the LNURL-pay lookup, Zeus also tries a **BOLT12
+DNS lookup** (BIP-353 style: TXT record at `<user>.user._bitcoin-payment.<domain>` via
+`cloudflare-dns.com/dns-query`) and offers a payment-method choice if both exist.
+
+**Onion gap:** direct `.onion` lightning-address lookups go through `doTorRequest` when
+Tor is enabled, but generic LNURL parameter fetches via `js-lnurl`'s `getParams` do NOT
+route over Zeus's internal Tor — there is a literal
+`// TODO handle fetching of params with internal Tor` in `handleAnything.ts`; `.onion`
+LNURL endpoints currently error out of that path. Open gap, not a bug you introduced.
+
+Nested URI schemes `lnurlp://` / `lnurlw://` / `lnurlc://` / `lnurlauth://` are rewritten
+to `https://` (or `http://` for `.onion`) before processing.
+
+## 5. ZEUS Pay / Zaplocker — `stores/LightningAddressStore.ts` + `stores/LnurlPayStore.ts`
+
+ZEUS Pay gives a self-custodial wallet a lightning address (`user@zeuspay.com`) even
+though the phone is usually offline. Server: `LNURL_HOST = 'https://zeuspay.com'`. Three
+address types exist (`address_type` sent to the server): `'zaplocker'` (hodl-invoice
+scheme, below), `'cashu'` (payments held as Cashu mint quotes, redeemed via
+`/api/lnurl/nuts/redeem`), and `'nwc'`. Gate: `supportsLightningAddress()` in
+`utils/BackendUtils.ts` is the composite `supportsCustomPreimages() || supportsCashuWallet()`.
+
+**Zaplocker lifecycle (receiver side):**
+
+1. **Pre-generate preimages**: `generatePreimages` creates **250 preimages per batch**
+   (32-byte entropy each), computes `hash = sha256(preimage)`, schnorr-signs each hash
+   with the user's nostr private key, and POSTs `{pubkey, hashes, nostrSignatures, ...}`
+   to `zeuspay.com/api/lnurl/submitHashes`. Preimages stay ONLY on the phone
+   (storage key `zeuspay-lightning-address-hashes`). Auto-replenishes when the server
+   reports fewer than 50 unused hashes.
+2. **Someone pays**: zeuspay.com issues a hodl invoice against one of your hashes and
+   holds the HTLC. It cannot settle — it doesn't know the preimage.
+3. **Redeem** (`lookupPreimageAndRedeemZaplocker`): the app looks up the preimage for the
+   hash, creates a local invoice with that **fixed preimage**
+   (`BackendUtils.createInvoice({ preimage, expiry: '86400', ... })`), and POSTs it to
+   `/api/lnurl/redeem`; the server pays it, which reveals the preimage and settles the
+   held HTLC. This is why the gate is `supportsCustomPreimages` — the backend must accept
+   caller-chosen preimages.
+
+**Anti-fraud attestations (nostr kind 55869):**
+
+- **Payer side** (`LnurlPayStore.broadcastAttestation`, triggered from
+  `views/PaymentRequest.tsx` when `isZaplocker`): publish a kind-`55869` event, signed by
+  an **ephemeral key**, whose `p` tag is `getPublicKey(paymentHash)` — the payment hash
+  itself is used as a nostr secret key so anyone holding the hash can find attestations —
+  and whose content is the bolt11 invoice being paid.
+- **Receiver side** (`LightningAddressStore.lookupAttestations`): for each hash, query
+  relays for kind 55869 with `#p = getPublicKey(hash)`, then `analyzeAttestation` checks
+  the embedded invoice actually commits to that hash and amount. Exactly one valid
+  attestation → success status; **more than one attestation → status `'error'`** (a fraud
+  signal: two different "payers" claiming the same hash means someone is lying).
+- The payer also verifies the receiver's zaplocker setup: `LnurlPayStore.load` checks
+  schnorr signatures over the payment hash (`isPmtHashSigValid`) and the relay list
+  (`isRelaysSigValid`) against the receiver's advertised nostr pubkey.
+
+## 6. LSP integration — three generations, all in `stores/LSPStore.ts`
+
+Default endpoints (Olympus, per network) are exported from `stores/SettingsStore.ts`
+(`DEFAULT_LSP_MAINNET = 'https://0conf.lnolymp.us'`, LSPS1 REST
+`https://lsps1.lnolymp.us`, etc.); resolution via `getLspConfig` — endpoint/default
+details belong to `zeus-config-and-flags`.
+
+### Generation 1: Olympus "Flow 2.0" REST (JIT channels on receive)
+
+- `getZeroConfFee` POSTs the msat amount to `<flowHost>/api/v1/fee`;
+  `getZeroConfInvoice(bolt11)` POSTs to `/api/v1/proposal` and resolves `data.jit_bolt11`
+  — a **wrapped invoice** routing through the LSP, which opens a 0-conf channel just in
+  time and deducts its fee.
+- **The wrapping MUTATES the requested amount** (`stores/InvoicesStore.ts`,
+  `createInvoice`): when Flow LSP is active and `value > zeroConfFee`, Zeus creates the
+  local invoice for `req.value = requested − zeroConfFee`, then swaps the displayed
+  payment request for `jit_bolt11` (which asks the payer for the full amount). The payer
+  sees the full amount; your node's invoice is smaller by the fee.
+- **Silent degradation**: if `getZeroConfInvoice` rejects, Zeus clears the error state and
+  shows the UNWRAPPED invoice — receiving still works if a channel already exists, but no
+  JIT channel will be opened. Don't "fix" the swallowed error without understanding this.
+- **LNURL-withdraw interaction**: the withdraw callback must receive the wrapped invoice —
+  `qs.pr = jit_bolt11 || invoice.getPaymentRequest` in `InvoicesStore`. Passing the
+  unwrapped one would make the withdrawing service pay an invoice the LSP never sees.
+
+### Generation 2/3: LSPS0 transport + LSPS1 (buy channel) / LSPS7 (extend lease)
+
+- **LSPS0** = JSON-RPC 2.0 over the Lightning peer-to-peer **custom message type `37913`**
+  (`CUSTOM_MESSAGE_TYPE` in `LSPStore.ts`). Requests are correlated by `uuidv4()` ids
+  (`this.getInfoId = uuidv4()`; responses matched by `data.id` in
+  `handleCustomMessages`) with a **7-second timeout**
+  (`CUSTOM_MESSAGE_RESPONSE_TIMEOUT_MS = 7000`).
+- Three transports, chosen by backend capability flags: **native** (embedded-lnd goes
+  straight to `lndmobile` custom-message APIs), **custom message** via
+  `BackendUtils.sendCustomMessage`/`subscribeCustomMessages` (other LND-family), and
+  **REST** (`<lsps1Rest>/api/v1/get_info`, `/api/v1/create_order`) for backends that can't
+  send peer messages. Methods: `lsps1.get_info`, `lsps1.create_order`, `lsps1.get_order`,
+  and the LSPS7 equivalents for channel-lease extension.
+- **0-conf acceptance policy** (`handleChannelAcceptorEvent`): a channel-acceptor hook
+  rejects any **0-conf** channel unless the opener is the LSP pubkey or listed in
+  `settings.zeroConfPeers`; normal (confirmed) channels are accepted regardless. On
+  embedded-lnd this is wired via the `ChannelAcceptor` native event stream; other backends
+  go through `BackendUtils.initChanAcceptor`.
+
+## 7. Cashu / ecash — `stores/CashuStore.ts` + `utils/CashuUtils.ts`
+
+Ecash primer: a Cashu **mint** custodies sats and issues blinded bearer tokens
+(**proofs**). Receiving Lightning through a mint = **mint quote** (pay invoice → get
+proofs); paying Lightning from proofs = **melt quote**. Tokens serialize as
+`cashuA...` (v3 JSON) / `cashuB...` (v4 CBOR) strings.
+
+- **Implementation is the CDK Rust FFI, NOT cashu-ts**: `import CashuDevKit ... from
+  '../cashu-cdk'` — a native module wrapping the Cashu Dev Kit with its own SQLite DB.
+  Wallet ops (`initializeWallet(mnemonic, 'sat')`, `addMint`, `getBalances`, `melt`,
+  `restoreFromSeed`) all cross the FFI. Cashu is available only where
+  `supportsCashuWallet()` is true: **embedded-lnd and ldk-node**.
+- **Seed versions**: `seedVersion` is `'v1'` (legacy: key material derived from the LND
+  seed, bytes [32:64]) or `'v2-bip39'` (dedicated cashu BIP-39 phrase; stored under
+  `<nodeDir>-cashu-seed-phrase` with version marker `<nodeDir>-cashu-seed-version`).
+  v1 wallets keep their original P2PK key via `originalSeedVersion` special-casing.
+  Per-node storage namespacing (`getNodeDir()` and the collision it fixed) is owned by
+  `zeus-storage-and-migrations`.
+- **Multimint MPP (NUT-15) bypasses CDK**: to pay one invoice from several mints at once,
+  `mintSupportsMpp` probes each mint's info for NUT-15 (note the quirk: `nuts['15']` is
+  an ARRAY of methods, not `{methods: [...]}`), then `queryMeltQuoteMpp` POSTs **raw mint
+  REST** — `<mint>/v1/melt/quote/bolt11` with `options: { mpp: { amount: <msat> } }` —
+  because CDK doesn't expose partial-amount melt quotes. Rejections are classified by
+  `classifyMppRejection`: "internal mpp not allowed" / "self payment" → `'selfSend'`
+  (mints refuse MPP toward their own invoices; the planner falls back to a single-mint
+  regular quote via `prepareSingleMintRegularQuote`, executed with `CashuDevKit.melt`
+  instead of `meltPartial`).
+- **Token extraction from URL wrappers** (`CashuUtils.extractTokenString`): a greedy regex
+  `cashu[AB][0-9A-Za-z+/_=-]+` pulls a token out of any wrapper (zeusln.com/e/,
+  wallet.cashu.me, nutstash, etc.) and stops at URL noise like `&memo=`; failing that it
+  strips the known prefixes in `cashuTokenPrefixes`
+  (`https://wallet.nutstash.app/#`, `https://wallet.cashu.me/?token=`, `web+cashu://`,
+  `cashu://`, `cashu:`).
+- **P2PK DoS guards**: P2PK-locked tokens carry attacker-controlled JSON in proof secrets.
+  `safeParseP2PKSecret` rejects secrets over `MAX_P2PK_SECRET_LENGTH = 2048` chars or
+  nested deeper than `MAX_P2PK_SECRET_DEPTH = 10` (bracket-scan before `JSON.parse`).
+  Keep these guards when touching token parsing.
+
+## 8. NWC (NIP-47) — Zeus plays BOTH roles
+
+- **Wallet service** (`stores/NostrWalletConnectStore.ts`): Zeus exposes its own node to
+  external apps. Each connection has an optional **budget**
+  (`budgetAmount`/`budgetRenewal` with `BudgetRenewalType`, periodic resets via
+  `checkAndResetAllBudgets`, capped by wallet balance `maxBudgetLimit`). Staying reachable
+  in the background is the hard part: on iOS the store drives a **background-audio
+  keep-alive** (`utils/IOSAudioKeepAliveUtils.ts`, bundled silent m4a) that auto-starts
+  whenever at least one connection exists; Android uses a foreground service. This store
+  is a known hotspot (~3200 lines, zero tests) — see `zeus-debugging-playbook` before
+  touching it.
+- **Client backend** (`backends/NostrWalletConnect.ts`): Zeus can itself be a thin client
+  driving a remote NWC wallet, via `@getalby/sdk`'s `NostrWebLNProvider` constructed from
+  the node's `nostr+walletconnect://` URL. Capability surface is minimal (no keysend, no
+  on-chain, no channels — see the `supports*` block at the bottom of the file). Quirk:
+  NWC `makeInvoice` returns only `paymentRequest`, so `createInvoice` back-fills
+  `payment_hash` by decoding the bolt11 with `Bolt11Utils`.
+
+## 9. Swaps — Boltz protocol v2, `stores/SwapStore.ts`
+
+Zeus speaks the Boltz v2 REST API; default provider is ZEUS's own instance
+(`DEFAULT_SWAP_HOST_MAINNET = 'https://swaps.zeuslsp.com/api/v2'` in
+`stores/SettingsStore.ts`), with Boltz (`https://api.boltz.exchange/v2`) selectable.
+Endpoints used: `/swap/submarine`, `/swap/reverse`, `/swap/restore`.
+
+**Deterministic rescue key** — the design goal is that a single mnemonic can recover any
+in-flight swap:
+
+- The rescue key is a BIP-39 mnemonic stored under `swaps-rescue-key`
+  (`SWAPS_RESCUE_KEY` in `utils/SwapUtils.ts`). On ldk-node it **reuses the node's own
+  mnemonic** instead of generating a new one (`generateRescueKey`).
+- Per-swap keys derive at **`m/44/0/0/0/<index>`** (`DERIVATION_PATH = 'm/44/0/0/0'`,
+  `getPath(index)` appends the index; last used index persisted under
+  `swaps-last-used-key`).
+- **Reverse-swap preimage = `sha256(child privkey)`** (`derivePreimageFromRescueKey`) —
+  so preimages never need separate backup; the mnemonic regenerates them.
+- **Restore**: `getRescuableSwaps` derives an xpub from the mnemonic and POSTs it to
+  `<host>/swap/restore`; the server returns swaps whose keys belong to that xpub.
+
+## 10. On-chain: address types, PSBT/coin control, CPFP, fees
+
+- **Address types** (`views/Receive.tsx`, values are LND `AddressType` enum strings):
+  `'0'` = p2wkh (native SegWit, `bc1q...`, the default), `'1'` = np2wkh (nested SegWit,
+  `3...`, shown only if `supportsNestedSegWit()`), `'4'` = p2tr (**taproot**, `bc1p...`,
+  shown only if `supportsTaproot()` — LND-family gates this at node ≥ v0.15.0).
+- **Coin control / PSBT**: a **UTXO** is an unspent output; **coin control** means picking
+  which UTXOs fund a transaction; a **PSBT** (Partially Signed Bitcoin Transaction) is the
+  interchange format for building/signing across devices. `stores/UTXOsStore.ts` lists
+  UTXOs and on-chain accounts; `BackendUtils.fundPsbt`/`finalizePsbt` dispatch to capable
+  backends (`supportsCoinControl()`: LND-family ≥ v0.12.0, CLNRest, LdkNode, and LNC
+  — gated on the session's `permNewAddress` permission). Scanned/pasted
+  PSBTs and raw tx hex route to the `PSBT` / `TxHex` screens via `handleAnything.ts`.
+- **CPFP bump with the output-index flip** (`stores/FeeStore.ts`,
+  `bumpFeeOpeningChannel`): **CPFP** (child-pays-for-parent) accelerates a stuck funding
+  tx by spending its change output at a high fee. Zeus parses `outpoint` as
+  `txid:output_index`, tries the bump, and if LND answers
+  `"the passed output does not belong to the wallet"` it **retries once with the index
+  flipped (0↔1)** — the channel-open change output is at whichever index the funding
+  output isn't. Comment in code: only works for single-party-funded channels. Force-close
+  bumps go through `bumpForceCloseFee` (no flip retry).
+- **Fee estimation**: `FeeStore.getOnchainFeesviaMempool` fetches
+  `https://mempool.space/<testnet/>api/v1/fees/recommended` (fastest/halfHour/hour/
+  economy); backend-native estimators exist per backend but the fee picker UI is
+  mempool.space-driven.
+
+## 11. `utils/handleAnything.ts` — the universal input router
+
+Every scanned QR, pasted string, deep link, and NFC payload goes through
+`handleAnything(data, setAmount?, isClipboardValue?)`. It returns a
+`[screenName, params]` navigation tuple — or, in **clipboard mode**
+(`isClipboardValue = true`, used to decide whether to show the "paste detected" prompt),
+**plain booleans** (`true` = recognized, `false` = not) from most detectors. Caveat:
+several late-chain detectors (npub, `zeuscontact:`, PSBT, TxHex, account imports, bare
+Cashu tokens, BOLT12 withdrawal requests) have no `isClipboardValue` check and return the
+navigation tuple even in clipboard mode — callers must treat any truthy return as
+"recognized". New detectors should add the boolean guard. Don't mix up
+the two return shapes.
+
+**Detector ORDER is load-bearing.** It is one giant if/else chain; earlier detectors
+shadow later ones. Current order (verified):
+
+1. BIP-21 URI unpack (`AddressUtils.processBIP21Uri`) + multiple-payment-method choice
+2. CLINK noffer → `ClinkPay`; BOLT12 offer → `Send`
+3. On-chain address (+ optional embedded lightning param) → `Send`/`Accounts`
+4. Lightning pubkey → keysend `Send`; BOLT11 → `PaymentRequest` (or
+   `ChoosePaymentMethod` when ecash enabled); BOLT12 offer string → `Send`
+5. Node-connection strings (clnrest://, nostr+walletconnect://, LNC pairing, lndconnect,
+   LNDHub) → `WalletConfiguration`
+6. Node URI (`pubkey@host`) → `OpenChannel`; lightning address (LUD-16, with BOLT12 DNS
+   probe and the cryptoqr.net casing exception, section 4)
+7. BTCPay pairing config
+8. **Web-wrapped Cashu tokens BEFORE the LNURL detector** — an https URL containing a
+   `cashu[AB]...` base64 body. The comment in the file is explicit: `findlnurl` can match
+   bech32-like substrings INSIDE cashu tokens and misroute them; the base64 shape gate
+   avoids swallowing URLs that merely contain the literal "cashuA" (e.g. `?ref=cashuAfrica`).
+9. LNURL (findlnurl / decoded lnurl / `/lnurl|lnurlp|...` path regex) → tag dispatch
+   (section 4)
+10. npub / `zeuscontact:` → contacts; PSBT; TxHex; account imports (xpub, descriptors,
+    keystore JSON) gated by `supportsAccounts()`
+11. Bare Cashu token (`isValidCashuTokenAsync`) → `CashuToken`
+12. BOLT12 withdrawal requests (gated `supportsWithdrawalRequests()`)
+13. **Merchant QR near-LAST** (`isMerchantQR`): South-African merchant payloads
+    (Pick n Pay, Ecentric, SnapScan, Zapper...) are converted to `...@cryptoqr.net`
+    lightning addresses and **recursively re-fed** into `handleAnything`. Guard:
+    `MERCHANT_QR_MAX_LEN = 500` — the alternation-heavy regexes catastrophically
+    backtrack and **overflow Hermes' regex stack** on long inputs (Hermes = React
+    Native's JS engine), so anything longer is skipped. Keep this near the end: its
+    regexes are greedy enough to steal inputs that earlier detectors parse precisely.
+14. Fallback: WIF private-key sweep → `WIFSweeper`, else "not valid" error.
+
+**When adding a detector**: place it as late as correctness allows, add clipboard-mode
+boolean returns, cap regex input length if patterns use nested alternation, and add cases
+to `utils/handleAnything.test.ts`.
+
+## 12. One-liners
+
+- **CLINK / noffer** (`utils/ClinkUtils.ts`): `noffer1...` bech32-TLV payment codes
+  resolved over nostr — kind-`21001` (`CLINK_KIND`) NIP-44-encrypted request/response with
+  a 30 s default timeout (`DEFAULT_TIMEOUT_MS = 30_000`); `.onion` relays are explicitly
+  refused (`ONION_NOT_SUPPORTED`) rather than silently leaking clearnet traffic.
+- **Watchtowers** (LND-family only): a watchtower watches the chain for old-state channel
+  breaches while you're offline. `BackendUtils` dispatches
+  `listWatchtowers`/`addWatchtower`/etc.; `supportsWatchtowerClient()` is true on
+  LND, EmbeddedLND, and LNC, false/absent elsewhere (absent methods dispatch to `false` —
+  see `zeus-backends-and-capabilities`).
+
+## Provenance and maintenance
+
+Facts verified **2026-07-06** against master `c5fd094fb` (v13.1.3-alpha) by reading the
+implementing files directly. No commands below mutate anything.
+
+| Volatile fact | Re-verify with |
+| --- | --- |
+| Bolt11 LRU size / lazy getters | `grep -n "CACHE_LIMIT\|defineLazyRecoveryFields" utils/Bolt11Utils.ts` |
+| Keysend TLV constants | `grep -n "5482373484\|34349334" stores/TransactionsStore.ts` |
+| `max_parts` defaults `'1'` vs `'16'` | `grep -n "max_parts" stores/TransactionsStore.ts views/PaymentRequest.tsx` |
+| Routing fee 5% / 1000-sat threshold | `grep -n "DEFAULT_ROUTING_FEE_PERCENT\|1000" utils/FeeUtils.ts` |
+| MPP/AMP version gates | `grep -rn "supportsMPP\|supportsAMP" backends/` |
+| cryptoqr.net casing exception, merchant QR 500-char cap | `grep -n "isCryptoQR\|MERCHANT_QR_MAX_LEN" utils/handleAnything.ts` |
+| js-lnurl version | `grep js-lnurl package.json` |
+| Zaplocker: 250 preimages, kind 55869, zeuspay.com | `grep -n "250\|55869\|zeuspay" stores/LightningAddressStore.ts stores/LnurlPayStore.ts` |
+| LSPS0 message type 37913 / 7 s timeout | `grep -n "CUSTOM_MESSAGE_TYPE\|TIMEOUT_MS" stores/LSPStore.ts` |
+| Flow amount mutation + jit_bolt11 swap | `grep -n "zeroConfFee\|jit_bolt11" stores/InvoicesStore.ts` |
+| Flow/LSPS1 default hosts | `grep -n "DEFAULT_LSP" stores/SettingsStore.ts` |
+| Cashu raw MPP melt endpoint | `grep -n "melt/quote/bolt11" stores/CashuStore.ts` |
+| Cashu token prefixes / P2PK limits | `grep -n "cashuTokenPrefixes\|MAX_P2PK" utils/CashuUtils.ts` |
+| Cashu seed versions | `grep -n "v2-bip39\|originalSeedVersion" stores/CashuStore.ts` |
+| NWC client SDK | `head -20 backends/NostrWalletConnect.ts` |
+| Swap hosts / path / preimage derivation | `grep -n "DEFAULT_SWAP_HOST" stores/SettingsStore.ts; grep -n "DERIVATION_PATH\|derivePreimageFromRescueKey\|swap/restore" stores/SwapStore.ts` |
+| CPFP output-index flip | `grep -n "does not belong" stores/FeeStore.ts` |
+| Address type values 0/1/4 | `grep -n "value: '0'\|value: '1'\|value: '4'" views/Receive.tsx` |
+| CLINK kind / timeout | `grep -n "CLINK_KIND\|DEFAULT_TIMEOUT_MS" utils/ClinkUtils.ts` |
+| Watchtower support matrix | `grep -rn "supportsWatchtowerClient" backends/` |
+| Detector chain order | read the if/else chain in `utils/handleAnything.ts` top to bottom |
+
+Labeled uncertainties: none of the facts above are speculative; server-side behavior of
+zeuspay.com / swaps.zeuslsp.com / lnolymp.us is described only as far as the client code
+shows (request/response shapes) — API contracts are not versioned in this repo.

--- a/.claude/skills/zeus-node-lifecycle-campaign/SKILL.md
+++ b/.claude/skills/zeus-node-lifecycle-campaign/SKILL.md
@@ -1,0 +1,348 @@
+---
+name: zeus-node-lifecycle-campaign
+description: Load when working on Zeus's node lifecycle races - the #1 live problem (maintainer, 2026-07-06). Symptoms/tasks that trigger this skill - embedded LND or LDK Node crashes on wallet switch/delete/create, "Node not initialized" errors, Tokio thread panics / native SIGABRT on stop or delete, app stuck on "Starting node" or infinite connecting spinner, duplicate node builds, fetchData or getSettingsAndNavigate re-entrancy, "lnd already started" after JS reload, wallet-switch leaves the previous node running, background/foreground storms breaking the connection, stopLnd/startLnd/stopLdkNode/buildNode ordering questions, or any change to Wallet.tsx connection flow / SettingsStore connecting-fetchLock flags / LndMobileService / LdkNodeModule. Contains the verified lifecycle state map, reproducible baseline experiments, a ranked solution menu with obligations, and fenced wrong paths with commit hashes.
+---
+
+# Zeus Node Lifecycle Campaign
+
+This is an executable, decision-gated investigation campaign for Zeus's hardest live problem (maintainer-confirmed, 2026-07-06): **races in starting, stopping, deleting, and switching embedded nodes** (embedded LND and LDK Node), including Tokio-thread crashes and `Wallet.tsx` `fetchData` re-entrancy. Everything below was verified by reading the code at master `c5fd094fb` (v13.1.3-alpha) unless explicitly labeled HYPOTHESIS.
+
+## When to use / When NOT to use
+
+**Use this skill when** you are reproducing, diagnosing, or fixing node start/stop/delete/switch races, or reviewing any PR that touches `views/Wallet/Wallet.tsx` connection flow, `SettingsStore` lifecycle flags, `utils/LndMobileUtils.ts`, `utils/LdkNodeUtils.ts`, or the native node modules.
+
+**Do NOT use this skill for:**
+
+| Need | Go to sibling skill |
+|---|---|
+| General symptom→triage for other bugs | zeus-debugging-playbook |
+| How to capture logs / measure (general tooling) | zeus-diagnostics-and-tooling |
+| Past incident narratives beyond lifecycle | zeus-failure-archaeology |
+| Backend capability matrix, adding an RPC | zeus-backends-and-capabilities |
+| Formal race-analysis method (generic recipes) | zeus-proof-and-analysis-toolkit |
+| PR/commit/review rules, the non-negotiables | zeus-change-control |
+| Running the app / connecting nodes at all | zeus-run-and-operate |
+| Settings blob, migrations, keychain | zeus-storage-and-migrations |
+| What counts as test evidence, jest traps | zeus-validation-and-qa |
+
+## Jargon (one line each, both domains)
+
+- **Embedded LND**: a full LND Lightning node compiled to a mobile library (gomobile) running *inside* the Zeus app process; Zeus implementation string `'embedded-lnd'`.
+- **LDK Node**: a Rust Lightning node (`ldk-node` crate, ZeusLN fork) embedded via uniffi FFI bindings; implementation string `'ldk-node'`.
+- **Tokio**: the Rust async runtime ldk-node uses. If the *last* reference to the Node object is dropped from one of Tokio's own worker threads, the runtime is destroyed from inside itself → Rust panic → native crash (SIGABRT), killing the whole app.
+- **uniffi**: Mozilla's Rust↔Kotlin/Swift binding generator; the checked-in `ldk_node.kt` / `LDKNode.swift` are its output.
+- **gomobile / Messenger IPC**: embedded LND is a Go library; on Android it runs behind `LndMobileService.java`, a bound Android Service the RN module talks to via `Messenger` message passing (Blixt-derived code, `TODO(hsjoberg)` debt).
+- **Foreground service**: an Android service with a persistent notification, allowed to keep running in background; used for "persistent mode".
+- **Focus event**: react-navigation fires `'focus'` every time a screen becomes active — including returning from another screen. `Wallet.tsx` re-runs its connect logic on focus.
+- **AppState**: React Native's app-level state (`active`/`background`/`inactive`); Wallet also re-runs connect logic on `active`.
+- **MobX observable**: mutable store field that re-renders observers; the lifecycle flags below are plain observables with **no atomicity guarantees**.
+- **Neutrino**: LND's light-client chain backend (connects to Bitcoin P2P peers). **Esplora/RGS/VSS**: LDK Node's chain API server / rapid gossip sync server / remote channel-state storage (`vss.zeusln.com`).
+- **fetchData**: the ~800-line method in `views/Wallet/Wallet.tsx` that resets stores, starts/attaches to the node for the active backend, and loads wallet data. It IS the boot sequence (not App.tsx).
+
+## The lifecycle state machine as it actually exists (verified 2026-07-06)
+
+There is **no single owner**. Lifecycle state is smeared across four layers:
+
+| Layer | File | Owns |
+|---|---|---|
+| Orchestration | `views/Wallet/Wallet.tsx` | `handleFocus` / `handleAppStateChange` / `handleOpenURL` → `getSettingsAndNavigate()` → `fetchData()`; the `_navigating` instance flag; a 60s slow-startup alert timer |
+| Flags | `stores/SettingsStore.ts` | `connecting` (init **true**), `fetchLock`, `embeddedLndStarted`, `walletJustCreated`, `triggerSettingsRefresh`, `posWasEnabled`, `ldkNodeSyncing`; `setConnectingStatus()`; `updateNodeProperties()` (swaps `implementation`, dirs, creds on every settings write) |
+| JS node control | `utils/LndMobileUtils.ts` (`initializeLnd`, `startLnd`, `stopLnd`, `waitForRpcReady`, `createLndWallet`, `deleteLndWallet`) and `utils/LdkNodeUtils.ts` (`startLdkNodeWallet`, `stopLdkNode`, `waitForLdkNodeReady`, `createLdkNodeWallet`, `deleteLdkNodeWallet`) | retry loops, sleeps, error classification (`utils/LndMobileErrors.ts`) |
+| Native | Android `android/app/src/main/java/com/zeus/LndMobileService.java` (+ `LndMobile.java`, `LndMobileScheduledSyncWorker.java`), `android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt`; iOS `ios/LndMobile/`, `ios/LdkNodeMobile/LdkNodeModule.swift` | the actual daemon/Node object, `lndStarted` boolean, `nodeLock`/`takeNode()` |
+| Mutation entry points | `views/Settings/Wallets.tsx` (switch), `views/Settings/WalletConfiguration.tsx` (create/edit/delete), `utils/WalletCreationUtils.ts` (Quick Start), `views/Settings/SeedRecovery.tsx` | write `settings.nodes`/`selectedNode` via `updateSettings`, then `setConnectingStatus(true)` + `popTo('Wallet')` |
+
+### The guards, in evaluation order
+
+1. **`_navigating`** (Wallet.tsx instance field) — guards `getSettingsAndNavigate` re-entry from the focus event and AppState `active`. Added in `c71a04ce9` (2026-04-07) because the focus event fires twice on startup and both raced into `fetchData` → duplicate `buildNode`, second build times out holding VSS resources. **Bypassed by three call sites** that invoke `getSettingsAndNavigate()` directly: pull-to-refresh (`LayerBalances onRefresh`), the error-screen Restart button (iOS branch), and `handleOpenURL` for `zeusln://share`.
+2. **`fetchLock`** (SettingsStore observable) — checked/set at `fetchData` entry (`if (fetchLock) return; SettingsStore.fetchLock = true;`). Cleared in exactly two places: the happy-path end of `fetchData`, and `setConnectingStatus(true)`. **Every early-return error path leaves `fetchLock === true`** — by design: the app then shows the error screen, and recovery requires `setConnectingStatus(true)` (Restart button, wallet switch, transient-retry loop), which clears the lock. Consequence: any code path that errors out and then expects a plain focus event to reconnect will hang silently.
+3. **`connecting`** — initialized `true`, so the first `fetchData` after cold start runs the full connect branch (stop→init→start + reset of ~12 stores). Set `false` at the end of a successful connect or on fatal errors; set `true` by every wallet-switch/create/restart path. When `false`, `fetchData` becomes a light data refresh (embedded-lnd still calls `waitForRpcReady()` + full data fetch on every focus).
+4. **`walletJustCreated`** — set by `createLndWallet` / LDK create paths; makes `fetchData` skip the stop→init→start cycle because the node is already running from wallet creation. Consumed (set `false`) on first use.
+5. **`embeddedLndStarted`** — whether `stopLnd()` is called before re-init (`if (!recovery && SettingsStore.embeddedLndStarted) await stopLnd();`). Set `true` in `startLnd` (only when a wallet password is present), `false` in `stopLnd` and several views.
+6. **Native guards** — LDK: `nodeLock` (Kotlin `synchronized`) / `takeNode()` (Swift) makes stop/build swap the node reference atomically; LND Android: a single `lndStarted` boolean inside `LndMobileService`; the Go daemon itself rejects double starts with "lnd already started".
+
+### `setConnectingStatus(true)` side effects (SettingsStore.ts)
+
+Resets `error`/`errorMsg`/`lndFolderMissing`, calls `BackendUtils.clearCachedCalls()` (flushes the request dedup cache — see zeus-backends-and-capabilities), and clears `fetchLock`. This is the universal "reconnect" lever; treat any call to it as a lifecycle transition.
+
+### Per-backend connect branch inside `fetchData` (only when `connecting`)
+
+- **ldk-node**: `stopLdkNode()` (unless `walletJustCreated`) → `startLdkNodeWallet` (`initializeNode` FFI + `node.start()` retried up to 5×500ms on "Node not initialized" + `syncWallets`) → later branch `waitForLdkNodeReady()` (polls `status()` every 500ms up to 60s, tolerating "Node not initialized" and not-running — added by `b54e8f138`, 2026-05-17; the companion `buildNode`-race fix `8fc9698a0`, same day, added the `walletJustCreated` skip).
+- **embedded-lnd**: `stopLnd()` (if started) → `initializeLnd` (writes lnd.conf, binds service) → optional express graph sync → `startLnd` (retry ladder incl. force-stop on `LND_ALREADY_RUNNING`, wallet unlock on `WALLET_LOCKED`) → `waitForRpcReady()` (polls `getInfo` 500ms up to 30s). Transient RPC errors route through `retryOnTransientError` (max 5 retries, 2s base exponential backoff; it toggles `connecting` false→true, which is also what re-clears `fetchLock`).
+- Remote backends (lndhub login, LNC `connect()`, NWC `connectNWC()`, REST default) have no native lifecycle but share the same flags.
+
+### Native stop/delete rules (the Tokio contract)
+
+From `LdkNodeModule.kt` (`stop`, `buildNode`) and `LdkNodeModule.swift` (same methods), established by `d416052cd` + `0e2b89164` (both 2026-03-10):
+
+1. Take the node reference out of the module under `nodeLock`/`takeNode()` **first**, so no other call can reach a stopping node.
+2. Call `node.stop()` on a **dedicated non-Tokio thread** (raw `Thread` on Android, GCD global queue on iOS) — never on a Tokio callback thread.
+3. Resolve the JS promise only **after** `stop()` returns — callers may delete wallet files or build a new node the moment `stop()` resolves.
+4. Keep the reference alive **2 more seconds** after resolving (`Thread.sleep(2000)` + `hashCode()` on Android, `withExtendedLifetime` on iOS) so internal Tokio tasks drop their `Arc` refs before ours — otherwise the "Runtime dropped on worker thread" panic.
+5. `buildNode` applies the same stop-and-hold to any existing node before building, and clears the JS-visible node reference up front — which is why **any FFI call during a rebuild window rejects with `"Node not initialized"`** (JS must tolerate it: `LDK_NODE_NOT_INITIALIZED` handling in `utils/LdkNodeUtils.ts`).
+
+Embedded LND has no equivalent contract; `stopLnd()` in `utils/LndMobileUtils.ts` approximates one (status check → `stopDaemon` → `killLnd` → poll status up to 10×500ms).
+
+## Known race windows (the target list)
+
+Each window is verified by code read at `c5fd094fb`. Runtime confirmation status noted.
+
+| # | Window | Status |
+|---|---|---|
+| W1 | Double focus → duplicate `getSettingsAndNavigate` | FIXED by `_navigating` (`c71a04ce9`); residual: the three bypass call sites rely only on `fetchLock`, which does NOT stop a second `getSettingsAndNavigate` from re-running the pre-`fetchData` navigation logic concurrently |
+| W2 | JS call into LDK during `buildNode` rebuild → `"Node not initialized"` rejection | Tolerated in `waitForLdkNodeReady` (`b54e8f138`) and the pre-existing `start` retries; **unguarded** for every other store that calls the backend during the window (e.g. polling stores) |
+| W3 | Cross-implementation switch leaves the previous node running: `fetchData`'s `ldk-node` branch calls only `stopLdkNode()`, the `embedded-lnd` branch only `stopLnd()`. Switching embedded-lnd → ldk-node (or reverse) stops NEITHER the old node; `views/Settings/Wallets.tsx onWalletPress` only calls `setPersistentMode(false)` (dismisses the Android notification, does not stop the node) and `BackendUtils.disconnect()` for LNC | Confirmed by code read; runtime impact (two chain-syncing nodes, memory/battery, port/db contention) needs Phase 3 measurement |
+| W4 | Delete-active-wallet flow: `WalletConfiguration.deleteNodeConfig` stops node → `updateSettings({ justDeletedWallet: active })` → deletes files → navigates to Wallets; selecting the next wallet runs `handleJustDeletedWallet` which does `setConnectingStatus(true)` then **`sleep(2000)`** — a bare time-based wait standing in for "old node fully gone" | Open; the sleep is a fenced symptom-patch pattern (below) |
+| W5 | JS reload with live daemon: LND runs **in the app process** (`android/app/src/main/AndroidManifest.xml` declares `LndMobileService` with no `android:process` attribute), so a JS-only restart (`RNRestart`, dev-menu reload, JS crash) leaves the Go daemon running → next start hits `LND_ALREADY_RUNNING` → force-stop ladder in `startLndWithRetry` with 2–4s cleanup sleeps | Handled but fragile; see W6 |
+| W6 | `LndMobileTools.killLnd()` scans running processes for `packageName + ":zeusLndMobile"`, but no such process is ever created (no `android:process` in the manifest) — so `killLnd` can never find/kill anything and resolves `false`. Recovery therefore rests entirely on the Go `stopDaemon` call. Also `killLndProcess()` uses `getCurrentActivity()` which is null when no Activity is attached (background) → NPE risk | Code-read finding; runtime confirmation = log `killLnd` result in Phase 4. Blixt heritage: Blixt runs the service in a separate process, Zeus does not |
+| W7 | `LndMobileScheduledSyncWorker.java` (background sync) binds the same `LndMobileService` and — per its own FIXME at ~line 310 — calls `thread.run()` instead of `thread.start()`, executing the "thread" body synchronously on the worker's calling thread with handlers on the **main looper**. A scheduled sync racing a foreground app start can send `MSG_START_LND` against an already-started daemon (the worker's own comment: "Make sure we don't attempt to start lnd twice... better fix would be MSG_CHECKSTATUS") | Open, acknowledged debt (`TODO(hsjoberg)`) |
+| W8 | `LndMobileService.onUnbind`: when the last client unbinds it calls `stopLnd(null, -1)` + `stopSelf()` — but the RN module (`LndMobile.java`) binds once in `initialize()` and its `unbindLndMobileService` is flagged in `lndmobile/LndMobile.d.ts` as "function looks broken" and is never called from TS (verified: zero TS call sites). So service lifetime ≈ process lifetime; unbind-triggered stop is effectively dead code in the app (only the sync worker unbinds) | Confirmed by code read |
+| W9 | Background/foreground storm: AppState `active` triggers `getSettingsAndNavigate` (guarded by `_navigating`), `inactive` resets `NostrWalletConnectStore`; iOS fires `inactive` on mere app-switcher/notification-shade interactions | Guarded but untested under storm; Phase 0 E4 |
+| W10 | LDK delete-then-create same dir: `stop()` resolves before the 2s native Arc-hold expires; `deleteLdkNodeWallet` then `RNFS.unlink`s the storage dir while background Tokio cleanup may still touch it | HYPOTHESIS — the 2s hold was added for the ref-drop panic, not for file-handle safety; needs Phase 5 experiment |
+
+---
+
+## Phase 0 — Baseline: reproduce and measure
+
+Goal: a numeric crash/hang rate per scenario BEFORE any fix, so any fix can be judged. Do not skip; the maintainer's revert-first culture means an unmeasured "fix" is unlandable.
+
+### Prerequisites
+
+- Dev builds on BOTH platforms (see zeus-run-and-operate; `yarn android` / `yarn ios`, Metro via `yarn start`).
+- Two test wallets on one device: one `embedded-lnd` (Mainnet or Testnet) and one `ldk-node`. Create via IntroSplash Quick Start + Settings → Wallets → Add.
+- Log capture:
+
+```bash
+# Android — native lifecycle tags + crashes (works on debug and release):
+adb logcat -v time | grep -E "ReactNativeJS|LdkNodeModule|LndMobileService|LndMobile|AndroidRuntime|FATAL|Fatal signal"
+
+# Android — crash buffer only (count crashes across trials):
+adb logcat -b crash -v time
+
+# Android JS console in DEBUG builds goes to the Metro terminal, not logcat.
+# In RELEASE builds console.log appears under the ReactNativeJS logcat tag.
+
+# LDK Node's own Rust log (debug builds; substitute the wallet's uuid dir):
+adb shell run-as app.zeusln.zeus sh -c 'ls files/ldk-node/'
+adb shell run-as app.zeusln.zeus sh -c 'tail -f files/ldk-node/<uuid>/ldk_node.log'
+
+# Embedded LND's log: in-app Settings → Embedded node → LND Logs, or (debug):
+adb shell run-as app.zeusln.zeus sh -c 'tail -f files/<lndDir>/logs/bitcoin/mainnet/lnd.log'
+
+# iOS — native NSLog (simulator; process name is "zeus"):
+xcrun simctl spawn booted log stream --predicate 'process == "zeus"' --style compact
+# iOS JS console: Metro terminal.
+```
+
+### Log milestones (the vocabulary of every experiment)
+
+All verified present in source:
+
+| Milestone | Exact string (grep-able) | Source |
+|---|---|---|
+| Focus fired, connect starting | `[Wallet] handleFocus: triggering getSettingsAndNavigate` | Wallet.tsx |
+| Re-entry suppressed | `skipping — getSettingsAndNavigate already in flight` | Wallet.tsx (focus + AppState variants) |
+| LDK teardown | `[LDK startup] stopping previous instance` / `[LDK startup] stopped` | Wallet.tsx |
+| LDK build+start | `[LDK startup] calling startLdkNodeWallet` / `LDK Node: Started successfully` / `LDK Node: Sync complete` | Wallet.tsx / LdkNodeUtils.ts |
+| LDK ready-wait | `[LDK startup] waiting for node to be ready` | Wallet.tsx |
+| LDK native timing | `LdkNodeModule: [timing] FFI buildWithDualStore starting/completed` | LdkNodeModule.kt/.swift |
+| LND ready | `RPC ready - Node pubkey:` | LndMobileUtils.ts `waitForRpcReady` |
+| LND states | `Current LND state:` (NON_EXISTING/LOCKED/UNLOCKED/RPC_ACTIVE/SERVER_ACTIVE) | LndMobileUtils.ts |
+| LND double-start recovery | `LND already started - force stop (Go thinks running)` | LndMobileUtils.ts |
+| Connect finished | `[Wallet] connect time: ` | Wallet.tsx |
+| LDK race symptom | `Node not initialized` | native modules / LdkNodeUtils.ts |
+| Transient-retry loop | `Transient ... - retry N/5 in Xms` | LndMobileErrors.ts |
+
+### E1 — Cold start, each backend (control; 5 trials each)
+
+Kill the app (swipe from recents), relaunch, wait for balance screen.
+
+- **Expect**: one `triggering` line, typically followed by one `skipping` line (the startup focus event fires twice — see `c71a04ce9`), the backend's start milestones once each, exactly one `connect time:` line.
+- **If you see two `triggering` lines with no `skipping`** → the `_navigating` guard regressed or a bypass path fired → branch to Phase 2.
+- **If `connect time:` never appears and the spinner persists** → note which milestone was last; `fetchLock` is likely stranded (Phase 2's flag table tells you which return path).
+
+### E2 — Rapid wallet switch, embedded-lnd ↔ ldk-node (20 cycles)
+
+Settings → Wallets → tap the other wallet; as soon as the Wallet screen shows *anything* (don't wait for full sync), switch back. Record: crashes (`logcat -b crash`), stuck-spinner incidents, and whether the OLD node keeps running.
+
+- **Old-node liveness probe (W3)**: after switching embedded→ldk, keep `tail -f` on the old wallet's `lnd.log` — if new log lines keep appearing (neutrino banner/filter activity), the LND daemon is still running alongside LDK. Expected per code read: **it is**. Symmetrically, `ldk_node.log` continues after switching ldk→embedded.
+- **Expect per switch**: `triggering` → store resets → old-backend stop milestone **only if switching within the same implementation** → new-backend start milestones → `connect time:`.
+- **If crash with `Fatal signal 6 (SIGABRT)` mentioning tokio/runtime** → LDK ref released on a Tokio thread; capture the full tombstone; this is the `d416052cd` class — branch to Phase 5.
+- **If `Node not initialized` surfaces in the UI (error screen)** rather than being retried → an unguarded call site hit W2 — branch to Phase 2 call-site census.
+- **If a switch hangs with no `triggering` line at all** → focus fired while `_navigating` was stuck true (a `getSettingsAndNavigate` that never resolved) — capture the last milestone.
+
+### E3 — Delete active wallet mid-operation (5 trials each backend)
+
+While the node is mid-sync (do this within ~30s of connect), Settings → Wallets → gear icon → Delete wallet → confirm; then immediately select the remaining wallet.
+
+- **Expect**: stop milestone, `justDeletedWallet` flow (2s pause in `Wallets.handleJustDeletedWallet` before reconnect), new wallet connects.
+- **If crash on the delete itself (LDK)** → W10 or a `d416052cd` regression — branch to Phase 5.
+- **If "wallet not found"/`LND_FOLDER_MISSING` alert on the NEXT connect** → stale `lndDir`/`ldkNodeDir` read from a not-yet-propagated settings write — record `selectedNode` at each step (Phase 1 instrumentation).
+
+### E4 — Background/foreground storm (20 cycles)
+
+Rapidly background/foreground the app (Android: home + reopen; iOS: app switcher). Then once more with ≥30s in background.
+
+- **Expect**: `skipping` lines for suppressed re-entries; at most one connect flow per foregrounding; NWC store reset lines on iOS `inactive` are normal.
+- **If store data visibly resets (balance flashes to 0) on every foreground** → `connecting` got stuck true, making every `fetchData` run the full reset branch.
+
+### E5 — JS reload with live daemon (Android, 10 trials)
+
+With embedded-lnd running: dev-menu Reload (debug) or trigger the in-app restart. The process survives, so the Go daemon does too.
+
+- **Expect**: `LND already started - force stop (Go thinks running)` → stop ladder → successful restart within ~10s (includes the 4s `ANDROID_PROCESS_CLEANUP_DELAY_MS`).
+- **If it loops on `LND still running (attempt N) - force stop`** until `LND_START_FAILED` → the stop ladder can't actually kill the daemon (consistent with W6: `killLnd` is a no-op on this manifest) → Phase 4.
+
+**Baseline record**: for each experiment, `crashes / trials`, `hangs / trials`, and the last milestone before each failure. This table is the campaign's ground truth.
+
+---
+
+## Phase 1 — Instrument the flags (temporary)
+
+Add TEMPORARY logging so every flag transition is attributable. **Instrumentation must not ship**: strip it before any PR, or land it only behind an explicit maintainer-approved debug gate — unconditional console noise in the connect path will be rejected in review (zeus-change-control; there is no developer-mode toggle to hide behind, see zeus-config-and-flags).
+
+Instrumentation points (grep anchors, all verified):
+
+| Where | Anchor | Log |
+|---|---|---|
+| `stores/SettingsStore.ts` `setConnectingStatus` | `public setConnectingStatus = (status = false)` | old→new value + `new Error().stack` (caller attribution — MobX gives you none) |
+| `views/Wallet/Wallet.tsx` `fetchData` entry | `if (fetchLock) return;` | log BOTH the rejected entries (currently silent) and the acquisitions, with `implementation`, `connecting`, `walletJustCreated` |
+| `views/Wallet/Wallet.tsx` `fetchData` exit | `SettingsStore.fetchLock = false;` | matched release log; any acquisition without a release = a stranded lock |
+| `utils/LndMobileUtils.ts` `stopLnd`/`startLnd` | function heads | entry/exit + `embeddedLndStarted` value |
+| `utils/LdkNodeUtils.ts` `stopLdkNode`/`startLdkNodeWallet` | function heads | entry/exit timestamps (measures overlap with builds) |
+| `views/Settings/Wallets.tsx` `onWalletPress` | `const onWalletPress` | old/new `selectedNode`, old/new implementation |
+
+Re-run E1–E5 with instrumentation. **Decision gate**: produce a timeline for every Phase 0 failure showing which flag was in the wrong state. If any failure shows two node-start sequences interleaved (start A begins, start B begins before A's ready milestone), the serialization defect is confirmed and Phase 2 is mandatory.
+
+## Phase 2 — Entry-path and lock-outcome census (desk analysis + targeted tests)
+
+Enumerate every path into `getSettingsAndNavigate`/`fetchData` and every exit's flag outcome. Starting set (verified at `c5fd094fb` — re-derive, don't trust):
+
+```bash
+grep -n "getSettingsAndNavigate\|_navigating" views/Wallet/Wallet.tsx
+grep -rn "setConnectingStatus(true)" --include="*.ts" --include="*.tsx" . | grep -v node_modules
+```
+
+Entry paths: focus (guarded), AppState active (guarded), componentDidMount→handleFocus, pull-to-refresh (UNguarded), error-screen Restart (UNguarded, iOS), `zeusln://share` URL (UNguarded), transient-retry recursion (`retryOnTransientError` → `getSettingsAndNavigate(undefined, count+1)`).
+
+For each `return`/`throw` inside `fetchData`, record: `fetchLock` left true? `connecting` left true? Is there a UI affordance that will call `setConnectingStatus(true)` to recover? Build the full table (there are ~12 early returns).
+
+**Decision gate**: 
+- If every observed Phase 0 hang maps to a "lock stranded + no recovery affordance" row → solution (b) below fixes the hangs; scope it to those rows.
+- If hangs occur even with clean flag states → the defect is deeper (native), go to Phase 4/5 first.
+
+## Phase 3 — Cross-implementation teardown (W3)
+
+Experiment: E2's old-node liveness probe, plus resource measurement:
+
+```bash
+# Memory of the app process while both nodes run vs one:
+adb shell dumpsys meminfo app.zeusln.zeus | head -30
+```
+
+Also test: switch embedded→ldk, wait 5 min, switch back — does the returning `stopLnd()`+`startLnd()` find a healthy daemon or a wedged one?
+
+**Decision gate**: if the old node demonstrably keeps syncing after a switch (expected), classify severity: (i) resource-only → fold the fix into solution (a)/(c); (ii) causes E2 crashes or db contention → promote solution (c) to first.
+
+## Phase 4 — Android native service model (W5–W8)
+
+1. Log `killLnd`'s return value during E5. Expected per code read: always `false` (no `:zeusLndMobile` process exists to kill). If confirmed, the "force stop" ladder is `stopDaemon`-only, and the manifest/no-process finding should be written into the fix design.
+2. Audit `LndMobileScheduledSyncWorker` interaction: enable persistent mode / scheduled sync, background the app, watch for a worker-initiated `MSG_START_LND` colliding with a foreground start.
+3. Decide (with maintainer, this is Blixt-heritage territory): separate process like Blixt (`android:process`), or keep in-process and delete the dead `killLnd` scan + fix the `thread.run()` FIXME.
+
+**Decision gate**: only proceed to native changes if Phase 0/1 shows failures that JS-level serialization cannot prevent (e.g. daemon survives all stop attempts). Native service changes require full re-test of: background receive, persistent mode notification, scheduled sync, graceful-stop notification action.
+
+## Phase 5 — LDK stop/delete timing (W2, W10)
+
+1. Census every JS call site that can reach the LDK FFI while `buildNode`/`stop` is in flight (`grep -rn "LdkNode\." stores/ backends/ utils/ --include="*.ts"`); classify each as tolerant (retries on `Node not initialized`) or crash/error-surfacing.
+2. W10 experiment: script delete-then-recreate of an ldk-node wallet as fast as the UI allows, 10 cycles, watching `ldk_node.log` and the crash buffer. If unlink-during-cleanup errors appear, the fix is to move the delete into native (delete after the Arc-hold) or extend the JS wait — with a real completion signal, NOT a longer sleep.
+
+**Decision gate**: any crash here re-opens the `d416052cd`/`0e2b89164` contract — fix in the native module (both platforms symmetrically; the Kotlin and Swift implementations are deliberate mirrors), never by adding JS-side sleeps.
+
+---
+
+## Solution menu — ranked, with obligations
+
+Ranking reflects maintainer culture: minimal diffs first, big designs only with prior sign-off. Every option below is **funds-adjacent** (a node torn down mid-payment can strand an HTLC or force-close exposure), so all inherit: no drive-by refactors in payment paths, manual 2-platform testing by the author, revert-first if release testing regresses (zeus-change-control).
+
+### 1. `fetchData` lock-hygiene + serialization audit (smallest, do first)
+Make lock acquire/release provably paired: single exit point (try/finally) for `fetchLock`; extend the `_navigating` guard (or fold it into one SettingsStore-owned in-flight promise) to cover the three bypass call sites.
+- **Theory obligations**: the Phase 2 table with every entry path × every exit → flags outcome; prove the error-screen Restart and transient-retry recovery still work (they depend on `setConnectingStatus(true)` clearing the lock — don't break that contract silently).
+- **Blast radius**: Wallet.tsx + SettingsStore only. No storage change, no migration.
+- **Gates**: standard PR gates + E1/E2/E4 re-run showing hang rate → 0.
+
+### 2. Cross-implementation teardown fix (W3)
+Before starting backend B, stop whichever embedded node type is actually running — e.g. track "last started native node" (type + dir) in SettingsStore and stop it in `fetchData`'s connect branch regardless of the NEW implementation, or stop-old in `onWalletPress` before `updateSettings`.
+- **Theory obligations**: prove `stopLnd()` is safe when LND isn't running (it is — status-check path returns early) and `stopLdkNode()` likewise (native stop resolves ok on null node); measure added switch latency; prove the delete flow (which stops nodes itself) doesn't double-stop into an error state.
+- **Blast radius**: Wallet.tsx or Wallets.tsx + SettingsStore. No storage change (the tracking flag must stay a non-persisted observable — persisting it would trigger the storage gate, zeus-storage-and-migrations).
+- **Gates**: E2 with liveness probe showing old node actually stops; both platforms.
+
+### 3. LDK stop/delete hardening (W2, W10)
+Give delete a real completion signal (native-side delete after Arc-hold, or a `stopAndAwaitCleanup` FFI method); make non-tolerant FFI call sites tolerant or gate them on a ready flag.
+- **Theory obligations**: preserve the four-step Tokio contract verbatim; enumerate all FFI call sites (Phase 5 census) and prove each is either serialized-after-ready or retry-tolerant.
+- **Blast radius**: `LdkNodeModule.kt` + `LdkNodeModule.swift` (must change in lockstep) + `utils/LdkNodeUtils.ts`. Native binary/bindings untouched (pure module-layer change) — if the ldk-node fork itself must change, that's a `fetch-libraries-versions.json` bump with its own process (zeus-build-and-env).
+- **Gates**: E3 ×20 both platforms, crash buffer clean.
+
+### 4. Single lifecycle state machine (the end state — design sign-off REQUIRED first)
+One owner (e.g. a `NodeLifecycleStore` / manager) with explicit states — `STOPPED, STARTING, RUNNING, STOPPING, DELETING, SWITCHING` — through which ALL start/stop/delete/switch flows pass; `Wallet.tsx` becomes a consumer, not an owner.
+- **Theory obligations (non-negotiable before code)**: (i) full state/transition enumeration with the illegal transitions listed; (ii) proof of no orphaned native handle — every `start` has exactly one matching `stop` on every path including error paths and app-kill (invariant: at most one native node per implementation, and after the W3 fix, at most one total); (iii) mapping of ALL existing flags (`connecting`, `fetchLock`, `embeddedLndStarted`, `walletJustCreated`, `_navigating`) onto machine states, with a staged migration so each PR stays reviewable; (iv) re-entrancy story: transitions are serialized on one async queue, concurrent requests coalesce or queue, never interleave.
+- **Blast radius**: Wallet.tsx, SettingsStore, Wallets/WalletConfiguration/SeedRecovery/WalletCreationUtils, both utils files. This is exactly the shape of refactor that produced `fdad118ed` — land it as a series of minimal PRs, each independently revertible.
+- **Gates**: maintainer design ACK before implementation; full Phase 0 suite as regression harness; both platforms per PR.
+
+### 5. Android native service overhaul (W6–W8)
+Fix/delete dead `killLnd`, resolve the `thread.run()` FIXME, decide the process model, fix or remove the broken `unbindLndMobileService`.
+- **Theory obligations**: document Blixt-divergence (separate process vs in-process) and its tradeoffs (a separate process makes kill reliable but changes IPC failure modes and memory accounting); prove scheduled-sync and persistent-mode still work.
+- **Blast radius**: highest — background receive, notifications, WorkManager. Android-only, which violates the "both platforms behave the same" instinct — extra review scrutiny.
+- **Gates**: only after Phase 4's decision gate says JS-level fixes are insufficient; maintainer sign-off; full background-services manual test matrix.
+
+## Fenced wrong paths (do not repeat; hashes verified in this repo)
+
+- **UNSAFE-lifecycle shortcut**: `fdad118ed` (2025-10-24) refactored Wallet's React lifecycle methods and caused infinite loading, fixed only three weeks later by `93227029e`. Fence: no mechanical lifecycle refactors of `Wallet.tsx`; behavior-preserving proof + full Phase 0 suite or don't touch it.
+- **Releasing LDK refs on the Tokio thread / resolving stop early**: crash class fixed by `d416052cd` + `0e2b89164` (2026-03-10). Fence: the four-step native contract above is load-bearing; any "simplification" that drops the dedicated thread, the blocking resolve, or the 2s hold re-introduces a hard native crash.
+- **Treating the buildNode window as fatal**: before `b54e8f138` (2026-05-17), startup had no ready-wait, so "Node not initialized" from post-start FFI calls could surface as a fatal error (the `node.start()` retry itself predates that commit). Fence: during rebuild windows, retry-with-classification (specific error strings, bounded retries) — but do NOT blanket-retry all FFI errors; only the two sentinels in `utils/LdkNodeUtils.ts`.
+- **Sleeps as synchronization**: the codebase already carries load-bearing sleeps (`sleep(2000)` in `Wallets.handleJustDeletedWallet`, `ANDROID_PROCESS_CLEANUP_DELAY_MS = 4000`, the 2s Arc-holds, `STATE_SUBSCRIPTION_SETTLE_MS`). Fence: adding another timeout to make a race "go away" is symptom-patching; every new wait must be a real completion signal (status poll, event, promise) or it will be NACKed. Existing sleeps may only be removed by a change that replaces them with an owned signal.
+- **Forward-fixing under release pressure**: regressions found in release testing get reverted same-day, never patched forward (maintainer rule; see zeus-change-control and the same-day-revert record in zeus-failure-archaeology). Fence: if your lifecycle change regresses anything in manual testing, the move is revert, then re-derive.
+- **Unattributed duplicate-work "fixes"**: `c71a04ce9` shows the right shape — the commit body names the exact double-fire mechanism (focus fires twice with `initialLoad=true`) before adding the guard. Fence: no guard/lock may be added without a written statement of which concrete interleaving it prevents.
+
+## Validation & promotion protocol
+
+A lifecycle fix is promotable when ALL of the following hold:
+
+1. **Scripted counts, both platforms** (Android device/emulator AND iOS device/simulator — maintainer's manual 2-platform rule, CI builds nothing mobile):
+   - E2 wallet-switch: **0 crashes and 0 stuck-spinners in 30 cycles** per platform.
+   - E3 delete/create: 0 crashes in 10 cycles per backend.
+   - E4 bg/fg storm: 0 duplicate connects, 0 hangs in 20 cycles.
+   - E5 JS-reload recovery: reconnect succeeds 10/10 (Android).
+2. **Log-assertion checklist** on captured logs: exactly one `triggering` per user action (plus `skipping` lines); one `connect time:` per connect; zero UI-surfaced `Node not initialized`; zero `Fatal signal` in `adb logcat -b crash`; after a cross-implementation switch, the old node's log file goes quiet (post W3 fix).
+3. **No stranded flags**: with Phase 1 instrumentation applied locally, every `fetchLock` acquisition has a matching release in every experiment (then strip the instrumentation).
+4. **`yarn verify` green** (Test, Lint, Prettier, Typescript Check — see zeus-validation-and-qa). Note stores/views have zero jest coverage; your manual evidence IS the test.
+5. **PR structure** (zeus-change-control): minimal diff; no drive-by refactors (especially none in payment paths); PR template intact with the backend testing matrix filled (embedded-lnd + ldk-node at minimum, plus one remote backend to prove the shared flags still work); commit message names the interleaving fixed and cites the relevant hashes; screenshots/recordings of the connect flow if UI-visible.
+6. **Change-control routing**: storage untouched (no new persisted keys — else zeus-storage-and-migrations gates apply); new dependencies need prior maintainer discussion; native ldk-node/lnd binary bumps go through `fetch-libraries-versions.json` (zeus-build-and-env).
+
+## Provenance and maintenance
+
+Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha) by direct code read; commit hashes verified with `git log`. The maintainer priority statement dates from 2026-07-06. Runtime numbers (crash rates) are deliberately absent — Phase 0 produces them.
+
+One-line re-verification commands (run from repo root):
+
+```bash
+git log -1 --format="%h %s"                                          # still c5fd094fb?
+grep -n "_navigating" views/Wallet/Wallet.tsx                        # re-entry guard still present
+grep -n "if (fetchLock) return" views/Wallet/Wallet.tsx              # lock acquire site
+grep -n "remove fetchLock on reconnect" stores/SettingsStore.ts      # lock cleared in setConnectingStatus(true)
+grep -n "connecting = true" stores/SettingsStore.ts                  # connecting initialized true
+grep -n "walletJustCreated" views/Wallet/Wallet.tsx | head -3        # skip-start flag still consumed
+grep -n "stopLdkNode()" views/Wallet/Wallet.tsx                      # ldk branch stops only ldk (W3)
+grep -rn "stopLnd" views/Wallet/Wallet.tsx | head -3                 # lnd branch stops only lnd (W3)
+grep -n "thread.run()" android/app/src/main/java/com/zeus/LndMobileScheduledSyncWorker.java   # W7 FIXME
+grep -n "zeusLndMobile" android/app/src/main/java/com/zeus/LndMobileTools.java                # W6 dead scan
+grep -n "android:process" android/app/src/main/AndroidManifest.xml   # expect NO output (in-process LND)
+grep -n "looks broken" lndmobile/LndMobile.d.ts                      # W8 unbind still flagged broken
+grep -n "Thread.sleep(2000)" android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt       # 2s Arc-hold
+grep -n "withExtendedLifetime" ios/LdkNodeMobile/LdkNodeModule.swift # iOS mirror of the hold
+grep -n "LDK_NODE_NOT_INITIALIZED" utils/LdkNodeUtils.ts             # tolerated sentinel
+grep -n "MAX_TRANSIENT_RPC_RETRIES\|TRANSIENT_RPC_RETRY_BASE_MS" utils/LndMobileErrors.ts     # 5 / 2000ms
+grep -n "sleep(2000)" views/Settings/Wallets.tsx                     # delete-flow sleep still load-bearing
+git log -1 --format="%h %ad %s" --date=short c71a04ce9 d416052cd 0e2b89164 b54e8f138 8fc9698a0 fdad118ed 93227029e
+```
+
+If any of these greps come back empty or changed, the corresponding claim above is stale — re-read the file before acting on it.

--- a/.claude/skills/zeus-proof-and-analysis-toolkit/SKILL.md
+++ b/.claude/skills/zeus-proof-and-analysis-toolkit/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: zeus-proof-and-analysis-toolkit
+description: 'First-principles analysis recipes for Zeus — how to PROVE a change correct instead of merely shipping it. Load when you need to: analyze a race condition or lifecycle crash (start/stop/delete/focus interleavings, Tokio panics, "Node not initialized", fetchData re-entrancy); prove a settings/keychain migration correct across all persisted-state shapes (fresh install, legacy blob, zeus-settings-v2, iCloud restore, one-shot MOD_KEY flags); audit whether a BackendUtils method is implemented/gated across all 7 backends (supports* gating, inherited-leak, silent false); verify satoshi/msat amount or fee arithmetic; write a spec-conformance test with known-good vectors (BOLT11, TLV, key derivation); prove a bug fix with a failing-test-first regression test; or verify reproducible Android build equivalence. Keywords: race analysis, interleaving table, migration proof, idempotency, dispatch audit, capability leak, unit trace, test vector, regression test, reproducible build.'
+---
+
+# Zeus proof and analysis toolkit
+
+Zeus moves real bitcoin. CONTRIBUTING.md requires tests that would have caught the bug ("Test Coverage") and proof-of-work evidence for first-time contributors; this skill generalizes that into an evidence discipline: correctness claims come with an enumeration, a trace, a test, or a byte-for-byte comparison. This skill is the catalog of the analysis methods that produce that evidence, each written as a recipe with a worked example from this repo's actual history (all commit hashes verified against `master`).
+
+"Prove it, don't just install it" here means: before you claim a fix works, you can name the full space of states/interleavings/backends/inputs it must handle, show which cell of that space the bug lived in, and show a check (test, table, diff) that would have caught it and now guards it.
+
+## When to use / When NOT to use
+
+Use this skill when you must **establish that something is correct**: a race is closed, a migration is safe, a dispatch is complete, an amount path is exact, a decoder matches the spec, a fix cannot regress, a build is reproducible.
+
+Do NOT use this skill for:
+
+| Need | Use instead |
+|---|---|
+| How changes are classified/gated, PR and review rules, storage-change sign-off | zeus-change-control |
+| Writing/locating migrations, keychain contract details, iCloud rules | zeus-storage-and-migrations |
+| The 7-backend capability matrix and per-backend quirks | zeus-backends-and-capabilities |
+| What happened historically (full incident chronicle) | zeus-failure-archaeology |
+| `yarn verify` anatomy, jest configuration traps, adding tests mechanically | zeus-validation-and-qa |
+| Measuring at runtime: logs, dev tools, inspection scripts | zeus-diagnostics-and-tooling |
+| The live node-lifecycle-races campaign (decision-gated work plan) | zeus-node-lifecycle-campaign |
+| Lightning/Bitcoin domain theory (BOLT11 fields, LSPS, Cashu semantics) | zeus-lightning-reference |
+| Evidence bar / idea lifecycle / adversarial refutation discipline | zeus-research-methodology |
+
+This skill owns the **methods**; siblings own the facts those methods operate on.
+
+## Terms used below (defined once)
+
+- **sat / msat** — satoshi (1e-8 BTC) / millisatoshi (1/1000 sat). Lightning protocols speak msat; most Zeus UI speaks sats. Every amount variable has exactly one of these units.
+- **BOLT11** — the Lightning invoice encoding spec (bech32 string starting `lnbc…`). **TLV** — type-length-value binary encoding used in Lightning custom records.
+- **LSP** — Lightning Service Provider; sells inbound channels. **Zero-conf fee** — the fee an LSP deducts for a just-in-time channel, subtracted from the invoice amount.
+- **Backend** — one of Zeus's 7 node implementations dispatched through `utils/BackendUtils.ts` (`lnd`, `embedded-lnd`, `ldk-node`, `lightning-node-connect`, `cln-rest`, `lndhub`, `nostr-wallet-connect`).
+- **Keychain** — the OS secure credential store (iOS Keychain / Android Keystore), Zeus's canonical persistence via `storage/index.ts`. **Settings blob** — the single JSON document under key `zeus-settings-v2` holding all wallets and settings.
+- **MobX observable** — reactive state object; Zeus stores are MobX classes, views re-render when observables change.
+- **Tokio** — the Rust async runtime inside the LDK Node native library. Dropping its last reference **on one of its own worker threads** panics Rust ("runtime dropped from within a runtime") and kills the app.
+- **FFI / UniFFI** — foreign-function interface; the generated Kotlin/Swift bindings that bridge React Native to Rust (LDK Node, Cashu).
+- **One-shot migration flag (MOD_KEY)** — a key in legacy EncryptedStorage marking that a settings migration already ran, so it never runs twice.
+
+---
+
+## Recipe 1 — Race / interleaving analysis
+
+**When to use:** any crash or corruption that only reproduces "sometimes"; any change to node start/stop/delete, wallet create/switch, or `views/Wallet/Wallet.tsx` connection logic; any native module holding a long-lived resource (node handle, file, socket).
+
+**Steps**
+
+1. **Enumerate the trigger events.** In Zeus the recurring set is:
+   - *Wallet screen focus* — `handleFocus` in `views/Wallet/Wallet.tsx` runs `getSettingsAndNavigate()` → `fetchData()` on Wallet-screen focus when `initialLoad`, `posWasEnabled`, or `triggerSettingsRefresh` is set (guarded by an in-flight `_navigating` flag).
+   - *App foreground* — `handleAppStateChange('active')` in the same file, again calling `getSettingsAndNavigate()`.
+   - *Wallet creation* — `createOnboardingWallet` in `utils/WalletCreationUtils.ts` (may build the node itself, then sets `settingsStore.walletJustCreated = true` so Wallet.tsx skips re-init).
+   - *Wallet deletion / switch* — `views/Settings/WalletConfiguration.tsx` (stop node, delete on-disk dirs, update `settings.nodes`).
+   - *Reconnect* — `SettingsStore` clears `fetchLock` when connection settings change (see `fetchLock = false` near the bottom of `stores/SettingsStore.ts`).
+2. **Enumerate the shared mutable state** each event touches: the native node reference (Kotlin/Swift module field), `SettingsStore.connecting` (initialized `true`), `SettingsStore.fetchLock`, `SettingsStore.walletJustCreated`, on-disk node directories, and the ~12 stores `fetchData` resets. Grep the guards:
+   ```bash
+   grep -n "fetchLock\|walletJustCreated\|connecting" views/Wallet/Wallet.tsx | head -30
+   ```
+3. **Build the interleaving table.** Rows = ordered steps of operation A (e.g. delete: `stop node → release ref → delete dirs → clear settings`); columns = every other event that can fire between two rows (focus, foreground, create, second delete). For each cell ask: *what state does the interloper observe, and is that state valid?*
+4. **Classify each unsafe cell**: needs serialization (lock/flag/blocking await), or can be **tolerated** (retry on a known transient error), or is unreachable (prove why — e.g. `fetchLock` early-return at the top of `fetchData`).
+5. **Verify with a discriminating experiment** — add temporary interleaving logs (the repo's own pattern: the `[Wallet] handleFocus: triggering getSettingsAndNavigate (…connecting=…)` lines in Wallet.tsx were added exactly for this) and force the ordering by hand (delete-then-immediately-recreate; background/foreground during startup). See zeus-diagnostics-and-tooling for log capture.
+
+**Worked example — the LDK Node delete crash (`d416052cd` + `0e2b89164`, both 2026-03-10) and buildNode race (`b54e8f138` + `8fc9698a0`, 2026-05-17).**
+
+Symptom: deleting an LDK Node wallet crashed the app in Rust. Root cause: the native `stop` handler released the **last reference** to the Rust `Node` object on a Tokio worker thread, so the Tokio runtime destructor ran on its own thread → panic. The interleaving table that would have caught it has one row that native code hid from JS: *"who drops the final Arc reference, and on which thread?"* — a critical section invisible at the TypeScript layer.
+
+The fix history is itself a lesson in incomplete interleaving analysis:
+
+- `d416052cd` released the ref off-thread but **resolved the JS promise immediately**, stopping the node in the background. That opened a new unsafe cell: *delete-then-create* — JS proceeded to delete wallet files and build a new node while the old one was still stopping.
+- `0e2b89164`, same day, closed that cell: block on `stop()` (on a dedicated non-Tokio thread) **before** resolving, hold the reference ~2s afterward so internal Tokio tasks drop their references first, and add an `NSLock` around the node field on iOS. Read both diffs: `git show d416052cd` / `git show 0e2b89164`.
+
+The buildNode race (fixed 2026-05-17 in two commits three minutes apart): `createOnboardingWallet` builds the node, then Wallet.tsx `fetchData` re-runs on focus and calls into the module while native `buildNode` has **cleared the node reference up-front** and is rebuilding on a background queue — every call in that window rejects with "Node not initialized". Fix = *tolerate* rather than serialize: `b54e8f138` added `waitForLdkNodeReady` in `utils/LdkNodeUtils.ts`, which retries `status()` every 500 ms treating "Node not initialized" and "not running yet" as retryable; `8fc9698a0` added the `walletJustCreated` flag to skip redundant re-init. The docstring on `waitForLdkNodeReady` documents the race explicitly — that is the standard: a tolerated race must be written down at the tolerance point.
+
+**What counts as done:** the table exists in your PR description or analysis notes; every event×step cell is labeled serialized / tolerated (with the retryable error named) / unreachable (with the guard named); thread-affinity of native resource release is stated explicitly; you reproduced the bad interleaving at least once before the fix and not after.
+
+---
+
+## Recipe 2 — Migration correctness proof
+
+**When to use:** any change to `utils/MigrationUtils.ts`, `stores/SettingsStore.ts` load/save paths, keychain keys, or default values for existing users. Note: these changes are **gated** — maintainer sign-off plus a migration plan is mandatory (see zeus-change-control); this recipe produces the proof that goes in that plan.
+
+**Steps**
+
+1. **Enumerate the persisted-state space (rows).** Minimum rows for Zeus:
+   | # | State on disk before app launch |
+   |---|---|
+   | 1 | Fresh install — nothing stored |
+   | 2 | Legacy blob only — `zeus-settings` in EncryptedStorage, no v2 |
+   | 3 | v2 blob — `zeus-settings-v2` in keychain (the common case) |
+   | 4 | iCloud-restored device — old un-prefixed cloud-synced keychain entries exist, local `zeus:` entries do not |
+   | 5 | Multi-wallet — `settings.nodes[]` has several entries, mixed implementations |
+   | 6 | Post-duress — `settings.nodes` nulled but on-disk node dirs / Cashu DB / orphaned keychain copies survive |
+   Add rows for any state your change introduces. Columns = each migration function, in **actual execution order**.
+2. **Pin the execution order from the code, not from memory.** Verified order in `SettingsStore.getSettings`:
+   `keychainCloudSyncMigration()` runs **first**, before any settings read → then try `Storage.getItem('zeus-settings-v2')` → if present: `migrateRgsDefaultToZeus` + `migrateInvoiceExpiryDisplay` run on the parsed object → **else** fall back to legacy `zeus-settings` → `legacySettingsMigrations()` (the MOD_KEY chain) → `storageMigrationV2()`. Consequence: **a repair placed only in `legacySettingsMigrations` never runs for any user already on v2.**
+   ```bash
+   grep -n "keychainCloudSyncMigration\|legacySettingsMigrations\|storageMigrationV2\|migrateInvoiceExpiryDisplay" stores/SettingsStore.ts
+   ```
+3. **Prove each cell terminates in a valid state.** For every row × column: does the migration fire? If yes, is the result valid AND is the source state gone or harmless? If no, is skipping correct for that row?
+4. **Prove one-shot flag idempotency.** Each MOD_KEY block must be a no-op on second run (flag read → skip) and the flag must be set only after the mutation persisted (`await settingsStore.setSettings(...)` — un-awaited setSettings was a real bug, fixed in `d8e648b58`). Run the mental test "app killed between mutation and flag write": re-running the mutation must be safe.
+5. **Check the two poison patterns:** (a) passing a `JSON.stringify`'d payload to `setSettings` — corrupts the MobX observable (issue #4150, fixed `7ed901a10`, guarded by a test in `utils/MigrationUtils.test.ts` asserting the persisted argument is not a string); (b) shallow `updateSettings` merges destroying sibling keys in nested groups (see zeus-storage-and-migrations).
+
+**Worked example A — the #4149 double-repair (missing column cell).** `26d4215ea` (2026-05-30) added the "3600 hours" invoice-expiry display repair as `MOD_KEY9 = 'invoices-expiry-display-fix'` **inside `legacySettingsMigrations`** — which only executes when the v2 blob is absent (row 2). Every already-upgraded user (row 3, the majority) never ran it. The repair had to be shipped a second time: `e8e5b8811` (2026-06-01) moved it onto the v2 load path as the shared `migrateInvoiceExpiryDisplay` (removing the v1 MOD_KEY9 block) — under the ORIGINAL flag key. A third repair for pre-Feb-2024 installs that never stored `expirySeconds` then bumped the flag to `invoices-expiry-display-fix-v2` (`a7860aa96`, merged `f7b2c30a8`, PR #4149, 2026-06-08). The 6×N table makes the first miss a mechanical catch: cell (row 3 × repair) was empty. Bonus: the first attempt also passed `JSON.stringify(newSettings)` to `setSettings` — poison pattern (a) — later fixed by `7ed901a10`.
+
+**Worked example B — the iCloud keychain saga (missing row).** The dated timeline with hashes is owned by **zeus-failure-archaeology FA-1** — cite that, don't retell it. The proof-relevant lesson: the Dec 2025 migration rewrote keychain entries as local-only (`cloudSync: false`) but never deleted the old `kSecAttrSynchronizable` cloud copies, and row 4 of the table ("iCloud-restored new device") was never analyzed — on a new device, iCloud repopulated the old entries and the migration faithfully resurrected stale wallet data. Deletion attempts followed and were ultimately disabled. Current master policy: `deleteFromOldKeychain` in `utils/MigrationUtils.ts` is a deliberate no-op ("safety measure"); orphaned pre-migration copies persist by design and `utils/KeychainRecoveryUtils.ts` depends on them. **Do not "fix" this** — it is a policy decision, and reversing it goes through change control.
+
+The lesson for your table: a migration's source state is a **live replica** if the OS can regenerate it (iCloud sync). "Copied to new location" does not empty the source cell; either delete it (with its own proof) or document it as a permanent row.
+
+**What counts as done:** the full table with every cell justified; idempotency argument for each new flag (including kill-between-steps); explicit statement that both the legacy and v2 load paths are covered (or why one is N/A); jest cases in `utils/MigrationUtils.test.ts` for the new blocks; the plan reviewed under the storage-change gate.
+
+---
+
+## Recipe 3 — Dispatch-completeness audit
+
+**When to use:** adding a method to `utils/BackendUtils.ts`; adding a `supports*` capability; investigating a crash like `false.then is not a function` or a feature silently doing nothing on one backend.
+
+**Background (verified):** `BackendUtils.call(funcName)` returns **`false` synchronously** when the active backend class lacks the method — no throw, no rejected promise (`utils/BackendUtils.ts`, the `if (!cls[funcName]) return false;` line). `EmbeddedLND` and `LndHub` `extend LND`, so a method or flag **absent** from those two files is **inherited from LND**, not absent. The other four backends (`CLNRest`, `LdkNode`, `LightningNodeConnect`, `NostrWalletConnect`) are standalone.
+
+**Steps — the exact greps**
+
+```bash
+# 1. Does the dispatcher wrapper exist? (a typo'd name silently no-ops)
+grep -n "myMethod" utils/BackendUtils.ts
+
+# 2. Who implements or overrides it? Absence in EmbeddedLND.ts/LndHub.ts = inherited from LND.ts
+grep -n "myMethod" backends/*.ts
+
+# 3. Confirm the inheritance edges (do not assume)
+grep -n "extends" backends/*.ts     # EmbeddedLND extends LND; LndHub extends LND
+
+# 4. Every call site, and what gates it
+grep -rn "BackendUtils.myMethod(" views/ components/ stores/ utils/
+
+# 5. For each call site: is it reachable only behind a supports* gate?
+grep -rn "supportsMyFeature" views/ components/ stores/
+```
+
+Build the 7-row table for the method: for each of `lnd`, `embedded-lnd`, `ldk-node`, `lightning-node-connect`, `cln-rest`, `lndhub`, `nostr-wallet-connect`, label the method **implemented** (own definition), **deliberately absent** (explicit `=> false` override or no definition on a standalone class, with a gate protecting every call site), or **inherited-leak** (subclass of LND with no override where LND's behavior is wrong for it). Then prove every view call site is unreachable when the capability is false.
+
+**Worked example — the LndHub `supportsChannelFundMax` inherited-leak (present on master today).** Grep output: explicit `=> true` in `LND.ts`, `EmbeddedLND.ts`, `CLNRest.ts`, `LightningNodeConnect.ts`, `LdkNode.ts`; explicit `=> false` in `NostrWalletConnect.ts`; **no override in `LndHub.ts`** → LndHub inherits `true` from LND even though a custodial LNDHub account cannot fund channels at all. The only view call site is `views/OpenChannel.tsx`, and the leak is currently *latent* because LndHub sets `supportsChannelManagement = () => false`, which gates every route into that screen — but the flag itself is wrong, and any new call site trusting `supportsChannelFundMax()` alone would misbehave on LndHub. Classify, then either fix the override or record the masking gate. (Cross-backend crash history and the full capability matrix: zeus-backends-and-capabilities.)
+
+Second pattern worth grepping for — **dead dispatch**: `payLightningInvoiceStreaming` is declared in `utils/BackendUtils.ts` but implemented by zero backends (`grep -rn "payLightningInvoiceStreaming" backends/` returns nothing), so it always returns `false`. A completeness audit of a new method should confirm you did not just add another one of these.
+
+**What counts as done:** the 7-row table with a file:line evidence pointer per row; every call site listed with its gate; each inherited-leak either fixed (override added) or documented with the exact masking condition; for LND-family version-gated flags, a note on behavior **before** `getNodeInfo` resolves (version is unknown then).
+
+---
+
+## Recipe 4 — Amount / fee arithmetic verification
+
+**When to use:** anything that computes, converts, or displays an amount or fee — invoice creation, LSP wrapping, routing-fee limits, swaps, Cashu melts.
+
+**Steps**
+
+1. **Unit-trace the path.** Write every variable in the path with its unit annotated (`value: sats (string)`, `amount_msat: msat (number)`, …). Each `×1000` / `÷1000` must sit at a named boundary (usually the wire). A path with an unannotatable variable is unproven.
+2. **BigNumber everywhere.** Amount arithmetic uses `bignumber.js` (imported in 16+ utils/stores incl. `AmountUtils`, `Bolt11Utils`, `FeeStore`, `InvoicesStore`). Never use float math on msat values; msat quantities exceed float-safe display assumptions and decimal sats (e.g. `123.456` sats) are legal inputs.
+3. **Test the boundary values:** `0`, `1`, `999`, `1000`, `1001` sats (the fee-rule boundary), amounts with msat remainders (`x.5` sats), and fee == amount.
+4. **Know the fee rule (verified in `utils/FeeUtils.ts`):** `calculateDefaultRoutingFee(amount)` returns `amount * 0.05` rounded (`DEFAULT_ROUTING_FEE_PERCENT = 0.05`) when `amount > 1000` sats, but returns **the full amount** (i.e. a 100% fee limit) when `amount <= 1000` — tiny payments may cost up to themselves in routing fees. `views/PaymentRequest.tsx` mirrors the same boundary: `requestAmount > 1000` selects the percent fee option, otherwise fixed. Tests pinning this: `utils/FeeUtils.test.ts` (`1000 → '1000'`, `10000 → '500'`).
+5. **Check error-shape traps on the same path** — e.g. LND REST payment timeouts *resolve* success-shaped with `{payment_error: …}` (see zeus-backends-and-capabilities); an amount proof that ends at "the call resolved" has not proven payment.
+
+**Worked example — the Flow LSP wrapped-invoice amount mutation (`stores/InvoicesStore.ts` + `stores/LSPStore.ts`, verified on master).** Unit trace for "user requests an invoice for `value` sats with LSP enabled":
+
+| Step | Code | Unit |
+|---|---|---|
+| 1 | user input `value` | sats (string) |
+| 2 | `lspStore.getZeroConfFee(Number(new BigNumber(value).times(1000)))` | **msat** over the wire (`amount_msat` in the POST body) |
+| 3 | LSPStore stores `zeroConfFee = parseInt(fee_amount_msat / 1000)` | back to **sats** |
+| 4 | if `value > zeroConfFee`: `req.value = new BigNumber(value).minus(zeroConfFee)` | sats — **the created invoice is for less than the user asked** |
+| 5 | `getZeroConfInvoice(...)` wraps it; `jit_bolt11` replaces the payment request | — |
+| 6 | on wrap failure: silently fall back to the **unwrapped** invoice (error state cleared) | — |
+| 7 | lnurl-withdraw callback uses `qs.pr = jit_bolt11 || invoice.getPaymentRequest` | must be the wrapped one when it exists |
+
+Three provable claims fall out: (a) the msat↔sat conversions occur exactly at steps 2–3; (b) the amount the payer pays ≠ the amount the node receives, by design — any display or bookkeeping code comparing them must add `zeroConfFee` back; (c) step 6 means "invoice created" does not imply "channel will be opened" — degradation is silent. If your change touches this path, your proof must state which of the three it preserves.
+
+**What counts as done:** a unit-annotated trace table like the above in the PR; BigNumber (or integer msat) for every operation; a colocated jest test exercising the boundary set from step 3; no float appears between user input and wire encoding.
+
+---
+
+## Recipe 5 — Crypto / protocol conformance
+
+**When to use:** writing or modifying any encoder/decoder or key-derivation function — invoice parsing, TLV records, bech32 variants, signature schemes, seed→key paths.
+
+**Steps**
+
+1. **Prefer the spec's own vectors.** BOLT11 ships worked examples (`11-payment-encoding.md` in the lightning/bolts repo). Pin them as constants with a comment citing the source.
+2. **When the spec has no vectors, capture them from a reference implementation** (lnd/CLN decode output, or the library version currently in production) and pin the exact hex. The vector then *defines* the contract across future library swaps.
+3. **Test failure modes too:** truncated input, wrong prefix, bad checksum — assert the exact error.
+4. **If the decoder caches or lazies, test that behavior explicitly** — caching bugs are conformance bugs (a mutated cached object corrupts every later decode).
+
+**Where the known-good vectors live in this repo (all verified):**
+
+| File | What it pins |
+|---|---|
+| `utils/Bolt11Utils.test.ts` | BOLT11 **spec reference vectors** (the `lnbc2500u` hashed-description example and the no-amount example, with source URL in comments), including the expected payee pubkey `BOLT11_SPEC_PAYEE` recovered via secp256k1 signature recovery; regtest/signet fixtures; amount-prefix parsing (`1230n` = 123 sats = 123000 msat); **lazy-getter semantics** — a `jest.spyOn(secp, 'recoverPublicKey')` asserts recovery runs zero times unless `destination` is read, and exactly once when read repeatedly |
+| `utils/SigningUtils.test.ts` | secp256k1 DER-signature vectors, including the canonical `privKey = 1 → pubkey = G`, `hash = SHA256("")` case, plus invalid-key rejections |
+| `utils/VssAuthUtils.test.ts` | mnemonic → BIP-32 `m/130'/0'` VSS auth-key vectors, commented "captured against bip39@3.1.0 … MUST remain stable across any BIP-39 library swap" — the textbook example of step 2 |
+| `utils/ClinkUtils.test.ts` | `noffer` bech32-TLV round-trip tests with a local `encodeTLV` helper (round-trip style — weaker than pinned vectors; if you touch the wire format, add pinned hex) |
+| `utils/AddressUtils.test.ts`, `utils/CashuUtils.test.ts` | address-format and cashu-token fixtures for the input-router paths |
+
+**Worked example — verifying an invoice decode against BOLT11.** `utils/Bolt11Utils.ts` is a hand-rolled decoder (LRU-cached, with lazy self-replacing getters deferring signature recovery). Its conformance proof is exactly the pattern to copy: (1) spec vector in, assert every parsed field including the recovered `destination` equals the spec's stated payee; (2) realistic network fixtures (regtest `bcrt`, signet `tbs`) for prefixes the spec examples don't cover; (3) invalid string throws the exact message `'Not a proper lightning payment request'`; (4) the caching/laziness contract is itself under test — which is why "don't naively serialize/spread decoded invoices" (see zeus-lightning-reference) is an enforced property, not folklore.
+
+**What counts as done:** at least one spec-sourced vector (or reference-captured, provenance-commented), one repo-realistic fixture, and one invalid-input case; any caching/lazy behavior asserted; vectors are constants with a source citation, never generated inside the test.
+
+---
+
+## Recipe 6 — Regression proof (failing-test-first)
+
+**When to use:** every bug fix. CONTRIBUTING.md, Test Coverage section: *"Bug fixes should include a test that would have caught the bug."*
+
+**Steps**
+
+1. **Write the test before (or at worst, alongside) the fix, at the layer that owns the logic.** Reality check (verified): tests exist only for `utils/` (45 files), `models/` (2), and `lndmobile/channel.test.ts` — plus the repo-root `check-styles.test.ts` lint helper, 49 files total. `stores/`, `views/`, `components/`, `backends/` have **zero** coverage.
+2. **If the bug lives in an untested layer, extract the pure logic into `utils/` first, then test it there.** This is established repo practice, not a workaround — see the worked examples.
+3. **Demonstrate the test fails without the fix.** Temporarily undo the fix hunk in your working tree, run the single test, watch it fail, restore. State this in the PR ("test fails on pre-fix code").
+4. **Run the full gate:** `yarn verify` (jest + prettier + tsc + eslint, matching the 4 PR checks — anatomy and jest traps in zeus-validation-and-qa).
+5. The test must **encode the bug's mechanism, not its symptom** — assert the property whose violation caused the bug.
+
+**Worked examples (verified in git):**
+
+- **Extract-then-test:** invoice-expiry logic was extracted to `utils/ExpiryUtils.ts` (#3795, merged `3b4cdd0b5`, 2026-03-08); when the "3600 hours" bug was fixed (`26d4215ea`), the fix shipped with new cases in both `ExpiryUtils.test.ts` and `MigrationUtils.test.ts`. Similarly `d6af12ae4` ("extract signing utils, add test") pulled DER signing out of backend code into `utils/SigningUtils.ts` + vectors.
+- **Mechanism-encoding test:** the #4150 fix (`7ed901a10`) added a `MigrationUtils.test.ts` case asserting `settingsStore.setSettings` receives a **non-string object** (`expect(typeof persistedSettings).not.toBe('string')`) — guarding the entire "stringified payload corrupts the MobX observable" class, not just the one call site.
+- **Race fixed in an untestable layer:** `b54e8f138` placed the tolerance (`waitForLdkNodeReady`) in `utils/LdkNodeUtils.ts` — where a jest test *can* reach it — with the race documented in its docstring; companion commit `8fc9698a0` added the `walletJustCreated` skip flag.
+
+**What counts as done:** a colocated test that fails on pre-fix code and passes after; if the fix is in stores/views/backends, either extracted-and-tested pure logic or an explicit PR note that the layer is untestable and what manual test covered it (manual iOS+Android testing is mandatory regardless — zeus-change-control).
+
+---
+
+## Recipe 7 — Reproducible-build equivalence
+
+**When to use:** verifying a released APK matches the source; changing anything under `android/` that could affect determinism (Gradle config, packaging, dependencies); auditing the release pipeline.
+
+**How determinism is achieved (all verified by source read; the build itself was not executed for this document):**
+
+| Mechanism | Where |
+|---|---|
+| Builder image pinned by **sha256 digest** (`reactnativecommunity/react-native-android@sha256:c390bfb3…`) | `build.sh` |
+| `SOURCE_DATE_EPOCH` fixed (defaults to `0`) and exported into the container | `build.sh` |
+| `yarn install --frozen-lockfile` inside the container | `build.sh` |
+| Parallel Gradle **disabled** ("parallel execution causes non-deterministic file ordering") | `android/gradle.properties` (`org.gradle.parallel=false`) |
+| `tasks.withType(Zip) { reproducibleFileOrder = true; preserveFileTimestamps = false }` | `android/app/build.gradle` |
+| Release APKs are **unsigned**; per-ABI `versionCodeOverride = versionCode*1000 + {armeabi-v7a:1, x86:2, arm64-v8a:3, x86_64:4}` (base `versionCode 131` at this writing) | `android/app/build.gradle` |
+| Output: 5 renamed APKs (`app-` → `zeus-`, `-release-unsigned` stripped) + `sha256sum` per file | `build.sh` |
+
+The only `build.sh` flag is `--no-tty`. CI never runs this on PRs — `.github/workflows/build-android.yml` is `workflow_dispatch`-only. Android only; there is no iOS reproducible build.
+
+**Steps to verify equivalence (per `docs/ReproducibleBuilds.md` — read it first):**
+
+1. Clone the exact tag: `git clone --depth 1 --branch <tag> https://github.com/ZeusLN/zeus.git && cd zeus`
+2. `./build.sh` (requires Docker; add `--no-tty` in scripts/CI).
+3. Compare your `sha256sum` output against the GitHub release page hashes. The web-distributed APK is the `-universal` one.
+4. Hashes will **not** match the official signed APK byte-for-byte — the official one carries a signature. Unpack both and diff: `diffoscope`, `apksigcopier`, or `diff --brief --recursive ./unpacked_official ./unpacked_built`.
+5. **Equivalence claim = the only differences are the signing certificates** (META-INF signature files). Any other diff is a finding: trace it to a non-determinism source and check the table above for which mechanism failed.
+
+**Worked example:** the mechanisms table *is* the archaeology — each row exists because its absence produced non-identical builds (the `gradle.properties` comment records the parallel-ordering failure explicitly). When auditing a Gradle change, re-run the mental checklist: does it introduce a timestamp, an absolute path, a parallel task, or an unpinned input? Releases and commits are PGP-signed with key `AAC48DE8AB8DEE84` (`PGP.txt`) — hash comparison plus signature check is the full trust chain.
+
+**What counts as done:** two independent builds of the same tag produce identical sha256 sums; official-vs-built unpacked diff shows only signing material; any new build input is digest- or lockfile-pinned.
+
+---
+
+## Provenance and maintenance
+
+All facts verified **2026-07-06** against `master` @ `c5fd094fb` (v13.1.3-alpha). Commit hashes cited were confirmed with read-only `git show`/`git log` on first-parent master. Re-verify volatile facts before relying on them:
+
+| Fact | Re-verification command |
+|---|---|
+| Cited commits still exist / messages match | `git show -s --oneline d416052cd 0e2b89164 b54e8f138 8fc9698a0 c6323fff4 26d4215ea e8e5b8811 a7860aa96 7ed901a10 d8e648b58 3b4cdd0b5 d6af12ae4 f7b2c30a8` |
+| `call()` returns `false` for missing methods | `grep -n "return false" utils/BackendUtils.ts` |
+| Backend inheritance edges | `grep -n "extends" backends/*.ts` |
+| LndHub fund-max leak still present | `grep -n "supportsChannelFundMax" backends/*.ts` (fixed when LndHub.ts gains an override) |
+| `payLightningInvoiceStreaming` still dead | `grep -rn "payLightningInvoiceStreaming" backends/` (empty = still dead) |
+| Fee rule boundary (5% / ≤1000 sats) | `grep -n "DEFAULT_ROUTING_FEE_PERCENT\|amount > 1000" utils/FeeUtils.ts` |
+| Settings blob keys | `grep -n "STORAGE_KEY\b\|LEGACY_STORAGE_KEY" stores/SettingsStore.ts` |
+| Migration execution order | `grep -n "keychainCloudSyncMigration\|legacySettingsMigrations\|storageMigrationV2\|migrateInvoiceExpiryDisplay" stores/SettingsStore.ts` |
+| Keychain deletion still disabled (policy) | `grep -n "Skipping delete" utils/MigrationUtils.ts` |
+| Expiry-repair flag (v2 only; the v1 MOD_KEY9 block was removed by `e8e5b8811`) | `grep -n "invoices-expiry-display-fix-v2" utils/MigrationUtils.ts` |
+| Race-tolerance retry still in place | `grep -n "LDK_NODE_NOT_INITIALIZED\|LDK_NODE_NOT_RUNNING_YET" utils/LdkNodeUtils.ts` |
+| `fetchData` re-entrancy guard | `grep -n "fetchLock" views/Wallet/Wallet.tsx stores/SettingsStore.ts` |
+| Builder image digest / SOURCE_DATE_EPOCH | `grep -n "BUILDER_IMAGE\|SOURCE_DATE_EPOCH" build.sh` |
+| Gradle determinism settings | `grep -n "org.gradle.parallel" android/gradle.properties && grep -n "reproducibleFileOrder\|versionCodeOverride\|versionCode " android/app/build.gradle` |
+| build workflow still dispatch-only | `grep -n "workflow_dispatch" .github/workflows/build-android.yml` |
+| Test-coverage reality (count) | `find . -name "*.test.ts*" -not -path "./node_modules/*" -not -path "./zeus_modules/*" \| wc -l` (49 at this writing) |
+| BOLT11 spec vectors present | `grep -n "BOLT11_SPEC" utils/Bolt11Utils.test.ts` |
+| Regression-test rule in docs | `grep -n "would have caught the bug" CONTRIBUTING.md` |
+
+Labeled uncertainties: the LndHub `supportsChannelFundMax` leak is **latent** (masked by `supportsChannelManagement = false`) — reconfirm both flags before citing it; `versionCode 131` and the Docker digest change every release; execution of `build.sh` itself is verified by source read only.

--- a/.claude/skills/zeus-research-frontier/SKILL.md
+++ b/.claude/skills/zeus-research-frontier/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: zeus-research-frontier
+description: Load when the task is choosing or scoping research/roadmap work on Zeus — "what should we build next", "where can Zeus advance the state of the art", "is this feature/scheme novel", "can we claim X publicly", picking up stalled work (bip-321, android-16kb-page-size, LSPS7 refund UI, payLightningInvoiceStreaming), or writing external-facing claims (blog posts, release notes, conference talks, comparisons with other wallets). Covers the four maintainer-endorsed research directions (self-custodial UX parity, protocol leadership, multi-backend robustness, privacy leadership), candidate infrastructure problems, and the proof/reproducibility standards required before any public novelty claim.
+---
+
+# Zeus Research Frontier
+
+Open problems where Zeus can advance the state of the art in self-custodial Lightning wallets, plus the standards for claiming anything publicly. Four directions below are maintainer-endorsed (2026-07-06); everything labeled **candidate** or **open** is discovery output, not endorsed roadmap.
+
+## When to use / When NOT to use
+
+**Use this skill when:**
+- Deciding what research or frontier work to pick up next in this repo.
+- Picking up a stalled thread named here (LSPS7 refund UI, `bip-321` branch, `payLightningInvoiceStreaming`, `android-16kb-page-size`, NUT-15 upstreaming).
+- Writing anything external-facing that makes a claim about Zeus (novelty, "first", benchmarks, privacy properties).
+- Evaluating whether a feature idea is genuinely novel vs. already known in the ecosystem.
+
+**Do NOT use this skill for:**
+- *How* to turn a hunch into an accepted change (evidence bar, idea lifecycle) → **zeus-research-methodology**.
+- Concrete analysis recipes (race analysis, dispatch audits, migration proofs) → **zeus-proof-and-analysis-toolkit**.
+- The node-lifecycle-races problem specifically → **zeus-node-lifecycle-campaign** (it has its own executable campaign).
+- Backend capability mechanics and adding an RPC → **zeus-backends-and-capabilities**.
+- Storage/migration changes (several steps below touch defaults or persisted data — those are gated) → **zeus-storage-and-migrations** and **zeus-change-control**.
+- Domain theory (what BOLT12/LSPS/Cashu *are* in depth) → **zeus-lightning-reference**. This skill defines terms only enough to scope the work.
+
+## Glossary (first-use definitions)
+
+| Term | Meaning here |
+|---|---|
+| LSP | Lightning Service Provider — a well-connected node that sells inbound capacity (channels) to wallets |
+| LSPS1 / LSPS7 | Interop specs for buying channels from an LSP (LSPS1) and extending a channel lease (LSPS7) |
+| JIT channel | "Just-in-time" channel an LSP opens while a payment is in flight, so a fresh wallet can receive |
+| BOLT11 / BOLT12 | Lightning invoice formats; BOLT12 "offers" are static, reusable payment codes |
+| NWC | Nostr Wallet Connect (NIP-47) — remote-control a wallet over nostr relays |
+| Cashu / ecash / NUT-15 | Chaumian ecash protocol; a "mint" is its custodian; NUT-15 = paying one invoice from multiple mints via MPP |
+| MPP | Multi-part payment — one invoice paid in several HTLC shards |
+| CLINK / noffer | Nostr-based payment negotiation (`noffer1…` bech32 codes, kind-21001 events) |
+| BIP-321 | Successor to BIP-21 `bitcoin:` payment URIs (unified on-chain + Lightning QR) |
+| hodl invoice / preimage | Invoice whose settlement is deferred until a chosen secret (preimage) is released — lets a third party hold payments for an offline wallet |
+| Tor / .onion | Anonymity network / its hidden-service addresses; Zeus embeds Tor via `react-native-nitro-tor` |
+| Embedded node | A full Lightning node compiled into the app: `embedded-lnd` (Go, gomobile) or `ldk-node` (Rust, uniffi) |
+| supports\*() | Per-backend capability flags in `backends/*.ts`, dispatched through `utils/BackendUtils.ts` — the gate for every feature |
+
+---
+
+## Direction 1 — Self-custodial UX parity (zero-config receive, background payments, swaps)
+
+**Why current SOTA fails.** Custodial wallets receive instantly with zero setup and work while the app is closed. Self-custodial mobile wallets need inbound liquidity (a channel) before first receive, and the node is offline whenever the OS suspends the app — so unattended receive/pay is unreliable. No shipping wallet has closed both gaps without custody.
+
+**Zeus's specific assets.**
+- Two embedded node engines behind one UI: `embedded-lnd` (gomobile AAR/xcframework) and `ldk-node` (uniffi FFI, ZeusLN fork `v0.7.0-zeus-pathfinder-config` per `fetch-libraries-versions.json`).
+- A three-generation LSP stack in `stores/LSPStore.ts`: Olympus Flow 2.0 REST (default `https://0conf.lnolymp.us`, JIT invoice wrapping via `jit_bolt11`), LSPS1 over three transports (custom message type `37913`, REST, native — chosen per backend via `supportsLSPScustomMessage` / `supportsLSPS1rest` / `supportsLSPS1native`), and LSPS7 lease extension (`supportsLSPS7native`, currently `true` only on `backends/LdkNode.ts`).
+- ZEUS Pay lightning address (`stores/LightningAddressStore.ts`) with three receive modes — `zaplocker`, `cashu`, `nwc` — giving offline receive without custody of keys.
+- Boltz-protocol swaps (`stores/SwapStore.ts`, default host `https://swaps.zeuslsp.com/api/v2` defined in `stores/SettingsStore.ts`) with deterministic rescue keys (`DERIVATION_PATH = 'm/44/0/0/0'`).
+
+**First three concrete steps in this repo.**
+1. **Finish LSPS7.** The refund-address UI in `views/LSPS7/index.tsx` is disabled behind `{false && (` with the comment `TODO add conditions for refund onchain address` (search: `grep -n "false && (" views/LSPS7/index.tsx`). Note `state.refundOnchainAddress` is ALREADY plumbed into both LSPS7 order paths (`stores/LSPStore.ts` lines ~1174 and ~1207); because the input is fenced, the value is always `''`. The remaining work is defining when the LSP requires a refund address and enabling the fenced input block — not re-implementing the wiring.
+2. **Measure NWC background delivery before changing it.** `stores/NostrWalletConnectStore.ts` (3232 lines, zero tests) runs the wallet-service side; iOS keep-alive is a background-audio hack (`ios/zeus/NWCAudioKeepAlive.m` + bundled ambient `.m4a` files in `ios/zeus/`), Android uses a persistent foreground service gated by the AsyncStorage flag `persistentNWCServicesEnabled` (constant `NWC_PERSISTENT_SERVICE_ENABLED` in the store). Build a delivery-success-rate harness (N payment attempts against a backgrounded device, per platform, per keep-alive mode) so improvements are measurable. Measurement recipes: **zeus-diagnostics-and-tooling**.
+3. **Map the fresh-install receive funnel.** Instrument the path from new embedded wallet → first receive: `views/Wallet/Wallet.tsx` post-connect LSP init (`getLSPInfo`, `initChannelAcceptor`), Flow JIT wrapping in `stores/LSPStore.ts` (note: wrapping mutates the invoice amount by subtracting the zero-conf fee and silently degrades to unwrapped on failure), and `views/Receive.tsx`. Record where users stall and what fees they pay.
+
+**You have a result when:** a fresh install on both platforms receives a Lightning payment within a bounded time (pick and publish the bound, e.g. 5 minutes) with zero manual channel-management screens, and the measured all-in fee vs. a custodial baseline is documented. Falsified if any step requires the user to understand channels, or if background NWC payment delivery stays below the published target rate.
+
+---
+
+## Direction 2 — Protocol leadership (BOLT12, Cashu NUT-15, CLINK, BIP-321)
+
+**Why current SOTA fails.** BOLT12 offers barely exist on mobile: receiving to an offer needs an online node with blinded-path support, so most wallets ship nothing. Multimint ecash payments (NUT-15) are unimplemented in mainstream client libraries. Unified payment URIs (BIP-321) are stalled ecosystem-wide.
+
+**Zeus's specific assets.** Offers already work on two backends — `supportsOffers()` is `true` only in `backends/CLNRest.ts` and `backends/LdkNode.ts` (verify: `grep -rn supportsOffers backends/`); Zeus maintains its own ldk-node fork; the Cashu integration is CDK-FFI-based with a working NUT-15 client that CDK itself lacks.
+
+**Concrete threads, file-level.**
+- **BOLT12 beyond cln-rest/ldk-node.** LDK Node cannot persist offers — `listOffers` in `backends/LdkNode.ts` hard-returns `{ offers: [] }` with the comment "LDK Node doesn't store offers natively". Local offer persistence (per-node, keychain- or SQLite-backed) is the missing piece for real offer management on the embedded backend. Any persisted-key addition is a gated storage change → **zeus-storage-and-migrations**.
+- **Cashu multimint NUT-15 — upstream or standardize.** `stores/CashuStore.ts` `queryMeltQuoteMpp` bypasses CDK entirely, POSTing raw `{mint}/v1/melt/quote/bolt11` with `options.mpp`, then classifying rejections (`classifyMppRejection`). CDK is pinned at `0.14.2` (`fetch-libraries-versions.json`). Either upstream multimint melt to CDK (removing the bypass) or publish the probe/rejection-classification approach as a client-interop note.
+- **CLINK/noffer.** `utils/ClinkUtils.ts`: `noffer1…` bech32 TLV, `CLINK_KIND = 21001`, NIP-44 encryption, and a hard `ONION_NOT_SUPPORTED` error (no .onion relay support — overlaps Direction 4).
+- **BIP-321 pickup.** Local branch `bip-321` (one commit `3c1210922`, 2025-08-20, unmerged: `git branch --list bip-321`; diff vs master touches `views/Receive.tsx`, `utils/AmountUtils.ts` + test, `stores/InvoicesStore.ts`). Concrete pickup: rebase onto current master and re-test the receive flow.
+- **`payLightningInvoiceStreaming` — resolve the dead dispatch.** Declared in `utils/BackendUtils.ts` but implemented by NO backend (verify: `grep -rn payLightningInvoiceStreaming backends/ utils/` — only BackendUtils hits). Because missing methods return sync `false` (see Direction 3), every call would silently no-op. Decide: delete the wrapper, or implement streaming payment progress on the LND family. This is a design decision to surface to the maintainer, not a drive-by fix — payment-path changes must be minimal diffs (**zeus-change-control**).
+
+**First three steps:** (1) rebase and revive `bip-321`; (2) write the maintainer proposal for `payLightningInvoiceStreaming` (delete vs. implement, with call-site evidence); (3) open the CDK upstream issue for multimint melt with Zeus's `queryMeltQuoteMpp` as the reference client.
+
+**You have a result when:** (a) a mainnet BOLT12 offer created on an embedded ldk-node wallet survives app restart and receives a payment from a third-party wallet, or (b) the NUT-15 bypass is deleted because an upstream CDK release covers it, or (c) BIP-321 receive ships and a third-party wallet parses the QR. Each is binary and externally checkable.
+
+---
+
+## Direction 3 — Multi-backend robustness (the 7-backend matrix, crash-free)
+
+**Why current SOTA fails.** No other wallet drives 7 heterogeneous backends (`embedded-lnd`, `ldk-node`, `lnd`, `lightning-node-connect`, `cln-rest`, `lndhub`, `nostr-wallet-connect`) behind one UI. The cost is silent capability drift: `BackendUtils.call()` returns **synchronous `false`** when the active backend lacks a method (`utils/BackendUtils.ts`: `if (!cls[funcName]) return false;`), so a typo'd or unimplemented dispatch never throws — it no-ops, and `false.then(...)` crashes at the call site. Missing `supports*` gates are historically the top cross-backend crash source.
+
+**Zeus's specific assets.** The `supports*` capability system already exists: 55 distinct `supports*` flags dispatched through `utils/BackendUtils.ts` (count: `grep -o 'supports[A-Za-z0-9]*' utils/BackendUtils.ts | sort -u | wc -l`), including composites like `supportsLightningAddress = supportsCustomPreimages() || supportsCashuWallet()` computed in the dispatcher itself.
+
+**First three concrete steps in this repo.**
+1. **Dispatch-completeness audit tooling.** Mechanically enumerate every wrapper in `utils/BackendUtils.ts`, check which of the 7 backend classes implement it, and flag call sites lacking a `supports*` guard. Known true-positive the tool must catch: `payLightningInvoiceStreaming` (zero implementers); known cosmetic finding: `backends/NostrWalletConnect.ts` declares `supportsLSPS1customMessage` (typo — the dispatched name is `supportsLSPScustomMessage`; harmless only because both resolve to `false`). The audit recipe with worked examples lives in **zeus-proof-and-analysis-toolkit** — build the runnable version there, not here.
+2. **Store test scaffolding.** There are zero tests under `stores/` today — all 49 test files live in `utils/` (45), `models/` (2), `lndmobile/` (1), plus root `check-styles.test.ts` (verify: `ls stores/*.test.ts` → no matches). Start with a keychain-mocking harness for `SettingsStore` (everything depends on it), then the dispatch-heavy stores. Jest ESM/transform traps → **zeus-validation-and-qa**.
+3. **Typed dispatcher (candidate design, not started).** Replace the stringly `call(funcName: string)` with a typed interface over the backend classes so a missing implementation is a compile error, and absence must be expressed as an explicit capability. This changes payment-path plumbing — proposal first, minimal diff, maintainer sign-off (**zeus-change-control**).
+
+**You have a result when:** the audit tool runs in CI and reports zero dispatched methods that are both unimplemented on some backend AND unguarded by `supports*` at every call site — and adding a new unguarded wrapper fails the build. Falsified if the tool exists but the matrix still produces a missing-method crash in release testing.
+
+---
+
+## Direction 4 — Privacy leadership (Tor gaps, TLS defaults, ecash, stealth)
+
+**Why current SOTA fails.** "Tor support" in wallets is usually partial: some code paths route through Tor, others silently leak to clearnet, and users can't tell the difference. Zeus is closest to full Tor-by-default among self-custodial wallets but has verified gaps.
+
+**Verified gaps in this repo (2026-07-06).**
+| Gap | Evidence | Verify |
+|---|---|---|
+| WebSocket streams bypass Tor entirely | `backends/LND.ts` constructs `new WebSocket(url, …)` directly in 4 places; only the REST path goes through `doTorRequest` | `grep -n "new WebSocket" backends/LND.ts` |
+| .onion LNURL params unfetchable | 3 identical `// TODO handle fetching of params with internal Tor` sites | `grep -rn "internal Tor" utils/ components/` → `utils/handleAnything.ts`, `components/LayerBalances/LightningSwipeableRow.tsx`, `components/LayerBalances/EcashSwipeableRow.tsx` |
+| TLS verification OFF by default | `@observable certVerification: boolean = false` in `stores/SettingsStore.ts`; passed as `trusty: !certVerification` to react-native-blob-util | `grep -n "certVerification: boolean = " stores/SettingsStore.ts` |
+| CLINK refuses .onion relays | `ONION_NOT_SUPPORTED` error in `utils/ClinkUtils.ts` | `grep -n ONION_NOT_SUPPORTED utils/ClinkUtils.ts` |
+
+**Zeus's specific assets.** Embedded Tor (`react-native-nitro-tor` `0.6.0` in `package.json`); the hardened Tor TLS rule (cert bypass only for HTTPS .onion — the invariant and its incident history belong to **zeus-failure-archaeology** FA-5); Android Stealth Mode (three disabled-by-default `activity-alias` app disguises — calculator, VPN, QR scanner — in `android/app/src/main/AndroidManifest.xml`); an ecash small-balance model already wired (`settings.ecash` defaults in `stores/SettingsStore.ts`: `enableCashu: false`, `enableMultiMint: false`, `automaticallySweep: false`, `sweepThresholdSats: 10000` — ecash holds small change, auto-sweeps to Lightning above threshold).
+
+**First three concrete steps in this repo.**
+1. **Close the .onion LNURL gap:** implement Tor fetching of LNURL params at the 3 TODO sites using `utils/TorUtils.ts` (`doTorRequest`), respecting the .onion-HTTPS-only TLS rule.
+2. **Route or fence the WebSocket gap:** either proxy `backends/LND.ts` WS streams through the embedded Tor SOCKS layer, or make the UI state explicitly that streaming falls back to clearnet when Tor is enabled — today it leaks silently.
+3. **`certVerification` default-flip campaign:** flipping the default to `true` for existing users is a settings-default change requiring a MOD_KEY migration and maintainer sign-off — scope the breakage first (self-signed home-node certs are the common case), design the migration + UX (pin-on-first-use?), and route through **zeus-storage-and-migrations** + **zeus-change-control**. Do not just flip the initializer.
+
+**You have a result when:** with Tor enabled, a full send+receive+stream session on a device under packet capture shows zero clearnet connections (WS included), and the LNURL flows work against a .onion service. Falsified by a single observed clearnet packet.
+
+---
+
+## Candidate infrastructure problems (discovery output — NOT maintainer-endorsed roadmap)
+
+| Problem | Status | Evidence / verify |
+|---|---|---|
+| Supply-chain hash gaps in `fetch-libraries.sh` | **candidate** | CDK and zeus-cashu-restore SHA256 checks are conditional: `[ -n "$CDK_ANDROID_SHA256" ]` etc. — an empty hash field in `fetch-libraries-versions.json` silently skips verification (all four hashes ARE currently populated: `cat fetch-libraries-versions.json`). Worse: the uniffi binding SOURCE downloads (`CashuDevKit.swift`, `zeus_cashu_restore.swift`/`.kt` — `grep -n curl fetch-libraries.sh`) have no checksum at all. Fix = pin binding-source hashes + fail on empty hash. Maintainer intent unknown (open question: deliberate dev escape hatch?). |
+| `android-16kb-page-size` branch | **open/stalled** | Single commit `fa2212457` (2025-10-10), touches 3 gradle files, unmerged; `android/check_elf_alignment.sh` exists in master but no build script invokes it (`grep -rn check_elf_alignment --include='*.gradle' --include='*.yml' .` → no hits). Google Play's 16 KB page-size requirement makes this time-sensitive — check current Play policy before scoping. |
+| Test coverage for the 5 largest untested stores | **candidate** (feeds Direction 3 step 2) | `wc -l stores/*.ts \| sort -rn \| head`: `CashuStore.ts` 5591, `NostrWalletConnectStore.ts` 3232, `SettingsStore.ts` 2248, `LightningAddressStore.ts` 1486, `LSPStore.ts` 1330 — all with zero tests. |
+
+---
+
+## External positioning: novelty claims and proof obligations
+
+Three things in Zeus are *candidates* for genuine novelty. For each, the proof obligation before ANY public "first"/"only" claim:
+
+| Candidate claim | What's actually in the repo | Known prior art to check | Proof obligation before claiming |
+|---|---|---|---|
+| Self-custodial lightning address at scale (ZEUS Pay zaplocker mode) | `stores/LightningAddressStore.ts`: 250 pre-generated preimages, schnorr-signed hash submission to `zeuspay.com`, redemption by creating an invoice with a fixed preimage, nostr kind-`55869` attestations (>1 attestation per hash = fraud signal). Requires `supportsCustomPreimages()` (true on LND family only). | The Zaplocker scheme itself is supertestnet's prior work — Zeus's contribution is the production implementation + attestation-based fraud detection, NOT the scheme | Prior-art survey vs. Zaplocker repo and any LSP-held-invoice services; then claim "production deployment of" not "invention of" |
+| Multimint NUT-15 MPP melt (pay one invoice from multiple mints) | `stores/CashuStore.ts` `queryMeltQuoteMpp` + per-mint NUT-15 probing and rejection classification, bypassing CDK | NUT-15 is specified; nutshell implements the mint side. Survey client wallets (Minibits, eNuts, cashu-ts consumers) for client-side multi-mint orchestration before claiming first | Working mainnet demo across ≥2 public mints, reproducible by a third party from a tagged release |
+| NWC as a full wallet backend (not just a service) | `backends/NostrWalletConnect.ts` is one of the 7 dispatched backends; Zeus is simultaneously an NWC wallet-service (`stores/NostrWalletConnectStore.ts`) | Alby Go and others are NWC-native clients — "NWC as one of N interchangeable backends" is the defensible framing, plain "NWC client" is not novel | Comparative table vs. named wallets, dated |
+
+**Standing proof obligations for ANY published claim:**
+1. **Prior-art survey artifact** — dated, named projects checked, kept with the claim. No survey → no novelty claim.
+2. **Third-party reproducibility** — the demo must work from a public tagged release, on mainnet where applicable, without Zeus-internal infrastructure knowledge.
+3. **Verifiable builds** — Android releases are reproducible via `./build.sh` (Docker image pinned by sha256 digest, `SOURCE_DATE_EPOCH=0`; procedure in `docs/ReproducibleBuilds.md` — **Android only, there is no iOS reproducibility story**; don't imply one). Releases/commits are PGP-signed — key fingerprint `96C225207F2137E278C31CF7AAC48DE8AB8DEE84` (long ID `AAC48DE8AB8DEE84`, `PGP.txt`).
+4. **AGPLv3 obligations** (see `LICENSE`): derivative works and network-served modifications must publish source. Any published benchmark/claim about Zeus must be checkable from the public repo.
+5. **No-oversell rule:** "Zeus supports X" is only claimable when a `supports*` gate returns `true` on at least one shipping backend AND the feature passed the maintainer's mandatory hands-on iOS+Android testing. Benchmarks ship with methodology. Disabled code (`{false && ...}`), stalled branches, and dead dispatches are never "supported" — they are "in progress" at most. When in doubt, the framing standard is Bitcoin-Core-style conservatism: understate, link evidence.
+
+---
+
+## Provenance and maintenance
+
+Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha) by direct file reads and read-only commands in this repo. Maintainer endorsement of the four directions dated 2026-07-06. Expensive claims (build reproducibility procedure) verified by source read of `build.sh`/`docs/ReproducibleBuilds.md`, not executed.
+
+Re-verify volatile facts before relying on them:
+
+| Fact | Re-verify with |
+|---|---|
+| LSPS7 refund UI still disabled | `grep -n "false && (" views/LSPS7/index.tsx` |
+| `payLightningInvoiceStreaming` still unimplemented | `grep -rn payLightningInvoiceStreaming backends/ utils/` (backends/ hits = implemented) |
+| Offers backends (cln-rest, ldk-node only) | `grep -rn "supportsOffers" backends/` |
+| LDK Node offers not persisted | `grep -n -A2 "listOffers" backends/LdkNode.ts` |
+| NUT-15 CDK bypass still present | `grep -n "v1/melt/quote/bolt11" stores/CashuStore.ts` |
+| CDK / ldk-node / lnd pinned versions | `cat fetch-libraries-versions.json` |
+| Empty-hash skip + unchecked binding downloads | `grep -n 'SHA256" ]' fetch-libraries.sh; grep -n curl fetch-libraries.sh` |
+| Stalled branches exist | `git branch --list \| grep -E 'bip-321\|16kb'` |
+| Zero store tests | `ls stores/*.test.ts` (expect: no matches) |
+| Largest untested stores | `wc -l stores/*.ts \| sort -rn \| head -6` |
+| `certVerification` default | `grep -n "certVerification: boolean = " stores/SettingsStore.ts` |
+| WS-bypasses-Tor | `grep -n "new WebSocket" backends/LND.ts` |
+| .onion LNURL TODO count (3) | `grep -rn "internal Tor" utils/ components/` |
+| ecash defaults (enableCashu false, sweep 10000) | `grep -n -A4 "ecash: {" stores/SettingsStore.ts` |
+| CLINK kind 21001 / onion unsupported | `grep -n "CLINK_KIND\|ONION_NOT_SUPPORTED" utils/ClinkUtils.ts` |
+| supports\* flag count (55) | `grep -o 'supports[A-Za-z0-9]*' utils/BackendUtils.ts \| sort -u \| wc -l` |
+| NWC typo flag | `grep -n supportsLSPS1customMessage backends/NostrWalletConnect.ts` |
+| nitro-tor version (0.6.0) | `grep -n nitro-tor package.json` |
+| PGP key fingerprint | `gpg --show-keys PGP.txt` |
+| Zaplocker constants (250 preimages, kind 55869, zeuspay.com) | `grep -n "i < 250\|55869\|zeuspay.com" stores/LightningAddressStore.ts` |
+| Stealth aliases disabled by default | `grep -n -A2 activity-alias android/app/src/main/AndroidManifest.xml` |
+| Reproducible-build pins | `head -12 build.sh` |

--- a/.claude/skills/zeus-research-methodology/SKILL.md
+++ b/.claude/skills/zeus-research-methodology/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: zeus-research-methodology
+description: The discipline that turns a hunch into an accepted change in Zeus — or a documented retirement. Load BEFORE proposing a fix for a bug whose cause you have not proven, designing an experiment or feature rollout, deciding whether a hypothesis is confirmed, promoting an experimental setting to default, deprecating/removing a flag or feature, or deciding when to abandon an investigation. Triggers/symptoms - "I think the cause is X", "should this be behind a flag", "can we make this the default now", "is this feature dead, can I delete it", "how do I prove this fix works", "my fix works on my machine", "when do I give up on this bug", "where do Zeus features come from", "hypothesis", "experiment", "root cause", "retire this setting".
+---
+
+# Zeus Research Methodology
+
+How an idea (a bug hypothesis, a feature, a protocol integration) becomes an accepted change in Zeus — a React Native Bitcoin/Lightning wallet — or gets retired with a paper trail. Zeus moves real money across 7 node backends on 2 mobile platforms with near-zero automated test coverage outside `utils/`; the methodology below is what has actually kept quality up, reconstructed from the repo's own history. Every stage, rule, and example here is verifiable with the commands in the final section.
+
+Glossary (defined once, used throughout):
+
+- **Backend** — one of the 7 node implementations Zeus can drive: embedded LND, LDK Node (both on-device), remote LND REST, Lightning Node Connect (LNC), CLNRest, LndHub, Nostr Wallet Connect (NWC). Details: zeus-backends-and-capabilities.
+- **Settings blob** — the single keychain JSON object (key `zeus-settings-v2`) holding ALL settings and wallet secrets. **MOD_KEY migration** — Zeus's one-shot settings-migration pattern: a flag key checked in legacy storage, mutate settings, persist, set flag (see `utils/MigrationUtils.ts`; recipes live in zeus-storage-and-migrations).
+- **Fresh vs migrated user** — a new install gets the inline defaults in `stores/SettingsStore.ts`; an upgrading user gets defaults *as rewritten by migrations*. The two populations can legitimately diverge (worked example in Section 2).
+- **`supports*()` capability flag** — per-backend boolean method gating features; views must branch on these, never on the backend name.
+- **LSP / LSPS1 / LSPS7** — Lightning Service Provider (sells inbound channel capacity); LSPS1/LSPS7 are the standardized channel-purchase/extension protocols.
+- **Pathfinding (apriori / bimodal)** — LND's two payment-route probability estimators; bimodal is the newer experimental one.
+- **Bolt / SQLite** — the two on-disk database backends of embedded LND.
+- **Fabric / New Architecture** — React Native's re-written rendering layer, ON in Zeus since RN 0.83.1; old layout/animation patterns can crash under it.
+- **Same-day revert** — Zeus's release-pressure policy: a regression found in release testing is reverted, not forward-fixed (policy owned by zeus-change-control).
+
+## When to use / When NOT to use
+
+USE this skill for: the evidence bar for claiming a root cause or a working fix; how to design an experiment (prediction-first); the observed lifecycle idea → flag → default → retirement; retirement/deprecation discipline; where ideas come from; the hypothesis template and promotion checklist; when and how to stop.
+
+Do NOT use this skill for — go to the sibling instead:
+
+| Need | Sibling skill |
+|---|---|
+| The actual gates/sign-offs/PR mechanics your promoted change must pass | zeus-change-control |
+| Writing the migration your default-change needs | zeus-storage-and-migrations |
+| Adding the setting itself (defaults, options, checklist) | zeus-config-and-flags |
+| Live-debugging a symptom right now (triage tables) | zeus-debugging-playbook |
+| Formal analysis machinery (race analysis, migration proofs) | zeus-proof-and-analysis-toolkit |
+| Full incident narratives with evidence chains | zeus-failure-archaeology |
+| What counts as test evidence, jest mechanics | zeus-validation-and-qa |
+| Open problems worth researching / external claim standards | zeus-research-frontier |
+
+## 1. The evidence bar
+
+A hypothesis about a Zeus bug, and a fix for it, are ACCEPTED only when all three hold:
+
+### 1a. One mechanism explains ALL observations — including the negatives
+
+If your mechanism explains why the bug happens on Android but not why it *doesn't* happen on iOS, you don't have the mechanism yet. Negative observations (backends/platforms/paths where the bug does NOT reproduce) are constraints, not noise.
+
+Repo-history motivation: the invoice-expiry migration bug produced "3600 hours" displays only for *upgraded* users, never fresh installs — a repair first shipped in `26d4215ea` (2026-05-30) covering only the legacy load path, and had to be shipped **again** (`e8e5b8811`, 2026-06-01, "run invoice expiry display repair on zeus-settings-v2 path") because the first pass missed that settings load through two distinct code paths (modern `zeus-settings-v2` vs legacy) in `stores/SettingsStore.ts getSettings`. A mechanism that had explained "why only some users" fully would have named both paths the first time.
+
+### 1b. Predictions are written down BEFORE the experiment runs
+
+State the observable outcome your hypothesis entails, with numbers, before you run anything. Format:
+
+> If [mechanism] is the cause, then [concrete experiment] must produce [observable outcome with a threshold], and [control experiment] must NOT.
+
+Example of the required specificity: "If the in-flight request dedup cache is the cause, the second identical request must return in <5ms with the *same* error object instance; after `clearCachedCalls()` it must take network time again."
+
+A prediction you write after seeing the data is a description, not a test. If the outcome surprises you, the hypothesis is wrong or incomplete — do not quietly widen it to fit; write a new prediction and re-run.
+
+### 1c. The fix survives ASSIGNED adversarial refutation
+
+Before promotion, someone other than the author — a reviewer, or an AI model given this instruction verbatim — is assigned to actively try to BREAK the fix, not confirm it. The refutation sweep, in priority order (each item has caught or would have caught a real Zeus incident):
+
+| Attack axis | What to try | Real miss it targets |
+|---|---|---|
+| Other 6 backends | Does the fix assume methods/semantics only your backend has? Does a `supports*` flag gate it? Check inherited flags: LndHub extends LND and silently inherits `supportsChannelFundMax = true` with no override (verify: `grep supportsChannelFundMax backends/LndHub.ts` returns nothing) | Missing capability gates are historically the top cross-backend crash source |
+| Both platforms | Run it on iOS AND Android hardware; Fabric rendering, keychain, and background behavior all differ | RN New-Arch fallout; iCloud is iOS-only |
+| Upgrade paths | Fresh install AND legacy→v2 migrated AND already-on-v2 upgraded user; both settings load paths | Invoice-expiry repair re-shipped (`e8e5b8811`; first pass `26d4215ea` covered only the legacy path); iCloud fix left stale synced copies for upgraders, needing a third migration (`46f2bac00`, 2026-01-14) |
+| Re-entrancy/lifecycle | Trigger the flow twice fast; background/foreground mid-flow; kill/restart | `fdad118ed` lifecycle refactor (2025-10-24) caused infinite loading, found only 3 weeks later (`93227029e`) |
+| Revert the fix | Does the bug come back on demand? If you can't re-trigger the bug without the fix, you haven't proven the fix did anything | General |
+
+Record the refutation attempts and their outcomes in the PR description. "I tried to break it via X, Y, Z and failed" is evidence; "works for me" is not.
+
+## 2. The idea lifecycle observed in this repo
+
+Zeus does not have a written RFC process. The observed, repeated lifecycle is:
+
+```
+discussion → experiment behind a setting (default OFF) → default ON (fresh installs)
+   → [bug or obsolescence] → migrate existing users' default via MOD_KEY migration
+   → retire: flag marked optional + "// deprecated", RETAINED in the blob forever
+```
+
+**Stage 0 — discussion-first.** `CONTRIBUTING.md` ("Share Early, Share Often"): open an issue to discuss the approach before writing code for significant changes; discuss new dependencies with maintainers BEFORE adding them. Gates and mechanics: zeus-change-control.
+
+**Stage 1 — experiment behind a default-off setting.** New risky behavior lands as an opt-in boolean in the settings blob with an inline default in `stores/SettingsStore.ts`. Adding the setting correctly (shallow-merge trap, defaults): zeus-config-and-flags.
+
+**Stage 2 — promote the default.** Flip the inline default (affects fresh installs only) and, if existing users should follow, ship a MOD_KEY migration (zeus-storage-and-migrations owns the recipe; the migration MUST pass a real object to `setSettings`, never a `JSON.stringify`'d one — that corrupted MobX observables, fixed in `7ed901a10`, #4150).
+
+**Stage 3 — demote or retire.** When upstream bugs or product decisions kill the experiment: migrate existing users OFF via a new MOD_KEY, and/or mark the flag deprecated-but-retained (Section 3).
+
+### Worked example A: `bimodalPathfinding` (full lifecycle; all hashes reachable from master `c5fd094fb`)
+
+| Date | Commit | Stage |
+|---|---|---|
+| 2023-08-07 | `cc735f923` | Introduced as opt-in, default `false` (experiment) |
+| 2023-10-03 | `519dea9ad` | Promoted: default `true` |
+| 2024-09-16 | `88dd94abe` | Demoted for existing users: "switch to apriori pathfinding for now" — MOD_KEY migration `bimodal-bug-9085` flips migrated users to `false` because of upstream bug lnd#9085 (URL in the code comment, `utils/MigrationUtils.ts`) |
+| today | — | Fresh-install default remains `true` (`grep bimodalPathfinding stores/SettingsStore.ts`) while users who ran the migration stay `false` — a **deliberate fresh-vs-migrated divergence**, not a bug |
+
+Lessons: upstream bugs demote experiments without deleting them; MOD_KEY migrations are the tool for touching existing users; fresh/migrated divergence is an accepted end state (second known case: `showMillisatoshiAmounts`).
+
+### Worked example B: `lsps1ShowPurchaseButton` (introduce → retire)
+
+Introduced with the LSPS1 client (`f81439ee7`, 2024-05-06), with a migration setting it `true` for existing users. Retired by `c89b75426` (2025-07-16, "remove 'Purchase inbound channel' button"): the UI went away, the inline default and the migration block were deleted, but the interface key was kept as `lsps1ShowPurchaseButton?: boolean; // deprecated`. The key was never removed from users' blobs.
+
+### Worked example C: embedded LND SQLite/Bolt (platform experiment → selector + conservative default)
+
+`ef4a42112` (2026-03-27) restricted SQLite to iOS → `3c6f4175e` (next day) re-enabled it on Android → `d475ef2b4` (2026-04-20, #4002) settled on: default **Bolt** for new wallets (`isSqlite: false` in `utils/WalletCreationUtils.ts`) plus a per-wallet DB selector in Wallet Configuration → `3e04e6bf2` (2026-04-23) fixed a restart crash the selector exposed. Lesson: when an experiment thrashes across platforms, converge on a user-visible selector with the conservative option as default, rather than flip-flopping a hidden global.
+
+## 3. Retirement discipline
+
+Zeus retires ideas without destroying evidence or user data. Follow these three patterns; never invent a fourth.
+
+**3a. Deprecated flags are RETAINED, never hard-deleted.** Current deprecated-retained keys in `stores/SettingsStore.ts` (all marked `// deprecated`, verified 2026-07-06): `defaultFeeMethod`, `displayAmountOnInvoice`, `squareEnabled`, `automaticallyRequestOlympusChannels`, `lsps1ShowPurchaseButton`. Removing a key from users' `zeus-settings-v2` blobs is a storage-format change and goes through the storage gate — maintainer sign-off plus migration plan, always (rule owned by zeus-change-control; mechanics by zeus-storage-and-migrations). The minimum retirement is a `// deprecated` comment on the interface field; the inline default MAY also be deleted and the field marked optional (done for `lsps1ShowPurchaseButton` in `c89b75426`), but 4 of the 5 current deprecated keys retain their inline defaults (and `automaticallyRequestOlympusChannels` is not marked optional). Either way, the bytes stay in users' blobs.
+
+**3b. Dead UI is fenced in place, with a marker.** Two observed fencing styles:
+- `{false && ( ... )}` around the JSX plus a TODO comment stating the re-enable condition — e.g. the LSPS7 refund-onchain-address block in `views/LSPS7/index.tsx` ("TODO add conditions for refund onchain address").
+- A comment citing a `ZEUS-NNNN` private-tracker ID — e.g. `// TODO re-enable for iOS once ZEUS-3514 is resolved` in `views/Wallet/Wallet.tsx` (bottom-tab animation), and the LNC `checkPerms` workaround `// ZEUS-3642` in `backends/LightningNodeConnect.ts`. `ZEUS-NNNN` IDs map (at least sometimes) to ZeusLN/zeus GitHub issue numbers — the ZEUS-3642 comment links to https://github.com/ZeusLN/zeus/issues/3642 right in `backends/LightningNodeConnect.ts`. Check github.com/ZeusLN/zeus/issues/NNNN first; if the issue is missing or not readable, treat the fenced code as intentionally dormant — do not delete or re-enable it without maintainer confirmation.
+
+**3c. Stalled work is left as archaeology, not deleted.** Abandoned or paused efforts survive as branches (observed 2026-07-06 on maintainer-fork remotes in a contributor clone — NOT branches of ZeusLN/zeus itself; treat as leads, environment-dependent): `android-16kb-page-size` (single commit, 2025-10), `bip-321`, `cdk-init-remote-nodes` (remote-node Cashu), `cashu-backup`, `zeus-rgs` (partially landed elsewhere). Before restarting any such effort, run `git log master --oneline -S '<distinctive-symbol>'` to check whether it landed piecemeal already.
+
+## 4. Where good ideas historically came from
+
+Calibrate where to look before inventing from scratch:
+
+1. **Upstream ecosystems, adapted.** The embedded-LND native layer (`lndmobile/`, `android/app/src/main/java/com/zeus/LndMobileService.java`) was adapted from Blixt Wallet — it still carries its author's `TODO(hsjoberg)`/`FIXME(hsjoberg)` markers (attribution inferred from those markers plus commit "Neutrino: update Blixt peers", `bd2bbd996`). LDK Node ships as a ZeusLN fork; Cashu rides the CDK Rust library. Pattern: adopt a proven implementation, fork only when Zeus needs diverge.
+2. **Specs shipped early.** Zeus implements Lightning/ecash protocols close to spec publication: LSPS1 client landed 2024-05 (`f81439ee7`); LSPS7 (`views/LSPS7/`), NWC as both service and backend (`stores/NostrWalletConnectStore.ts`), Cashu multimint, CLINK. Early-spec work is EXPECTED to enter at lifecycle Stage 1 (flag, default off) and to keep dormant fenced UI (Section 3b) while the spec settles.
+3. **User reports.** Telegram (`t.me/zeusLN`, linked from README.md and CONTRIBUTING.md) and GitHub issues are the primary bug-hypothesis source. A Telegram report is an observation, not a mechanism — it enters at Section 1, not straight to a fix.
+4. **The same-day-revert loop as a quality mechanism.** Merged ≠ accepted. Release testing routinely ejects merged work the same day (NWC txlist: #3432 merged `285da755a` and reverted via #3444 `28bc50f5e` both on 2025-12-15; the iCloud PR #3307 likewise). Methodological consequences: (a) a revert is DATA — the idea returns to Stage 1 with a new constraint, it is not a rejection of the idea; (b) always check `git log --grep='revert-<PR#>'` before citing any merged commit as the accepted state. Revert policy and etiquette: zeus-change-control.
+
+## 5. Hypothesis → experiment → numbers template, and the promotion checklist
+
+### 5a. Investigation template (copy-paste into your issue/PR/notes)
+
+```markdown
+## Hypothesis
+Mechanism (one sentence, causal):
+Explains ALL of these observations:        [list, incl. where the bug does NOT occur]
+Fails to explain (open):                   [be honest; empty = suspicious]
+
+## Predictions (written BEFORE running anything)
+P1: If the mechanism is right, [experiment] must show [observable, with number/threshold].
+P2: Control — [experiment without the suspected factor] must NOT show it.
+
+## Experiments & numbers
+| # | Setup (backend, platform, fresh/migrated) | Predicted | Observed | Verdict |
+|---|---|---|---|---|
+| P1 |  |  |  | pass/fail |
+| P2 |  |  |  | pass/fail |
+
+## Fix & refutation record
+Fix (minimal diff, no drive-by refactors — see zeus-change-control):
+Refuter assigned:                          [person or model]
+Refutation attempts (axis → outcome):      [other backends / other platform /
+                                            upgrade paths / re-entrancy / fix reverted → bug returns]
+
+## Status
+[open | confirmed | fix merged (PR #) | reverted (PR #) | dead end → archaeology entry filed]
+```
+
+### 5b. Promotion checklist (experiment → default / merged fix)
+
+All gates are owned by zeus-change-control; this list is the methodology-side ordering. Do not merge until every line is true:
+
+- [ ] Discussion happened first (issue opened; deps discussed before adding — CONTRIBUTING.md).
+- [ ] Evidence bar met: one mechanism, pre-registered predictions passed, adversarial refutation survived and RECORDED in the PR (Section 1).
+- [ ] Manual evidence on BOTH platforms (iOS + Android, real hands-on — maintainer non-negotiable) and on every backend the code path can reach, recorded in the PR-template backend matrix.
+- [ ] Bug fixes include a test that would have caught the bug (CONTRIBUTING.md "Test Coverage") — feasible today for `utils/` and `models/` code; see zeus-validation-and-qa for coverage reality.
+- [ ] `yarn verify` green (= the 4 PR CI checks; anatomy in zeus-validation-and-qa).
+- [ ] Default-change for existing users ships as a MOD_KEY migration (zeus-storage-and-migrations), which triggers the storage gate: maintainer sign-off + migration plan.
+- [ ] **Revert-readiness**: the change is a single squashable unit that can be reverted same-day without a data migration. If reverting your change would strand users' data in a new format, it is not ready — redesign so the format change is separable, or get the storage gate's explicit plan for both directions.
+
+### 5c. Escalation routing
+
+- Fix touches send/receive/payment code → minimal-diff rule, zeus-change-control.
+- Fix touches `zeus-settings-v2` / keychain / migrations → storage gate, zeus-storage-and-migrations.
+- Hypothesis is about a start/stop/delete race → the live campaign in zeus-node-lifecycle-campaign.
+- You need formal machinery (interleaving analysis, migration proof) → zeus-proof-and-analysis-toolkit.
+
+## 6. When to stop: the documented dead end
+
+Stop when any of these holds: (a) two full hypothesis cycles (Section 5a) ended with failed predictions and no surviving mechanism; (b) the fix would require breaking a maintainer non-negotiable (e.g. a payment-path refactor) for an unproven gain; (c) the bug is upstream and tracked there (then do what `88dd94abe` did: mitigate via settings/migration, link the upstream issue in a code comment, move on).
+
+Stopping is a deliverable. File an entry in zeus-failure-archaeology (its skill owns the chronicle format) containing at minimum:
+
+```markdown
+### <symptom, one line>  [status: DEAD END — <date>]
+- Observations: [incl. negatives]
+- Hypotheses tried: H1 <mechanism> → prediction <P> → observed <O> → refuted
+                    H2 ...
+- Evidence: commit hashes, logs, device/backend matrix actually tested
+- Upstream refs: [issue links, e.g. lnd#9085 pattern]
+- What would reopen this: [the specific new observation that would justify another cycle]
+```
+
+A dead end without a written trail is the one outcome this methodology forbids: the repo's costliest sagas (iCloud keychain, RN-upgrade fallout) were expensive precisely where earlier attempts left no machine-findable record of what was already refuted. Fenced code and deprecated flags (Section 3) are the in-code half of the trail; the archaeology entry is the narrative half.
+
+## Provenance and maintenance
+
+Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha) by direct file reads and read-only git commands. Every cited commit hash was confirmed reachable from `c5fd094fb` via `git merge-base --is-ancestor <hash> c5fd094fb` (grafted `git log --all` duplicates avoided; note a clone's local `master` ref may lag — verify against the ZeusLN/zeus master tip). Branch leads are labeled environment-dependent. `TODO(hsjoberg)`→Blixt attribution is inferred from in-repo markers, labeled as such in Section 4. Re-verify volatile facts before relying on them:
+
+| Fact | Re-verification command |
+|---|---|
+| HEAD / version | `git log --oneline -1 && grep '"version"' package.json` |
+| Deprecated-retained flag list | `grep -n '// deprecated' stores/SettingsStore.ts` |
+| bimodalPathfinding fresh default | `grep -n 'bimodalPathfinding' stores/SettingsStore.ts` |
+| bimodal demotion migration + lnd#9085 link | `grep -n -B2 'bimodal-bug-9085' utils/MigrationUtils.ts` |
+| MOD_KEY migration inventory | `grep -n 'MOD_KEY' utils/MigrationUtils.ts` |
+| Two settings load paths (modern/legacy) | `grep -n 'modernSettings\|LEGACY_STORAGE_KEY' stores/SettingsStore.ts` |
+| Fenced LSPS7 UI | `grep -n -B3 'false && (' views/LSPS7/index.tsx` |
+| ZEUS-3514 / ZEUS-3642 fences | `grep -rn 'ZEUS-3514' views/Wallet/Wallet.tsx; grep -n 'ZEUS-3642' backends/LightningNodeConnect.ts` |
+| LndHub capability-inheritance gap | `grep -n 'supportsChannelFundMax' backends/*.ts` (no LndHub line) |
+| SQLite/Bolt conservative default | `grep -n 'isSqlite' utils/WalletCreationUtils.ts` |
+| Same-day revert example | `git log --format='%h %ad %s' --date=short -1 285da755a; git log --format='%h %ad %s' --date=short -1 28bc50f5e` |
+| Lifecycle example hashes | `git show --no-patch --format='%h %ad %s' --date=short cc735f923 519dea9ad 88dd94abe f81439ee7 c89b75426 ef4a42112 3c6f4175e d475ef2b4 3e04e6bf2 26d4215ea e8e5b8811 7ed901a10 fdad118ed 93227029e 46f2bac00` |
+| Discussion-first + test-coverage rules | `grep -n -i 'open an issue first\|Discuss new dependencies\|would have caught the bug' CONTRIBUTING.md` |
+| Stalled-branch leads (environment-dependent) | `git branch -r \| grep -E '16kb\|bip-321\|cashu-backup\|cdk-init\|zeus-rgs'` |
+| Blixt-origin markers | `grep -rn 'hsjoberg' lndmobile/ android/app/src/main/java/com/zeus/` |

--- a/.claude/skills/zeus-run-and-operate/SKILL.md
+++ b/.claude/skills/zeus-run-and-operate/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: zeus-run-and-operate
+description: Load when you need to RUN Zeus — start Metro / yarn android / yarn ios, decide whether to restart Metro or rebuild the native app, connect a dev node (Polar, Android emulator 10.0.2.2, macaroon/rune/pairing-phrase/NWC credentials, mutinynet), or perform release operations — ./build.sh reproducible Android Docker build, verify a release APK hash, per-ABI versionCode, PGP-signed commits, "Version bump:" convention, workflow_dispatch-only CI builds, iOS Xcode workspace and its ShareQR/NWCWidget extension targets. Symptoms — "app won't reflect my change", "connection refused from emulator", "how do I verify the APK", "how do releases work".
+---
+
+# Zeus: Run and Operate
+
+Runbook for running the app in development, connecting it to a Lightning node, and performing release/reproducible-build operations. Verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha).
+
+## When to use / When NOT to use
+
+USE this skill when you are:
+- Starting the app in dev (Metro, emulator, simulator, physical device).
+- Deciding "restart Metro or rebuild the native app?" after a change.
+- Connecting Zeus to a node in dev (Polar, testnet, mutinynet) or picking which of the 7 backend types to configure.
+- Building or verifying a release APK, or answering questions about the release process (versioning, signing, tags).
+
+Do NOT use it for these — load the named sibling instead:
+
+| Need | Sibling skill |
+|---|---|
+| Recreating the dev environment from scratch, postinstall chain, native binary fetching, vendoring | zeus-build-and-env |
+| Per-backend quirks, `supports*` capability gating, adding an RPC | zeus-backends-and-capabilities |
+| App misbehaves at runtime (crashes, hangs, wrong data) | zeus-debugging-playbook |
+| `yarn verify`, tests, CI check anatomy | zeus-validation-and-qa |
+| PR/commit/review rules, what changes are gated | zeus-change-control |
+| Settings axes and their defaults | zeus-config-and-flags |
+
+This skill assumes dependencies are already installed (`yarn install` succeeded, including its postinstall chain). If `yarn install` itself fails or native binaries are missing, that is zeus-build-and-env territory.
+
+## 1) Dev run anatomy
+
+Term definitions (once): **Metro** is React Native's JavaScript bundler/dev server — it serves your TS/JS code to the app over HTTP and hot-swaps it ("Fast Refresh"). The **native app** (Java/Kotlin/Swift/ObjC/Rust/Go code plus the React Native runtime) is compiled separately by Gradle (Android) or Xcode (iOS) and only changes when you rebuild it.
+
+Commands (all verified in `package.json` scripts):
+
+```bash
+yarn start        # start Metro (react-native start)
+yarn android      # build + install + launch on Android emulator/device (react-native run-android)
+yarn ios          # build + install + launch on iOS simulator (react-native run-ios)
+yarn ra           # alias for yarn android
+yarn ri           # alias for yarn ios
+```
+
+Notes:
+- `yarn android`/`yarn ios` auto-start Metro if it is not running; running `yarn start` in its own terminal first gives you a persistent log window (README's recommended flow).
+- iOS can also be run from Xcode: open `ios/zeus.xcworkspace` (the WORKSPACE, not `zeus.xcodeproj` — CocoaPods requires the workspace) and hit Run. See section 4.
+- Helper scripts: `yarn gradlew <task>` (runs `./gradlew` inside `android/`), `yarn android:clean` (deletes `android/app/.cxx`, `android/build`, then `gradlew clean`) for corrupted-native-build situations.
+- Faster Android debug builds: the debug build type honors `-PreactNativeDebugArchitectures=arm64-v8a` (Gradle property read in `android/app/build.gradle`) to compile only one ABI.
+
+### Restart Metro vs rebuild native — decision table
+
+| You changed... | Action |
+|---|---|
+| `.ts`/`.tsx` app code, `locales/en.json` | Nothing — Fast Refresh picks it up. Shake device / Cmd+R to force reload |
+| `metro.config.js`, `babel.config.js` | Restart Metro: `yarn start --reset-cache` |
+| Added a pure-JS npm dependency | `yarn install`, then restart Metro |
+| Added/updated a dependency with native code, or anything in `android/`, `ios/`, `patches/`, `fetch-libraries-versions.json`, `zeus_modules/` native parts | **Rebuild native**: `yarn install` (re-runs the postinstall patch/fetch chain — see zeus-build-and-env), then `yarn android` / `cd ios && pod install && cd ..` + `yarn ios` |
+| `proto/*.proto` | `yarn gen-proto`, then reload |
+
+Rule of thumb: if the change lives outside the JS bundle (native module, patch, binary, Gradle/Podfile config), Metro cannot deliver it — rebuild. Mysterious "my change does nothing" symptoms after touching native deps are almost always a missing rebuild.
+
+## 2) Connecting a node in dev
+
+CONTRIBUTING.md recommends [Polar](https://github.com/jamaljsr/polar) for a quick local Lightning dev environment (spins up bitcoind + LND/CLN nodes in Docker with a GUI that shows each node's connection credentials).
+
+**Android emulator networking (top dev trap):** the emulator's `127.0.0.1` is the emulator itself, not your machine. When configuring a node in dev on the Android emulator, the Host field MUST be `10.0.2.2` (the emulator's alias for the host machine). Stated in CONTRIBUTING.md. iOS simulator shares the host network, so `127.0.0.1` works there.
+
+Create wallets in-app: Menu → Settings-equivalent wallet list → add wallet (`views/Settings/WalletConfiguration.tsx`). The implementation dropdown offers exactly these 7 (from `INTERFACE_KEYS` in `stores/SettingsStore.ts`):
+
+| Implementation (`value`) | UI label | Type | Credentials you need |
+|---|---|---|---|
+| `ldk-node` | LDK Node | On-device | None — mnemonic generated in-app (network + optional esplora/RGS/VSS server overrides) |
+| `embedded-lnd` | Embedded LND | On-device | None — seed generated in-app (network choice; optional recovery seed + channel-backup base64) |
+| `lnd` | LND (REST) | Remote | Host, port, macaroon in **hex** (a macaroon is LND's bearer-token auth credential; convert with `xxd -ps -u -c 1000 admin.macaroon`, per docs/RemoteConnections.md — Polar shows the hex directly) |
+| `lightning-node-connect` | LND (Lightning Node Connect) | Remote | LNC pairing phrase (word phrase issued by litd/Terminal) + mailbox server (default `mailbox.terminal.lightning.today:443`; `lnc.zeusln.app:443` and custom also offered) |
+| `cln-rest` | Core Lightning (CLNRest) | Remote | Host, port, rune (CLN's auth token format, replaces macaroons) |
+| `nostr-wallet-connect` | Nostr Wallet Connect | Remote | A single `nostr+walletconnect://` connection URL from an NWC-capable wallet/service |
+| `lndhub` | LNDHub | Remote (custodial) | LNDHub server URL + username + password, or paste an `lndhub://user:pass@url` URI; can also create a new account on the server |
+
+Remote configs also carry per-node `certVerification` and `enableTor` toggles. For per-backend behavior differences and `supports*` capability gating, load zeus-backends-and-capabilities — do not assume a feature exists on all 7.
+
+### Embedded wallet networks
+
+Both on-device implementations pick a network at creation (`EMBEDDED_NODE_NETWORK_KEYS`): `mainnet`, `testnet`, `mutinynet`. **Mutinynet** is a custom public Signet test network (Zeus points its esplora default at `https://mutinynet.com/api`) — inside LDK Node it is mapped to network type `signet` (`getNetworkType` in `utils/LdkNodeUtils.ts`). Caveat verified in `WalletConfiguration.tsx`: the network dropdown for NEW embedded-lnd wallets filters out `mutinynet`; only `ldk-node` offers all three. Remote nodes have no network setting — the network is detected from the node itself.
+
+## 3) Release operations (Android)
+
+Everything in this section verified by reading `build.sh`, `android/app/build.gradle`, `android/gradle.properties`, `.github/workflows/build-android.yml`, and `docs/ReproducibleBuilds.md`. The build itself is verified by source read, not executed here.
+
+### Reproducible build via ./build.sh
+
+`./build.sh` (repo root) runs the whole Android release build inside Docker — requires only Docker, no local Android SDK:
+
+```bash
+./build.sh            # interactive terminal
+./build.sh --no-tty   # CI / non-interactive (only flag the script accepts)
+```
+
+What it does (all in `build.sh`):
+- Docker image pinned **by sha256 digest**: `reactnativecommunity/react-native-android@sha256:c390bfb...` (comment says tag 18.0). Digest pinning = byte-identical toolchain for every builder.
+- Exports `SOURCE_DATE_EPOCH` (default `0`, overridable via env) so embedded timestamps are deterministic.
+- Mounts the repo at `/olympus/zeus`, runs `yarn install --frozen-lockfile`, then `./gradlew generateCodegenArtifactsFromSchema && ./gradlew app:assembleRelease`.
+- Renames `app-*-release-unsigned.apk` → `zeus-*.apk` and prints `sha256sum` for each to stdout (hashes are printed, not written to a file).
+
+Reproducibility support in the Gradle config: `org.gradle.parallel=false` in `android/gradle.properties` (comment: parallel execution causes non-deterministic file ordering) and `reproducibleFileOrder = true` / `preserveFileTimestamps = false` on all Zip tasks in `android/app/build.gradle`.
+
+### Outputs
+
+5 APKs land in `android/app/build/outputs/apk/release/` (paths confirmed by the artifact steps in `.github/workflows/build-android.yml`):
+
+`zeus-armeabi-v7a.apk`, `zeus-arm64-v8a.apk`, `zeus-x86.apk`, `zeus-x86_64.apk`, `zeus-universal.apk`
+
+All **unsigned** — the release build type's `signingConfig` line is commented out in `android/app/build.gradle`. APK = Android package file; ABI = CPU architecture a binary targets; the "universal" APK bundles all four ABIs and is the one distributed on the website/GitHub releases.
+
+### Per-ABI versionCode
+
+From `android/app/build.gradle` (`versionCodeOverride`): each ABI split gets `versionCode = base * 1000 + {armeabi-v7a: 1, x86: 2, arm64-v8a: 3, x86_64: 4}`; the universal APK keeps the base. At v13.1.3-alpha the base is `131`, so: armeabi-v7a 131001, x86 131002, arm64-v8a 131003, x86_64 131004, universal 131.
+
+### How a user verifies a release
+
+Per `docs/ReproducibleBuilds.md`:
+1. `git clone --depth 1 --branch vX.Y.Z https://github.com/ZeusLN/zeus.git && cd zeus`
+2. `./build.sh` — compare the printed sha256 of `zeus-universal.apk` against the hash on the [GitHub releases page](https://github.com/ZeusLN/zeus/releases).
+3. Against the officially distributed (signed) APK, unpack both and diff (`diffoscope`, `apksigcopier`, or `diff --brief --recursive`): the ONLY expected differences are the signing certificates.
+4. To install your own build you must sign it yourself (`apksigner` + your own keystore, procedure in the same doc) and uninstall the store version first — certificates won't match, and reinstalling loses local connection details.
+
+### CI workflows are manual-only
+
+`.github/workflows/build-android.yml` (runs `bash ./build.sh --no-tty` on ubuntu, Node 24.x, uploads the 5 APKs as artifacts, 5-day retention) and `.github/workflows/dependency-scan.yml` (GuardDog + npm-scan) are both `workflow_dispatch:`-only — they take a branch input and never run on push/PR. PR CI is only the 4 verify checks (see zeus-validation-and-qa).
+
+### PGP signing
+
+Commits and releases are signed with the key published in `PGP.txt` (repo root): RSA-4096, fingerprint `96C225207F2137E278C31CF7AAC48DE8AB8DEE84` (short key ID `AAC48DE8AB8DEE84`), UIDs "Zeus LN <zeusln@tutanota.com>" and "ZEUS Support <support@zeusln.com>", currently expiring 2027-10-21. Verify a commit: `git log --show-signature -1 <hash>`. Note: git tags are **lightweight** (they point straight at commits — `git tag -v` fails with "cannot verify a non-tag object"), with one historical annotated exception (`v0.10.2-rc2`); signature verification therefore happens on the tagged commit, not the tag object.
+
+### What is OUT of this repo (do not look for it here)
+
+- **Release APK signing keys / keystore.** `MYAPP_RELEASE_STORE_FILE` etc. appear as optional Gradle properties but the release build type does not use them; official signing happens outside the repo.
+- **Store upload pipeline** (Google Play, App Store, zeusln.com hosting) — no workflow or script in-repo performs uploads.
+- **Who can dispatch** `build-android.yml` — GitHub org permission, not visible in-repo.
+- **iOS release pipeline** — entirely out-of-repo (see section 4).
+
+## 4) iOS operations
+
+- **No reproducible builds for iOS** — `docs/ReproducibleBuilds.md` explicitly says Android only.
+- Run/build via Xcode: open `ios/zeus.xcworkspace`, select the `zeus` scheme, hit Run (after `cd ios && pod install`).
+- Targets in `ios/zeus.xcodeproj` you WILL encounter (don't be surprised when Xcode asks about signing for each):
+  - `zeus` — the app.
+  - `ShareQR` — a **share extension** (app-extension product type): lets users share an image from another app into Zeus; it scans it for a QR code, writes the result into app group `group.com.zeusln.zeus`, and opens `zeusln://share` (`ios/ShareQR/ShareViewController.swift`).
+  - `NWCWidget` — a **widget extension** hosting the NWC Live Activity (ActivityKit lock-screen/Dynamic Island UI for the Nostr Wallet Connect background service; `ios/NWCWidget/`).
+  - `zeus-tvOS` — present in the project file (React Native template leftover); not a distributed product.
+- Extension targets need their own provisioning when building on-device; on simulator they build without special setup.
+
+## 5) Operational conventions
+
+- **Version bump commits**: subject is exactly `Version bump: vX.Y.Z[-suffix]` (e.g. `Version bump: v13.1.3-alpha`, current HEAD `c5fd094fb`). The maximal file set a bump commit touches is 4: `package.json` `version`, `android/app/build.gradle` `versionName` (+ `versionCode` when incremented), `ios/zeus.xcodeproj/project.pbxproj` `MARKETING_VERSION` (all build configs), and the version list in `.github/ISSUE_TEMPLATE/bug_report.yml` — but not every bump touches all 4. Observed at `c5fd094fb`: the pbxproj and bug_report.yml entries only change when the suffix-less base version changes (i.e. on the post-release `-alpha` bump, e.g. `c5fd094fb`); beta/rc/final bumps typically touch only `package.json` + `build.gradle` (e.g. `a2dc04ab8` v13.1.2, `8b45b4111` v13.1.1-beta1 — 2 files each).
+- **Cadence** (observed in `git log --grep='Version bump'`): after a release, master is bumped to the next `-alpha`; a release line then walks `-alpha → -beta1… → -rc1… → final` (e.g. v13.1.0-alpha → beta1 → beta2 → rc1 → v13.1.0). Master effectively always sits on an `-alpha` (or in-flight beta/rc) version.
+- **Tags**: one tag per shipped version (`v13.1.2` etc., 269 tags at time of writing), lightweight with one historical annotated exception (`v0.10.2-rc2`), usually pointing at the version-bump commit — but not always (`v13.1.1` points at a non-bump commit, and final-release bump commits may sit on release branches rather than master). Signing lives on the commit (PGP key above), not the tag.
+- Release-time discipline (revert-first near releases, mandatory 2-platform manual testing) is owned by zeus-change-control — read it before touching anything during a release window.
+
+## Provenance and maintenance
+
+Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha, versionCode 131). `./build.sh` execution itself verified by source read (build.sh + build-android.yml), not executed. Re-verification one-liners for volatile facts:
+
+| Fact | Re-verify with |
+|---|---|
+| yarn scripts (`start`/`android`/`ios`/`ra`/`ri`, `android:clean`, `gen-proto`) | `python3 -c "import json;print(json.load(open('package.json'))['scripts'])"` |
+| Docker image digest, SOURCE_DATE_EPOCH default, `--no-tty` | `head -30 build.sh` |
+| `org.gradle.parallel=false` | `grep parallel android/gradle.properties` |
+| Unsigned release + per-ABI versionCode map + reproducible Zip settings | `grep -n 'signingConfig\|versionCodeOverride\|versionCodes\|reproducibleFileOrder' android/app/build.gradle` |
+| Current versionCode/versionName | `grep -n 'versionCode \|versionName' android/app/build.gradle` |
+| 5 APK names/paths | `grep 'path:' .github/workflows/build-android.yml` |
+| Workflows dispatch-only | `grep -A2 '^on:' .github/workflows/build-android.yml .github/workflows/dependency-scan.yml` |
+| 7 implementations + labels | `grep -n -A14 'INTERFACE_KEYS' stores/SettingsStore.ts \| head -25` |
+| Embedded networks + mutinynet filter | `grep -n 'EMBEDDED_NODE_NETWORK_KEYS\|mutinynet' stores/SettingsStore.ts views/Settings/WalletConfiguration.tsx utils/LdkNodeUtils.ts` |
+| Android emulator host 10.0.2.2 / Polar | `grep -n '10.0.2.2\|Polar' CONTRIBUTING.md` |
+| PGP key/fingerprint/expiry | `gpg --show-keys PGP.txt` |
+| Version-bump convention + cadence | `git log --oneline -15 --grep='Version bump'` |
+| Tags lightweight | `git cat-file -t v13.1.2` (prints `commit`) |
+| LNC mailbox defaults | `grep -n -A8 'LNC_MAILBOX_KEYS' stores/SettingsStore.ts` |
+| iOS extension targets | `grep -B2 'app-extension' ios/zeus.xcodeproj/project.pbxproj` |

--- a/.claude/skills/zeus-storage-and-migrations/SKILL.md
+++ b/.claude/skills/zeus-storage-and-migrations/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: zeus-storage-and-migrations
+description: Load when touching ANY persisted data in Zeus - keychain reads/writes, the zeus-settings-v2 settings blob, SettingsStore.setSettings/updateSettings, MigrationUtils MOD_KEY migrations, DataClearUtils/KeychainRecoveryUtils, adding a new storage key, iCloud keychain behavior, duress-PIN wipe, Cashu/LDK/LND on-disk data, or VSS remote state. Also load when debugging symptoms like "settings lost after update", "wallet disappeared", "nested settings group reset to defaults", "migration ran twice / never ran", "old data reappeared on a new iPhone", "data survives Clear All Data", or "3600 hours" style display corruption. Keywords: Storage.getItem, Storage.setItem, EncryptedStorage, AsyncStorage, keychain, cloudSync, zeus-settings-v2, MOD_KEY, migration, storageMigrationV2, keychainCloudSyncMigration, clearAllData, duress.
+---
+
+# Zeus Storage and Migrations
+
+Persistence contracts for the ZEUS wallet (React Native, Bitcoin/Lightning) and the safety protocol for changing them. Storage/keychain integrity is one of the two hardest live problem areas in this repo (maintainer, 2026-07-06). Bugs here lose users' wallet configurations, seeds, and money-adjacent data. Treat every change as high-risk.
+
+**The maintainer's gate (non-negotiable):** anything touching `zeus-settings-v2`, keychain keys, or migrations requires maintainer sign-off plus a written migration plan BEFORE implementation. See the `zeus-change-control` skill for the gating process; this skill tells you what to write in that plan and how to not corrupt data while executing it.
+
+## When to use / When NOT to use
+
+**Use this skill when you are:**
+- Reading or writing anything through `storage/index.ts`, `react-native-encrypted-storage`, or `AsyncStorage`
+- Adding, renaming, or removing a persisted key
+- Modifying `SettingsStore` (`setSettings`, `updateSettings`, `getSettings`), the `Settings`/`Node` shapes, or a settings default that existing users already have
+- Writing or reviewing a migration in `utils/MigrationUtils.ts`
+- Touching wipe/recovery paths: `utils/DataClearUtils.ts`, `utils/KeychainRecoveryUtils.ts`, duress PIN, wallet deletion
+- Debugging lost/duplicated/stale persisted data
+
+**Do NOT use this skill for:**
+- The catalog of settings options/defaults and the add-a-setting UI checklist → `zeus-config-and-flags`
+- The change-classification/review/PR process itself → `zeus-change-control`
+- General race analysis or proving a migration correct from first principles → `zeus-proof-and-analysis-toolkit`
+- The history of past storage incidents in narrative form → `zeus-failure-archaeology` (this skill embeds only what you need to act safely)
+- Running/adding Jest tests in general → `zeus-validation-and-qa`
+- Boot sequence and store dependency-injection order → `zeus-architecture-contract`
+
+## Glossary (jargon used below, defined once)
+
+| Term | Meaning |
+|---|---|
+| Keychain | The OS-level encrypted credential store (iOS Keychain / Android Keystore-backed), accessed via the `react-native-keychain` package. Survives app reinstall on iOS; the most durable storage the app has. |
+| Internet credentials | The `react-native-keychain` API flavor Zeus uses (`getInternetCredentials`/`setInternetCredentials`): each entry is keyed by a `server` string and stores a `password` string. Zeus stores JSON in the `password` field. |
+| `cloudSync` | iOS-only keychain attribute (`kSecAttrSynchronizable`). `true` = the entry syncs to the user's iCloud Keychain and follows them to new devices. Zeus writes with `cloudSync: false` — always. |
+| EncryptedStorage | The `react-native-encrypted-storage` package (v4.0.3, `package.json`). Zeus's PREVIOUS storage backend. Legacy-only now. |
+| AsyncStorage | `@react-native-async-storage/async-storage` — plain unencrypted key-value storage. Non-sensitive flags only. |
+| Settings blob | ONE JSON document holding all app settings AND all wallet secrets, stored in the keychain under key `zeus-settings-v2`. |
+| MobX observable | Reactive state object (`stores/` classes use MobX decorators). UI re-renders when observables change; replacing an observable object with a string corrupts every observer. |
+| Macaroon | LND's bearer-token credential (hex in `Node.macaroonHex` / `Node.adminMacaroon`). Possession = control of the node. |
+| Seed / mnemonic | BIP-39 word list that derives all wallet keys (`Node.seedPhrase`, `Node.ldkMnemonic`). Loss = loss of funds. |
+| Embedded LND / LDK Node | The two node implementations that run INSIDE the app and keep native on-disk state (channel databases etc.), unlike remote backends. |
+| Cashu / CDK | Ecash wallet subsystem backed by the Cashu Dev Kit Rust FFI; keeps its own SQLite database (`cashu_wallet.db`) outside the keychain. |
+| VSS | Versioned Storage Service — remote server (`https://vss.zeusln.com/vss`, `utils/LdkNodeUtils.ts` `DEFAULT_VSS_SERVER`) where LDK Node persists encrypted channel state, keyed from the node mnemonic. |
+| Duress PIN | Alternate PIN that, when entered, silently wipes wallet references instead of unlocking (`views/Lockscreen.tsx`). |
+
+## 1. The four storage layers — what belongs where
+
+| Layer | Access via | What belongs there | Examples |
+|---|---|---|---|
+| **Keychain (canonical)** | `storage/index.ts` ONLY | Everything persisted by app code: the settings blob, all secrets, per-store data | `zeus-settings-v2`, `zeus-contacts-v2`, `zeus-notes-v2`, `swaps-rescue-key`, `<nodeDir>-cashu-seed-phrase` |
+| **Legacy EncryptedStorage** | `react-native-encrypted-storage` | ONLY two things: (a) the old `zeus-settings` blob read during legacy upgrade, (b) one-shot migration flag keys (`MOD_KEY*`, `ios-keychain-cloud-sync-migration-v1`, …). **Never add new data here.** | `lsp-taproot-mod`, `invoices-expiry-display-fix-v2` |
+| **AsyncStorage** | `@react-native-async-storage/async-storage` | Non-sensitive UI/service flags only | persistent-service flags (`views/Settings/EmbeddedNode/`), Stealth Mode app data (`views/Stealth/`), NWC service flags |
+| **Native disk + remote** | native modules / FFI | Node and ecash state that app-level storage never sees | LND dirs (deleted via `deleteLndWallet` → `LndMobileTools.deleteLndDirectory`), `Documents/ldk-node/<uuid>/` (`utils/LdkNodeUtils.ts getLdkNodeStoragePath`), CDK SQLite `cashu_wallet.db`, remote VSS channel state |
+
+Rules of thumb:
+- New persisted app data → keychain via `storage/index.ts`. No exceptions for "small" or "temporary" data.
+- If you find yourself importing `react-native-keychain` directly outside `storage/`, `MigrationUtils`, `DataClearUtils`, or `KeychainRecoveryUtils`, stop — you are bypassing the contract.
+- Migration flags go in EncryptedStorage (that is their one remaining legitimate home — a flag must survive independently of the keychain data it guards).
+
+## 2. The storage contract (`storage/index.ts`, 57 lines — read it)
+
+The canonical wrapper is a singleton `Storage` with exactly three methods. Its semantics are load-bearing:
+
+| Behavior | Detail | Trap |
+|---|---|---|
+| Key prefix | Every key is stored as `zeus:<key>` (`KEY_PREFIX = 'zeus:'`) | Raw keychain inspection shows `zeus:zeus-settings-v2`; unprefixed entries are pre-2026 orphans (Section 6) |
+| `cloudSync: false` | On get, set, AND remove | Never flip to `true` for app data — that re-opens the iCloud saga (Section 6) |
+| `getItem` returns **`false`** when missing | Not `null`, not `undefined` | `value !== null` checks are always true; use truthiness (`if (value)`) like the rest of the codebase |
+| `setItem('')` **deletes** the key | Empty/null string values route to `removeItem` (keychain rejects empty passwords) | "Clearing" a value and "deleting" a key are the same operation; a later `getItem` gives `false`, not `''` |
+| `setItem` auto-stringifies | Non-string values pass through `JSON.stringify` | Convenient for `Storage.setItem` — but NEVER pre-stringify for `settingsStore.setSettings` (Section 4, incident `7ed901a10`) |
+
+## 3. `zeus-settings-v2`: one blob, one shallow merge, the #1 data-loss footgun
+
+**What's inside (`stores/SettingsStore.ts`, `Settings` + `Node` interfaces):** every wallet's connection config and secrets — `macaroonHex`, `rune`, `pairingPhrase` (LNC), `nostrWalletConnectUrl`, `seedPhrase`, `walletPassword`, `adminMacaroon`, `ldkMnemonic`, `ldkPassphrase` — plus app-level `pin`, `passphrase`, `duressPin`, `duressPassphrase` (stored in plaintext inside the blob; keychain-is-the-boundary is the current model — known/accepted, do not "fix" drive-by), plus every settings group (`privacy`, `display`, `payments`, `invoices`, `channels`, `pos`, `ecash`, …).
+
+**The two write APIs (`stores/SettingsStore.ts`):**
+
+- `setSettings(settings)` — writes the WHOLE object to `Storage.setItem(STORAGE_KEY, settings)` and replaces `this.settings`. Callers must pass a complete settings object.
+- `updateSettings(newSetting)` — does `{ ...existingSettings, ...newSetting }`. This is a **SHALLOW top-level merge**: any nested group you pass **replaces that group wholesale**.
+
+```ts
+// DESTRUCTIVE ANTI-PATTERN — silently deletes every other key in settings.invoices
+// (memo, addressType, expiry, routeHints, blindedPaths, ...):
+await updateSettings({
+    invoices: { receiverName: text }
+});
+
+// CORRECT — spread the existing group, then override
+// (real example: views/Settings/InvoicesSettings.tsx):
+await updateSettings({
+    invoices: {
+        ...settings.invoices,
+        receiverName: text
+    }
+});
+```
+
+This is the single most likely way to silently destroy user data in this codebase. In review, treat any `updateSettings({ group: { ... } })` call without a spread of the existing group as a bug until proven otherwise. Top-level scalar keys (`fiat`, `locale`, `nodes`, …) are safe to pass alone.
+
+Also note: `updateSettings` internally calls `getSettings()` first (which can trigger migrations) and sets `settingsUpdateInProgress` / `triggerSettingsRefresh` flags — do not call it in tight loops or during boot races.
+
+## 4. Migrations: load paths and the MOD_KEY recipe
+
+### The two load paths (`SettingsStore.getSettings`)
+
+```
+getSettings()
+├── await MigrationsUtils.keychainCloudSyncMigration()   // ALWAYS first, before any settings read
+├── Storage.getItem('zeus-settings-v2') exists?
+│   ├── YES (modern path): parse → migrateRgsDefaultToZeus() → migrateInvoiceExpiryDisplay()
+│   └── NO  (legacy path): EncryptedStorage.getItem('zeus-settings')
+│         → legacySettingsMigrations()   // all MOD_KEY blocks + migrateInvoiceExpiryDisplay + migrateRgsDefaultToZeus
+│         → storageMigrationV2()         // copies every legacy key into the zeus: keychain namespace
+└── updateNodeProperties(settings)
+```
+
+**Every settings migration must run on BOTH paths** if it can affect users who already migrated to v2. Incident: the invoice-expiry display repair (`26d4215ea`, 2026-05-30) initially ran only on the legacy path; users already on v2 kept the corrupted "3600 hours" display, and the migration had to be re-shipped two days later on the v2 path — under the ORIGINAL flag key (`e8e5b8811`, 2026-06-01). When a further miss (pre-Feb-2024 installs) then forced a re-run, the flag key was bumped to `invoices-expiry-display-fix-v2` (`a7860aa96`, merged `f7b2c30a8`, PR #4149, 2026-06-08) — full narrative: zeus-failure-archaeology FA-3. If your migration missed people, you cannot "re-arm" the old flag — bump the key with a `-v2`/`-v3` suffix and make the migration idempotent.
+
+### The MOD_KEY recipe (copy this shape)
+
+One-shot migrations live in `utils/MigrationUtils.ts`. Pattern (see `MOD_KEY7 = 'bimodal-bug-9085'` or `migrateRgsDefaultToZeus` for live examples):
+
+```ts
+const MOD_KEY_MY_FIX = 'my-fix-v1';                          // flag key, EncryptedStorage
+const mod = await EncryptedStorage.getItem(MOD_KEY_MY_FIX);
+if (!mod) {
+    // ... mutate newSettings in place (idempotently!) ...
+    await settingsStore.setSettings(newSettings);            // (a) AWAIT it  (b) pass the OBJECT
+    await EncryptedStorage.setItem(MOD_KEY_MY_FIX, 'true');  // set flag ONLY after write succeeds
+}
+```
+
+Hard rules, each backed by a shipped incident:
+
+1. **Pass a real object to `setSettings`, never `JSON.stringify(settings)`.** A stringified payload briefly turns the MobX `settings` observable into a string and crashes observers reading nested keys. Incident fixed in `7ed901a10` (issue #4150, merged via PR #4155, 2026-06-09); a regression test now pins this (`utils/MigrationUtils.test.ts`, "persists the settings object rather than a JSON string"). (`Storage.setItem` stringifies internally — that is fine; the observable assignment is what breaks.)
+2. **`await` the `setSettings` call.** Un-awaited writes let the flag get set before the data lands (or after the app moves on), producing migrations that "ran" but persisted nothing. Fixed across all MOD_KEY blocks in `d8e648b58` (2026-05-30).
+3. **Set the flag AFTER the mutation is persisted**, so a crash mid-migration retries next boot instead of skipping forever.
+4. **Make the mutation idempotent** (safe to run twice) — flags can be lost (EncryptedStorage cleared) while keychain data survives.
+5. **Cover both load paths** (see above). For settings-shape migrations that must also hit v2 users, call your function from the modern branch of `getSettings` too, like `migrateInvoiceExpiryDisplay`.
+6. **New defaults need no migration; CHANGED defaults do.** Inline defaults in `SettingsStore` only apply to keys the user has never persisted. To change behavior for existing users you must ship a MOD_KEY migration (details of the settings axes: `zeus-config-and-flags`).
+
+Add a test in `utils/MigrationUtils.test.ts` (22 tests passing as of 2026-07-06; run `npx jest utils/MigrationUtils.test.ts`).
+
+## 5. Checklist: adding a NEW persisted key
+
+Convention: export the key constant from its owning store/util (e.g. `export const NOTES_KEY = 'zeus-notes-v2'` in `stores/NotesStore.ts`) and import it everywhere else — never inline string literals. New keys use a `zeus-` prefix and `-v2` style suffix by convention.
+
+Then register it, or it leaks:
+
+| # | Register in | Why | Mandatory? |
+|---|---|---|---|
+| 1 | `utils/DataClearUtils.ts` → `STORAGE_KEYS` | Otherwise the key **survives "Clear All Data"** (Tools → clear storage) — orphaned user data, possibly secrets, left on device | **Always** |
+| 2 | `utils/KeychainRecoveryUtils.ts` → `OTHER_KEYS` | Otherwise the Keychain Recovery tool (`views/Tools/NodeConfigExportImport.tsx`) cannot find/restore it for users with lost data | Yes, if it holds user data worth recovering |
+| 3 | `utils/MigrationUtils.ts` → `keychainCloudSyncMigration` `migrationKeys` | Otherwise pre-2026 unprefixed keychain copies of the key are never migrated into the `zeus:` namespace | Only if the key **existed before the `zeus:` prefix migration** (Jan 2026, `318c721e7`). Brand-new keys have no unprefixed ancestor — skip. (Precedent: `FAVORITE_CURRENCIES_KEY`, added post-migration, is in `STORAGE_KEYS` only.) |
+
+If the key is dynamic (per-node/per-mint, like `<nodeDir>-cashu-*`), you must ALSO handle enumeration in `DataClearUtils` (see `clearCashuDataForNode`) — static lists can't clear keys they can't name.
+
+## 6. iCloud rules and the orphaned-entry policy
+
+History you must know before "improving" anything here: the multi-attempt iCloud keychain saga (merge → same-day revert → re-land → stale-restore fallout → `zeus:`-prefix re-keying → deletion disabled). The full dated timeline with hashes is owned by **zeus-failure-archaeology FA-1** — do not rely on memory of it; read that entry before touching this area.
+
+Current rules (verified against master 2026-07-06):
+
+1. **All writes are `cloudSync: false`** — enforced inside `storage/index.ts`. Never write app data with `cloudSync: true`.
+2. **Orphaned pre-migration entries are retained BY DESIGN.** `MigrationUtils.deleteFromOldKeychain` is a no-op with the delete code commented out. Old unprefixed local AND iCloud-synced entries (including seed copies) persist on purpose: the Keychain Recovery tool (`views/Tools/NodeConfigExportImport.tsx` + `utils/KeychainRecoveryUtils.ts`) scans exactly those four sources (`current` / `unprefixed-local` / `unprefixed-cloud` / `encrypted-storage`) to rescue users' lost wallets. **Do not "clean up" orphans** — that deletes the recovery path. Re-enabling deletion is maintainer-gated.
+3. **Explicit purges must clear BOTH sync variants and BOTH namespaces.** `DataClearUtils.clearKey` is the reference: it resets `zeus:<key>` local + cloud, and unprefixed `<key>` local + cloud, five calls total. Any new wipe path that clears fewer locations leaves secrets behind.
+4. `migrateKey` uses read → write → verify → delete ordering with 500 ms iOS sleeps around keychain ops (iCloud sync latency, `35aaf8897`) — keep that ordering and pacing if you extend it.
+
+## 7. Caveats — data that does NOT die when you think it does
+
+| Path | What it actually clears | What SURVIVES |
+|---|---|---|
+| **Duress PIN/passphrase** (`views/Lockscreen.tsx deleteNodes`) | `updateSettings({ nodes: undefined, selectedNode: undefined, authenticationAttempts: 0 })` — only the wallet REFERENCES in the blob | Embedded LND dirs, `ldk-node/<uuid>` dirs, CDK Cashu SQLite DB, per-node keychain keys (`<nodeDir>-cashu-seed-phrase`, …), other blob keys, VSS remote state. Forensically recoverable — this is the current design; document, don't silently "harden" |
+| **Clear All Data** (`utils/DataClearUtils.clearAllData`, Tools view, then `RNRestart.Restart()`) | Registered keys (all 5 locations), notes, Cashu keys for `node.lndDir` namespaces (plus literals `'lnd'` and `''`) + CDK DB, AsyncStorage, EncryptedStorage | Any key NOT in `STORAGE_KEYS`/enumerable (Section 5); LND/LDK native dirs (deleted only via wallet deletion in `views/Settings/WalletConfiguration.tsx`); VSS remote state. Note: `<ldkNodeDir>-cashu-*` keys are not enumerated by `clearAllData` — this is **by design** (maintainer-stated 2026-07-06): the Cashu seed is deterministically re-derived from the wallet seed every time, so these entries carry no independent secret material. Do not re-flag this as a wipe gap |
+| **Wallet deletion** (`WalletConfiguration.tsx`) | Blob entry; embedded-lnd → `deleteLndWallet(lndDir)`; ldk-node → `deleteLdkNodeWallet(ldkNodeDir)` (local `RNFS.unlink` only) | **VSS remote channel state — there is NO delete path** (`utils/LdkNodeUtils.ts` has no VSS delete; open gap, maintainer-acknowledged). Cashu data unless separately cleared |
+
+**Per-node Cashu namespacing:** always use `CashuStore.getNodeDir()` (returns `ldkNodeDir || 'ldk'` for ldk-node, else `lndDir || 'lnd'`) — NOT `getLndDir()`, which returns `'lnd'` for every LDK wallet. That collision mixed ecash funds across LDK wallets; fixed by `1242ce94a` (2026-03-20) with a copy migration (`migrateLegacyCashuKeysToNodeDir`), and again for multimint keys in `35fa31fee` (2026-04-08) — incident narrative: zeus-failure-archaeology FA-11. Any new per-node key must be namespaced with `getNodeDir()`.
+
+**Node dirs are UUIDs:** new embedded wallets get `lndDir = uuidv4()` / `ldkNodeDir = uuidv4()` (`views/Settings/WalletConfiguration.tsx`); old single-wallet installs used the literal `'lnd'` — which is why fallbacks and `clearCashuDataForNode('lnd')` exist.
+
+## 8. SAFETY PROTOCOL for any storage-touching change
+
+This executes within the gate defined in `zeus-change-control` (maintainer sign-off + migration plan required, always).
+
+### Pre-change checklist (do this BEFORE writing code)
+
+- [ ] Written migration plan: what data moves/changes, for which cohorts (legacy-blob users, v2 users, fresh installs), and what happens on crash mid-migration
+- [ ] Idempotency argument: running the migration twice is harmless
+- [ ] Both load paths covered (Section 4) — state explicitly which of `legacySettingsMigrations` / modern `getSettings` branch calls your code
+- [ ] Flag key named and versioned (`<thing>-<fix>-v1`), stored in EncryptedStorage
+- [ ] New keys registered per Section 5 (all applicable locations)
+- [ ] No `JSON.stringify` into `setSettings`; every `setSettings` awaited; every `updateSettings` nested group spread
+- [ ] No deletion of orphaned/unprefixed/iCloud keychain entries (Section 6 rule 2)
+- [ ] Jest coverage added in `utils/MigrationUtils.test.ts` for the new migration logic
+- [ ] Rollback story written (below)
+
+### Mandatory manual test matrix
+
+PR CI never builds the app (test/lint/prettier/tsc only; the Android build workflow is manual `workflow_dispatch`) and there are zero store-level integration tests — this matrix is hand-executed, and the maintainer requires hands-on testing on BOTH platforms before merge regardless of CI green. Record results in the PR (the PR template's testing section — see `zeus-change-control`).
+
+| # | Scenario | How to set up | Pass condition |
+|---|---|---|---|
+| 1 | Fresh install | Wipe app / new simulator | Defaults correct; migration flags set without touching anything; no migration UI flash |
+| 2 | Upgrade from legacy blob | Seed `zeus-settings` in EncryptedStorage (dev helper: `KeychainRecoveryUtils.copyToLegacyLocations()` writes current settings to all legacy locations) | Full `storageMigrationV2` runs once; all wallets, contacts, notes intact |
+| 3 | Upgrade from current v2 | Install released build, add wallets + nested settings, then install your build | Your migration runs exactly once; NO nested settings group reset (diff the blob before/after) |
+| 4 | iCloud-restored device (iOS) | Restore a device/simulator from a backup of a pre-`zeus:`-prefix install, or seed unprefixed cloud entries via `copyToLegacyLocations()` | No stale wallet resurrection; Keychain Recovery tool still lists orphans |
+| 5 | Multi-wallet | ≥2 embedded wallets incl. ≥2 LDK Node wallets with Cashu enabled | No cross-wallet data bleed; `getNodeDir()` namespacing holds; per-wallet balances distinct |
+| 6 | Duress wipe | Set duress PIN, trigger it | `nodes`/`selectedNode` nulled, app lands on IntroSplash; verify (and note in PR) what survives per Section 7 |
+
+Also re-run the automated floor: `yarn verify` (jest + prettier + tsc + lint — anatomy in `zeus-validation-and-qa`).
+
+### Rollback thinking (revert-first culture)
+
+- Regressions found in release testing get **reverted same-day, never forward-fixed under pressure** (maintainer rule; observed repeatedly for storage/keychain changes — e.g. #3307 merged and reverted within hours on 2025-11-10).
+- Design so a revert is safe: a migration that only ADDS/repairs fields can be reverted without a counter-migration; one that deletes or re-keys data cannot. If your change is not revert-safe, say so in the PR and provide the counter-migration.
+- Never reuse a burned flag key after a botched migration — bump the suffix (`-v2`) so already-flagged users are re-processed by the fixed logic.
+
+### Evidence the maintainer expects in the PR
+
+1. The migration plan (cohorts, idempotency, both-paths coverage, revert story)
+2. The filled test matrix with device/OS noted per row, iOS AND Android
+3. Before/after dumps of the relevant blob section for scenario 3 (redact secrets)
+4. New/updated Jest tests passing (`npx jest utils/MigrationUtils.test.ts`)
+5. Explicit statement of which of the Section 5 registration points you touched and why the others don't apply
+
+## Provenance and maintenance
+
+Facts verified 2026-07-06 against master `c5fd094fb` (v13.1.3-alpha) by reading `storage/index.ts`, `stores/SettingsStore.ts`, `utils/MigrationUtils.ts`, `utils/DataClearUtils.ts`, `utils/KeychainRecoveryUtils.ts`, `utils/LdkNodeUtils.ts`, `stores/CashuStore.ts`, `views/Lockscreen.tsx`, `views/Settings/WalletConfiguration.tsx`, `views/Tools/*`; cited hashes checked with `git log`/`git show`; `npx jest utils/MigrationUtils.test.ts` executed (22/22 pass). Maintainer policy statements dated 2026-07-06.
+
+Re-verification one-liners for volatile facts:
+
+| Fact | Re-verify with |
+|---|---|
+| Storage contract (`zeus:` prefix, `cloudSync:false`, `false` on miss, empty→delete) | `cat storage/index.ts` |
+| Blob keys `zeus-settings-v2` / legacy `zeus-settings` | `grep -n "STORAGE_KEY" stores/SettingsStore.ts \| head -3` |
+| `updateSettings` still shallow-merges | `grep -n -A8 "updateSettings = async" stores/SettingsStore.ts` |
+| `getSettings` migration order (cloud-sync migration first, both load paths) | `grep -n -A35 "public getSettings" stores/SettingsStore.ts` |
+| `deleteFromOldKeychain` still a no-op | `grep -n -A6 "deleteFromOldKeychain" utils/MigrationUtils.ts` |
+| Current MOD_KEY flag names | `grep -n "MOD_KEY\|MIGRATION_KEY" utils/MigrationUtils.ts` |
+| `migrationKeys` list contents | `grep -n -A22 "const migrationKeys" utils/MigrationUtils.ts` |
+| `STORAGE_KEYS` registration list | `grep -n -A45 "const STORAGE_KEYS" utils/DataClearUtils.ts` |
+| `OTHER_KEYS` recovery list | `grep -n -A22 "const OTHER_KEYS" utils/KeychainRecoveryUtils.ts` |
+| Duress wipe scope | `grep -n -A10 "deleteNodes = " views/Lockscreen.tsx` |
+| `getNodeDir` namespacing | `grep -n -A7 "getNodeDir = " stores/CashuStore.ts` |
+| VSS default + (absence of) delete path | `grep -n "DEFAULT_VSS_SERVER\|deleteLdkNodeWallet" utils/LdkNodeUtils.ts` |
+| CDK DB path | `grep -n -A12 "clearCDKDatabase" utils/DataClearUtils.ts` |
+| EncryptedStorage version | `grep -n "react-native-encrypted-storage" package.json` |
+| Migration tests still green | `npx jest utils/MigrationUtils.test.ts` |
+| Cited incident hashes | `git log -1 --format='%h %ci %s' 7ed901a10 d8e648b58 26d4215ea e8e5b8811 a7860aa96 f7b2c30a8 c6323fff4 318c721e7 1242ce94a 35fa31fee` |
+
+Open/unresolved (do not treat as settled): VSS remote-state deletion (no client delete path); permanent-retention-vs-eventual-deletion of orphaned keychain entries (retention is current policy, revisiting is maintainer-gated); plaintext PIN/passphrase in the blob (accepted debt).

--- a/.claude/skills/zeus-validation-and-qa/SKILL.md
+++ b/.claude/skills/zeus-validation-and-qa/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: zeus-validation-and-qa
+description: Load when validating changes to Zeus — running or fixing `yarn verify` / CI checks (Test, Lint, Prettier, Typescript Check), writing or extending Jest unit tests, deciding what evidence a PR needs (manual testing matrix, screenshots, which backends to test), or debugging CI-only failures. Symptoms/keywords - "yarn verify fails", "check-styles.test.ts", "themeColor StyleSheet lint error", "Cannot use import statement outside a module" in jest, "prettier check fails in CI but not locally", "how do I run one test", "where are the tests", "do stores have tests", "what do I need to test before opening a PR", transformIgnorePatterns, moduleNameMapper, test coverage.
+---
+
+# Zeus Validation and QA
+
+What counts as evidence in this repo, how the CI gate works internally, how to write tests that actually run, and the honest map of what is (and is not) covered by automation.
+
+Facts verified 2026-07-06 against commit `c5fd094fb` (v13.1.3-alpha). See "Provenance and maintenance" for re-verification commands.
+
+## When to use / When NOT to use
+
+Use this skill when you are:
+- Running or debugging `yarn verify` or any of the four PR CI checks
+- Writing, extending, or running Jest tests
+- Deciding what manual testing / screenshots / backend coverage a change needs before PR
+- Hit by the `check-styles.test.ts` lint failure or a jest transform error
+
+Use a sibling skill instead when you need:
+- PR/commit/review/locales rules, dependency policy, the storage-change gate → **zeus-change-control**
+- Which of the 7 backends supports a feature, `supports*()` flags → **zeus-backends-and-capabilities**
+- Recreating the dev environment, postinstall chain, native builds → **zeus-build-and-env**
+- Running the app and connecting to test nodes (needed for manual testing) → **zeus-run-and-operate**
+- Triage of runtime bugs (not CI failures) → **zeus-debugging-playbook**
+- Logging/measurement tooling → **zeus-diagnostics-and-tooling**
+- Formal proofs/analysis beyond tests (race analysis, migration proofs) → **zeus-proof-and-analysis-toolkit**
+
+## Glossary (skip if you know both stacks)
+
+| Term | Meaning here |
+|---|---|
+| Jest | The JavaScript unit-test runner (`yarn test`). Version 29, preset `@react-native/jest-preset`. |
+| tsc | The TypeScript compiler run in check-only mode (`yarn tsc`) — no output files, just type errors. |
+| ESLint / Prettier | Linter (code-pattern rules) / formatter (whitespace, quotes). Both are CI-blocking. |
+| MobX store | Observable state singleton class in `stores/` (e.g. `SettingsStore`). Zeus uses MobX 5 decorators. |
+| Backend | One of 7 node-connection implementations in `backends/` (LND REST, embedded LND, LDK Node, CLN, LNC, LNDHub, NWC). |
+| `StyleSheet.create` | React Native API that freezes a style object at module load time. |
+| `themeColor('key')` | Zeus helper (`utils/ThemeUtils.ts`) returning a color from the *currently selected* theme at call time. |
+| BOLT11 | The Lightning invoice string format (`lnbc...`). LNURL = HTTP-based Lightning protocols. Cashu = ecash tokens. Macaroon = LND's auth credential. |
+
+## 1) `yarn verify` anatomy — the entire quality gate
+
+`yarn verify` (package.json) runs four checks in parallel via `concurrently`:
+
+```
+"verify": "concurrently \"yarn test\" \"yarn prettier\" \"yarn tsc\" \"yarn lint\""
+```
+
+These SAME four checks are the ENTIRE PR CI gate. `.github/workflows/` contains `test.yml`, `lint.yml`, `prettier.yml`, `tsc.yml` (each: ubuntu-latest, Node 24.x, `yarn install --frozen-lockfile`, then the one script). `build-android.yml` and `dependency-scan.yml` are `workflow_dispatch`-only, and `telegram.yml` is a push/issues/release notification workflow, not a check — no mobile build, no emulator, no dependency scan runs on PRs. Green CI proves types, format, lint, and 48 unit-test suites. Nothing more.
+
+| CI check name | Exact local command | What it runs | Common failure modes |
+|---|---|---|---|
+| Test | `yarn test` | `jest` — 48 suites (45 `utils/`, 2 `models/`, 1 `lndmobile/`); `check-styles.test.ts` excluded via `testPathIgnorePatterns` | New ESM dependency not in `transformIgnorePatterns` ("Cannot use import statement outside a module"); un-mocked native module; importing `stores/Stores` without mocking it drags in the whole app graph |
+| Prettier | `yarn prettier` | `prettier --check "**/*.ts*"` (ignores only `zeus_modules`, per `.prettierignore`) | Formatting with a global/newer Prettier — the repo pins **prettier 2.4.1** (devDependency) with `.prettierrc`: tabWidth 4, singleQuote, semi, trailingComma "none". Newer Prettier majors format differently and fail CI. Fix: `yarn prettier-write` (uses the pinned version) |
+| Typescript Check | `yarn tsc` | `tsc` check-only; tsconfig has `strict: true`, `noUnusedLocals: true`, `noUnusedParameters: true`, but `strictPropertyInitialization: false` (MobX store fields) | Unused variables/params fail the build; excludes are `node_modules`, `zeus_modules`, `android`, `ios`. Repo convention for suppression is `@ts-ignore` (ban-ts-comment is off) — never `eslint-disable` comments (zero exist in the codebase) |
+| Lint | `yarn lint` | `eslint . && yarn run test check-styles.test.ts --testPathIgnorePatterns=` | ESLint 9 flat config (`eslint.config.js`) includes `prettier/prettier` as an **error** rule — so a formatting mistake fails BOTH the Prettier and Lint checks. Second half is the style-sheet ban, see section 2. ESLint ignores `zeus_modules/`, `android/`, `ios/`, `proto/`, `shim.js`, config JS files |
+
+Run the full gate before every PR. Node engines requirement is `>= 22.11.0` (package.json); CI uses 24.x; there is no `.nvmrc`.
+
+Checklist before opening a PR:
+- [ ] `yarn verify` passes locally (all four)
+- [ ] If you touched a utility: unit tests added/updated (the PR template asks this explicitly)
+- [ ] Manual test evidence collected (section 5)
+
+## 2) The `check-styles.test.ts` mechanism, precisely
+
+`check-styles.test.ts` sits at the repo root. It is a Jest test, but it is NOT part of `yarn test`:
+
+- package.json jest config: `"testPathIgnorePatterns": ["check-styles.test.ts"]` → excluded from the Test check.
+- `yarn lint` re-includes it by passing an EMPTY ignore list: `yarn run test check-styles.test.ts --testPathIgnorePatterns=` → so a styling violation fails the **Lint** CI check, not Test. This surprises everyone once.
+
+**What it bans:** calling `themeColor()` inside a static `StyleSheet.create({...})` block in any `.tsx` file.
+
+**Why:** `StyleSheet.create` at module scope executes ONCE, at import time. `themeColor('key')` reads the user's *currently selected* theme (Zeus ships 23 themes). A theme color baked into a static sheet freezes at whatever theme was active at first import and silently ignores theme switches — a real correctness bug, not a style nit. The test's own error message says exactly this.
+
+**How it detects:** a dot-all regex — `/\n[^\s][^\n]+StyleSheet\.create\(\{.*themeColor\(/s` — flags any `.tsx` file where a **non-indented (top-level) line containing `StyleSheet.create({`** is followed *anywhere later in the file* by `themeColor(`. Two practical consequences:
+
+1. Keep `const styles = StyleSheet.create({...})` as the LAST thing in the file (the repo-wide convention, e.g. `components/WalletHeader.tsx`) and keep it free of `themeColor()`.
+2. Because the `.*` spans newlines, a `themeColor(` call in ordinary component code placed BELOW the styles block will also trip the check even if the sheet itself is clean. Styles-at-bottom avoids this entirely.
+
+**How to fix a violation** — move the themed color out of the static sheet:
+
+```tsx
+// BANNED: frozen at import time
+const styles = StyleSheet.create({
+    label: { fontSize: 16, color: themeColor('text') }
+});
+
+// OK: static layout in the sheet, themed color applied at render time
+const styles = StyleSheet.create({
+    label: { fontSize: 16 }
+});
+// in render():
+<Text style={[styles.label, { color: themeColor('text') }]} />
+// or compute the style object inside render/a function, as components/Button.tsx does
+```
+
+Run just this check locally: `yarn run test check-styles.test.ts --testPathIgnorePatterns=`
+
+## 3) Jest traps
+
+**`transformIgnorePatterns` whitelist.** React Native ships untranspiled ESM in many packages; jest only transpiles `node_modules` packages explicitly whitelisted. The current list (package.json jest config):
+
+```
+react-native | @react-native | react-native-blob-util | react-native-randombytes |
+react-native-nfc-manager | dateformat | nostr-tools | @nostr | @noble | @scure | uuid
+```
+
+Symptom of a missing entry: `SyntaxError: Cannot use import statement outside a module` (or `Unexpected token 'export'`) pointing into `node_modules/<pkg>`. Fix: add the package name inside the `(?!(...))` group in `"transformIgnorePatterns"` in package.json. (New dependencies themselves require maintainer discussion first — see **zeus-change-control**.)
+
+**`moduleNameMapper` for `@noble/hashes`.** Five explicit mappings (`_assert`, `pbkdf2`, `sha256`, `sha512`, `utils`) pin `@noble/hashes/*` subpath imports to concrete `.js` files, because jest's resolver predates that package's `exports`-map style. If you import a new `@noble/hashes` subpath in tested code and jest says "Cannot find module", add a matching mapper line.
+
+**Colocated test convention.** Tests live NEXT TO the code, named `<File>.test.ts`: `utils/FeeUtils.ts` + `utils/FeeUtils.test.ts`. No `__tests__/` directories, no `.spec.ts`, no `.test.tsx` anywhere. Variants are allowed (`utils/AddressUtils-testnet.test.ts`, `utils/UnitsUtils.alt.test.ts`).
+
+**Mock before import.** Test files start with `jest.mock(...)` calls for native modules and stores BEFORE importing the unit under test — see the top of `utils/handleAnything.test.ts` (mocks `../stores/Stores`, `react-native-notifications`, AsyncStorage, `./BackendUtils`, the Cashu FFI) and `utils/MigrationUtils.test.ts`. Copy one of these preambles when your unit transitively touches stores or native code; importing `stores/Stores` un-mocked pulls in the entire 30-store app graph and usually explodes on a native module.
+
+**Run a subset** (verified working):
+
+```bash
+yarn test utils/Bolt11Utils.test.ts          # one file (path pattern)
+yarn test utils/Bolt11Utils.test.ts -t "LRU" # one file, test-name filter
+yarn jest --listTests                        # enumerate all suites jest will run
+```
+
+## 4) Coverage reality — where automation actually protects you
+
+Counted at `c5fd094fb`: **48 test suites** run by `yarn test` — `utils/` 45, `models/` 2 (`Payment.test.ts`, `ClaimTransaction.test.ts`), `lndmobile/` 1 (`channel.test.ts`) — plus the lint-only `check-styles.test.ts` (49 `.test.ts` files total).
+
+**Zero tests exist for `stores/`, `views/`, `components/`, and `backends/`.** That is: all MobX state logic (including the 5000+-line CashuStore), every screen, every reusable component, and all 7 node-backend implementations have NO automated safety net. Consequences you must act on:
+
+- A green `yarn verify` on a store/view/backend change proves only that it compiles, lints, and didn't break *utility* tests. **Manual testing is the real safety net there** (section 5).
+- CONTRIBUTING.md ("Test Coverage"): *bug fixes should include a test that would have caught the bug*. For store/view bugs, satisfy this via the extraction pattern in section 7.
+- The maintainer-confirmed rule "no drive-by refactors in payment paths" exists largely BECAUSE of this coverage hole (see **zeus-change-control**).
+
+## 5) Evidence standards — what a PR must prove
+
+CI green is necessary, never sufficient. The evidence bar (CONTRIBUTING.md + PR template + maintainer rules confirmed 2026-07-06):
+
+1. **Manual testing on BOTH platforms is mandatory.** CONTRIBUTING.md says "when possible"; the maintainer's actual rule (confirmed 2026-07-06, stricter than the written doc) is: **no merge without hands-on iOS + Android testing by the author, regardless of CI green.** See **zeus-run-and-operate** for how to run the app and connect nodes.
+2. **Fill out the PR template — never delete it** (`.github/PULL_REQUEST_TEMPLATE.md`). It requires: change category; the four-check checklist; whether you added unit tests for touched utilities; platforms tested (with OS version and phone model/VM); and the **7-backend testing matrix**: on-device LDK Node, Embedded LND; remote LND (REST), LND (Lightning Node Connect), Core Lightning (CLNRest), Nostr Wallet Connect, LndHub. Check ONLY the boxes for what you actually tested.
+3. **Screenshots/video for UI changes** (CONTRIBUTING.md), tested on both platforms because rendering differs. First-time contributors MUST attach screenshot/video proof for features/UI or the PR is closed within 24 hours (CONTRIBUTING.md "Proof of Work").
+4. **Regression test with every bug fix** where the logic is unit-testable (CONTRIBUTING.md).
+
+**Which backends to actually test** — guidance derived from the capability matrix (authoritative flags live in **zeus-backends-and-capabilities**); the template asks you to report honestly, not to test all 7 for every change:
+
+| Change class | Minimum sensible manual matrix |
+|---|---|
+| Pure `utils/`/`models/` logic | Unit tests + smoke-test one backend that exercises the call path |
+| Cross-backend feature (dispatched via `BackendUtils`) | Every backend whose `supports*()` gate enables it — missing gates are historically the top cross-backend crash source |
+| Payment send/receive paths | Each backend whose code path the diff touches; keep the diff minimal (maintainer rule — see **zeus-change-control**) |
+| Cashu/ecash | Embedded LND + LDK Node (the only two with `supportsCashuWallet = true`) |
+| Watchtowers | LND-family only |
+| Node lifecycle / startup | Embedded LND AND LDK Node (both have distinct race histories) plus one remote backend |
+| UI/theme-only | Both platforms, screenshots, at least one theme switch if colors changed; backend largely irrelevant |
+
+## 6) Golden inventory — the highest-value existing suites
+
+Read these before writing your own; they are the house style. Line counts at `c5fd094fb`.
+
+| Suite | Lines | What it protects |
+|---|---|---|
+| `utils/handleAnything.test.ts` | 1818 | The universal input router (QR scan / clipboard / deep link): detection and its ORDER — bitcoin address, pubkey, BOLT11, BIP21+lnurl fallbacks, nested `LIGHTNING:lnurlp://` schemes, merchant-QR→lightning-address conversion, lightning-address casing. Also the best template for mocking stores/native deps. |
+| `utils/AddressUtils.test.ts` (+ `AddressUtils-testnet.test.ts`) | 1398 (+) | All input validators: BIP21 URIs, bitcoin address types, BOLT11 detection, lightning addresses, LNDHub creds, npub/xpub, PSBT, tx hex, wallet-export formats. First line of defense against misrouting funds. |
+| `utils/AmountUtils.test.ts` | 1051 | Sat/msat amount parsing, formatting, and millisatoshi-display edge cases — user-visible money math. |
+| `utils/MigrationUtils.test.ts` | 567 | Settings-blob migrations (a historically bug-prone area — see **zeus-storage-and-migrations**); mocks `stores/Stores` down to `settingsStore.setSettings`. |
+| `utils/ValidationUtils.test.ts` | 447 | Node-connection input validation: server address, port, rune/macaroon charsets, LNC pairing phrase, pubkey/host. |
+| `utils/CashuUtils.test.ts` | 347 | Ecash token extraction (URL wrappers), validity checks, proof summing, P2PK helpers. |
+| `utils/Bolt11Utils.test.ts` | 243 | Hand-rolled BOLT11 decoder against spec reference vectors; the LRU cache identity guarantee; the lazy signature-recovery getters (deferred secp256k1). Small but guards subtle invariants. |
+| `models/Payment.test.ts` | 105 | `Payment.getAmount` with partial/multi-HTLC successes, fee exclusion — displayed-amount correctness. |
+| `lndmobile/channel.test.ts` | 57 | The only native-bridge-layer test: verifies channel-backup commands encode the right protobuf request/response types. |
+
+## 7) Testing store-like logic despite zero store tests
+
+Do NOT try to instantiate a real MobX store in jest — none of the 30 stores is constructed in any existing test, the DI graph makes it impractical, and there is no established harness. The observed, accepted pattern is **extract pure logic into `utils/` and test it there**:
+
+- `stores/ActivityStore.ts` delegates filtering to `utils/ActivityFilterUtils.ts` → tested in `utils/ActivityFilterUtils.test.ts` (464 lines).
+- `stores/SettingsStore.ts` and `stores/CashuStore.ts` delegate migrations to `utils/MigrationUtils.ts` → tested in `utils/MigrationUtils.test.ts`.
+
+Recipe when fixing a bug in a store:
+1. Isolate the buggy computation (parsing, filtering, amount math, migration transform) into a pure function in `utils/<Thing>Utils.ts` — inputs in, value out, no store references. Keep the store method as a thin caller. Keep the diff minimal if it's a payment path (**zeus-change-control**).
+2. Add colocated `utils/<Thing>Utils.test.ts` with a case reproducing the bug (fails before the fix, passes after) — this satisfies CONTRIBUTING's "test that would have caught the bug".
+3. Where the logic genuinely needs store/native context, mock at the boundary exactly as `utils/MigrationUtils.test.ts` mocks `../stores/Stores` and `utils/handleAnything.test.ts` mocks `./BackendUtils` — mock modules the unit imports, before importing the unit.
+
+Writing the FIRST test harness for an actual store class would be new ground: treat it as a proposal for maintainer discussion, not something to bolt onto a bug-fix PR (see **zeus-research-methodology** for the evidence bar).
+
+## Provenance and maintenance
+
+All facts verified 2026-07-06 against commit `c5fd094fb` (v13.1.3-alpha). Commands below were executed except where a fact is inherently CI-side (workflow YAML claims verified by reading `.github/workflows/*.yml`, not by dispatching CI).
+
+Re-verify volatile facts:
+
+| Fact | Command |
+|---|---|
+| `verify`/`test`/`lint`/`prettier`/`tsc` script definitions | `grep -A2 '"verify"' package.json` and `grep '"lint"\|"prettier"\|"tsc"\|"test"' package.json` |
+| CI = exactly these 4 PR checks | `ls .github/workflows/` and `grep -A3 '^on:' .github/workflows/*.yml` (`build-android.yml`/`dependency-scan.yml` must still say `workflow_dispatch`; note a bare `grep -l 'pull_request'` also matches build-android.yml via a concurrency-group expression, not a trigger) |
+| CI Node version / engines | `grep node-version .github/workflows/test.yml`; `grep -A2 '"engines"' package.json` |
+| jest `testPathIgnorePatterns`, `transformIgnorePatterns`, `moduleNameMapper` | `python3 -c "import json;print(json.load(open('package.json'))['jest'])"` |
+| check-styles ban + regex | `cat check-styles.test.ts` |
+| Prettier pin + config | `grep '"prettier"' package.json` (expect `2.4.1` in devDependencies); `cat .prettierrc .prettierignore` |
+| tsconfig strictness | `grep 'strict\|noUnused\|exclude' tsconfig.json` |
+| Test-file census (expect 45/2/1 + check-styles) | `find . -name "*.test.ts" -not -path "./node_modules/*" -not -path "./zeus_modules/*" \| grep -v check-styles \| awk -F/ '{print $2}' \| sort \| uniq -c` |
+| Stores/views/components/backends still untested | `find stores views components backends -name "*.test.ts*"` (expect empty) |
+| Suite line counts (golden inventory) | `wc -l utils/*.test.ts models/*.test.ts lndmobile/*.test.ts \| sort -rn \| head` |
+| PR template backend matrix | `cat .github/PULL_REQUEST_TEMPLATE.md` |
+| CONTRIBUTING testing rules | `grep -n -A5 'Test Coverage\|Manual Testing' CONTRIBUTING.md` |
+| Cashu backend support (guidance table) | `grep -rn 'supportsCashuWallet' backends/` |
+| Extraction-pattern examples still hold | `grep -n 'ActivityFilterUtils\|MigrationUtils' stores/ActivityStore.ts stores/SettingsStore.ts` |
+
+Note: "no merge without hands-on iOS+Android testing" is a maintainer-stated rule (2026-07-06), stricter than CONTRIBUTING.md's written "when possible" — if CONTRIBUTING.md is later updated, prefer the doc.

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ android/app/src/main/jniLibs/
 ios/LdkNodeMobile/LDKNodeFFI.xcframework
 ios/LdkNodeLibZipFile
 ios/LdkNodeMobile/__MACOSX/
+# Claude Code: share skills, keep everything else local
+.claude/*
+!.claude/skills/


### PR DESCRIPTION
# Description

Relates to issue: N/A

Adds a 16-skill Claude Code skill library under `.claude/skills/` (plus 3 runnable diagnostic scripts) so contributors and AI coding sessions can operate at maintainer standard without rederiving project knowledge:

- **Core runbooks:** change control (incl. previously unwritten gating rules), architecture contract, backend capability matrix, storage/migration safety protocol, config catalog, build/env, run/operate, debugging playbook, failure archaeology (verified commit hashes), Lightning domain reference, diagnostics + scripts, validation/QA
- **Advanced:** node-lifecycle-races campaign, proof/analysis toolkit, research frontier, research methodology

All factual claims (commands, paths, flags, hashes, defaults) were verified against master `c5fd094fb` and passed adversarial factual/doctrine/usability review passes before inclusion. Volatile facts are date-stamped with one-line re-verification commands in each skill's "Provenance and maintenance" section.

Also updates `.gitignore` to share `.claude/skills/` while keeping all other `.claude/` files (e.g. `settings.local.json`) local to each contributor.

Docs-only change: no app code, dependencies, or locales touched.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

N/A — documentation-only; no runtime surface to test.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

N/A — documentation-only.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
