### PR TITLE
fix(nwc): correct NIP-47 transaction field mapping

### DIFF
--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -69,6 +69,8 @@ export default class Invoice extends BaseModel {
     public invoice_amount_msat: string | number;
     public bolt12: string;
     public payment_preimage: string;
+    // NIP-47 (Nostr Wallet Connect) transaction objects
+    public preimage?: string;
     // pay req
     public timestamp?: string | number;
     public destination?: string;
@@ -107,8 +109,11 @@ export default class Invoice extends BaseModel {
     }
 
     @computed public get getRPreimage(): string {
-        if (!this.r_preimage) return '';
-        const preimage = this.r_preimage.data || this.r_preimage;
+        // LND uses r_preimage, Core Lightning payment_preimage, NIP-47 preimage
+        const source =
+            this.r_preimage || this.payment_preimage || this.preimage;
+        if (!source) return '';
+        const preimage = source.data || source;
         return typeof preimage === 'object'
             ? Base64Utils.bytesToHex(preimage)
             : typeof preimage === 'string'
@@ -119,8 +124,10 @@ export default class Invoice extends BaseModel {
     }
 
     @computed public get getRHash(): string {
-        if (!this.r_hash) return '';
-        const hash = this.r_hash.data || this.r_hash;
+        // LND uses r_hash, Core Lightning and NIP-47 payment_hash
+        const source = this.r_hash || this.payment_hash;
+        if (!source) return '';
+        const hash = source.data || source;
         return typeof hash === 'object'
             ? Base64Utils.bytesToHex(hash)
             : typeof hash === 'string'

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -37,6 +37,10 @@ import * as nostrTools from 'nostr-tools';
 
 import NostrConnectUtils from './NostrConnectUtils';
 import Payment from '../models/Payment';
+import Invoice from '../models/Invoice';
+import Base64Utils from './Base64Utils';
+import BackendUtils from './BackendUtils';
+import type { ConnectionActivity } from '../models/NWCConnection';
 
 // Stable hex values: repeat a hex digit 64 times to fill 32 bytes
 const hex64 = (c: string) => c.repeat(64);
@@ -740,6 +744,127 @@ describe('NostrConnectUtils', () => {
 
                     expect(result).toEqual({ inTransit: false });
                 });
+            });
+        });
+    });
+
+    describe('NIP-47 transaction field mapping', () => {
+        const CREATION_DATE = 1700000000;
+        const EXPIRY_SECONDS = 3600;
+        const SETTLE_DATE = 1700000500;
+        const PREIMAGE = hex64('a');
+
+        /** LND REST returns r_hash and r_preimage base64-encoded */
+        const lndInvoice = (overrides: object = {}) => ({
+            r_hash: Base64Utils.hexToBase64(HASH_A),
+            payment_request: INVOICE_A,
+            creation_date: String(CREATION_DATE),
+            expiry: String(EXPIRY_SECONDS),
+            value: '1000',
+            settled: false,
+            ...overrides
+        });
+
+        const lookupLightningInvoice = (rawInvoice: object) => {
+            (BackendUtils as any).lookupInvoice = jest
+                .fn()
+                .mockResolvedValue(rawInvoice);
+            return NostrConnectUtils.buildNip47TransactionForLightningInvoiceLookup(
+                HASH_A
+            );
+        };
+
+        describe('lookup_invoice', () => {
+            it('reads the payment hash from the LND r_hash field', async () => {
+                const tx = await lookupLightningInvoice(lndInvoice());
+
+                expect(tx.payment_hash).toBe(HASH_A);
+            });
+
+            it('reports expiry as creation plus expiry, not the creation date', async () => {
+                const tx = await lookupLightningInvoice(lndInvoice());
+
+                expect(tx.created_at).toBe(CREATION_DATE);
+                expect(tx.expires_at).toBe(CREATION_DATE + EXPIRY_SECONDS);
+            });
+
+            it('marks an unpaid invoice past its expiry as failed', async () => {
+                const tx = await lookupLightningInvoice(lndInvoice());
+
+                expect(tx.state).toBe('failed');
+            });
+
+            it('returns preimage and settle time for a settled invoice', async () => {
+                const tx = await lookupLightningInvoice(
+                    lndInvoice({
+                        settled: true,
+                        settle_date: String(SETTLE_DATE),
+                        r_preimage: Base64Utils.hexToBase64(PREIMAGE)
+                    })
+                );
+
+                expect(tx.state).toBe('settled');
+                expect(tx.preimage).toBe(PREIMAGE);
+                expect(tx.settled_at).toBe(SETTLE_DATE);
+            });
+
+            it('reads Core Lightning payment_hash and payment_preimage', async () => {
+                const tx = await lookupLightningInvoice({
+                    payment_hash: HASH_A,
+                    payment_preimage: PREIMAGE,
+                    bolt11: INVOICE_A,
+                    created_at: CREATION_DATE,
+                    expires_at: CREATION_DATE + EXPIRY_SECONDS,
+                    paid_at: SETTLE_DATE,
+                    status: 'paid',
+                    msatoshi: 1000000
+                });
+
+                expect(tx.payment_hash).toBe(HASH_A);
+                expect(tx.preimage).toBe(PREIMAGE);
+                expect(tx.expires_at).toBe(CREATION_DATE + EXPIRY_SECONDS);
+            });
+
+            it('does not report a settle time for an unpaid invoice', async () => {
+                const tx = await lookupLightningInvoice({
+                    payment_hash: HASH_A,
+                    bolt11: INVOICE_A,
+                    created_at: CREATION_DATE,
+                    timestamp: CREATION_DATE,
+                    expires_at: CREATION_DATE + EXPIRY_SECONDS,
+                    status: 'unpaid'
+                });
+
+                expect(tx.state).not.toBe('settled');
+                expect(tx.settled_at).toBe(0);
+            });
+        });
+
+        describe('list_transactions', () => {
+            it('derives payment_hash from r_hash for LND invoices', () => {
+                const [tx] =
+                    NostrConnectUtils.convertLightningDataToNip47Transactions({
+                        invoices: [new Invoice(lndInvoice())]
+                    });
+
+                expect(tx.payment_hash).toBe(HASH_A);
+            });
+
+            it('never reports the payment request as a payment hash', () => {
+                const activity: ConnectionActivity = {
+                    id: INVOICE_A,
+                    type: 'make_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    invoice: new Invoice(lndInvoice())
+                };
+
+                const tx =
+                    NostrConnectUtils.convertConnectionActivityToNip47Transaction(
+                        activity
+                    );
+
+                expect(tx.payment_hash).toBe(HASH_A);
             });
         });
     });

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -649,20 +649,29 @@ export default class NostrConnectUtils {
             Number(invoice.expires_at) ||
             timestamp + DEFAULT_INVOICE_EXPIRY_SECONDS;
 
+        // The request may carry only the invoice, so recover the hash from it
+        let paymentHash = request.payment_hash || '';
+        if (!paymentHash) {
+            try {
+                const decoded = await NostrConnectUtils.decodeInvoiceTags(
+                    invoice.getPaymentRequest
+                );
+                paymentHash = decoded.paymentHash || '';
+            } catch {
+                // Undecodable mint quote — report an empty hash rather than a wrong one
+            }
+        }
+
         return NostrConnectUtils.createNip47Transaction({
             type: 'incoming',
             state: isPaid ? 'settled' : 'pending',
             invoice: invoice.getPaymentRequest,
-            payment_hash: request.payment_hash!,
+            payment_hash: paymentHash,
             amount: satsToMillisats(amtSat || 0),
-            ...(isPaid && {
-                preimage:
-                    invoice.getPaymentRequest ||
-                    request.invoice ||
-                    request.payment_hash
-            }),
             description: invoice.getMemo,
-            settled_at: isPaid ? invoice.settleDate.getTime() / 1000 : 0,
+            settled_at: isPaid
+                ? Math.floor(invoice.settleDate.getTime() / 1000)
+                : 0,
             created_at: timestamp,
             expires_at: expiresAt
         });
@@ -683,10 +692,16 @@ export default class NostrConnectUtils {
         }
         const invoice = new Invoice(rawInvoice);
         const now = Math.floor(Date.now() / 1000);
+        const createdAt = Math.floor(invoice.getCreationDate.getTime() / 1000);
+        // Core Lightning reports an absolute expires_at, LND expiry seconds
+        const expiresAt =
+            Number(invoice.expires_at) > 0
+                ? Number(invoice.expires_at)
+                : Number(invoice.expiry) > 0
+                ? createdAt + Number(invoice.expiry)
+                : 0;
 
-        const isExpired =
-            Number(invoice.expiry) > 0 &&
-            Number(invoice.timestamp) + Number(invoice.expiry) < now;
+        const isExpired = expiresAt > 0 && expiresAt < now;
 
         const state = invoice.isPaid
             ? 'settled'
@@ -705,9 +720,11 @@ export default class NostrConnectUtils {
                 preimage: invoice.getRPreimage
             }),
             description_hash: invoice.getDescriptionHash,
-            settled_at: invoice.settleDate.getTime() / 1000,
-            created_at: invoice.getCreationDate.getTime() / 1000,
-            expires_at: invoice.getCreationDate.getTime() / 1000
+            settled_at: invoice.isPaid
+                ? Math.floor(invoice.settleDate.getTime() / 1000)
+                : 0,
+            created_at: createdAt,
+            expires_at: expiresAt
         });
     }
 
@@ -1027,10 +1044,13 @@ export default class NostrConnectUtils {
             return activity.payment.paymentHash;
         }
         if (activity.invoice) {
-            const invoiceHash = (activity.invoice as Invoice).payment_hash;
+            const invoiceHash =
+                (activity.invoice as Invoice).getRHash ||
+                (activity.invoice as Invoice).payment_hash;
             if (invoiceHash) return invoiceHash;
         }
-        return activity.id || '';
+        // activity.id holds the payment request, which is not a payment hash
+        return '';
     }
 
     private static extractAmountFromActivity(
@@ -1409,7 +1429,8 @@ export default class NostrConnectUtils {
                     const amount = Number(invoice.getAmount) || 0;
                     const timestamp =
                         Number(invoice.getTimestamp) || Date.now() / 1000;
-                    const paymentHash = invoice.payment_hash || '';
+                    // LND returns r_hash, Core Lightning payment_hash
+                    const paymentHash = invoice.getRHash || '';
                     const invoiceString = invoice.getPaymentRequest || '';
                     const description = invoice.getMemo || '';
                     const expiresAt = Number(invoice.expires_at) || 0;


### PR DESCRIPTION
# Description

Relates to issue: **#4006**, **#4036**

> Opened as a draft: on-device testing on Android and iOS is still outstanding,
> and the platform/backend matrix below is unticked until then. Feedback on the
> approach is welcome in the meantime.

When ZEUS acts as an NWC wallet service, several NIP-47 transaction fields are
mapped from raw backend fields instead of the normalized model getters. The raw
field names only match LND, so anything else loses data.

**`payment_hash` is empty for non-LND invoices (#4006).**
`convertLightningDataToNip47Transactions` read `invoice.payment_hash`, which only
Core Lightning sets — LND returns `r_hash`. `Invoice.getRHash` is the normalizer
for exactly this, and the `lookup_invoice` path already used it. The model getter
itself only read `r_hash`, although `getFormattedRhash` in the same file already
did `this.r_hash || this.payment_hash`. Both getters now cover both field names.

`extractPaymentHashFromActivity` had the same gap and fell back to `activity.id`,
which holds the payment request — a BOLT11 string is not a payment hash, so it
now reports an empty string rather than a wrong value.

**`preimage` is empty for paid invoices (#4036).**
`Invoice.getRPreimage` only read `r_preimage`. Core Lightning uses
`payment_preimage` and NIP-47 transaction objects (returned by
`backends/NostrWalletConnect.ts`) use `preimage`. Both are now covered.

**`expires_at` equalled `created_at`.**
`buildNip47TransactionForLightningInvoiceLookup` set `expires_at` to the creation
date. It is now derived from Core Lightning's absolute `expires_at`, or LND's
`creation_date + expiry`, or `0` when the invoice does not expire.

The old expiry check used `invoice.timestamp`, which LND does not set, so the
comparison was `NaN` and an expired invoice was reported as `pending` forever.
It now reuses the computed expiry, so the check actually fires.

Note this makes the existing `failed` mapping reachable for the first time.
NIP-47 defines `expired` as the state for expired invoices and reserves `failed`
for payments, but `Nip47Transaction` in `@getalby/sdk` types `state` as
`"settled" | "pending" | "failed" | "accepted"`, so `expired` is not expressible
without casting around the SDK type. I kept the existing mapping rather than do
that — happy to revisit if you'd prefer it handled here.

**`settled_at` was reported for unpaid invoices.**
It was emitted unconditionally, and `Invoice.settleDate` falls back to
`timestamp`, so unpaid invoices carried a settle time. It is now `0` unless the
invoice is paid.

**The Cashu lookup reported the payment request as the preimage.**
`buildNip47TransactionForCashuInvoiceLookup` set `preimage` to the BOLT11 string
when the quote was paid. Clients use the preimage as proof of payment, so a wrong
value is worse than none; `CashuInvoice` carries no preimage, so the field is now
left empty. The same function assumed `request.payment_hash` was always present —
NIP-47 permits looking up by `invoice` alone — and now recovers the hash from the
payment request in that case.

The model getters can only turn an empty string into a real value, never the
other way around, so nothing that worked before can break. They are shared,
though, so there are two visible side effects outside NIP-47 — both surface data
that was previously dropped rather than changing anything that worked:

- `views/Invoice.tsx` renders its R hash and R preimage rows conditionally on
  these getters, so Core Lightning invoices now show those rows where they were
  previously blank.
- The `Payment Hash` column of the activity CSV export (`ActivityCsvUtils.ts`)
  is now populated for Core Lightning invoices.

I can narrow the fix to the NWC call sites instead if you'd rather leave the
shared getters alone — say the word.

### Known limitation

Cashu `make_invoice` activities now report an empty `payment_hash` in
`list_transactions` where they previously reported the payment request.
`CashuInvoice` carries a mint `quote`, not a payment hash, and
`extractPaymentHashFromActivity` is synchronous, so it cannot decode the BOLT11
to recover one. Both values are wrong per spec — an empty field is the honest
one, and it stops a BOLT11 string being consumed as a transaction identifier.

Recovering the real hash means decoding the quote's payment request, which I've
kept out of this PR to hold the diff to field mapping. I'll address it in a
follow-up PR covering the Cashu and outgoing-payment lookup paths — or fold it
in here if you'd rather not ship the intermediate state.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

Eight cases were added to `utils/NostrConnectUtils.test.ts` covering LND-shaped
and Core Lightning-shaped invoices through `lookup_invoice`,
`list_transactions` and the connection-activity conversion. Six of them fail
against master; the remaining two guard paths that were already correct.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
