### PR TITLE
fix: display units for invoice expiry and CLTV expiry

### DIFF
--- a/models/Invoice.test.ts
+++ b/models/Invoice.test.ts
@@ -1,0 +1,56 @@
+jest.mock('../stores/Stores', () => ({}));
+
+import Invoice from './Invoice';
+
+// decodes with timestamp 1700074718 and expiry 3600 (see Bolt11Utils.test.ts)
+const paymentRequest =
+    'lnbcrt1230n1pj429x7pp57t97q4awqj3f529snr0pa6senk83sq5pp760qf5a4jzvd7xgwcksdqqcqzzsxqrrsssp57eqtv7vxr46arupna3w4ct0lkf2mqmz9wt044cwkks0rwlnhfr5s9qyyssqragwpwav7nfwv2xyuuamxxj4pnnpzv2hlw7j473repd3sq7st698ta9kmzmygt0w7tmncl56a6mnma0w7e5dlpqd0wy6x3v35rssldspjhh8p0';
+
+describe('Invoice.originalTimeUntilExpiryInSeconds', () => {
+    it('derives expiry from a decodable payment request', () => {
+        const invoice = new Invoice({ payment_request: paymentRequest });
+        expect(invoice.originalTimeUntilExpiryInSeconds).toBe(3600);
+    });
+
+    it('falls back to the expiry field when no payment request string is present (decodepayreq response)', () => {
+        const invoice = new Invoice({
+            destination: '02758997f184be06f4350b136db0bed6f8',
+            timestamp: '1700074718',
+            expiry: '3600',
+            cltv_expiry: '80'
+        });
+        expect(invoice.originalTimeUntilExpiryInSeconds).toBe(3600);
+    });
+
+    it('uses expires_at with the model timestamp when no payment request string is present', () => {
+        const invoice = new Invoice({
+            timestamp: '1700074718',
+            expires_at: 1700074718 + 600
+        });
+        expect(invoice.originalTimeUntilExpiryInSeconds).toBe(600);
+    });
+
+    it('returns undefined when no expiry information is available', () => {
+        const invoice = new Invoice({
+            destination: '02758997f184be06f4350b136db0bed6f8'
+        });
+        expect(invoice.originalTimeUntilExpiryInSeconds).toBeUndefined();
+    });
+});
+
+describe('Invoice.determineFormattedOriginalTimeUntilExpiry', () => {
+    it('humanizes the fallback expiry seconds', () => {
+        const invoice = new Invoice({
+            timestamp: '1700074718',
+            expiry: '3600'
+        });
+        invoice.determineFormattedOriginalTimeUntilExpiry('en');
+        expect(invoice.formattedOriginalTimeUntilExpiry).toBe('1 hour');
+    });
+
+    it('humanizes the expiry of a decodable payment request', () => {
+        const invoice = new Invoice({ payment_request: paymentRequest });
+        invoice.determineFormattedOriginalTimeUntilExpiry('en');
+        expect(invoice.formattedOriginalTimeUntilExpiry).toBe('1 hour');
+    });
+});

--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -387,12 +387,17 @@ export default class Invoice extends BaseModel {
         | number
         | undefined {
         const decoded = this.decodedPaymentRequest;
-        if (!decoded) return undefined;
+        const timestamp = decoded ? decoded.timestamp : Number(this.timestamp);
         if (this.expires_at != null) {
             // expiry is missing in payment request in Core Lightning
-            return this.expires_at - decoded.timestamp;
+            return !isNaN(timestamp) ? this.expires_at - timestamp : undefined;
         }
-        return decoded.expiry;
+        if (decoded) return decoded.expiry;
+        // no bolt11 string to decode (e.g. pay_req built from a backend
+        // decodepayreq response) — use the reported expiry seconds
+        return this.expiry != null && this.expiry !== ''
+            ? Number(this.expiry)
+            : undefined;
     }
 
     public determineFormattedOriginalTimeUntilExpiry(

--- a/views/Invoice.tsx
+++ b/views/Invoice.tsx
@@ -418,7 +418,9 @@ export default class InvoiceView extends React.Component<
                                 keyValue={localeString(
                                     'views.Invoice.cltvExpiry'
                                 )}
-                                value={cltv_expiry}
+                                value={`${cltv_expiry} ${localeString(
+                                    'general.blocks'
+                                )}`}
                             />
                         )}
 

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -518,6 +518,9 @@ export default class PaymentRequest extends React.Component<
 
         const isZaplockerValid = isPmtHashSigValid && isRelaysSigValid;
 
+        const locale = SettingsStore.settings.locale;
+        if (pay_req) pay_req.determineFormattedOriginalTimeUntilExpiry(locale);
+
         // variables cannot be destructured traditionally here
         // due to how we clear the pay_req from the store upon
         // navigating back
@@ -525,7 +528,7 @@ export default class PaymentRequest extends React.Component<
             pay_req && pay_req.getRequestAmount
                 ? pay_req.getRequestAmount
                 : undefined;
-        const expiry = pay_req && pay_req.expiry;
+        const expiry = pay_req && pay_req.formattedOriginalTimeUntilExpiry;
         const cltv_expiry = pay_req && pay_req.cltv_expiry;
         const destination = pay_req && pay_req.destination;
         const payment_hash = pay_req && pay_req.payment_hash;
@@ -971,7 +974,9 @@ export default class PaymentRequest extends React.Component<
                                         keyValue={localeString(
                                             'views.PaymentRequest.cltvExpiry'
                                         )}
-                                        value={cltv_expiry}
+                                        value={`${cltv_expiry} ${localeString(
+                                            'general.blocks'
+                                        )}`}
                                     />
                                 )}
 


### PR DESCRIPTION
# Description

Closes #4223

The Lightning Invoice (PaymentRequest) view rendered the decoded expiry as raw seconds (e.g. `3600`) and CLTV expiry as a bare number (e.g. `80`), with no units.

|Before|After|
|-|-|
|<img width="1206" height="2622" alt="before" src="https://github.com/user-attachments/assets/48b40958-89d8-4204-be01-16036192a9e1" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-13 at 16 12 45" src="https://github.com/user-attachments/assets/ec8244b1-7daa-4bbd-881c-9171278a4939" />|

**Changes:**
- `views/PaymentRequest.tsx`: Expiry now displays as a locale-aware humanized duration ("1 hour") using the Invoice model's existing `determineFormattedOriginalTimeUntilExpiry` formatter — the same pattern the Invoice detail view already uses.
- `views/PaymentRequest.tsx` + `views/Invoice.tsx`: CLTV Expiry now renders with the existing `general.blocks` locale string ("80 blocks").
- `models/Invoice.ts`: `originalTimeUntilExpiryInSeconds` previously only worked when a bolt11 string was available to re-decode, but `pay_req` is built from a backend `decodepayreq` response that carries no bolt11 string — so the formatter silently produced nothing. It now falls back to the raw `expiry` / `expires_at` + `timestamp` fields in that case. The decoded path is unchanged.
- `models/Invoice.test.ts`: new regression tests covering the decoded path (existing bolt11 test vector) and the fallback paths, including the exact `decodepayreq` shape from the issue.

No new locale strings needed — `general.blocks` already exists with translations.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
