### PR TITLE
stores: prevent stale closeChannel error from wiping channel list

### DIFF
--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -691,27 +691,35 @@ export default class ChannelsStore {
         if (implementation === 'lightning-node-connect') {
             return BackendUtils.closeChannel(urlParams);
         } else {
-            let resolved = false;
+            let settled = false;
             return await Promise.race([
                 new Promise((resolve) => {
                     BackendUtils.closeChannel(urlParams)
                         .then(() => {
+                            if (settled) return;
+                            settled = true;
                             this.handleChannelClose();
-                            resolved = true;
                             resolve(true);
                         })
                         .catch((error: Error) => {
+                            if (settled) return;
+                            settled = true;
                             this.handleChannelCloseError(error);
-                            resolved = true;
                             resolve(true);
                         });
                 }),
                 // LND REST call tends to time out, so let's put a 6 second
                 // forced resolution, as true errors will typically throw
-                // before that time
+                // before that time. The settled flag ensures the call's
+                // eventual result (e.g. the 30s REST timeout on the
+                // streaming close call) can't fire handlers after the
+                // forced resolution has already succeeded
                 new Promise(async (resolve) => {
                     await new Promise((res) => setTimeout(res, 6000));
-                    if (!resolved) this.handleChannelClose();
+                    if (!settled) {
+                        settled = true;
+                        this.handleChannelClose();
+                    }
                     resolve(true);
                 })
             ]);
@@ -728,7 +736,9 @@ export default class ChannelsStore {
     @action
     public handleChannelCloseError = (error: Error) => {
         this.closeChannelErr = errorToUserFriendly(error);
-        this.getChannelsError();
+        // a failed close request doesn't invalidate the channel list,
+        // so don't call getChannelsError here - it would wipe channels
+        this.closingChannel = false;
     };
 
     @action


### PR DESCRIPTION
# Description

Relates to issue: **#4229**

Fixes the open channel list going blank after closing a channel on LND (REST).

## Root cause analysis

The channel list isn't failing to load — it's being actively wiped ~30 seconds after the close, by a stale error handler from the close call itself:

1. **LND's REST close-channel is a streaming endpoint.** `DELETE /v1/channels/{txid}/{index}` (`backends/LND.ts`) keeps the HTTP response open until the closing tx confirms on-chain. `ReactNativeBlobUtil.fetch` buffers the whole body, so this promise can never resolve during a co-op close — it just hangs.
2. **ZEUS knows this and force-resolves after 6 seconds.** `ChannelsStore.closeChannel` races the REST call against a 6s timer; the timer fires `handleChannelClose()`, the view pops to Wallet, and `getChannels()` repopulates the list. So far so good — the user sees their channels.
3. **But the underlying DELETE promise was never detached.** The `resolved` flag (added in a8f537ab8) only guards the wrong direction — it stops the 6s timer from firing after the real call settles, but doesn't stop the real call's `.then`/`.catch` from firing after the 6s fallback has already won the race.
4. **The generic 30s REST timeout guarantees a late rejection.** `restReq` races every non-Tor request against a 30s `Request timeout` (added in 44c3800968, hardened in e3c1818f71). Since the close stream stays open for at least one block, this rejection fires every single time on LND REST.
5. **The late rejection nukes the list.** `.catch` → `handleChannelCloseError` → `getChannelsError()`, which sets `channels = []` and `error = true`. The MobX reaction cascades that into empty `enrichedChannels`/`filteredChannels`. So ~24 seconds after the user is back on Wallet looking at a healthy list, it silently blanks out.
6. **Nothing refreshes it.** Channels only refetch on Wallet focus, app-state change, or pull-to-refresh — sitting on the Wallet screen, the wipe persists, which reads as "empty until restart".

The reporter's `delivery_address` detail is a red herring — any co-op close over LND (REST) reproduces this. It's effectively a regression from the Nov 2024/Apr 2025 global REST timeout interacting with the March 2024 close-error handler.

## Fix

Two minimal changes in `stores/ChannelsStore.ts`:

- **Detach late results in `closeChannel`:** the `resolved` flag is now a shared `settled` guard — the 6s forced resolution sets it too, and the real call's `.then`/`.catch` no-op once it's set. The late 30s timeout rejection can no longer mutate the store.
- **Stop wiping the list on close errors:** `handleChannelCloseError` no longer calls `getChannelsError()` — a failed close request doesn't invalidate the channel list. It now only sets `closeChannelErr` (still surfaced on the Channel view, which doesn't pop when it's set) and clears `closingChannel`. This also applies to the LNC `subscribeChannelClose` error path, where keeping the list intact is likewise correct.

## Testing notes

- Draft: not yet manually tested on device. To reproduce/verify on LND (REST): co-op close a channel, return to Wallet, wait 30+ seconds — before this patch the open channels list blanks; after, it stays populated and the channel appears under pending.
- No regression test added: stores currently have no jest coverage and `ChannelsStore` isn't importable under the current jest config without substantial mocking.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
