### PR TITLE
fix: deep links handled twice with 'Select wallet on start-up'

### DIFF
--- a/utils/LinkingUtils.ts
+++ b/utils/LinkingUtils.ts
@@ -9,6 +9,13 @@ import { settingsStore } from '../stores/Stores';
 class LinkingUtils {
     private shareIntentProcessed = false;
     private pendingDeepLink: string | null = null;
+    // Linking.getInitialURL() returns the same URL for the lifetime of the
+    // activity (and on Android, onNewIntent + setIntent refreshes it with
+    // each warm deep link), while the Wallet view — which consumes it — can
+    // mount more than once, e.g. when 'Select wallet on start-up' is
+    // enabled. Track the last URL actually processed so it is only ever
+    // handled once.
+    private lastHandledUrl: string | null = null;
 
     processPendingDeepLink = (
         navigation: NativeStackNavigationProp<any, any>
@@ -53,7 +60,9 @@ class LinkingUtils {
             }
 
             if (url) {
-                this.handleDeepLink(url, navigation);
+                if (url !== this.lastHandledUrl) {
+                    this.handleDeepLink(url, navigation);
+                }
                 return;
             }
             if (Platform.OS === 'android') {
@@ -109,6 +118,8 @@ class LinkingUtils {
             this.pendingDeepLink = url;
             return;
         }
+
+        this.lastHandledUrl = url;
 
         if (url.startsWith('nostr:')) {
             Linking.openURL(url);

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1313,14 +1313,12 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 );
             }
         }
-        // only navigate to initial url after connection and main calls are made
-        if (
-            this.state.initialLoad &&
-            !(
-                SettingsStore.settings.selectNodeOnStartup &&
-                SettingsStore.initialStart
-            )
-        ) {
+        // only navigate to initial url after connection and main calls are
+        // made. No selectNodeOnStartup check is needed here: an instance
+        // that deferred to the startup wallet selection screen never reaches
+        // fetchData (_replacedForWalletSelection), and LinkingUtils only
+        // handles a given initial URL once
+        if (this.state.initialLoad) {
             this.setState({
                 initialLoad: false
             });

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -4,6 +4,7 @@ import {
     AppState,
     AppStateStatus,
     BackHandler,
+    EmitterSubscription,
     Linking,
     NativeEventSubscription,
     PanResponder,
@@ -187,8 +188,13 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
     private panResponder: PanResponderInstance;
     private handleAppStateChangeSubscription: NativeEventSubscription;
     private backPressSubscription: NativeEventSubscription;
+    private linkingSubscription: EmitterSubscription | undefined;
     private startupTimeoutId?: ReturnType<typeof setTimeout>;
     private _navigating = false;
+    // Set once this instance replaces itself with the startup wallet
+    // selection screen; late focus/AppState triggers must not connect to
+    // the previously selected wallet or consume the initial deep link
+    private _replacedForWalletSelection = false;
 
     constructor(props: WalletProps) {
         super(props);
@@ -334,6 +340,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             this.props.navigation.removeListener('focus', this.handleFocus);
         this.handleAppStateChangeSubscription?.remove();
         this.backPressSubscription?.remove();
+        this.linkingSubscription?.remove();
         if (this.startupTimeoutId) {
             clearTimeout(this.startupTimeoutId);
             this.startupTimeoutId = undefined;
@@ -377,13 +384,19 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
     };
 
     startListeners() {
-        Linking.addEventListener('url', this.handleOpenURL);
+        this.linkingSubscription?.remove();
+        this.linkingSubscription = Linking.addEventListener(
+            'url',
+            this.handleOpenURL
+        );
     }
 
     async getSettingsAndNavigate(
         explicitShareIntentData?: any,
         transientRetryCount = 0
     ) {
+        if (this._replacedForWalletSelection) return;
+
         try {
             this.setState({ loading: true });
             const { SettingsStore, navigation } = this.props;
@@ -473,6 +486,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                         this.setState({ unlocked: true });
                     }
                     // Skip wallet activation by navigating directly to Wallets screen
+                    this._replacedForWalletSelection = true;
                     navigation.replace('Wallets', {
                         fromStartup: true,
                         shareIntentData


### PR DESCRIPTION
# Description

Relates to issue: #4218

## Root cause

The "handle the launch deep link exactly once" invariant lived in per-instance Wallet component state (`initialLoad`), while `Linking.getInitialURL()` is global and returns the same URL on every call — and on Android, `MainActivity.onNewIntent` calls `setIntent()`, so it returns the most recent warm deep link forever after. With **Select wallet on start-up** disabled, the Wallet view mounts exactly once, so the invariant held by accident. With it enabled, the Wallet view is replaced by the wallet picker (`navigation.replace('Wallets')`) and later re-created (`popTo('Wallet')` pushes a fresh instance), so multiple instances could each consume the same initial URL:

1. A late focus/AppState trigger on the replaced instance slipped past the startup branch (`initialStart` had already been set false), fell through to `fetchData`, silently connected to the *previously selected* wallet, and opened the invoice over the wallet picker (load #1).
2. After the user picked a wallet, the fresh Wallet instance ran `fetchData` with its own `initialLoad = true` and consumed `getInitialURL()` again (load #2).

Whether both loads fired depended on event timing — hence *sometimes*.

## Fix

- **`utils/LinkingUtils.ts`**: track the last handled URL in the singleton and skip it in `handleInitialUrl`, so the initial URL is processed at most once no matter how many Wallet instances mount. Also covers the Android `setIntent` re-read of old warm links on later fresh mounts. Deliberate re-taps of the same link still work (the `'url'` event path bypasses the check), and links deferred behind the lockscreen are only marked handled once actually processed.
- **`views/Wallet/Wallet.tsx`**: gate `getSettingsAndNavigate` once the instance has replaced itself with the startup wallet picker, so a stale instance can't connect to the old wallet or consume the deep link; store the `Linking` `'url'` subscription, de-dupe registration, and remove it on unmount (it was never cleaned up, so an unmounted instance could keep handling warm deep links alongside the live one).
- Follow-up commit removes the now-vestigial `selectNodeOnStartup && initialStart` clause in `fetchData` — it was self-defeating (any connecting run set `initialStart` false ~30 lines earlier), and the invariant it aimed for is now enforced by the two mechanisms above.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [x] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding