### PR TITLE
ci: add Dependabot config for npm and GitHub Actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # npm dependencies (root manifest)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+    # Bundle routine minor/patch bumps into a single PR to keep noise down
+    # in a large dependency tree; major bumps still get their own PRs so
+    # native / crypto-sensitive upgrades can be reviewed and tested in
+    # isolation.
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by the CI workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` to enable scheduled **version-update** PRs. (Security updates were already enabled at the repo level — that's what opens the existing `chore(deps)` security PRs across all manifests, including the vendored `zeus_modules` sublocks. This layers routine version bumps on top; the two are independent Dependabot features.)

## What it does
- **npm** (`/`): weekly, up to 10 open PRs, commit prefix `chore(deps)` (matching the existing convention). Minor/patch bumps are **grouped into a single PR** to keep noise down across the large dependency tree.
- **github-actions** (`/`): weekly, commit prefix `ci`, for the actions used by CI (`actions/checkout`, `actions/setup-node`, `actions/upload-artifact`).

## Design notes
- **Majors get their own PRs** (not grouped) so native modules and security-critical crypto libraries can be reviewed and tested in isolation — appropriate for a mobile wallet.
- Scope is the **root manifest only**. The vendored `zeus_modules` sublocks are intentionally pinned; their vulnerabilities are already covered by automatic Dependabot **security** updates, so routine version churn there is avoided.
- If maintainers want to suppress noise from specific high-risk packages (e.g. `react-native` core, crypto libs), `ignore` rules can be added later.