### PR TITLE
Receive: surface Flow LSP proposal rejection as dismissable warning

### DIFF
--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -457,9 +457,12 @@ export default class InvoicesStore {
                         );
                         jit_bolt11 = response as string;
                     } catch (e: any) {
-                        // Clear error state so the unwrapped invoice
-                        // can be displayed without a stale error banner
+                        // Surface the LSP's rejection as a dismissable
+                        // warning, clearing the error state so the
+                        // unwrapped invoice can still be displayed
                         runInAction(() => {
+                            this.lspStore.flow_warning_msg =
+                                this.lspStore.flow_error_msg;
                             this.lspStore.flow_error = false;
                             this.lspStore.flow_error_msg = '';
                             this.lspStore.showLspSettings = false;

--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -43,6 +43,7 @@ export default class LSPStore {
     @observable public error_msg: string = '';
     @observable public flow_error: boolean = false;
     @observable public flow_error_msg: string = '';
+    @observable public flow_warning_msg: string = '';
     @observable public showLspSettings: boolean = false;
     @observable public channelAcceptor: any;
     @observable public customMessagesSubscriber: any;
@@ -124,6 +125,7 @@ export default class LSPStore {
         this.error_msg = '';
         this.flow_error = false;
         this.flow_error_msg = '';
+        this.flow_warning_msg = '';
         this.showLspSettings = false;
     };
 
@@ -133,6 +135,7 @@ export default class LSPStore {
         this.feeId = undefined;
         this.flow_error = false;
         this.flow_error_msg = '';
+        this.flow_warning_msg = '';
         this.showLspSettings = false;
     };
 
@@ -463,6 +466,7 @@ export default class LSPStore {
     public getZeroConfInvoice = (bolt11: string) => {
         this.flow_error = false;
         this.flow_error_msg = '';
+        this.flow_warning_msg = '';
         this.showLspSettings = false;
 
         const { settings } = this.settingsStore;

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -1827,6 +1827,12 @@ export default class Receive extends React.Component<
                             {error_msg && (
                                 <ErrorMessage message={error_msg} dismissable />
                             )}
+                            {LSPStore.flow_warning_msg && (
+                                <WarningMessage
+                                    message={LSPStore.flow_warning_msg}
+                                    dismissable
+                                />
+                            )}
 
                             {showLspSettings && (
                                 <View style={{ margin: 10 }}>


### PR DESCRIPTION
## Description

When the Flow LSP rejects a `/proposal` call, `InvoicesStore.createInvoice` cleared `flow_error`, `flow_error_msg`, and `showLspSettings` entirely so the unwrapped invoice could be displayed without a stale error banner. The side effect: the LSP's human-readable rejection message never reached the user — they'd get a plain invoice with no indication the LSP declined to wrap it.

This matters for upcoming events where the LSP temporarily freezes channel opens (e.g. around a reorg-risk block range for a fork): the server sends an explanatory message ("Not accepting channel open requests between blocks X and Y."), and the app silently dropped it.

## Changes

- `stores/LSPStore.ts`: new `flow_warning_msg` observable; cleared in `reset()`, `resetFee()`, and at the start of `getZeroConfInvoice()` so a stale warning never carries into a new invoice attempt.
- `stores/InvoicesStore.ts`: on `/proposal` rejection, move the LSP's message into `flow_warning_msg` before clearing the error state — the unwrapped-invoice fallback behavior is unchanged.
- `views/Receive.tsx`: render `flow_warning_msg` as a dismissable `WarningMessage` above the invoice, distinct from the red error banner.

## Testing

- `tsc --noEmit`, `prettier --check`, and `eslint` pass on the changed files.