### PR TITLE
LDK: Add support for external accounts

### DIFF
--- a/android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt
+++ b/android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt
@@ -1261,6 +1261,190 @@ class LdkNodeModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
         }
     }
 
+    // Watch-only Account Methods
+
+    @ReactMethod
+    fun importWatchonlyAccount(accountId: String, externalDescriptor: String, internalDescriptor: String, promise: Promise) {
+        moduleScope.launch {
+            try {
+                val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
+                node.importWatchonlyAccount(accountId, externalDescriptor, internalDescriptor)
+                withContext(Dispatchers.Main) {
+                    promise.resolve(null)
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    promise.reject("error", errorMessage(e))
+                }
+            }
+        }
+    }
+
+    @ReactMethod
+    fun watchonlyNewAddress(accountId: String, promise: Promise) {
+        moduleScope.launch {
+            try {
+                val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
+                val address = node.watchonlyNewAddress(accountId)
+                val result = Arguments.createMap().apply {
+                    putString("address", address)
+                }
+                withContext(Dispatchers.Main) {
+                    promise.resolve(result)
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    promise.reject("error", errorMessage(e))
+                }
+            }
+        }
+    }
+
+    @ReactMethod
+    fun watchonlyBalance(accountId: String, promise: Promise) {
+        moduleScope.launch {
+            try {
+                val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
+                val balance = node.watchonlyBalance(accountId)
+                val result = Arguments.createMap().apply {
+                    putDouble("balanceSats", balance.toLong().toDouble())
+                }
+                withContext(Dispatchers.Main) {
+                    promise.resolve(result)
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    promise.reject("error", errorMessage(e))
+                }
+            }
+        }
+    }
+
+    @ReactMethod
+    fun watchonlyListUtxos(accountId: String, promise: Promise) {
+        moduleScope.launch {
+            try {
+                val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
+                val utxos = node.watchonlyListUtxos(accountId)
+                val utxoArray = Arguments.createArray()
+                for (utxo in utxos) {
+                    val utxoMap = Arguments.createMap().apply {
+                        putString("txid", utxo.txid)
+                        putInt("vout", utxo.vout.toInt())
+                        putDouble("value_sats", utxo.valueSats.toLong().toDouble())
+                        putString("address", utxo.address)
+                        putBoolean("is_spent", utxo.isSpent)
+                    }
+                    utxoArray.pushMap(utxoMap)
+                }
+                val result = Arguments.createMap().apply {
+                    putArray("utxos", utxoArray)
+                }
+                withContext(Dispatchers.Main) {
+                    promise.resolve(result)
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    promise.reject("error", errorMessage(e))
+                }
+            }
+        }
+    }
+
+    @ReactMethod
+    fun watchonlyListAddresses(accountId: String, promise: Promise) {
+        moduleScope.launch {
+            try {
+                val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
+                val addresses = node.watchonlyListAddresses(accountId)
+                val addressArray = Arguments.createArray()
+                for (address in addresses) {
+                    addressArray.pushString(address)
+                }
+                val result = Arguments.createMap().apply {
+                    putArray("addresses", addressArray)
+                }
+                withContext(Dispatchers.Main) {
+                    promise.resolve(result)
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    promise.reject("error", errorMessage(e))
+                }
+            }
+        }
+    }
+
+    @ReactMethod
+    fun syncWatchonlyAccounts(promise: Promise) {
+        moduleScope.launch {
+            try {
+                val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
+                node.syncWatchonlyAccounts()
+                withContext(Dispatchers.Main) {
+                    promise.resolve(null)
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    promise.reject("error", errorMessage(e))
+                }
+            }
+        }
+    }
+
+    @ReactMethod
+    fun listWatchonlyAccounts(promise: Promise) {
+        moduleScope.launch {
+            try {
+                val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
+                val accounts = node.listWatchonlyAccounts()
+                val accountArray = Arguments.createArray()
+                for (account in accounts) {
+                    accountArray.pushString(account)
+                }
+                val result = Arguments.createMap().apply {
+                    putArray("accounts", accountArray)
+                }
+                withContext(Dispatchers.Main) {
+                    promise.resolve(result)
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    promise.reject("error", errorMessage(e))
+                }
+            }
+        }
+    }
+
+    @ReactMethod
+    fun previewWatchonlyAccount(externalDescriptor: String, internalDescriptor: String, count: Double, promise: Promise) {
+        moduleScope.launch {
+            try {
+                val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
+                val preview = node.previewWatchonlyAccount(externalDescriptor, internalDescriptor, count.toInt().toUByte())
+                val externalArray = Arguments.createArray()
+                for (address in preview.externalAddresses) {
+                    externalArray.pushString(address)
+                }
+                val internalArray = Arguments.createArray()
+                for (address in preview.internalAddresses) {
+                    internalArray.pushString(address)
+                }
+                val result = Arguments.createMap().apply {
+                    putArray("externalAddresses", externalArray)
+                    putArray("internalAddresses", internalArray)
+                }
+                withContext(Dispatchers.Main) {
+                    promise.resolve(result)
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    promise.reject("error", errorMessage(e))
+                }
+            }
+        }
+    }
+
     @ReactMethod
     fun openChannelFundMax(nodeId: String, address: String, pushToCounterpartyMsat: Double?, announceChannel: Boolean, utxos: ReadableArray?, promise: Promise) {
         moduleScope.launch {

--- a/android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt
+++ b/android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt
@@ -1445,6 +1445,40 @@ class LdkNodeModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
         }
     }
 
+    private fun parseRecipients(recipientsArray: ReadableArray): List<PsbtRecipient> {
+        val recipients = mutableListOf<PsbtRecipient>()
+        for (i in 0 until recipientsArray.size()) {
+            val dict = recipientsArray.getMap(i) ?: continue
+            val address = dict.getString("address") ?: continue
+            val amountSats = dict.getDouble("amountSats").toLong().toULong()
+            recipients.add(PsbtRecipient(address = address, amountSats = amountSats))
+        }
+        return recipients
+    }
+
+    @ReactMethod
+    fun watchonlyCreatePsbt(accountId: String, recipients: ReadableArray, utxos: ReadableArray, satPerVbyte: Double, promise: Promise) {
+        moduleScope.launch {
+            try {
+                val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
+                val parsedRecipients = parseRecipients(recipients)
+                val outpoints = parseOutPoints(utxos)
+                val feeRate = FeeRate.fromSatPerVbUnchecked(satPerVbyte.toLong().toULong())
+                val psbt = node.watchonlyCreatePsbt(accountId, parsedRecipients, outpoints, feeRate)
+                val result = Arguments.createMap().apply {
+                    putString("psbt", psbt)
+                }
+                withContext(Dispatchers.Main) {
+                    promise.resolve(result)
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    promise.reject("error", errorMessage(e))
+                }
+            }
+        }
+    }
+
     @ReactMethod
     fun openChannelFundMax(nodeId: String, address: String, pushToCounterpartyMsat: Double?, announceChannel: Boolean, utxos: ReadableArray?, promise: Promise) {
         moduleScope.launch {

--- a/android/app/src/main/java/org/lightningdevkit/ldknode/ldk_node.kt
+++ b/android/app/src/main/java/org/lightningdevkit/ldknode/ldk_node.kt
@@ -1949,6 +1949,15 @@ internal interface UniffiLib : Library {
         uniffi_out_err: UniffiRustCallStatus,
     ): Long
 
+    fun uniffi_ldk_node_fn_method_node_watchonly_create_psbt(
+        `ptr`: Pointer,
+        `accountId`: RustBuffer.ByValue,
+        `recipients`: RustBuffer.ByValue,
+        `utxos`: RustBuffer.ByValue,
+        `feeRate`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+
     fun uniffi_ldk_node_fn_method_node_watchonly_list_addresses(
         `ptr`: Pointer,
         `accountId`: RustBuffer.ByValue,
@@ -2858,6 +2867,8 @@ internal interface UniffiLib : Library {
 
     fun uniffi_ldk_node_checksum_method_node_watchonly_balance(): Short
 
+    fun uniffi_ldk_node_checksum_method_node_watchonly_create_psbt(): Short
+
     fun uniffi_ldk_node_checksum_method_node_watchonly_list_addresses(): Short
 
     fun uniffi_ldk_node_checksum_method_node_watchonly_list_utxos(): Short
@@ -3427,6 +3438,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ldk_node_checksum_method_node_watchonly_balance() != 39708.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_ldk_node_checksum_method_node_watchonly_create_psbt() != 19695.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ldk_node_checksum_method_node_watchonly_list_addresses() != 48800.toShort()) {
@@ -8146,6 +8160,13 @@ public interface NodeInterface {
 
     fun `watchonlyBalance`(`accountId`: AccountId): kotlin.ULong
 
+    fun `watchonlyCreatePsbt`(
+        `accountId`: AccountId,
+        `recipients`: List<PsbtRecipient>,
+        `utxos`: List<OutPoint>,
+        `feeRate`: FeeRate,
+    ): kotlin.String
+
     fun `watchonlyListAddresses`(`accountId`: AccountId): List<Address>
 
     fun `watchonlyListUtxos`(`accountId`: AccountId): List<WalletUtxo>
@@ -8896,6 +8917,28 @@ open class Node :
                     UniffiLib.INSTANCE.uniffi_ldk_node_fn_method_node_watchonly_balance(
                         it,
                         FfiConverterTypeAccountId.lower(`accountId`),
+                        _status,
+                    )
+                }
+            },
+        )
+
+    @Throws(NodeException::class)
+    override fun `watchonlyCreatePsbt`(
+        `accountId`: AccountId,
+        `recipients`: List<PsbtRecipient>,
+        `utxos`: List<OutPoint>,
+        `feeRate`: FeeRate,
+    ): kotlin.String =
+        FfiConverterString.lift(
+            callWithPointer {
+                uniffiRustCallWithError(NodeException) { _status ->
+                    UniffiLib.INSTANCE.uniffi_ldk_node_fn_method_node_watchonly_create_psbt(
+                        it,
+                        FfiConverterTypeAccountId.lower(`accountId`),
+                        FfiConverterSequenceTypePsbtRecipient.lower(`recipients`),
+                        FfiConverterSequenceTypeOutPoint.lower(`utxos`),
+                        FfiConverterTypeFeeRate.lower(`feeRate`),
                         _status,
                     )
                 }
@@ -12650,6 +12693,38 @@ public object FfiConverterTypePeerDetails : FfiConverterRustBuffer<PeerDetails> 
         FfiConverterTypeSocketAddress.write(value.`address`, buf)
         FfiConverterBoolean.write(value.`isPersisted`, buf)
         FfiConverterBoolean.write(value.`isConnected`, buf)
+    }
+}
+
+data class PsbtRecipient(
+    var `address`: Address,
+    var `amountSats`: kotlin.ULong,
+) {
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypePsbtRecipient : FfiConverterRustBuffer<PsbtRecipient> {
+    override fun read(buf: ByteBuffer): PsbtRecipient =
+        PsbtRecipient(
+            FfiConverterTypeAddress.read(buf),
+            FfiConverterULong.read(buf),
+        )
+
+    override fun allocationSize(value: PsbtRecipient) =
+        (
+            FfiConverterTypeAddress.allocationSize(value.`address`) +
+                FfiConverterULong.allocationSize(value.`amountSats`)
+        )
+
+    override fun write(
+        value: PsbtRecipient,
+        buf: ByteBuffer,
+    ) {
+        FfiConverterTypeAddress.write(value.`address`, buf)
+        FfiConverterULong.write(value.`amountSats`, buf)
     }
 }
 
@@ -17700,6 +17775,34 @@ public object FfiConverterSequenceTypePeerDetails : FfiConverterRustBuffer<List<
         buf.putInt(value.size)
         value.iterator().forEach {
             FfiConverterTypePeerDetails.write(it, buf)
+        }
+    }
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterSequenceTypePsbtRecipient : FfiConverterRustBuffer<List<PsbtRecipient>> {
+    override fun read(buf: ByteBuffer): List<PsbtRecipient> {
+        val len = buf.getInt()
+        return List<PsbtRecipient>(len) {
+            FfiConverterTypePsbtRecipient.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<PsbtRecipient>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterTypePsbtRecipient.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(
+        value: List<PsbtRecipient>,
+        buf: ByteBuffer,
+    ) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterTypePsbtRecipient.write(it, buf)
         }
     }
 }

--- a/android/app/src/main/java/org/lightningdevkit/ldknode/ldk_node.kt
+++ b/android/app/src/main/java/org/lightningdevkit/ldknode/ldk_node.kt
@@ -1684,6 +1684,14 @@ internal interface UniffiLib : Library {
         uniffi_out_err: UniffiRustCallStatus,
     ): Unit
 
+    fun uniffi_ldk_node_fn_method_node_import_watchonly_account(
+        `ptr`: Pointer,
+        `accountId`: RustBuffer.ByValue,
+        `externalDescriptor`: RustBuffer.ByValue,
+        `internalDescriptor`: RustBuffer.ByValue,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
+
     fun uniffi_ldk_node_fn_method_node_list_balances(
         `ptr`: Pointer,
         uniffi_out_err: UniffiRustCallStatus,
@@ -1705,6 +1713,11 @@ internal interface UniffiLib : Library {
     ): RustBuffer.ByValue
 
     fun uniffi_ldk_node_fn_method_node_list_peers(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+
+    fun uniffi_ldk_node_fn_method_node_list_watchonly_accounts(
         `ptr`: Pointer,
         uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
@@ -1819,6 +1832,14 @@ internal interface UniffiLib : Library {
         uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
 
+    fun uniffi_ldk_node_fn_method_node_preview_watchonly_account(
+        `ptr`: Pointer,
+        `externalDescriptor`: RustBuffer.ByValue,
+        `internalDescriptor`: RustBuffer.ByValue,
+        `count`: Byte,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+
     fun uniffi_ldk_node_fn_method_node_remove_payment(
         `ptr`: Pointer,
         `paymentId`: RustBuffer.ByValue,
@@ -1886,6 +1907,11 @@ internal interface UniffiLib : Library {
         uniffi_out_err: UniffiRustCallStatus,
     ): Unit
 
+    fun uniffi_ldk_node_fn_method_node_sync_watchonly_accounts(
+        `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Unit
+
     fun uniffi_ldk_node_fn_method_node_unified_qr_payment(
         `ptr`: Pointer,
         uniffi_out_err: UniffiRustCallStatus,
@@ -1914,6 +1940,30 @@ internal interface UniffiLib : Library {
 
     fun uniffi_ldk_node_fn_method_node_wait_next_event(
         `ptr`: Pointer,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+
+    fun uniffi_ldk_node_fn_method_node_watchonly_balance(
+        `ptr`: Pointer,
+        `accountId`: RustBuffer.ByValue,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): Long
+
+    fun uniffi_ldk_node_fn_method_node_watchonly_list_addresses(
+        `ptr`: Pointer,
+        `accountId`: RustBuffer.ByValue,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+
+    fun uniffi_ldk_node_fn_method_node_watchonly_list_utxos(
+        `ptr`: Pointer,
+        `accountId`: RustBuffer.ByValue,
+        uniffi_out_err: UniffiRustCallStatus,
+    ): RustBuffer.ByValue
+
+    fun uniffi_ldk_node_fn_method_node_watchonly_new_address(
+        `ptr`: Pointer,
+        `accountId`: RustBuffer.ByValue,
         uniffi_out_err: UniffiRustCallStatus,
     ): RustBuffer.ByValue
 
@@ -2724,6 +2774,8 @@ internal interface UniffiLib : Library {
 
     fun uniffi_ldk_node_checksum_method_node_force_close_channel(): Short
 
+    fun uniffi_ldk_node_checksum_method_node_import_watchonly_account(): Short
+
     fun uniffi_ldk_node_checksum_method_node_list_balances(): Short
 
     fun uniffi_ldk_node_checksum_method_node_list_channels(): Short
@@ -2733,6 +2785,8 @@ internal interface UniffiLib : Library {
     fun uniffi_ldk_node_checksum_method_node_list_payments(): Short
 
     fun uniffi_ldk_node_checksum_method_node_list_peers(): Short
+
+    fun uniffi_ldk_node_checksum_method_node_list_watchonly_accounts(): Short
 
     fun uniffi_ldk_node_checksum_method_node_listening_addresses(): Short
 
@@ -2766,6 +2820,8 @@ internal interface UniffiLib : Library {
 
     fun uniffi_ldk_node_checksum_method_node_payment(): Short
 
+    fun uniffi_ldk_node_checksum_method_node_preview_watchonly_account(): Short
+
     fun uniffi_ldk_node_checksum_method_node_remove_payment(): Short
 
     fun uniffi_ldk_node_checksum_method_node_reset_network_graph(): Short
@@ -2788,6 +2844,8 @@ internal interface UniffiLib : Library {
 
     fun uniffi_ldk_node_checksum_method_node_sync_wallets(): Short
 
+    fun uniffi_ldk_node_checksum_method_node_sync_watchonly_accounts(): Short
+
     fun uniffi_ldk_node_checksum_method_node_unified_qr_payment(): Short
 
     fun uniffi_ldk_node_checksum_method_node_update_channel_config(): Short
@@ -2797,6 +2855,14 @@ internal interface UniffiLib : Library {
     fun uniffi_ldk_node_checksum_method_node_verify_signature(): Short
 
     fun uniffi_ldk_node_checksum_method_node_wait_next_event(): Short
+
+    fun uniffi_ldk_node_checksum_method_node_watchonly_balance(): Short
+
+    fun uniffi_ldk_node_checksum_method_node_watchonly_list_addresses(): Short
+
+    fun uniffi_ldk_node_checksum_method_node_watchonly_list_utxos(): Short
+
+    fun uniffi_ldk_node_checksum_method_node_watchonly_new_address(): Short
 
     fun uniffi_ldk_node_checksum_method_offer_absolute_expiry_seconds(): Short
 
@@ -3237,6 +3303,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_ldk_node_checksum_method_node_force_close_channel() != 48831.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_ldk_node_checksum_method_node_import_watchonly_account() != 56121.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_ldk_node_checksum_method_node_list_balances() != 57528.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -3250,6 +3319,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ldk_node_checksum_method_node_list_peers() != 14889.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_ldk_node_checksum_method_node_list_watchonly_accounts() != 26665.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ldk_node_checksum_method_node_listening_addresses() != 2665.toShort()) {
@@ -3300,6 +3372,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_ldk_node_checksum_method_node_payment() != 60296.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_ldk_node_checksum_method_node_preview_watchonly_account() != 12122.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_ldk_node_checksum_method_node_remove_payment() != 47952.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -3333,6 +3408,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_ldk_node_checksum_method_node_sync_wallets() != 32474.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_ldk_node_checksum_method_node_sync_watchonly_accounts() != 20455.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_ldk_node_checksum_method_node_unified_qr_payment() != 9837.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -3346,6 +3424,18 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ldk_node_checksum_method_node_wait_next_event() != 55101.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_ldk_node_checksum_method_node_watchonly_balance() != 39708.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_ldk_node_checksum_method_node_watchonly_list_addresses() != 48800.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_ldk_node_checksum_method_node_watchonly_list_utxos() != 7922.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_ldk_node_checksum_method_node_watchonly_new_address() != 12204.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ldk_node_checksum_method_offer_absolute_expiry_seconds() != 22836.toShort()) {
@@ -7905,6 +7995,12 @@ public interface NodeInterface {
         `reason`: kotlin.String?,
     )
 
+    fun `importWatchonlyAccount`(
+        `accountId`: AccountId,
+        `externalDescriptor`: kotlin.String,
+        `internalDescriptor`: kotlin.String,
+    )
+
     fun `listBalances`(): BalanceDetails
 
     fun `listChannels`(): List<ChannelDetails>
@@ -7914,6 +8010,8 @@ public interface NodeInterface {
     fun `listPayments`(): List<PaymentDetails>
 
     fun `listPeers`(): List<PeerDetails>
+
+    fun `listWatchonlyAccounts`(): List<AccountId>
 
     fun `listeningAddresses`(): List<SocketAddress>?
 
@@ -7985,6 +8083,12 @@ public interface NodeInterface {
 
     fun `payment`(`paymentId`: PaymentId): PaymentDetails?
 
+    fun `previewWatchonlyAccount`(
+        `externalDescriptor`: kotlin.String,
+        `internalDescriptor`: kotlin.String,
+        `count`: kotlin.UByte,
+    ): WatchonlyAccountPreview
+
     fun `removePayment`(`paymentId`: PaymentId)
 
     fun `resetNetworkGraph`()
@@ -8020,6 +8124,8 @@ public interface NodeInterface {
 
     fun `syncWallets`()
 
+    fun `syncWatchonlyAccounts`()
+
     fun `unifiedQrPayment`(): UnifiedQrPayment
 
     fun `updateChannelConfig`(
@@ -8037,6 +8143,14 @@ public interface NodeInterface {
     ): kotlin.Boolean
 
     fun `waitNextEvent`(): Event
+
+    fun `watchonlyBalance`(`accountId`: AccountId): kotlin.ULong
+
+    fun `watchonlyListAddresses`(`accountId`: AccountId): List<Address>
+
+    fun `watchonlyListUtxos`(`accountId`: AccountId): List<WalletUtxo>
+
+    fun `watchonlyNewAddress`(`accountId`: AccountId): Address
 
     companion object
 }
@@ -8236,6 +8350,23 @@ open class Node :
         }
     }
 
+    @Throws(NodeException::class)
+    override fun `importWatchonlyAccount`(
+        `accountId`: AccountId,
+        `externalDescriptor`: kotlin.String,
+        `internalDescriptor`: kotlin.String,
+    ) = callWithPointer {
+        uniffiRustCallWithError(NodeException) { _status ->
+            UniffiLib.INSTANCE.uniffi_ldk_node_fn_method_node_import_watchonly_account(
+                it,
+                FfiConverterTypeAccountId.lower(`accountId`),
+                FfiConverterString.lower(`externalDescriptor`),
+                FfiConverterString.lower(`internalDescriptor`),
+                _status,
+            )
+        }
+    }
+
     override fun `listBalances`(): BalanceDetails =
         FfiConverterTypeBalanceDetails.lift(
             callWithPointer {
@@ -8277,6 +8408,15 @@ open class Node :
             callWithPointer {
                 uniffiRustCall { _status ->
                     UniffiLib.INSTANCE.uniffi_ldk_node_fn_method_node_list_peers(it, _status)
+                }
+            },
+        )
+
+    override fun `listWatchonlyAccounts`(): List<AccountId> =
+        FfiConverterSequenceTypeAccountId.lift(
+            callWithPointer {
+                uniffiRustCall { _status ->
+                    UniffiLib.INSTANCE.uniffi_ldk_node_fn_method_node_list_watchonly_accounts(it, _status)
                 }
             },
         )
@@ -8534,6 +8674,26 @@ open class Node :
         )
 
     @Throws(NodeException::class)
+    override fun `previewWatchonlyAccount`(
+        `externalDescriptor`: kotlin.String,
+        `internalDescriptor`: kotlin.String,
+        `count`: kotlin.UByte,
+    ): WatchonlyAccountPreview =
+        FfiConverterTypeWatchonlyAccountPreview.lift(
+            callWithPointer {
+                uniffiRustCallWithError(NodeException) { _status ->
+                    UniffiLib.INSTANCE.uniffi_ldk_node_fn_method_node_preview_watchonly_account(
+                        it,
+                        FfiConverterString.lower(`externalDescriptor`),
+                        FfiConverterString.lower(`internalDescriptor`),
+                        FfiConverterUByte.lower(`count`),
+                        _status,
+                    )
+                }
+            },
+        )
+
+    @Throws(NodeException::class)
     override fun `removePayment`(`paymentId`: PaymentId) =
         callWithPointer {
             uniffiRustCallWithError(NodeException) { _status ->
@@ -8656,6 +8816,14 @@ open class Node :
             }
         }
 
+    @Throws(NodeException::class)
+    override fun `syncWatchonlyAccounts`() =
+        callWithPointer {
+            uniffiRustCallWithError(NodeException) { _status ->
+                UniffiLib.INSTANCE.uniffi_ldk_node_fn_method_node_sync_watchonly_accounts(it, _status)
+            }
+        }
+
     override fun `unifiedQrPayment`(): UnifiedQrPayment =
         FfiConverterTypeUnifiedQrPayment.lift(
             callWithPointer {
@@ -8716,6 +8884,62 @@ open class Node :
             callWithPointer {
                 uniffiRustCall { _status ->
                     UniffiLib.INSTANCE.uniffi_ldk_node_fn_method_node_wait_next_event(it, _status)
+                }
+            },
+        )
+
+    @Throws(NodeException::class)
+    override fun `watchonlyBalance`(`accountId`: AccountId): kotlin.ULong =
+        FfiConverterULong.lift(
+            callWithPointer {
+                uniffiRustCallWithError(NodeException) { _status ->
+                    UniffiLib.INSTANCE.uniffi_ldk_node_fn_method_node_watchonly_balance(
+                        it,
+                        FfiConverterTypeAccountId.lower(`accountId`),
+                        _status,
+                    )
+                }
+            },
+        )
+
+    @Throws(NodeException::class)
+    override fun `watchonlyListAddresses`(`accountId`: AccountId): List<Address> =
+        FfiConverterSequenceTypeAddress.lift(
+            callWithPointer {
+                uniffiRustCallWithError(NodeException) { _status ->
+                    UniffiLib.INSTANCE.uniffi_ldk_node_fn_method_node_watchonly_list_addresses(
+                        it,
+                        FfiConverterTypeAccountId.lower(`accountId`),
+                        _status,
+                    )
+                }
+            },
+        )
+
+    @Throws(NodeException::class)
+    override fun `watchonlyListUtxos`(`accountId`: AccountId): List<WalletUtxo> =
+        FfiConverterSequenceTypeWalletUtxo.lift(
+            callWithPointer {
+                uniffiRustCallWithError(NodeException) { _status ->
+                    UniffiLib.INSTANCE.uniffi_ldk_node_fn_method_node_watchonly_list_utxos(
+                        it,
+                        FfiConverterTypeAccountId.lower(`accountId`),
+                        _status,
+                    )
+                }
+            },
+        )
+
+    @Throws(NodeException::class)
+    override fun `watchonlyNewAddress`(`accountId`: AccountId): Address =
+        FfiConverterTypeAddress.lift(
+            callWithPointer {
+                uniffiRustCallWithError(NodeException) { _status ->
+                    UniffiLib.INSTANCE.uniffi_ldk_node_fn_method_node_watchonly_new_address(
+                        it,
+                        FfiConverterTypeAccountId.lower(`accountId`),
+                        _status,
+                    )
                 }
             },
         )
@@ -12590,6 +12814,38 @@ public object FfiConverterTypeWalletUtxo : FfiConverterRustBuffer<WalletUtxo> {
         FfiConverterULong.write(value.`valueSats`, buf)
         FfiConverterString.write(value.`address`, buf)
         FfiConverterBoolean.write(value.`isSpent`, buf)
+    }
+}
+
+data class WatchonlyAccountPreview(
+    var `externalAddresses`: List<Address>,
+    var `internalAddresses`: List<Address>,
+) {
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeWatchonlyAccountPreview : FfiConverterRustBuffer<WatchonlyAccountPreview> {
+    override fun read(buf: ByteBuffer): WatchonlyAccountPreview =
+        WatchonlyAccountPreview(
+            FfiConverterSequenceTypeAddress.read(buf),
+            FfiConverterSequenceTypeAddress.read(buf),
+        )
+
+    override fun allocationSize(value: WatchonlyAccountPreview) =
+        (
+            FfiConverterSequenceTypeAddress.allocationSize(value.`externalAddresses`) +
+                FfiConverterSequenceTypeAddress.allocationSize(value.`internalAddresses`)
+        )
+
+    override fun write(
+        value: WatchonlyAccountPreview,
+        buf: ByteBuffer,
+    ) {
+        FfiConverterSequenceTypeAddress.write(value.`externalAddresses`, buf)
+        FfiConverterSequenceTypeAddress.write(value.`internalAddresses`, buf)
     }
 }
 
@@ -17647,6 +17903,34 @@ public object FfiConverterSequenceSequenceTypeRouteHintHop : FfiConverterRustBuf
 /**
  * @suppress
  */
+public object FfiConverterSequenceTypeAccountId : FfiConverterRustBuffer<List<AccountId>> {
+    override fun read(buf: ByteBuffer): List<AccountId> {
+        val len = buf.getInt()
+        return List<AccountId>(len) {
+            FfiConverterTypeAccountId.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<AccountId>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterTypeAccountId.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(
+        value: List<AccountId>,
+        buf: ByteBuffer,
+    ) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterTypeAccountId.write(it, buf)
+        }
+    }
+}
+
+/**
+ * @suppress
+ */
 public object FfiConverterSequenceTypeAddress : FfiConverterRustBuffer<List<Address>> {
     override fun read(buf: ByteBuffer): List<Address> {
         val len = buf.getInt()
@@ -17796,6 +18080,14 @@ public object FfiConverterMapStringString : FfiConverterRustBuffer<Map<kotlin.St
         }
     }
 }
+
+/**
+ * Typealias from the type name used in the UDL file to the builtin type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ * It's also what we have an external type that references a custom type.
+ */
+public typealias AccountId = kotlin.String
+public typealias FfiConverterTypeAccountId = FfiConverterString
 
 /**
  * Typealias from the type name used in the UDL file to the builtin type.  This

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -11,7 +11,17 @@ import { Hash as sha256Hash } from 'fast-sha256';
 import libraryVersions from '../fetch-libraries-versions.json';
 import LdkNodeInjection from '../ldknode/LdkNodeInjection';
 import Base64Utils from '../utils/Base64Utils';
+import {
+    buildWatchonlyDescriptors,
+    normalizeExtendedKey,
+    recoverMasterFingerprintHex,
+    resolveAddressType
+} from '../utils/DescriptorUtils';
 import { localeString } from '../utils/LocaleUtils';
+import {
+    loadWatchonlyRegistry,
+    saveWatchonlyAccountMeta
+} from '../utils/WatchonlyAccountRegistry';
 import type {
     Network,
     NodeStatus,
@@ -257,7 +267,17 @@ export default class LdkNode {
     /**
      * Get blockchain (on-chain) balance
      */
-    getBlockchainBalance = async (): Promise<any> => {
+    getBlockchainBalance = async (data?: any): Promise<any> => {
+        if (data?.account && data.account !== 'default') {
+            const balanceSats =
+                await LdkNodeInjection.watchonly.watchonlyBalance(data.account);
+            return {
+                total_balance: balanceSats.toString(),
+                confirmed_balance: balanceSats.toString(),
+                unconfirmed_balance: '0'
+            };
+        }
+
         const balances = await LdkNodeInjection.node.listBalances();
         return {
             total_balance: balances.totalOnchainBalanceSats.toString(),
@@ -1101,6 +1121,127 @@ export default class LdkNode {
                 amount_sat: u.value_sats,
                 confirmations: u.is_spent ? '0' : '1'
             }))
+        };
+    };
+
+    // ========================================================================
+    // Watch-only Account Methods
+    // ========================================================================
+
+    /**
+     * Import a watch-only account from an extended public key. Mirrors the
+     * LND-family import: a dry run returns a preview (address samples the user
+     * verifies against their hardware wallet) without persisting; the real
+     * import creates the account in ldk-node, records display metadata, and
+     * kicks off a sync so balances populate.
+     */
+    importAccount = async (data: any): Promise<any> => {
+        const {
+            name,
+            extended_public_key,
+            master_key_fingerprint,
+            address_type,
+            dry_run
+        } = data;
+
+        const network = settingsStore.ldkNetwork || 'mainnet';
+
+        const resolvedType = resolveAddressType(
+            extended_public_key,
+            address_type
+        );
+        const xpub = normalizeExtendedKey(extended_public_key, network);
+        const mfpHex = master_key_fingerprint
+            ? recoverMasterFingerprintHex(master_key_fingerprint)
+            : undefined;
+        const { external, internal, derivationPath } =
+            buildWatchonlyDescriptors({
+                xpub,
+                mfpHex,
+                addressType: resolvedType,
+                network
+            });
+
+        if (dry_run) {
+            const preview =
+                await LdkNodeInjection.watchonly.previewWatchonlyAccount(
+                    external,
+                    internal,
+                    5
+                );
+            return {
+                account: {
+                    name,
+                    extended_public_key,
+                    master_key_fingerprint,
+                    address_type: resolvedType,
+                    derivation_path: derivationPath,
+                    watch_only: true
+                },
+                dry_run_external_addrs: preview.externalAddresses,
+                dry_run_internal_addrs: preview.internalAddresses
+            };
+        }
+
+        // The account name doubles as the ldk-node KVStore namespace.
+        if (
+            !name ||
+            !/^[A-Za-z0-9_-]{1,120}$/.test(name) ||
+            name === 'default'
+        ) {
+            throw new Error(
+                localeString('backends.LdkNode.invalidAccountName')
+            );
+        }
+
+        await LdkNodeInjection.watchonly.importWatchonlyAccount(
+            name,
+            external,
+            internal
+        );
+
+        const nodeDir = settingsStore.ldkNodeDir || 'ldk';
+        await saveWatchonlyAccountMeta(nodeDir, name, {
+            extended_public_key,
+            master_key_fingerprint,
+            address_type: resolvedType,
+            derivation_path: derivationPath
+        });
+
+        // Fire-and-forget: pull balances/UTXOs for the new account in the
+        // background. Tolerate NotRunning (e.g. imported before node start).
+        LdkNodeInjection.watchonly.syncWatchonlyAccounts().catch(() => {});
+
+        return { account: { name, watch_only: true } };
+    };
+
+    /**
+     * List imported watch-only accounts. The ldk-node node is the source of
+     * truth for which accounts exist (survives a VSS recovery); the local
+     * registry supplies display metadata, absent gracefully when missing.
+     */
+    listAccounts = async (): Promise<any> => {
+        const names = await LdkNodeInjection.watchonly.listWatchonlyAccounts();
+        const nodeDir = settingsStore.ldkNodeDir || 'ldk';
+        const registry = await loadWatchonlyRegistry(nodeDir);
+
+        return {
+            accounts: names.map((name) => {
+                const meta = registry[name];
+                return {
+                    name,
+                    watch_only: true,
+                    ...(meta
+                        ? {
+                              extended_public_key: meta.extended_public_key,
+                              master_key_fingerprint:
+                                  meta.master_key_fingerprint,
+                              address_type: meta.address_type,
+                              derivation_path: meta.derivation_path
+                          }
+                        : {})
+                };
+            })
         };
     };
 

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -15,7 +15,8 @@ import {
     buildWatchonlyDescriptors,
     normalizeExtendedKey,
     recoverMasterFingerprintHex,
-    resolveAddressType
+    resolveAddressType,
+    WalletAddressType
 } from '../utils/DescriptorUtils';
 import { localeString } from '../utils/LocaleUtils';
 import {
@@ -1097,9 +1098,17 @@ export default class LdkNode {
     // ========================================================================
 
     /**
-     * Get new on-chain address
+     * Get new on-chain address. Reveals a receive address for a watch-only
+     * account when one is passed, otherwise for the node's own wallet.
      */
-    getNewAddress = async (): Promise<any> => {
+    getNewAddress = async (data?: any): Promise<any> => {
+        if (data?.account && data.account !== 'default') {
+            const address =
+                await LdkNodeInjection.watchonly.watchonlyNewAddress(
+                    data.account
+                );
+            return { address };
+        }
         const address = await LdkNodeInjection.onchain.newOnchainAddress();
         return {
             address
@@ -1107,10 +1116,29 @@ export default class LdkNode {
     };
 
     /**
-     * Get UTXOs for coin control
+     * Get a new change address. Watch-only accounts have no separate change
+     * keychain exposed here, so this resolves to a no-op — the import
+     * pre-generation loop calls it and only needs it to settle.
      */
-    getUTXOs = async (): Promise<any> => {
-        const utxos = await LdkNodeInjection.onchain.listUtxos();
+    getNewChangeAddress = async (data?: any): Promise<any> => {
+        if (data?.account && data.account !== 'default') {
+            return { addr: null };
+        }
+        const addr = await LdkNodeInjection.onchain.newOnchainAddress();
+        return { addr };
+    };
+
+    /**
+     * Get UTXOs for coin control. Scoped to a watch-only account when passed,
+     * otherwise the node's own wallet.
+     */
+    getUTXOs = async (data?: any): Promise<any> => {
+        const utxos =
+            data?.account && data.account !== 'default'
+                ? await LdkNodeInjection.watchonly.watchonlyListUtxos(
+                      data.account
+                  )
+                : await LdkNodeInjection.onchain.listUtxos();
         return {
             utxos: utxos.map((u) => ({
                 outpoint: {
@@ -1243,6 +1271,65 @@ export default class LdkNode {
                 };
             })
         };
+    };
+
+    /**
+     * List addresses grouped by watch-only account, in the walletrpc
+     * ListAddresses shape the OnChainAddresses view consumes. ldk-node reveals
+     * external (receive) addresses only, ordered by derivation index, so the
+     * per-address path is synthesized as `${accountPath}/0/${i}` and every
+     * address is external (is_internal: false). Per-address balance is summed
+     * from the account's unspent UTXOs.
+     */
+    listAddresses = async (): Promise<any> => {
+        const nodeDir = settingsStore.ldkNodeDir || 'ldk';
+        const network = settingsStore.ldkNetwork || 'mainnet';
+        const coin =
+            network === 'mainnet' || network === 'bitcoin' ? "0'" : "1'";
+
+        const [names, registry] = await Promise.all([
+            LdkNodeInjection.watchonly.listWatchonlyAccounts(),
+            loadWatchonlyRegistry(nodeDir)
+        ]);
+
+        const account_with_addresses = [];
+        for (const name of names) {
+            const meta = registry[name];
+            const addressTypeNum =
+                meta?.address_type ?? WalletAddressType.WITNESS_PUBKEY_HASH;
+            const accountPath = meta?.derivation_path ?? `m/84'/${coin}/0'`;
+
+            const [addresses, utxos] = await Promise.all([
+                LdkNodeInjection.watchonly.watchonlyListAddresses(name),
+                LdkNodeInjection.watchonly.watchonlyListUtxos(name)
+            ]);
+
+            const balanceByAddress: { [addr: string]: BigNumber } = {};
+            for (const u of utxos) {
+                if (u.is_spent) continue;
+                balanceByAddress[u.address] = (
+                    balanceByAddress[u.address] ?? new BigNumber(0)
+                ).plus(u.value_sats);
+            }
+
+            account_with_addresses.push({
+                name,
+                address_type:
+                    WalletAddressType[addressTypeNum] ?? 'WITNESS_PUBKEY_HASH',
+                derivation_path: accountPath,
+                addresses: addresses.map((address, i) => ({
+                    address,
+                    is_internal: false,
+                    balance: (
+                        balanceByAddress[address] ?? new BigNumber(0)
+                    ).toString(),
+                    derivation_path: `${accountPath}/0/${i}`,
+                    public_key: ''
+                }))
+            });
+        }
+
+        return { account_with_addresses };
     };
 
     /**

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -2346,7 +2346,7 @@ export default class LdkNode {
     supportsCoinControl = () => true;
     supportsChannelCoinControl = () => true;
     supportsHopPicking = () => false;
-    supportsAccounts = () => false;
+    supportsAccounts = () => true;
     supportsRouting = () => false;
     supportsNodeInfo = () => true;
     supportsWithdrawalRequests = () => true;
@@ -2372,7 +2372,7 @@ export default class LdkNode {
     supportsListingOffers = () => false;
     supportsBolt12Address = () => false;
     supportsBolt11BlindedRoutes = () => false;
-    supportsAddressesWithDerivationPaths = () => false;
+    supportsAddressesWithDerivationPaths = () => true;
     supportsCustomFeeLimit = () => true;
     isLNDBased = () => false;
     supportsForwardingHistory = () => false;

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -1350,13 +1350,42 @@ export default class LdkNode {
     };
 
     /**
+     * Build an unsigned PSBT that spends from a watch-only account, ready to be
+     * signed externally (e.g. on a hardware wallet). Mirrors LND's `fundPsbt`:
+     * the caller passes the same LND-shaped request (`raw.outputs` map,
+     * `raw.inputs`, `sat_per_vbyte`, `account`) and receives `funded_psbt`.
+     */
+    fundPsbt = async (data: any): Promise<any> => {
+        const outputs = data?.raw?.outputs || {};
+        const recipients = Object.keys(outputs).map((address) => ({
+            address,
+            amountSats: Number(outputs[address])
+        }));
+
+        const inputs = data?.raw?.inputs || [];
+        const utxos = inputs.map((input: any) => ({
+            txid: input.txid_str,
+            vout: Number(input.output_index)
+        }));
+
+        const funded_psbt =
+            await LdkNodeInjection.watchonly.watchonlyCreatePsbt(
+                data.account,
+                recipients,
+                utxos,
+                Number(data.sat_per_vbyte)
+            );
+
+        return { funded_psbt };
+    };
+
+    /**
      * Send coins on-chain
      */
     sendCoins = async (data: any): Promise<any> => {
-        // SAFETY: without this guard a send initiated from a watch-only
-        // account row would fall through to the branches below and spend the
-        // NODE's own wallet instead. Spending from a watch-only account
-        // requires externally signing a PSBT, which is not wired up here yet.
+        // SAFETY: a watch-only account cannot spend the node wallet. Account
+        // sends are built as an unsigned PSBT via `fundPsbt` and signed
+        // externally; they must never reach the node-wallet send paths below.
         if (data.account && data.account !== 'default') {
             throw new Error(localeString('views.Send.accountSendNotSupported'));
         }

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -196,10 +196,17 @@ export default class LdkNode {
     }
 
     /**
-     * Sync wallets (on-chain and lightning)
+     * Sync wallets (on-chain and lightning), plus any imported watch-only
+     * accounts. Account sync failures are tolerated — the node's own sync
+     * result is what callers depend on.
      */
     syncWallets = async (): Promise<void> => {
         await LdkNodeInjection.node.syncWallets();
+        try {
+            await LdkNodeInjection.watchonly.syncWatchonlyAccounts();
+        } catch (e) {
+            console.log('Watch-only account sync failed:', e);
+        }
     };
 
     /**
@@ -1333,9 +1340,27 @@ export default class LdkNode {
     };
 
     /**
+     * Rescan for account funds. The existing-account import flow calls this
+     * after pre-generating addresses; ldk-node's watch-only sync is always a
+     * full scan, so the start_height in the request is ignored.
+     */
+    rescan = async (_data?: any): Promise<any> => {
+        await LdkNodeInjection.watchonly.syncWatchonlyAccounts();
+        return {};
+    };
+
+    /**
      * Send coins on-chain
      */
     sendCoins = async (data: any): Promise<any> => {
+        // SAFETY: without this guard a send initiated from a watch-only
+        // account row would fall through to the branches below and spend the
+        // NODE's own wallet instead. Spending from a watch-only account
+        // requires externally signing a PSBT, which is not wired up here yet.
+        if (data.account && data.account !== 'default') {
+            throw new Error(localeString('views.Send.accountSendNotSupported'));
+        }
+
         let txid: string;
 
         if (data.utxos?.length > 0) {

--- a/ios/LdkNodeMobile/LDKNode.swift
+++ b/ios/LdkNodeMobile/LDKNode.swift
@@ -2890,6 +2890,8 @@ public protocol NodeProtocol : AnyObject {
     
     func watchonlyBalance(accountId: AccountId) throws  -> UInt64
     
+    func watchonlyCreatePsbt(accountId: AccountId, recipients: [PsbtRecipient], utxos: [OutPoint], feeRate: FeeRate) throws  -> String
+    
     func watchonlyListAddresses(accountId: AccountId) throws  -> [Address]
     
     func watchonlyListUtxos(accountId: AccountId) throws  -> [WalletUtxo]
@@ -3371,6 +3373,17 @@ open func watchonlyBalance(accountId: AccountId)throws  -> UInt64 {
     return try  FfiConverterUInt64.lift(try rustCallWithError(FfiConverterTypeNodeError.lift) {
     uniffi_ldk_node_fn_method_node_watchonly_balance(self.uniffiClonePointer(),
         FfiConverterTypeAccountId.lower(accountId),$0
+    )
+})
+}
+    
+open func watchonlyCreatePsbt(accountId: AccountId, recipients: [PsbtRecipient], utxos: [OutPoint], feeRate: FeeRate)throws  -> String {
+    return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeNodeError.lift) {
+    uniffi_ldk_node_fn_method_node_watchonly_create_psbt(self.uniffiClonePointer(),
+        FfiConverterTypeAccountId.lower(accountId),
+        FfiConverterSequenceTypePsbtRecipient.lower(recipients),
+        FfiConverterSequenceTypeOutPoint.lower(utxos),
+        FfiConverterTypeFeeRate.lower(feeRate),$0
     )
 })
 }
@@ -7446,6 +7459,72 @@ public func FfiConverterTypePeerDetails_lift(_ buf: RustBuffer) throws -> PeerDe
 #endif
 public func FfiConverterTypePeerDetails_lower(_ value: PeerDetails) -> RustBuffer {
     return FfiConverterTypePeerDetails.lower(value)
+}
+
+
+public struct PsbtRecipient {
+    public var address: Address
+    public var amountSats: UInt64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(address: Address, amountSats: UInt64) {
+        self.address = address
+        self.amountSats = amountSats
+    }
+}
+
+
+
+extension PsbtRecipient: Equatable, Hashable {
+    public static func ==(lhs: PsbtRecipient, rhs: PsbtRecipient) -> Bool {
+        if lhs.address != rhs.address {
+            return false
+        }
+        if lhs.amountSats != rhs.amountSats {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(address)
+        hasher.combine(amountSats)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePsbtRecipient: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PsbtRecipient {
+        return
+            try PsbtRecipient(
+                address: FfiConverterTypeAddress.read(from: &buf), 
+                amountSats: FfiConverterUInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: PsbtRecipient, into buf: inout [UInt8]) {
+        FfiConverterTypeAddress.write(value.address, into: &buf)
+        FfiConverterUInt64.write(value.amountSats, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePsbtRecipient_lift(_ buf: RustBuffer) throws -> PsbtRecipient {
+    return try FfiConverterTypePsbtRecipient.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePsbtRecipient_lower(_ value: PsbtRecipient) -> RustBuffer {
+    return FfiConverterTypePsbtRecipient.lower(value)
 }
 
 
@@ -11957,6 +12036,31 @@ fileprivate struct FfiConverterSequenceTypePeerDetails: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceTypePsbtRecipient: FfiConverterRustBuffer {
+    typealias SwiftType = [PsbtRecipient]
+
+    public static func write(_ value: [PsbtRecipient], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypePsbtRecipient.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [PsbtRecipient] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [PsbtRecipient]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypePsbtRecipient.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeRouteHintHop: FfiConverterRustBuffer {
     typealias SwiftType = [RouteHintHop]
 
@@ -13732,6 +13836,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ldk_node_checksum_method_node_watchonly_balance() != 39708) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_node_watchonly_create_psbt() != 19695) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ldk_node_checksum_method_node_watchonly_list_addresses() != 48800) {

--- a/ios/LdkNodeMobile/LDKNode.swift
+++ b/ios/LdkNodeMobile/LDKNode.swift
@@ -2806,6 +2806,8 @@ public protocol NodeProtocol : AnyObject {
     
     func forceCloseChannel(userChannelId: UserChannelId, counterpartyNodeId: PublicKey, reason: String?) throws 
     
+    func importWatchonlyAccount(accountId: AccountId, externalDescriptor: String, internalDescriptor: String) throws 
+    
     func listBalances()  -> BalanceDetails
     
     func listChannels()  -> [ChannelDetails]
@@ -2815,6 +2817,8 @@ public protocol NodeProtocol : AnyObject {
     func listPayments()  -> [PaymentDetails]
     
     func listPeers()  -> [PeerDetails]
+    
+    func listWatchonlyAccounts()  -> [AccountId]
     
     func listeningAddresses()  -> [SocketAddress]?
     
@@ -2848,6 +2852,8 @@ public protocol NodeProtocol : AnyObject {
     
     func payment(paymentId: PaymentId)  -> PaymentDetails?
     
+    func previewWatchonlyAccount(externalDescriptor: String, internalDescriptor: String, count: UInt8) throws  -> WatchonlyAccountPreview
+    
     func removePayment(paymentId: PaymentId) throws 
     
     func resetNetworkGraph() throws 
@@ -2870,6 +2876,8 @@ public protocol NodeProtocol : AnyObject {
     
     func syncWallets() throws 
     
+    func syncWatchonlyAccounts() throws 
+    
     func unifiedQrPayment()  -> UnifiedQrPayment
     
     func updateChannelConfig(userChannelId: UserChannelId, counterpartyNodeId: PublicKey, channelConfig: ChannelConfig) throws 
@@ -2879,6 +2887,14 @@ public protocol NodeProtocol : AnyObject {
     func verifySignature(msg: [UInt8], sig: String, pkey: PublicKey)  -> Bool
     
     func waitNextEvent()  -> Event
+    
+    func watchonlyBalance(accountId: AccountId) throws  -> UInt64
+    
+    func watchonlyListAddresses(accountId: AccountId) throws  -> [Address]
+    
+    func watchonlyListUtxos(accountId: AccountId) throws  -> [WalletUtxo]
+    
+    func watchonlyNewAddress(accountId: AccountId) throws  -> Address
     
 }
 
@@ -3006,6 +3022,15 @@ open func forceCloseChannel(userChannelId: UserChannelId, counterpartyNodeId: Pu
 }
 }
     
+open func importWatchonlyAccount(accountId: AccountId, externalDescriptor: String, internalDescriptor: String)throws  {try rustCallWithError(FfiConverterTypeNodeError.lift) {
+    uniffi_ldk_node_fn_method_node_import_watchonly_account(self.uniffiClonePointer(),
+        FfiConverterTypeAccountId.lower(accountId),
+        FfiConverterString.lower(externalDescriptor),
+        FfiConverterString.lower(internalDescriptor),$0
+    )
+}
+}
+    
 open func listBalances() -> BalanceDetails {
     return try!  FfiConverterTypeBalanceDetails.lift(try! rustCall() {
     uniffi_ldk_node_fn_method_node_list_balances(self.uniffiClonePointer(),$0
@@ -3037,6 +3062,13 @@ open func listPayments() -> [PaymentDetails] {
 open func listPeers() -> [PeerDetails] {
     return try!  FfiConverterSequenceTypePeerDetails.lift(try! rustCall() {
     uniffi_ldk_node_fn_method_node_list_peers(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func listWatchonlyAccounts() -> [AccountId] {
+    return try!  FfiConverterSequenceTypeAccountId.lift(try! rustCall() {
+    uniffi_ldk_node_fn_method_node_list_watchonly_accounts(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -3197,6 +3229,16 @@ open func payment(paymentId: PaymentId) -> PaymentDetails? {
 })
 }
     
+open func previewWatchonlyAccount(externalDescriptor: String, internalDescriptor: String, count: UInt8)throws  -> WatchonlyAccountPreview {
+    return try  FfiConverterTypeWatchonlyAccountPreview.lift(try rustCallWithError(FfiConverterTypeNodeError.lift) {
+    uniffi_ldk_node_fn_method_node_preview_watchonly_account(self.uniffiClonePointer(),
+        FfiConverterString.lower(externalDescriptor),
+        FfiConverterString.lower(internalDescriptor),
+        FfiConverterUInt8.lower(count),$0
+    )
+})
+}
+    
 open func removePayment(paymentId: PaymentId)throws  {try rustCallWithError(FfiConverterTypeNodeError.lift) {
     uniffi_ldk_node_fn_method_node_remove_payment(self.uniffiClonePointer(),
         FfiConverterTypePaymentId.lower(paymentId),$0
@@ -3279,6 +3321,12 @@ open func syncWallets()throws  {try rustCallWithError(FfiConverterTypeNodeError.
 }
 }
     
+open func syncWatchonlyAccounts()throws  {try rustCallWithError(FfiConverterTypeNodeError.lift) {
+    uniffi_ldk_node_fn_method_node_sync_watchonly_accounts(self.uniffiClonePointer(),$0
+    )
+}
+}
+    
 open func unifiedQrPayment() -> UnifiedQrPayment {
     return try!  FfiConverterTypeUnifiedQrPayment.lift(try! rustCall() {
     uniffi_ldk_node_fn_method_node_unified_qr_payment(self.uniffiClonePointer(),$0
@@ -3315,6 +3363,38 @@ open func verifySignature(msg: [UInt8], sig: String, pkey: PublicKey) -> Bool {
 open func waitNextEvent() -> Event {
     return try!  FfiConverterTypeEvent.lift(try! rustCall() {
     uniffi_ldk_node_fn_method_node_wait_next_event(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func watchonlyBalance(accountId: AccountId)throws  -> UInt64 {
+    return try  FfiConverterUInt64.lift(try rustCallWithError(FfiConverterTypeNodeError.lift) {
+    uniffi_ldk_node_fn_method_node_watchonly_balance(self.uniffiClonePointer(),
+        FfiConverterTypeAccountId.lower(accountId),$0
+    )
+})
+}
+    
+open func watchonlyListAddresses(accountId: AccountId)throws  -> [Address] {
+    return try  FfiConverterSequenceTypeAddress.lift(try rustCallWithError(FfiConverterTypeNodeError.lift) {
+    uniffi_ldk_node_fn_method_node_watchonly_list_addresses(self.uniffiClonePointer(),
+        FfiConverterTypeAccountId.lower(accountId),$0
+    )
+})
+}
+    
+open func watchonlyListUtxos(accountId: AccountId)throws  -> [WalletUtxo] {
+    return try  FfiConverterSequenceTypeWalletUtxo.lift(try rustCallWithError(FfiConverterTypeNodeError.lift) {
+    uniffi_ldk_node_fn_method_node_watchonly_list_utxos(self.uniffiClonePointer(),
+        FfiConverterTypeAccountId.lower(accountId),$0
+    )
+})
+}
+    
+open func watchonlyNewAddress(accountId: AccountId)throws  -> Address {
+    return try  FfiConverterTypeAddress.lift(try rustCallWithError(FfiConverterTypeNodeError.lift) {
+    uniffi_ldk_node_fn_method_node_watchonly_new_address(self.uniffiClonePointer(),
+        FfiConverterTypeAccountId.lower(accountId),$0
     )
 })
 }
@@ -7704,6 +7784,72 @@ public func FfiConverterTypeWalletUtxo_lower(_ value: WalletUtxo) -> RustBuffer 
     return FfiConverterTypeWalletUtxo.lower(value)
 }
 
+
+public struct WatchonlyAccountPreview {
+    public var externalAddresses: [Address]
+    public var internalAddresses: [Address]
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(externalAddresses: [Address], internalAddresses: [Address]) {
+        self.externalAddresses = externalAddresses
+        self.internalAddresses = internalAddresses
+    }
+}
+
+
+
+extension WatchonlyAccountPreview: Equatable, Hashable {
+    public static func ==(lhs: WatchonlyAccountPreview, rhs: WatchonlyAccountPreview) -> Bool {
+        if lhs.externalAddresses != rhs.externalAddresses {
+            return false
+        }
+        if lhs.internalAddresses != rhs.internalAddresses {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(externalAddresses)
+        hasher.combine(internalAddresses)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWatchonlyAccountPreview: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WatchonlyAccountPreview {
+        return
+            try WatchonlyAccountPreview(
+                externalAddresses: FfiConverterSequenceTypeAddress.read(from: &buf), 
+                internalAddresses: FfiConverterSequenceTypeAddress.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WatchonlyAccountPreview, into buf: inout [UInt8]) {
+        FfiConverterSequenceTypeAddress.write(value.externalAddresses, into: &buf)
+        FfiConverterSequenceTypeAddress.write(value.internalAddresses, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWatchonlyAccountPreview_lift(_ buf: RustBuffer) throws -> WatchonlyAccountPreview {
+    return try FfiConverterTypeWatchonlyAccountPreview.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWatchonlyAccountPreview_lower(_ value: WatchonlyAccountPreview) -> RustBuffer {
+    return FfiConverterTypeWatchonlyAccountPreview.lower(value)
+}
+
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
@@ -11986,6 +12132,31 @@ fileprivate struct FfiConverterSequenceSequenceTypeRouteHintHop: FfiConverterRus
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceTypeAccountId: FfiConverterRustBuffer {
+    typealias SwiftType = [AccountId]
+
+    public static func write(_ value: [AccountId], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeAccountId.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [AccountId] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [AccountId]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeAccountId.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeAddress: FfiConverterRustBuffer {
     typealias SwiftType = [Address]
 
@@ -12108,6 +12279,50 @@ fileprivate struct FfiConverterDictionaryStringString: FfiConverterRustBuffer {
         return dict
     }
 }
+
+
+/**
+ * Typealias from the type name used in the UDL file to the builtin type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ */
+public typealias AccountId = String
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeAccountId: FfiConverter {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AccountId {
+        return try FfiConverterString.read(from: &buf)
+    }
+
+    public static func write(_ value: AccountId, into buf: inout [UInt8]) {
+        return FfiConverterString.write(value, into: &buf)
+    }
+
+    public static func lift(_ value: RustBuffer) throws -> AccountId {
+        return try FfiConverterString.lift(value)
+    }
+
+    public static func lower(_ value: AccountId) -> RustBuffer {
+        return FfiConverterString.lower(value)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeAccountId_lift(_ value: RustBuffer) throws -> AccountId {
+    return try FfiConverterTypeAccountId.lift(value)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeAccountId_lower(_ value: AccountId) -> RustBuffer {
+    return FfiConverterTypeAccountId.lower(value)
+}
+
 
 
 /**
@@ -13393,6 +13608,9 @@ private var initializationResult: InitializationResult = {
     if (uniffi_ldk_node_checksum_method_node_force_close_channel() != 48831) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_ldk_node_checksum_method_node_import_watchonly_account() != 56121) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_ldk_node_checksum_method_node_list_balances() != 57528) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -13406,6 +13624,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ldk_node_checksum_method_node_list_peers() != 14889) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_node_list_watchonly_accounts() != 26665) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ldk_node_checksum_method_node_listening_addresses() != 2665) {
@@ -13456,6 +13677,9 @@ private var initializationResult: InitializationResult = {
     if (uniffi_ldk_node_checksum_method_node_payment() != 60296) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_ldk_node_checksum_method_node_preview_watchonly_account() != 12122) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_ldk_node_checksum_method_node_remove_payment() != 47952) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -13489,6 +13713,9 @@ private var initializationResult: InitializationResult = {
     if (uniffi_ldk_node_checksum_method_node_sync_wallets() != 32474) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_ldk_node_checksum_method_node_sync_watchonly_accounts() != 20455) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_ldk_node_checksum_method_node_unified_qr_payment() != 9837) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -13502,6 +13729,18 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ldk_node_checksum_method_node_wait_next_event() != 55101) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_node_watchonly_balance() != 39708) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_node_watchonly_list_addresses() != 48800) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_node_watchonly_list_utxos() != 7922) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_ldk_node_checksum_method_node_watchonly_new_address() != 12204) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_ldk_node_checksum_method_offer_absolute_expiry_seconds() != 22836) {

--- a/ios/LdkNodeMobile/LdkNodeModule.m
+++ b/ios/LdkNodeMobile/LdkNodeModule.m
@@ -70,6 +70,7 @@ RCT_EXTERN_METHOD(watchonlyListAddresses:(NSString *)accountId resolver:(RCTProm
 RCT_EXTERN_METHOD(syncWatchonlyAccounts:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(listWatchonlyAccounts:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(previewWatchonlyAccount:(NSString *)externalDescriptor internalDescriptor:(NSString *)internalDescriptor count:(nonnull NSNumber *)count resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(watchonlyCreatePsbt:(NSString *)accountId recipients:(NSArray *)recipients utxos:(NSArray *)utxos satPerVbyte:(nonnull NSNumber *)satPerVbyte resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
 // BOLT11 Payment Methods
 RCT_EXTERN_METHOD(receiveBolt11:(double)amountMsat invoiceDescription:(NSString *)invoiceDescription expirySecs:(double)expirySecs resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/LdkNodeMobile/LdkNodeModule.m
+++ b/ios/LdkNodeMobile/LdkNodeModule.m
@@ -61,6 +61,16 @@ RCT_EXTERN_METHOD(listUtxos:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromise
 RCT_EXTERN_METHOD(sendToOnchainAddressWithUtxos:(NSString *)address amountSats:(nonnull NSNumber *)amountSats utxos:(NSArray *)utxos resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(sendAllToOnchainAddressWithUtxos:(NSString *)address retainReserve:(BOOL)retainReserve utxos:(NSArray *)utxos resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
+// Watch-only Account Methods
+RCT_EXTERN_METHOD(importWatchonlyAccount:(NSString *)accountId externalDescriptor:(NSString *)externalDescriptor internalDescriptor:(NSString *)internalDescriptor resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(watchonlyNewAddress:(NSString *)accountId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(watchonlyBalance:(NSString *)accountId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(watchonlyListUtxos:(NSString *)accountId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(watchonlyListAddresses:(NSString *)accountId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(syncWatchonlyAccounts:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(listWatchonlyAccounts:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(previewWatchonlyAccount:(NSString *)externalDescriptor internalDescriptor:(NSString *)internalDescriptor count:(nonnull NSNumber *)count resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
 // BOLT11 Payment Methods
 RCT_EXTERN_METHOD(receiveBolt11:(double)amountMsat invoiceDescription:(NSString *)invoiceDescription expirySecs:(double)expirySecs resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(receiveVariableAmountBolt11:(NSString *)invoiceDescription expirySecs:(double)expirySecs resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/LdkNodeMobile/LdkNodeModule.swift
+++ b/ios/LdkNodeMobile/LdkNodeModule.swift
@@ -1157,6 +1157,152 @@ class LdkNodeModule: RCTEventEmitter {
         }
     }
 
+    // MARK: - Watch-only Account Methods
+
+    @objc(importWatchonlyAccount:externalDescriptor:internalDescriptor:resolver:rejecter:)
+    func importWatchonlyAccount(_ accountId: String, externalDescriptor: String, internalDescriptor: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let node = self.getNode() else {
+            reject("error", "Node not initialized", nil)
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try node.importWatchonlyAccount(accountId: accountId, externalDescriptor: externalDescriptor, internalDescriptor: internalDescriptor)
+                resolve(nil)
+            } catch {
+                reject("error", self.errorMessage(error), error)
+            }
+        }
+    }
+
+    @objc(watchonlyNewAddress:resolver:rejecter:)
+    func watchonlyNewAddress(_ accountId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let node = self.getNode() else {
+            reject("error", "Node not initialized", nil)
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let address = try node.watchonlyNewAddress(accountId: accountId)
+                resolve(["address": address])
+            } catch {
+                reject("error", self.errorMessage(error), error)
+            }
+        }
+    }
+
+    @objc(watchonlyBalance:resolver:rejecter:)
+    func watchonlyBalance(_ accountId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let node = self.getNode() else {
+            reject("error", "Node not initialized", nil)
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let balance = try node.watchonlyBalance(accountId: accountId)
+                resolve(["balanceSats": balance])
+            } catch {
+                reject("error", self.errorMessage(error), error)
+            }
+        }
+    }
+
+    @objc(watchonlyListUtxos:resolver:rejecter:)
+    func watchonlyListUtxos(_ accountId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let node = self.getNode() else {
+            reject("error", "Node not initialized", nil)
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let utxos = try node.watchonlyListUtxos(accountId: accountId)
+                let utxoList = utxos.map { utxo -> [String: Any] in
+                    return [
+                        "txid": utxo.txid,
+                        "vout": utxo.vout,
+                        "value_sats": utxo.valueSats,
+                        "address": utxo.address,
+                        "is_spent": utxo.isSpent
+                    ]
+                }
+                resolve(["utxos": utxoList])
+            } catch {
+                reject("error", self.errorMessage(error), error)
+            }
+        }
+    }
+
+    @objc(watchonlyListAddresses:resolver:rejecter:)
+    func watchonlyListAddresses(_ accountId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let node = self.getNode() else {
+            reject("error", "Node not initialized", nil)
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let addresses = try node.watchonlyListAddresses(accountId: accountId)
+                resolve(["addresses": addresses])
+            } catch {
+                reject("error", self.errorMessage(error), error)
+            }
+        }
+    }
+
+    @objc(syncWatchonlyAccounts:rejecter:)
+    func syncWatchonlyAccounts(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let node = self.getNode() else {
+            reject("error", "Node not initialized", nil)
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try node.syncWatchonlyAccounts()
+                resolve(nil)
+            } catch {
+                reject("error", self.errorMessage(error), error)
+            }
+        }
+    }
+
+    @objc(listWatchonlyAccounts:rejecter:)
+    func listWatchonlyAccounts(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let node = self.getNode() else {
+            reject("error", "Node not initialized", nil)
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let accounts = node.listWatchonlyAccounts()
+            resolve(["accounts": accounts])
+        }
+    }
+
+    @objc(previewWatchonlyAccount:internalDescriptor:count:resolver:rejecter:)
+    func previewWatchonlyAccount(_ externalDescriptor: String, internalDescriptor: String, count: NSNumber, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let node = self.getNode() else {
+            reject("error", "Node not initialized", nil)
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let preview = try node.previewWatchonlyAccount(externalDescriptor: externalDescriptor, internalDescriptor: internalDescriptor, count: count.uint8Value)
+                resolve([
+                    "externalAddresses": preview.externalAddresses,
+                    "internalAddresses": preview.internalAddresses
+                ])
+            } catch {
+                reject("error", self.errorMessage(error), error)
+            }
+        }
+    }
+
     // MARK: - Route Parameters Helper
 
     private func buildRouteParameters(maxTotalRoutingFeeMsat: Double, maxPathCount: Double) -> RouteParametersConfig? {

--- a/ios/LdkNodeMobile/LdkNodeModule.swift
+++ b/ios/LdkNodeMobile/LdkNodeModule.swift
@@ -1303,6 +1303,40 @@ class LdkNodeModule: RCTEventEmitter {
         }
     }
 
+    @objc(watchonlyCreatePsbt:recipients:utxos:satPerVbyte:resolver:rejecter:)
+    func watchonlyCreatePsbt(_ accountId: String, recipients: NSArray, utxos: NSArray, satPerVbyte: NSNumber, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let node = self.getNode() else {
+            reject("error", "Node not initialized", nil)
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                var parsedRecipients: [PsbtRecipient] = []
+                for item in recipients {
+                    if let dict = item as? [String: Any],
+                       let address = dict["address"] as? String,
+                       let amountSats = dict["amountSats"] as? NSNumber {
+                        parsedRecipients.append(PsbtRecipient(address: address, amountSats: amountSats.uint64Value))
+                    }
+                }
+                var outpoints: [OutPoint] = []
+                for item in utxos {
+                    if let dict = item as? [String: Any],
+                       let txid = dict["txid"] as? String,
+                       let vout = dict["vout"] as? NSNumber {
+                        outpoints.append(OutPoint(txid: txid, vout: vout.uint32Value))
+                    }
+                }
+                let feeRate = FeeRate.fromSatPerVbUnchecked(satVb: satPerVbyte.uint64Value)
+                let psbt = try node.watchonlyCreatePsbt(accountId: accountId, recipients: parsedRecipients, utxos: outpoints, feeRate: feeRate)
+                resolve(["psbt": psbt])
+            } catch {
+                reject("error", self.errorMessage(error), error)
+            }
+        }
+    }
+
     // MARK: - Route Parameters Helper
 
     private func buildRouteParameters(maxTotalRoutingFeeMsat: Double, maxPathCount: Double) -> RouteParametersConfig? {

--- a/ldknode/LdkNode.d.ts
+++ b/ldknode/LdkNode.d.ts
@@ -549,6 +549,27 @@ export interface ILdkNodeModule {
         utxos: Array<{ txid: string; vout: number }>
     ): Promise<{ txid: string }>;
 
+    // Watch-only Account Methods
+    importWatchonlyAccount(
+        accountId: string,
+        externalDescriptor: string,
+        internalDescriptor: string
+    ): Promise<void>;
+    watchonlyNewAddress(accountId: string): Promise<{ address: string }>;
+    watchonlyBalance(accountId: string): Promise<{ balanceSats: number }>;
+    watchonlyListUtxos(accountId: string): Promise<{ utxos: any[] }>;
+    watchonlyListAddresses(accountId: string): Promise<{ addresses: string[] }>;
+    syncWatchonlyAccounts(): Promise<void>;
+    listWatchonlyAccounts(): Promise<{ accounts: string[] }>;
+    previewWatchonlyAccount(
+        externalDescriptor: string,
+        internalDescriptor: string,
+        count: number
+    ): Promise<{
+        externalAddresses: string[];
+        internalAddresses: string[];
+    }>;
+
     // BOLT11 Payment Methods
     receiveBolt11(
         amountMsat: number,

--- a/ldknode/LdkNode.d.ts
+++ b/ldknode/LdkNode.d.ts
@@ -569,6 +569,12 @@ export interface ILdkNodeModule {
         externalAddresses: string[];
         internalAddresses: string[];
     }>;
+    watchonlyCreatePsbt(
+        accountId: string,
+        recipients: Array<{ address: string; amountSats: number }>,
+        utxos: Array<{ txid: string; vout: number }>,
+        satPerVbyte: number
+    ): Promise<{ psbt: string }>;
 
     // BOLT11 Payment Methods
     receiveBolt11(

--- a/ldknode/LdkNodeInjection.ts
+++ b/ldknode/LdkNodeInjection.ts
@@ -466,6 +466,21 @@ const previewWatchonlyAccount = async (
     };
 };
 
+const watchonlyCreatePsbt = async (
+    accountId: string,
+    recipients: Array<{ address: string; amountSats: number }>,
+    utxos: Array<{ txid: string; vout: number }>,
+    satPerVbyte: number
+): Promise<string> => {
+    const result: any = await LdkNodeModule.watchonlyCreatePsbt(
+        accountId,
+        recipients,
+        utxos,
+        satPerVbyte
+    );
+    return result.psbt;
+};
+
 // ============================================================================
 // BOLT11 Payment Functions
 // ============================================================================
@@ -1214,6 +1229,12 @@ export interface ILdkNodeInjections {
             externalAddresses: string[];
             internalAddresses: string[];
         }>;
+        watchonlyCreatePsbt: (
+            accountId: string,
+            recipients: Array<{ address: string; amountSats: number }>,
+            utxos: Array<{ txid: string; vout: number }>,
+            satPerVbyte: number
+        ) => Promise<string>;
     };
     bolt11: {
         receiveBolt11: (params: {
@@ -1437,7 +1458,8 @@ const LdkNodeInjection: ILdkNodeInjections = {
         watchonlyListAddresses,
         syncWatchonlyAccounts,
         listWatchonlyAccounts,
-        previewWatchonlyAccount
+        previewWatchonlyAccount,
+        watchonlyCreatePsbt
     },
     bolt11: {
         receiveBolt11,

--- a/ldknode/LdkNodeInjection.ts
+++ b/ldknode/LdkNodeInjection.ts
@@ -406,6 +406,67 @@ const sendAllToOnchainAddressWithUtxos = async ({
 };
 
 // ============================================================================
+// Watch-only Account Methods
+// ============================================================================
+
+const importWatchonlyAccount = async (
+    accountId: string,
+    externalDescriptor: string,
+    internalDescriptor: string
+): Promise<void> => {
+    return await LdkNodeModule.importWatchonlyAccount(
+        accountId,
+        externalDescriptor,
+        internalDescriptor
+    );
+};
+
+const watchonlyNewAddress = async (accountId: string): Promise<string> => {
+    const result: any = await LdkNodeModule.watchonlyNewAddress(accountId);
+    return result.address;
+};
+
+const watchonlyBalance = async (accountId: string): Promise<number> => {
+    const result: any = await LdkNodeModule.watchonlyBalance(accountId);
+    return result.balanceSats;
+};
+
+const watchonlyListUtxos = async (accountId: string): Promise<WalletUtxo[]> => {
+    const result: any = await LdkNodeModule.watchonlyListUtxos(accountId);
+    return result.utxos;
+};
+
+const watchonlyListAddresses = async (accountId: string): Promise<string[]> => {
+    const result: any = await LdkNodeModule.watchonlyListAddresses(accountId);
+    return result.addresses;
+};
+
+const syncWatchonlyAccounts = async (): Promise<void> => {
+    return await LdkNodeModule.syncWatchonlyAccounts();
+};
+
+const listWatchonlyAccounts = async (): Promise<string[]> => {
+    const result: any = await LdkNodeModule.listWatchonlyAccounts();
+    return result.accounts;
+};
+
+const previewWatchonlyAccount = async (
+    externalDescriptor: string,
+    internalDescriptor: string,
+    count: number
+): Promise<{ externalAddresses: string[]; internalAddresses: string[] }> => {
+    const result: any = await LdkNodeModule.previewWatchonlyAccount(
+        externalDescriptor,
+        internalDescriptor,
+        count
+    );
+    return {
+        externalAddresses: result.externalAddresses,
+        internalAddresses: result.internalAddresses
+    };
+};
+
+// ============================================================================
 // BOLT11 Payment Functions
 // ============================================================================
 
@@ -1133,6 +1194,27 @@ export interface ILdkNodeInjections {
             utxos: Array<{ txid: string; vout: number }>;
         }) => Promise<string>;
     };
+    watchonly: {
+        importWatchonlyAccount: (
+            accountId: string,
+            externalDescriptor: string,
+            internalDescriptor: string
+        ) => Promise<void>;
+        watchonlyNewAddress: (accountId: string) => Promise<string>;
+        watchonlyBalance: (accountId: string) => Promise<number>;
+        watchonlyListUtxos: (accountId: string) => Promise<WalletUtxo[]>;
+        watchonlyListAddresses: (accountId: string) => Promise<string[]>;
+        syncWatchonlyAccounts: () => Promise<void>;
+        listWatchonlyAccounts: () => Promise<string[]>;
+        previewWatchonlyAccount: (
+            externalDescriptor: string,
+            internalDescriptor: string,
+            count: number
+        ) => Promise<{
+            externalAddresses: string[];
+            internalAddresses: string[];
+        }>;
+    };
     bolt11: {
         receiveBolt11: (params: {
             amountMsat: number;
@@ -1346,6 +1428,16 @@ const LdkNodeInjection: ILdkNodeInjections = {
         listUtxos,
         sendToOnchainAddressWithUtxos,
         sendAllToOnchainAddressWithUtxos
+    },
+    watchonly: {
+        importWatchonlyAccount,
+        watchonlyNewAddress,
+        watchonlyBalance,
+        watchonlyListUtxos,
+        watchonlyListAddresses,
+        syncWatchonlyAccounts,
+        listWatchonlyAccounts,
+        previewWatchonlyAccount
     },
     bolt11: {
         receiveBolt11,

--- a/locales/en.json
+++ b/locales/en.json
@@ -1717,6 +1717,7 @@
     "components.LayerBalances.lightningViaEcash": "Lightning via ecash",
     "backends.LND.wsReq.warning": "You may have to enable Certificate Verification to make these kind of calls",
     "backends.LND.restReq.connectionError": "Connection error",
+    "backends.LdkNode.invalidAccountName": "Account name must be 1–120 characters using only letters, numbers, hyphens, and underscores.",
     "utils.handleAnything.lightningAddressError": "Error fetching Lightning Address data",
     "utils.handleAnything.notValid": "Value provided was not a valid Bitcoin address or Lightning Invoice",
     "utils.handleAnything.lnurlAuthNotSupported": "LnurlAuth not supported by your node implementation",

--- a/locales/en.json
+++ b/locales/en.json
@@ -904,6 +904,7 @@
     "views.Send.keysendAddress": "keysend address (if enabled)",
     "views.Send.mustBeValid": "Must be a valid",
     "views.Send.onChainNotSupported": "On-chain sends are not supported on",
+    "views.Send.accountSendNotSupported": "Sending from a watch-only account is not supported yet on the embedded LDK node",
     "views.Send.amount": "Amount",
     "views.Send.satoshis": "satoshis",
     "views.Send.message": "Message",

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -400,7 +400,7 @@ export default class TransactionsStore {
             });
     };
 
-    private sendCoinsLNDCoinControl = (
+    private sendCoinsWithPsbt = (
         transactionRequest: TransactionRequest,
         defaultAccount?: boolean
     ) => {
@@ -503,13 +503,20 @@ export default class TransactionsStore {
             });
             transactionRequest.outpoints = outpoints;
         } else if (
+            !BackendUtils.isLNDBased() &&
+            BackendUtils.supportsAccounts() &&
+            transactionRequest.account &&
+            transactionRequest.account !== 'default'
+        ) {
+            return this.sendCoinsWithPsbt(transactionRequest, false);
+        } else if (
             (BackendUtils.isLNDBased() &&
                 transactionRequest.utxos &&
                 transactionRequest.utxos.length > 0) ||
             (transactionRequest?.additional_outputs?.length &&
                 transactionRequest?.additional_outputs?.length > 0)
         ) {
-            return this.sendCoinsLNDCoinControl(
+            return this.sendCoinsWithPsbt(
                 transactionRequest,
                 transactionRequest.account === 'default'
             );

--- a/utils/DescriptorUtils.test.ts
+++ b/utils/DescriptorUtils.test.ts
@@ -4,6 +4,7 @@ import b58 from 'bs58check';
 import {
     normalizeExtendedKey,
     recoverMasterFingerprintHex,
+    resolveAddressType,
     buildWatchonlyDescriptors,
     WalletAddressType
 } from './DescriptorUtils';
@@ -140,6 +141,48 @@ describe('DescriptorUtils', () => {
             expect(() =>
                 normalizeExtendedKey('not-a-key', 'testnet')
             ).toThrow();
+        });
+    });
+
+    describe('resolveAddressType', () => {
+        it('uses the explicit type for a plain xpub/tpub', () => {
+            expect(
+                resolveAddressType(
+                    TPUB,
+                    WalletAddressType.NESTED_WITNESS_PUBKEY_HASH
+                )
+            ).toEqual(WalletAddressType.NESTED_WITNESS_PUBKEY_HASH);
+        });
+
+        it('infers native segwit from a zpub when no type is given', () => {
+            expect(resolveAddressType(ZPUB)).toEqual(
+                WalletAddressType.WITNESS_PUBKEY_HASH
+            );
+        });
+
+        it('accepts an explicit type that matches the prefix', () => {
+            expect(
+                resolveAddressType(ZPUB, WalletAddressType.WITNESS_PUBKEY_HASH)
+            ).toEqual(WalletAddressType.WITNESS_PUBKEY_HASH);
+        });
+
+        it('rejects an explicit type that contradicts the prefix', () => {
+            expect(() =>
+                resolveAddressType(
+                    ZPUB,
+                    WalletAddressType.NESTED_WITNESS_PUBKEY_HASH
+                )
+            ).toThrow();
+        });
+
+        it('treats UNKNOWN (0) as not provided', () => {
+            expect(resolveAddressType(ZPUB, WalletAddressType.UNKNOWN)).toEqual(
+                WalletAddressType.WITNESS_PUBKEY_HASH
+            );
+        });
+
+        it('requires a type for a plain xpub/tpub', () => {
+            expect(() => resolveAddressType(TPUB)).toThrow();
         });
     });
 

--- a/utils/DescriptorUtils.test.ts
+++ b/utils/DescriptorUtils.test.ts
@@ -1,0 +1,155 @@
+// @ts-ignore:next-line
+import b58 from 'bs58check';
+
+import {
+    normalizeExtendedKey,
+    recoverMasterFingerprintHex,
+    buildWatchonlyDescriptors,
+    WalletAddressType
+} from './DescriptorUtils';
+import Base64Utils from './Base64Utils';
+
+// Golden vector shared with the ldk-node Rust watch-only tests:
+// fingerprint 2de67592, testnet BIP84 account.
+const TPUB =
+    'tpubDCUJWjpCfXoCzDwWiHRwsALSWYSMXvHHzQ3q4CoiVgWAHcrvL2C89PUs1wC2QddbaDEvLNaL5PFVFdYm5oBf7DXZWoFK8X4PLXAUA8L9zsV';
+const MFP = '2de67592';
+
+// zpub/xpub pair (same key material) from the Passport keystore export fixture
+// already used in AddressUtils.test.ts.
+const ZPUB =
+    'zpub6rPHMjrf6SMGmAbYo2n1BjoHfZTGYcnrBchwYpCaC5hrMZJVdkyappjQkW1Gu3napr3BCvYCpwbPRaex52RdFXv2YFtTtUBu6xYYscVK2n9';
+
+describe('DescriptorUtils', () => {
+    describe('buildWatchonlyDescriptors', () => {
+        it('matches the ldk-node golden descriptor (native segwit, testnet)', () => {
+            const { external, internal, derivationPath } =
+                buildWatchonlyDescriptors({
+                    xpub: TPUB,
+                    mfpHex: MFP,
+                    addressType: WalletAddressType.WITNESS_PUBKEY_HASH,
+                    network: 'testnet'
+                });
+            expect(external).toEqual(`wpkh([2de67592/84'/1'/0']${TPUB}/0/*)`);
+            expect(internal).toEqual(`wpkh([2de67592/84'/1'/0']${TPUB}/1/*)`);
+            expect(derivationPath).toEqual("m/84'/1'/0'");
+        });
+
+        it('wraps nested segwit as sh(wpkh(...)) at purpose 49', () => {
+            const { external, derivationPath } = buildWatchonlyDescriptors({
+                xpub: TPUB,
+                mfpHex: MFP,
+                addressType: WalletAddressType.NESTED_WITNESS_PUBKEY_HASH,
+                network: 'testnet'
+            });
+            expect(external).toEqual(
+                `sh(wpkh([2de67592/49'/1'/0']${TPUB}/0/*))`
+            );
+            expect(derivationPath).toEqual("m/49'/1'/0'");
+        });
+
+        it('wraps taproot as tr(...) at purpose 86', () => {
+            const { external } = buildWatchonlyDescriptors({
+                xpub: TPUB,
+                mfpHex: MFP,
+                addressType: WalletAddressType.TAPROOT_PUBKEY,
+                network: 'testnet'
+            });
+            expect(external).toEqual(`tr([2de67592/86'/1'/0']${TPUB}/0/*)`);
+        });
+
+        it("uses coin 0' on mainnet", () => {
+            const { derivationPath } = buildWatchonlyDescriptors({
+                xpub: TPUB,
+                mfpHex: MFP,
+                addressType: WalletAddressType.WITNESS_PUBKEY_HASH,
+                network: 'mainnet'
+            });
+            expect(derivationPath).toEqual("m/84'/0'/0'");
+        });
+
+        it('omits the key origin when no fingerprint is given', () => {
+            const { external } = buildWatchonlyDescriptors({
+                xpub: TPUB,
+                addressType: WalletAddressType.WITNESS_PUBKEY_HASH,
+                network: 'testnet'
+            });
+            expect(external).toEqual(`wpkh(${TPUB}/0/*)`);
+        });
+
+        it('lowercases an uppercase fingerprint', () => {
+            const { external } = buildWatchonlyDescriptors({
+                xpub: TPUB,
+                mfpHex: '2DE67592',
+                addressType: WalletAddressType.WITNESS_PUBKEY_HASH,
+                network: 'testnet'
+            });
+            expect(external).toEqual(`wpkh([2de67592/84'/1'/0']${TPUB}/0/*)`);
+        });
+
+        it('rejects UNKNOWN address type', () => {
+            expect(() =>
+                buildWatchonlyDescriptors({
+                    xpub: TPUB,
+                    addressType: WalletAddressType.UNKNOWN,
+                    network: 'testnet'
+                })
+            ).toThrow();
+        });
+
+        it('rejects HYBRID_NESTED address type', () => {
+            expect(() =>
+                buildWatchonlyDescriptors({
+                    xpub: TPUB,
+                    addressType:
+                        WalletAddressType.HYBRID_NESTED_WITNESS_PUBKEY_HASH,
+                    network: 'testnet'
+                })
+            ).toThrow();
+        });
+    });
+
+    describe('normalizeExtendedKey', () => {
+        it('passes through a plain tpub unchanged', () => {
+            expect(normalizeExtendedKey(TPUB, 'testnet')).toEqual(TPUB);
+        });
+
+        it('accepts a tpub on signet and regtest (testnet family)', () => {
+            expect(normalizeExtendedKey(TPUB, 'signet')).toEqual(TPUB);
+            expect(normalizeExtendedKey(TPUB, 'regtest')).toEqual(TPUB);
+        });
+
+        it('converts a zpub to an xpub with identical key material', () => {
+            const result = normalizeExtendedKey(ZPUB, 'mainnet');
+            expect(result.startsWith('xpub')).toBe(true);
+            // everything after the 4-byte version prefix is unchanged
+            expect(Buffer.from(b58.decode(result)).subarray(4)).toEqual(
+                Buffer.from(b58.decode(ZPUB)).subarray(4)
+            );
+        });
+
+        it('rejects a testnet key on mainnet', () => {
+            expect(() => normalizeExtendedKey(TPUB, 'mainnet')).toThrow();
+        });
+
+        it('rejects a mainnet key on a non-mainnet network', () => {
+            expect(() => normalizeExtendedKey(ZPUB, 'testnet')).toThrow();
+        });
+
+        it('throws on non-base58check input', () => {
+            expect(() =>
+                normalizeExtendedKey('not-a-key', 'testnet')
+            ).toThrow();
+        });
+    });
+
+    describe('recoverMasterFingerprintHex', () => {
+        it('inverts the import request encoding', () => {
+            // ImportAccount sends hexToBase64(reverseMfpBytes(hex)).
+            const encoded = Base64Utils.hexToBase64(
+                Base64Utils.reverseMfpBytes(MFP)
+            );
+            expect(recoverMasterFingerprintHex(encoded)).toEqual(MFP);
+        });
+    });
+});

--- a/utils/DescriptorUtils.ts
+++ b/utils/DescriptorUtils.ts
@@ -51,8 +51,8 @@ export const normalizeExtendedKey = (key: string, network: string): string => {
         throw new Error('Invalid extended public key: not valid base58check.');
     }
 
-    const version = decoded.subarray(0, 4).toString('hex');
-    const payload = decoded.subarray(4);
+    const version = decoded.slice(0, 4).toString('hex');
+    const payload = decoded.slice(4);
 
     let targetVersion: string;
     if (MAINNET_VERSIONS.includes(version)) {
@@ -117,8 +117,9 @@ export const resolveAddressType = (
 ): number => {
     let implied: WalletAddressType | undefined;
     try {
+        // .slice(), not .subarray() — see normalizeExtendedKey above.
         const version = Buffer.from(b58.decode(key))
-            .subarray(0, 4)
+            .slice(0, 4)
             .toString('hex');
         implied = IMPLIED_ADDRESS_TYPE[version];
     } catch (e) {

--- a/utils/DescriptorUtils.ts
+++ b/utils/DescriptorUtils.ts
@@ -1,0 +1,167 @@
+// @ts-ignore:next-line
+import b58 from 'bs58check';
+
+import Base64Utils from './Base64Utils';
+
+/**
+ * Turns the { extended_public_key, master_key_fingerprint, address_type } that
+ * ZEUS's account-import UI produces into the output descriptors the ldk-node
+ * watch-only FFI expects.
+ *
+ * The LND family accepts the raw xpub + address type and builds the descriptor
+ * server-side; the ldk-node FFI does not, so that conversion happens here.
+ */
+
+// BIP32 / SLIP-132 extended-key version bytes (4-byte big-endian, hex). The
+// version prefix encodes BOTH the network and the intended script type.
+const VERSION_XPUB = '0488b21e'; // mainnet, legacy / unspecified
+const VERSION_YPUB = '049d7cb2'; // mainnet, BIP49 nested segwit
+const VERSION_ZPUB = '04b24746'; // mainnet, BIP84 native segwit
+const VERSION_TPUB = '043587cf'; // testnet, legacy / unspecified
+const VERSION_UPUB = '044a5262'; // testnet, BIP49 nested segwit
+const VERSION_VPUB = '045f1cf6'; // testnet, BIP84 native segwit
+
+const MAINNET_VERSIONS = [VERSION_XPUB, VERSION_YPUB, VERSION_ZPUB];
+const TESTNET_VERSIONS = [VERSION_TPUB, VERSION_UPUB, VERSION_VPUB];
+
+// walletrpc.AddressType (see proto/walletrpc/walletkit.proto). ZEUS's import UI
+// sends these numeric values.
+export enum WalletAddressType {
+    UNKNOWN = 0,
+    WITNESS_PUBKEY_HASH = 1, // native segwit  → BIP84 → wpkh
+    NESTED_WITNESS_PUBKEY_HASH = 2, // nested segwit → BIP49 → sh(wpkh)
+    HYBRID_NESTED_WITNESS_PUBKEY_HASH = 3, // unsupported for watch-only import
+    TAPROOT_PUBKEY = 4 // taproot → BIP86 → tr
+}
+
+const isMainnet = (network: string): boolean =>
+    network === 'mainnet' || network === 'bitcoin';
+
+/**
+ * Normalize an extended public key to the plain BIP32 form BDK requires. A
+ * SLIP-132 key (zpub/ypub/vpub/upub) is re-encoded to xpub/tpub by swapping its
+ * version bytes — the underlying key material is identical, only the 4-byte
+ * prefix differs. Also validates the key's network against the node's.
+ */
+export const normalizeExtendedKey = (key: string, network: string): string => {
+    let decoded: Buffer;
+    try {
+        decoded = Buffer.from(b58.decode(key));
+    } catch (e) {
+        throw new Error('Invalid extended public key: not valid base58check.');
+    }
+
+    const version = decoded.subarray(0, 4).toString('hex');
+    const payload = decoded.subarray(4);
+
+    let targetVersion: string;
+    if (MAINNET_VERSIONS.includes(version)) {
+        if (!isMainnet(network)) {
+            throw new Error(
+                'Mainnet extended key provided for a non-mainnet network.'
+            );
+        }
+        targetVersion = VERSION_XPUB;
+    } else if (TESTNET_VERSIONS.includes(version)) {
+        if (isMainnet(network)) {
+            throw new Error(
+                'Testnet extended key provided for the mainnet network.'
+            );
+        }
+        targetVersion = VERSION_TPUB;
+    } else {
+        throw new Error(
+            'Unrecognized extended key version (unsupported script type or multisig).'
+        );
+    }
+
+    return b58.encode(
+        Buffer.concat([Buffer.from(targetVersion, 'hex'), payload])
+    );
+};
+
+/**
+ * Recover the natural (big-endian) master-key-fingerprint hex from the base64
+ * form carried in the import request. ImportAccount stores
+ * hexToBase64(reverseMfpBytes(hex)); we invert both steps.
+ */
+export const recoverMasterFingerprintHex = (
+    masterKeyFingerprintBase64: string
+): string =>
+    Base64Utils.reverseMfpBytes(
+        Base64Utils.base64ToHex(masterKeyFingerprintBase64)
+    );
+
+interface AddressTypeConfig {
+    purpose: string;
+    wrap: (inner: string) => string;
+}
+
+const ADDRESS_TYPE_CONFIG: { [key: number]: AddressTypeConfig } = {
+    [WalletAddressType.WITNESS_PUBKEY_HASH]: {
+        purpose: "84'",
+        wrap: (inner) => `wpkh(${inner})`
+    },
+    [WalletAddressType.NESTED_WITNESS_PUBKEY_HASH]: {
+        purpose: "49'",
+        wrap: (inner) => `sh(wpkh(${inner}))`
+    },
+    [WalletAddressType.TAPROOT_PUBKEY]: {
+        purpose: "86'",
+        wrap: (inner) => `tr(${inner})`
+    }
+};
+
+export interface WatchonlyDescriptors {
+    external: string;
+    internal: string;
+    derivationPath: string;
+}
+
+/**
+ * Build the external (receive, /0/*) and internal (change, /1/*) output
+ * descriptors for a single-sig watch-only account. Output format matches the
+ * descriptors the ldk-node watch-only wallet is tested against, e.g.
+ * `wpkh([2de67592/84'/1'/0']tpub.../0/*)` — no checksum (BDK computes it).
+ *
+ * The account index is assumed to be 0' (as the LND import does); the xpub
+ * alone does not carry it. This only affects the key-origin metadata used for
+ * hardware signing, not address derivation.
+ *
+ * @param xpub        normalized xpub/tpub (see normalizeExtendedKey)
+ * @param mfpHex      natural-order master fingerprint hex (see
+ *                    recoverMasterFingerprintHex); omit to build descriptors
+ *                    without a key origin
+ * @param addressType walletrpc.AddressType numeric value
+ * @param network     node network
+ */
+export const buildWatchonlyDescriptors = ({
+    xpub,
+    mfpHex,
+    addressType,
+    network
+}: {
+    xpub: string;
+    mfpHex?: string;
+    addressType: number;
+    network: string;
+}): WatchonlyDescriptors => {
+    const config = ADDRESS_TYPE_CONFIG[addressType];
+    if (!config) {
+        throw new Error(
+            `Unsupported address type for watch-only import: ${addressType}. ` +
+                'Only native segwit, nested segwit, and taproot are supported.'
+        );
+    }
+
+    const coin = isMainnet(network) ? "0'" : "1'";
+    const account = "0'";
+    const path = `${config.purpose}/${coin}/${account}`;
+    const origin = mfpHex ? `[${mfpHex.toLowerCase()}/${path}]` : '';
+
+    return {
+        external: config.wrap(`${origin}${xpub}/0/*`),
+        internal: config.wrap(`${origin}${xpub}/1/*`),
+        derivationPath: `m/${path}`
+    };
+};

--- a/utils/DescriptorUtils.ts
+++ b/utils/DescriptorUtils.ts
@@ -92,6 +92,56 @@ export const recoverMasterFingerprintHex = (
         Base64Utils.base64ToHex(masterKeyFingerprintBase64)
     );
 
+// Script type implied by a SLIP-132 version prefix. Plain xpub/tpub imply
+// nothing and are absent here.
+const IMPLIED_ADDRESS_TYPE: { [version: string]: WalletAddressType } = {
+    [VERSION_ZPUB]: WalletAddressType.WITNESS_PUBKEY_HASH,
+    [VERSION_VPUB]: WalletAddressType.WITNESS_PUBKEY_HASH,
+    [VERSION_YPUB]: WalletAddressType.NESTED_WITNESS_PUBKEY_HASH,
+    [VERSION_UPUB]: WalletAddressType.NESTED_WITNESS_PUBKEY_HASH
+};
+
+/**
+ * Decide the address type for an import request. An explicitly selected type
+ * wins, but a SLIP-132 key whose prefix contradicts it is rejected rather than
+ * silently deriving addresses the key was never used for. A plain xpub/tpub
+ * carries no script-type hint, so the explicit type is required there.
+ *
+ * @param key          extended public key as provided (pre-normalization)
+ * @param explicitType walletrpc.AddressType from the import UI; UNKNOWN (0) is
+ *                     treated as not provided
+ */
+export const resolveAddressType = (
+    key: string,
+    explicitType?: number
+): number => {
+    let implied: WalletAddressType | undefined;
+    try {
+        const version = Buffer.from(b58.decode(key))
+            .subarray(0, 4)
+            .toString('hex');
+        implied = IMPLIED_ADDRESS_TYPE[version];
+    } catch (e) {
+        // invalid keys are rejected by normalizeExtendedKey
+    }
+
+    const explicit = explicitType || undefined; // UNKNOWN = 0 → undefined
+
+    if (explicit !== undefined) {
+        if (implied !== undefined && implied !== explicit) {
+            throw new Error(
+                'Selected address type contradicts the extended key prefix ' +
+                    '(e.g. a zpub is a native segwit key).'
+            );
+        }
+        return explicit;
+    }
+    if (implied !== undefined) return implied;
+    throw new Error(
+        'Address type is required to import a plain xpub/tpub key.'
+    );
+};
+
 interface AddressTypeConfig {
     purpose: string;
     wrap: (inner: string) => string;

--- a/utils/WatchonlyAccountRegistry.ts
+++ b/utils/WatchonlyAccountRegistry.ts
@@ -1,0 +1,47 @@
+import Storage from '../storage';
+
+/**
+ * Per-wallet registry of display metadata for imported watch-only accounts
+ * (LDK backend). The Rust node's account list is the source of truth for
+ * WHICH accounts exist; this registry only carries the import metadata the
+ * Accounts UI displays (xpub, fingerprint, address type, derivation path),
+ * which the ldk-node FFI does not store. Readers must degrade gracefully when
+ * an entry is missing — e.g. after a VSS recovery on a fresh install, where
+ * the Rust wallets are restored but local storage is empty.
+ */
+
+export interface WatchonlyAccountMeta {
+    extended_public_key: string;
+    // base64, as carried in the import request (Account.XFP decodes this form)
+    master_key_fingerprint?: string;
+    address_type: number;
+    derivation_path: string;
+}
+
+export interface WatchonlyRegistry {
+    [name: string]: WatchonlyAccountMeta;
+}
+
+const registryKey = (nodeDir: string) => `${nodeDir}-watchonly-accounts`;
+
+export const loadWatchonlyRegistry = async (
+    nodeDir: string
+): Promise<WatchonlyRegistry> => {
+    try {
+        const stored = await Storage.getItem(registryKey(nodeDir));
+        return stored ? JSON.parse(stored) : {};
+    } catch (e) {
+        console.log('Error loading watch-only account registry:', e);
+        return {};
+    }
+};
+
+export const saveWatchonlyAccountMeta = async (
+    nodeDir: string,
+    name: string,
+    meta: WatchonlyAccountMeta
+): Promise<void> => {
+    const registry = await loadWatchonlyRegistry(nodeDir);
+    registry[name] = meta;
+    await Storage.setItem(registryKey(nodeDir), registry);
+};

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1194,6 +1194,13 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 await NodeInfoStore.getNodeInfo();
                 console.log('[LDK startup] fetching balance');
                 await BalanceStore.getCombinedBalance();
+                if (BackendUtils.supportsAccounts()) {
+                    try {
+                        await UTXOsStore.listAccounts();
+                    } catch (e) {
+                        console.log('[LDK startup] listAccounts failed:', e);
+                    }
+                }
                 console.log('[LDK startup] polling channels');
                 ChannelsStore.getChannelsWithPolling().then(() => {
                     // Check for sweep to self-custody threshold after channels are online


### PR DESCRIPTION
# Description

Relates to issue: https://github.com/ZeusLN/zeus/issues/3859

Adds external (watch-only) accounts to the LDK Node backend, bringing it to parity with the LND backend. The Rust/FFI side lives in our ldk-node fork: https://github.com/ZeusLN/ldk-node/pull/1. This PR wires it into ZEUS.

### What's included

**Import**
- Import an account from an xpub + master fingerprint, by manual entry or QR (address type resolved from the SLIP-132 prefix)
- Dry-run preview of the first 5 receive and change addresses before confirming, to check against the hardware wallet

**Read**
- Per-account receive addresses, balance and UTXOs
- Accounts persist and sync across app restarts

**Send**
- Sending from an account builds an unsigned PSBT in the node
- It then goes through ZEUS's existing PSBT flow: QR to the hardware wallet, scan the signed PSBT back, finalize, broadcast
- Account sends never touch the node's own wallet, and node-wallet send paths reject account requests

### Testing status
- Import, receive, balance and UTXOs verified on mainnet with a Keystone
- Unsigned PSBT generation verified in the app; the full hardware signing round-trip is still to be tested on device

### Known limitations
- Sync uses a stop gap of 20, so an account with a run of more than 20 unused addresses before a used one can show an incomplete balance (funds are not lost)
- Birthday height is accepted but not yet used to bound the scan

### Before merge
- Native binaries are not included. The ldk-node changes need a fork release, then a `fetch-libraries-versions.json` bump.

### Next
- Funding channel opens directly from a watch-only account

This pull request is categorized as a:

- [X] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [X] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [X] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [X] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [X] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [X] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [X] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [X] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [X] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [X] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
