### PR TITLE
fix(nwc): resolve lookup_invoice by invoice as well as payment_hash

### DIFF
--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -46,7 +46,6 @@ import NostrConnectUtils, {
 import IOSAudioKeepAliveUtils from '../utils/IOSAudioKeepAliveUtils';
 import { satsToMillisats, millisatsToSats } from '../utils/AmountUtils';
 import { retry } from '../utils/SleepUtils';
-import Base64Utils from '../utils/Base64Utils';
 
 import NWCConnection, {
     BudgetRenewalType,
@@ -1713,9 +1712,9 @@ export default class NostrWalletConnectStore {
                 return { result, error: undefined };
             }
             const rHash =
-                request.payment_hash && request.payment_hash.includes('=')
-                    ? Base64Utils.base64ToHex(request.payment_hash)
-                    : request.payment_hash;
+                await NostrConnectUtils.resolveLookupInvoicePaymentHash(
+                    request
+                );
             if (!rHash) {
                 return NostrConnectUtils.createNip47Error(
                     localeString(

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1711,10 +1711,7 @@ export default class NostrWalletConnectStore {
                     );
                 return { result, error: undefined };
             }
-            const rHash =
-                await NostrConnectUtils.resolveLookupInvoicePaymentHash(
-                    request
-                );
+            const rHash = await NostrConnectUtils.resolvePaymentHash(request);
             if (!rHash) {
                 return NostrConnectUtils.createNip47Error(
                     localeString(

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -37,6 +37,7 @@ import * as nostrTools from 'nostr-tools';
 
 import NostrConnectUtils from './NostrConnectUtils';
 import Payment from '../models/Payment';
+import Base64Utils from './Base64Utils';
 
 // Stable hex values: repeat a hex digit 64 times to fill 32 bytes
 const hex64 = (c: string) => c.repeat(64);
@@ -741,6 +742,51 @@ describe('NostrConnectUtils', () => {
                     expect(result).toEqual({ inTransit: false });
                 });
             });
+        });
+    });
+
+    describe('lookup_invoice request resolution', () => {
+        // BOLT11 spec reference vector; hash confirmed by decoding it
+        const BOLT11 =
+            'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr';
+        const BOLT11_HASH =
+            '0001020304050607080900010203040506070809000102030405060708090102';
+
+        const resolve = (request: object) =>
+            NostrConnectUtils.resolveLookupInvoicePaymentHash(request as never);
+
+        it('passes a hex payment_hash through unchanged', async () => {
+            await expect(resolve({ payment_hash: HASH_A })).resolves.toBe(
+                HASH_A
+            );
+        });
+
+        it('converts a base64 payment_hash to hex', async () => {
+            await expect(
+                resolve({ payment_hash: Base64Utils.hexToBase64(HASH_A) })
+            ).resolves.toBe(HASH_A);
+        });
+
+        it('derives the hash from the invoice when no hash is given', async () => {
+            await expect(resolve({ invoice: BOLT11 })).resolves.toBe(
+                BOLT11_HASH
+            );
+        });
+
+        it('prefers payment_hash when both parameters are present', async () => {
+            await expect(
+                resolve({ payment_hash: HASH_A, invoice: BOLT11 })
+            ).resolves.toBe(HASH_A);
+        });
+
+        it('returns undefined when neither parameter is given', async () => {
+            await expect(resolve({})).resolves.toBeUndefined();
+        });
+
+        it('returns undefined for an undecodable invoice', async () => {
+            await expect(
+                resolve({ invoice: 'not-a-payment-request' })
+            ).resolves.toBeUndefined();
         });
     });
 });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -753,7 +753,7 @@ describe('NostrConnectUtils', () => {
             '0001020304050607080900010203040506070809000102030405060708090102';
 
         const resolve = (request: object) =>
-            NostrConnectUtils.resolveLookupInvoicePaymentHash(request as never);
+            NostrConnectUtils.resolvePaymentHash(request as never);
 
         it('passes a hex payment_hash through unchanged', async () => {
             await expect(resolve({ payment_hash: HASH_A })).resolves.toBe(

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -603,7 +603,7 @@ export default class NostrConnectUtils {
      * payment_hash or invoice is required". Resolves the request to a payment
      * hash in hex, or undefined when neither parameter yields one.
      */
-    static async resolveLookupInvoicePaymentHash(
+    static async resolvePaymentHash(
         request: Nip47LookupInvoiceRequest
     ): Promise<string | undefined> {
         const paymentHash = request.payment_hash?.trim();

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -23,6 +23,7 @@ import CashuInvoice from '../models/CashuInvoice';
 import CashuToken from '../models/CashuToken';
 import Transaction from '../models/Transaction';
 
+import Base64Utils from './Base64Utils';
 import { localeString } from './LocaleUtils';
 import dateTimeUtils from './DateTimeUtils';
 import Bolt11Utils from './Bolt11Utils';
@@ -594,6 +595,34 @@ export default class NostrConnectUtils {
             return new Invoice(result).isPaid;
         } catch {
             return false;
+        }
+    }
+
+    /**
+     * NIP-47 lookup_invoice takes either payment_hash or invoice — "one of
+     * payment_hash or invoice is required". Resolves the request to a payment
+     * hash in hex, or undefined when neither parameter yields one.
+     */
+    static async resolveLookupInvoicePaymentHash(
+        request: Nip47LookupInvoiceRequest
+    ): Promise<string | undefined> {
+        const paymentHash = request.payment_hash?.trim();
+        if (paymentHash) {
+            // Some clients send the hash base64-encoded rather than as hex
+            return paymentHash.includes('=')
+                ? Base64Utils.base64ToHex(paymentHash)
+                : paymentHash;
+        }
+
+        const invoice = request.invoice?.trim();
+        if (!invoice) return undefined;
+
+        try {
+            const decoded = await NostrConnectUtils.decodeInvoiceTags(invoice);
+            return decoded.paymentHash || undefined;
+        } catch {
+            // Undecodable payment request — the caller reports NOT_FOUND
+            return undefined;
         }
     }
 


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

> Opened as a draft: on-device testing on Android and iOS is still outstanding,
> and the platform/backend matrix below is unticked until then.

NIP-47 defines the `lookup_invoice` parameters as:

```
"payment_hash": "31afdf1..", // payment hash of the invoice, one of payment_hash or invoice is required
"invoice": "lnbc50n1..." // invoice to lookup
```

The Lightning path in `handleLookupInvoice` only ever read `request.payment_hash`
and returned `NOT_FOUND` when it was absent, so a spec-legal request carrying
only the payment request failed for every transaction. The Cashu path already
matched on the invoice string; only Lightning was affected.

The hash is now recovered from the payment request using the existing
`decodeInvoiceTags` helper, which the file already uses for the Cashu lookup and
for `make_invoice`. `payment_hash` still wins when both parameters are supplied.

The base64-decoding of `payment_hash` moved along with it — some clients send the
hash base64-encoded rather than as hex, which the previous inline code already
handled and which is preserved.

## Scope

This only fixes *how the request is resolved*. It does not make `lookup_invoice`
able to find outgoing payments: the lookup still queries the invoices table only,
so looking up a settled payment by its invoice will still return `NOT_FOUND` on
LND-family backends. That is a separate, larger change and I'd rather keep it in
its own PR so this one stays revertible on its own.

Independent of #4269 — the two touch different functions and can merge in either
order. They do both append a `describe` block at the end of
`utils/NostrConnectUtils.test.ts`, so whichever lands second will need a trivial
rebase there; happy to do that whenever you decide the order.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

Six cases in `utils/NostrConnectUtils.test.ts` cover hex and base64
`payment_hash`, resolution from the invoice alone, precedence when both are
given, and both undecodable-input cases. The fixture is the BOLT11 reference
vector from the spec; its payment hash was confirmed by decoding it rather than
quoted from anywhere.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
