### PR TITLE
SwipeButton: lock knob in place after successful swipe

### DIFF
--- a/components/SwipeButton.tsx
+++ b/components/SwipeButton.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import {
     View,
     Text,
@@ -41,13 +41,22 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
         extrapolate: 'clamp'
     });
 
-    const [offset, setOffset] = useState(0);
+    // the responder is created once, so its handlers only ever see refs
+    const completed = useRef(false);
+    const onSwipeSuccessRef = useRef(onSwipeSuccess);
+    onSwipeSuccessRef.current = onSwipeSuccess;
+
+    const springBack = () =>
+        Animated.spring(pan, {
+            toValue: 0,
+            useNativeDriver: false
+        }).start();
 
     const panResponder = useRef(
         PanResponder.create({
-            onStartShouldSetPanResponder: () => true,
+            onStartShouldSetPanResponder: () => !completed.current,
+            onMoveShouldSetPanResponder: () => !completed.current,
             onPanResponderGrant: () => {
-                pan.setOffset(offset);
                 pan.setValue(0);
             },
             onPanResponderMove: (_e, gesture) => {
@@ -60,18 +69,19 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
                 _e: GestureResponderEvent,
                 gesture: PanResponderGestureState
             ) => {
-                const finalValue =
-                    gesture.dx > maxTranslation * 0.95 ? maxTranslation : 0;
-                if (finalValue === maxTranslation) {
-                    onSwipeSuccess();
+                if (gesture.dx > maxTranslation * 0.95) {
+                    // lock the button in the completed position before
+                    // kicking off any work, so it can't be dragged again or
+                    // left hanging mid-track while navigation is pending
+                    completed.current = true;
+                    pan.setValue(maxTranslation);
+                    onSwipeSuccessRef.current();
+                } else {
+                    springBack();
                 }
-
-                Animated.spring(pan, {
-                    toValue: finalValue,
-                    useNativeDriver: false
-                }).start(() => {
-                    setOffset(finalValue);
-                });
+            },
+            onPanResponderTerminate: () => {
+                if (!completed.current) springBack();
             }
         })
     ).current;

--- a/components/SwipeButton.tsx
+++ b/components/SwipeButton.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import {
     View,
     Text,
@@ -9,6 +9,7 @@ import {
     GestureResponderEvent,
     Dimensions
 } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 
 import CaretRight from '../assets/images/SVG/Caret Right alt.svg';
 import { themeColor } from '../utils/ThemeUtils';
@@ -51,6 +52,18 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
             toValue: 0,
             useNativeDriver: false
         }).start();
+
+    // every screen using this button navigates away in onSwipeSuccess; if
+    // the user comes back (e.g. the send failed), unlock the knob so they
+    // can retry
+    useFocusEffect(
+        useCallback(() => {
+            if (completed.current) {
+                completed.current = false;
+                pan.setValue(0);
+            }
+        }, [])
+    );
 
     const panResponder = useRef(
         PanResponder.create({


### PR DESCRIPTION
# Description

Relates to issue: Fixes #4217

The Slide to Pay knob sometimes visibly popped back to the left side after a successful swipe, before the transition to the sending screen. Root cause in `components/SwipeButton.tsx`:

- The `PanResponder` stayed fully active after `onSwipeSuccess()` fired, so any new touch on the knob in the window before the navigation transition (finger-roll at the end of the swipe, impatient second tap) was granted the responder and ran `pan.setValue(0)` — which also kills the in-flight settle spring (`AnimatedValue.setValue` stops any running animation) — teleporting the knob back to the left and fading the "Slide to Pay" label back in.
- The `offset` accumulation never worked: the responder is created once via `useRef`, so its handlers captured the first-render `offset = 0` in a stale closure forever.
- The success spring (`useNativeDriver: false`) was started *after* the synchronous payment kickoff + `navigation.navigate`, so the JS thread was saturated mounting the sending screen and the knob could hang short of the right edge (the success threshold is 95% of the track).
- No `onPanResponderTerminate` handler, so a stolen gesture (e.g. the iOS interactive back gesture, which travels the same direction) left the knob stranded with no cleanup.

Fix:

- Add a `completed` ref set on success; `onStartShouldSetPanResponder` / `onMoveShouldSetPanResponder` refuse new grants once completed.
- Pin the knob at the end position synchronously with `pan.setValue(maxTranslation)` *before* invoking `onSwipeSuccess()`, so its final position no longer depends on a starved JS-driven animation.
- Drop the broken `offset` state; each gesture starts from 0 (as it effectively always did).
- Spring back to start on responder termination when not completed.
- Call the success handler through a ref so the once-created responder always sees the latest prop.

The `key={swipeButtonKey}` remount-on-focus in `PaymentRequest` / `CashuPaymentRequest` still re-arms the button (fresh refs) when navigating back, so repeat payments keep working.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding