### PR TITLE
backends: fix amountless invoice creation for LDK Node

### DIFF
--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -1165,11 +1165,13 @@ export default class LdkNode {
         // Ensure expiry is a number (it comes as a string from the UI)
         const expirySecs = Number(data.expiry_seconds) || 3600;
 
-        if (data.value || data.value_msat) {
-            const amountMsat = data.value_msat
-                ? Number(data.value_msat)
-                : Number(data.value) * 1000;
+        const amountMsat = data.value_msat
+            ? Number(data.value_msat)
+            : data.value != null && data.value !== ''
+            ? Number(data.value) * 1000
+            : 0;
 
+        if (amountMsat > 0) {
             invoice = await LdkNodeInjection.bolt11.receiveBolt11({
                 amountMsat,
                 description: data.memo || '',


### PR DESCRIPTION
# Description

_Please enter a description and screenshots, if appropriate, of the work covered in this PR_

## Problem

On **LDK Node**, creating an invoice with a blank amount (0 sats on Receive) produced invoices that could not be paid with a custom amount.

Receive sends `value: '0'` when the user leaves the amount field empty. In `LdkNode.createInvoice`, the check `if (data.value || data.value_msat)` treats `'0'` as truthy in JavaScript, so Zeus called `receiveBolt11` with `amountMsat: 0` instead of `receiveVariableAmountBolt11`.

In LDK Node those are different APIs:
| API | Behavior |
|-----|----------|
| `receiveBolt11(0)` | Fixed zero-msat invoice |
| `receiveVariableAmountBolt11()` | True amountless invoice (payer chooses the amount) |

Payers who entered a custom amount then hit errors such as `"amount must not be specified when paying a non-zero amount invoice"` (from LND) or equivalent failures on other backends.


## Fix

Compute `amountMsat` first and only call `receiveBolt11` when `amountMsat > 0`. For zero or missing amounts (`value: '0'`, empty, or unset), call `receiveVariableAmountBolt11` instead.

- Change is limited to `backends/LdkNode.ts` — no store or other backend changes.


## Test Plan

- [ ] **LDK Node:** Create a 0-sat invoice → BOLT11 decodes as amountless (`lnbc1...`, no amount in prefix)
- [ ] **LDK Node:** Pay that invoice from another node/wallet with a custom amount → succeeds
- [ ] **LDK Node:** Create a fixed-amount invoice (e.g. 1000 sats) → still works


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [x] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
