### PR TITLE
fix(nwc): let lookup_invoice find outgoing payments

### DIFF
--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -95,6 +95,10 @@ const SAVE_CONNECTIONS_DEBOUNCE_MS = 500;
 const PENDING_PAYMENT_STATUS_MIN_AGE_MS = 5_000;
 /** Per-connection debounce for pending pay_invoice status refresh in getActivities */
 const PENDING_PAYMENT_STATUS_REFRESH_MS = 30_000;
+/** Payments fetched when lookup_invoice falls back to searching payments */
+const LOOKUP_PAYMENT_FETCH_LIMIT = 100;
+/** Window in which that fetched list is reused across lookup_invoice calls */
+const LOOKUP_PAYMENT_CACHE_MS = 5_000;
 
 export const DEFAULT_NOSTR_RELAYS = [
     'wss://relay.getalby.com/v1',
@@ -173,6 +177,11 @@ export default class NostrWalletConnectStore {
         string,
         number
     >();
+    /** Short-lived payment list reused by lookup_invoice, see getPaymentsForLookup */
+    private lookupPaymentCache: {
+        payments: Payment[];
+        fetchedAt: number;
+    } | null = null;
 
     settingsStore: SettingsStore;
     balanceStore: BalanceStore;
@@ -1724,17 +1733,86 @@ export default class NostrWalletConnectStore {
                     Nip47ErrorCode.NOT_FOUND
                 );
             }
-            const result =
-                await NostrConnectUtils.buildNip47TransactionForLightningInvoiceLookup(
-                    rHash
-                );
-            return { result, error: undefined };
+            try {
+                const result =
+                    await NostrConnectUtils.buildNip47TransactionForLightningInvoiceLookup(
+                        rHash
+                    );
+                return { result, error: undefined };
+            } catch (invoiceLookupError) {
+                // NIP-47 lookup_invoice covers payments too, but the backend
+                // lookup only sees invoices — fall back to the payment list.
+                // A failure here must not mask the original lookup result.
+                let payment: Payment | undefined;
+                try {
+                    payment = await this.findPaymentForLookup(
+                        rHash,
+                        request.invoice
+                    );
+                } catch (paymentLookupError) {
+                    console.error(
+                        'NWC: payment lookup fallback failed:',
+                        paymentLookupError
+                    );
+                }
+                if (!payment) throw invoiceLookupError;
+                return {
+                    result: NostrConnectUtils.buildNip47TransactionForPayment(
+                        payment
+                    ),
+                    error: undefined
+                };
+            }
         } catch (error) {
             return NostrConnectUtils.createNip47Error(
                 (error as Error).message,
                 Nip47ErrorCode.NOT_FOUND
             );
         }
+    }
+
+    /**
+     * Finds an outgoing payment for lookup_invoice. Only runs when the invoice
+     * lookup missed, so the common case costs no extra node round-trip.
+     */
+    private async findPaymentForLookup(
+        rHash: string,
+        invoice?: string
+    ): Promise<Payment | undefined> {
+        const payments = await this.getPaymentsForLookup();
+        return NostrConnectUtils.findPaymentForInvoice(
+            invoice || '',
+            payments,
+            rHash
+        );
+    }
+
+    private async getPaymentsForLookup(): Promise<Payment[]> {
+        const now = Date.now();
+        if (
+            this.lookupPaymentCache &&
+            NostrConnectUtils.isLookupPaymentCacheFresh(
+                this.lookupPaymentCache.fetchedAt,
+                now,
+                LOOKUP_PAYMENT_CACHE_MS
+            )
+        ) {
+            return this.lookupPaymentCache.payments;
+        }
+
+        // Deliberately not via paymentsStore: that overwrites the shared
+        // payment list the wallet UI renders from, and toggles its loading
+        // state. `reversed` must be explicit — embedded LND defaults it to
+        // false and would return the oldest page instead of the newest.
+        const data = await BackendUtils.getPayments({
+            maxPayments: LOOKUP_PAYMENT_FETCH_LIMIT,
+            reversed: true
+        });
+        const payments: Payment[] = (data?.payments || []).map(
+            (payment: any) => new Payment(payment)
+        );
+        this.lookupPaymentCache = { payments, fetchedAt: now };
+        return payments;
     }
 
     private async handleListTransactions(

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1733,29 +1733,19 @@ export default class NostrWalletConnectStore {
                     Nip47ErrorCode.NOT_FOUND
                 );
             }
-            try {
-                const result =
-                    await NostrConnectUtils.buildNip47TransactionForLightningInvoiceLookup(
-                        rHash
-                    );
-                return { result, error: undefined };
-            } catch (invoiceLookupError) {
-                // NIP-47 lookup_invoice covers payments too, but the backend
-                // lookup only sees invoices — fall back to the payment list.
-                // A failure here must not mask the original lookup result.
-                let payment: Payment | undefined;
-                try {
-                    payment = await this.findPaymentForLookup(
-                        rHash,
-                        request.invoice
-                    );
-                } catch (paymentLookupError) {
-                    console.error(
-                        'NWC: payment lookup fallback failed:',
-                        paymentLookupError
-                    );
-                }
-                if (!payment) throw invoiceLookupError;
+            // NIP-47 lookup_invoice covers invoices and payments, so ask for
+            // each in turn. Both helpers answer with undefined when they have
+            // nothing, rather than signalling absence by throwing.
+            const invoice = await this.lookupInvoiceForNip47(rHash);
+            if (invoice) {
+                return { result: invoice, error: undefined };
+            }
+
+            const payment = await this.lookupPaymentForNip47(
+                rHash,
+                request.invoice
+            );
+            if (payment) {
                 return {
                     result: NostrConnectUtils.buildNip47TransactionForPayment(
                         payment
@@ -1763,6 +1753,13 @@ export default class NostrWalletConnectStore {
                     error: undefined
                 };
             }
+
+            return NostrConnectUtils.createNip47Error(
+                localeString(
+                    'stores.NostrWalletConnectStore.error.invoiceNotFound'
+                ),
+                Nip47ErrorCode.NOT_FOUND
+            );
         } catch (error) {
             return NostrConnectUtils.createNip47Error(
                 (error as Error).message,
@@ -1772,19 +1769,46 @@ export default class NostrWalletConnectStore {
     }
 
     /**
-     * Finds an outgoing payment for lookup_invoice. Only runs when the invoice
-     * lookup missed, so the common case costs no extra node round-trip.
+     * Invoice lookup expressed as a question. Backends disagree on how they
+     * report a miss — some throw, some resolve with `false` through
+     * BackendUtils.call — so every one of those collapses to undefined here
+     * instead of being inferred from an exception at the call site.
      */
-    private async findPaymentForLookup(
+    private async lookupInvoiceForNip47(
+        rHash: string
+    ): Promise<Nip47Transaction | undefined> {
+        try {
+            return await NostrConnectUtils.buildNip47TransactionForLightningInvoiceLookup(
+                rHash
+            );
+        } catch (error) {
+            return undefined;
+        }
+    }
+
+    /**
+     * Finds an outgoing payment for lookup_invoice. Only runs when the invoice
+     * lookup found nothing, so the common case costs no extra node round-trip.
+     * A failing node request is reported as "not found", never as a crash.
+     */
+    private async lookupPaymentForNip47(
         rHash: string,
         invoice?: string
     ): Promise<Payment | undefined> {
-        const payments = await this.getPaymentsForLookup();
-        return NostrConnectUtils.findPaymentForInvoice(
-            invoice || '',
-            payments,
-            rHash
-        );
+        try {
+            const payments = await this.getPaymentsForLookup();
+            return NostrConnectUtils.findPaymentForInvoice(
+                invoice || '',
+                payments,
+                rHash
+            );
+        } catch (error) {
+            console.error(
+                'NWC: payment lookup for lookup_invoice failed:',
+                error
+            );
+            return undefined;
+        }
     }
 
     private async getPaymentsForLookup(): Promise<Payment[]> {

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -743,4 +743,114 @@ describe('NostrConnectUtils', () => {
             });
         });
     });
+
+    describe('buildNip47TransactionForPayment', () => {
+        const TIMESTAMP = 1700000000;
+        const build = (payment: Payment) =>
+            NostrConnectUtils.buildNip47TransactionForPayment(payment);
+
+        it('types a payment as outgoing and gives it no expiry', () => {
+            const tx = build(
+                new Payment({
+                    payment_hash: HASH_A,
+                    payment_request: INVOICE_A,
+                    creation_date: String(TIMESTAMP),
+                    value_sat: '1000',
+                    status: 'SUCCEEDED'
+                })
+            );
+
+            expect(tx.type).toBe('outgoing');
+            expect(tx.expires_at).toBe(0);
+        });
+
+        it('reports the fee in msats (Payment.getFee is in sats)', () => {
+            const tx = build(
+                new Payment({
+                    payment_hash: HASH_A,
+                    creation_date: String(TIMESTAMP),
+                    value_sat: '1000',
+                    fee_msat: '2500',
+                    status: 'SUCCEEDED'
+                })
+            );
+
+            expect(tx.fees_paid).toBe(2500);
+        });
+
+        it('derives the Core Lightning fee from amount vs amount_sent', () => {
+            const tx = build(
+                new Payment({
+                    payment_hash: HASH_A,
+                    bolt11: INVOICE_A,
+                    created_at: String(TIMESTAMP),
+                    amount_msat: '1000000msat',
+                    amount_sent_msat: '1002000msat',
+                    status: 'complete'
+                })
+            );
+
+            expect(tx.fees_paid).toBe(2000);
+        });
+
+        it('decodes an LndHub buffer payment hash to hex', () => {
+            const tx = build(
+                new Payment({
+                    payment_hash: {
+                        type: 'Buffer',
+                        data: Array(32).fill(0xcc)
+                    },
+                    creation_date: String(TIMESTAMP),
+                    value_sat: '1000',
+                    status: 'SUCCEEDED'
+                })
+            );
+
+            expect(tx.payment_hash).toBe(HASH_A);
+        });
+
+        it('marks a settled payment settled and stamps settled_at', () => {
+            const tx = build(paymentFixtures.settled());
+
+            expect(tx.state).toBe('settled');
+            expect(tx.settled_at).toBe(tx.created_at);
+            expect(tx.preimage).toBe('abc123preimage');
+        });
+
+        it('marks a failed payment failed without a settle time', () => {
+            const tx = build(paymentFixtures.failed());
+
+            expect(tx.state).toBe('failed');
+            expect(tx.settled_at).toBe(0);
+        });
+
+        it('marks an in-flight payment pending without a settle time', () => {
+            const tx = build(paymentFixtures.inFlightStatus());
+
+            expect(tx.state).toBe('pending');
+            expect(tx.settled_at).toBe(0);
+        });
+    });
+
+    describe('isLookupPaymentCacheFresh', () => {
+        const TTL = 5000;
+        const fresh = (fetchedAt: number, now: number) =>
+            NostrConnectUtils.isLookupPaymentCacheFresh(fetchedAt, now, TTL);
+
+        it('reuses a list fetched within the window', () => {
+            expect(fresh(1_000_000, 1_004_999)).toBe(true);
+        });
+
+        it('refetches once the window has elapsed', () => {
+            expect(fresh(1_000_000, 1_005_000)).toBe(false);
+        });
+
+        it('treats an unset timestamp as stale', () => {
+            expect(fresh(0, 1_000_000)).toBe(false);
+        });
+
+        it('refetches when the clock moved backwards', () => {
+            expect(fresh(1_000_000, 999_000)).toBe(false);
+        });
+    });
 });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -37,6 +37,7 @@ import * as nostrTools from 'nostr-tools';
 
 import NostrConnectUtils from './NostrConnectUtils';
 import Payment from '../models/Payment';
+import BackendUtils from './BackendUtils';
 
 // Stable hex values: repeat a hex digit 64 times to fill 32 bytes
 const hex64 = (c: string) => c.repeat(64);
@@ -829,6 +830,36 @@ describe('NostrConnectUtils', () => {
 
             expect(tx.state).toBe('pending');
             expect(tx.settled_at).toBe(0);
+        });
+    });
+
+    describe('buildNip47TransactionForLightningInvoiceLookup guards', () => {
+        const lookupReturning = (raw: unknown) => {
+            (BackendUtils as any).lookupInvoice = jest
+                .fn()
+                .mockResolvedValue(raw);
+            return NostrConnectUtils.buildNip47TransactionForLightningInvoiceLookup(
+                hex64('c')
+            );
+        };
+
+        it('rejects the false returned for a backend without the method', async () => {
+            await expect(lookupReturning(false)).rejects.toThrow();
+        });
+
+        it('rejects an object that carries no invoice identity', async () => {
+            await expect(
+                lookupReturning({ error: 'unable to locate invoice' })
+            ).rejects.toThrow();
+        });
+
+        it('accepts an invoice identified by payment request alone', async () => {
+            const tx = await lookupReturning({
+                bolt11: 'lnbc2500u1pvjluez',
+                status: 'unpaid'
+            });
+
+            expect(tx.invoice).toBe('lnbc2500u1pvjluez');
         });
     });
 

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -711,6 +711,54 @@ export default class NostrConnectUtils {
         });
     }
 
+    /**
+     * NIP-47 transaction for an outgoing payment. Per spec, "outgoing" is the
+     * type for payments, and a payment has no expiry.
+     *
+     * Note `Payment.getFee` reports sats, so the fee is scaled to msats here.
+     */
+    static buildNip47TransactionForPayment(payment: Payment): Nip47Transaction {
+        const timestamp =
+            Number(payment.getTimestamp) || dateTimeUtils.getCurrentTimestamp();
+
+        let state: 'settled' | 'pending' | 'failed' = 'pending';
+        if (payment.isFailed) {
+            state = 'failed';
+        } else if (!payment.isIncomplete) {
+            state = 'settled';
+        }
+
+        return NostrConnectUtils.createNip47Transaction({
+            type: 'outgoing',
+            state,
+            invoice: payment.getPaymentRequest || '',
+            payment_hash: payment.paymentHash || '',
+            amount: satsToMillisats(Number(payment.getAmount) || 0),
+            description: payment.getMemo || '',
+            preimage: payment.getPreimage || '',
+            fees_paid: satsToMillisats(Number(payment.getFee) || 0),
+            settled_at: state === 'settled' ? timestamp : 0,
+            created_at: timestamp,
+            expires_at: 0
+        });
+    }
+
+    /**
+     * Whether a payment list fetched for lookup_invoice may still be reused.
+     * Collapses a client polling the same hash into a single node round-trip.
+     */
+    static isLookupPaymentCacheFresh(
+        fetchedAt: number,
+        now: number,
+        ttlMs: number
+    ): boolean {
+        if (fetchedAt <= 0) return false;
+        const age = now - fetchedAt;
+        // A negative age means the clock moved backwards — refetch rather than
+        // trust a timestamp from the future
+        return age >= 0 && age < ttlMs;
+    }
+
     static async decodeInvoiceTagsForMakeInvoice(
         paymentRequest: string,
         rHash?: string
@@ -1364,40 +1412,8 @@ export default class NostrConnectUtils {
         // Convert Lightning payments
         if (lightningData.payments) {
             const paymentTransactions = lightningData.payments.map(
-                (payment: Payment) => {
-                    const amount = Number(payment.getAmount) || 0;
-                    const timestamp =
-                        Number(payment.getTimestamp) || Date.now() / 1000;
-                    const paymentHash = payment.paymentHash || '';
-                    const invoice = payment.getPaymentRequest || '';
-                    const feesPaid = satsToMillisats(
-                        Number(payment.getFee) || 0
-                    );
-                    const description = payment.getMemo || '';
-                    const preimage = payment.getPreimage || '';
-
-                    // Determine state based on payment status
-                    let state: 'settled' | 'pending' | 'failed' = 'pending';
-                    if (payment.isFailed) {
-                        state = 'failed';
-                    } else if (!payment.isIncomplete) {
-                        state = 'settled';
-                    }
-
-                    return NostrConnectUtils.createNip47Transaction({
-                        type: 'outgoing',
-                        state,
-                        invoice,
-                        payment_hash: paymentHash,
-                        amount: satsToMillisats(amount),
-                        description,
-                        preimage,
-                        fees_paid: feesPaid,
-                        settled_at: state === 'settled' ? timestamp : 0,
-                        created_at: timestamp,
-                        expires_at: 0
-                    });
-                }
+                (payment: Payment) =>
+                    NostrConnectUtils.buildNip47TransactionForPayment(payment)
             );
             transactions.push(...paymentTransactions);
         }

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -682,6 +682,16 @@ export default class NostrConnectUtils {
             );
         }
         const invoice = new Invoice(rawInvoice);
+        // Being an object is not proof of being an invoice — a backend may
+        // resolve with an error body. Require something identifying before
+        // reporting this as a found invoice.
+        if (!invoice.getRHash && !invoice.getPaymentRequest) {
+            throw new Error(
+                localeString(
+                    'stores.NostrWalletConnectStore.error.invoiceNotFound'
+                )
+            );
+        }
         const now = Math.floor(Date.now() / 1000);
 
         const isExpired =


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

> Opened as a draft: on-device testing on Android and iOS is still outstanding.
> The per-backend table below marks exactly which claims are read off the code
> and which still need a real node — please read it before reviewing.

NIP-47 `lookup_invoice` returns `"incoming"` for invoices and `"outgoing"` for
payments; the spec is explicit that it "retrieves either type". ZEUS only ever
queried the invoices table, so a settled outgoing payment returned `NOT_FOUND`
on the LND-family backends, and on `ldk-node` — where `listPayments()` matches
outbound payments by hash and `formatPaymentAsInvoice` discards `direction` — it
came back typed `incoming` with `fees_paid: 0` and an expiry.

The handler now asks for an invoice, then for a payment, and reports `NOT_FOUND`
only when neither answers. A payment is mapped with `type: "outgoing"`, the real
fee, and `expires_at: 0`, since a payment has no expiry.

Both lookups return `undefined` when they have nothing rather than signalling
absence by throwing. That distinction matters: an earlier revision ran the
payment path from the invoice lookup's `catch` block, which silently skipped it
on any backend that reports a miss without throwing — exactly what LDK Node does.
Inferring "not an invoice" from an exception makes correctness depend on every
backend failing in the same way, and they don't.

For the same reason the invoice lookup no longer treats "is an object" as proof
of being an invoice: a response carrying neither a payment hash nor a payment
request is now a miss rather than a transaction built from an error body.

One caveat on `ldk-node`, since the wording above could be read as covering it:
this PR alone does **not** fix that backend. Its `lookupInvoice` finds the
outbound payment and returns it as an invoice, so the lookup never misses and
this fallback never runs. #4276 restricts that search to inbound payments, which
is what makes the two work together. Either merges on its own; LDK Node needs
both.

## Keeping the node round-trips down

Fetching the payment list on every lookup would be wasteful, so:

- **The fallback only runs when the invoice lookup missed.** A client polling an
  invoice it created — the common case — costs no extra request at all. Only
  requests that return `NOT_FOUND` today are affected.
- **One bounded fetch, not the default 500.** `maxPayments: 100`.
- **A 5 s window coalesces bursts.** A client polling the same hash while waiting
  for settlement causes one node round-trip, not one per poll. The window is
  deliberately short because stale payment state is what NWC clients already
  complain about; it's a single constant if you want it tuned.

Two things worth calling out in review:

**The fallback does not go through `PaymentsStore`.** `PaymentsStore.getPayments`
overwrites `this.payments` — the shared list the wallet UI renders from — and
toggles its loading flag. Routing a lookup through it with a reduced
`maxPayments` would have silently truncated the user's visible payment history on
every NWC lookup. It calls `BackendUtils.getPayments` directly and builds the
models locally instead.

**`reversed: true` is passed explicitly.** `lndmobile/index.ts` spreads it
conditionally (`...(params?.reversed && { reversed })`), so omitting it leaves the
protobuf default of `false` and embedded LND returns the *oldest* page — a
freshly settled payment would never be in the window. LND REST and LNC default it
to `true`, embedded LND does not.

## Per-backend basis for this change

Verified by reading the code in this repo:

| Backend | `maxPayments` honored | `payment_hash` shape | Fee source |
|---|---|---|---|
| LND (REST) | yes | hex string | `fee_msat` / `fee_sat` |
| Embedded LND | yes (default 1000) | hex string (lnrpc) | `fee_msat` |
| LNC | yes | hex string | `fee_msat` |
| CLNRest | **no** — SQL `limit 150` | hex string from `sendpays` | `amount_sent_msat − amount_msat` |
| LndHub | **no** — `/gettxs` | Buffer object, handled by `Payment.paymentHash` | unverified |
| LDK Node | **no** — in-memory, outbound only | string | `fee_msat` |
| NWC | yes (`limit`) | string | `fees_paid` |

So the bound is a real bound on LND-family and NWC, while CLNRest, LndHub and
LDK Node return their natural cap regardless. LDK Node is in-memory so this costs
nothing there; LndHub is the one that still fetches everything, which a targeted
lookup in a follow-up backends PR would fix.

The fee unit was checked rather than assumed: `Payment.getFee` returns **sats**
(it divides `fee_msat` down), so the mapper scales it back to msats for
`fees_paid`.

**Not verified without a node, and what I'd most like tested:** the runtime shape
of LndHub's `/gettxs` rows — whether a fee field survives into `Payment` at all,
and whether its buffer `payment_hash` matches what `lookup_invoice` is queried
with. Everything else above is read off code paths in this repo, but I have not
run any of it against a real node.

## Why a list scan rather than a targeted query

Worth being explicit, since scanning a payment list is not obviously the right
shape for a by-hash lookup: on the LND family there is no alternative in a
request/response style. `ListPaymentsRequest` in this repo's own
`proto/lightning.proto` offers `include_incomplete`, `index_offset`,
`max_payments`, `reversed` and creation-date bounds — no payment-hash filter. The
hash-targeted call is `TrackPaymentV2`, which returns a stream
(`proto/routerrpc/router.proto`), so using it for a one-shot lookup means opening
a stream, taking the first message and closing it.

Other backends could do better — Core Lightning's `listsendpays` accepts
`payment_hash` and `bolt11` directly, and LDK Node's payment list is in memory —
so a first-class `lookupPayment` per backend would beat this. That is a larger
change across all seven backends, proposed separately in #4286 rather than
smuggled in here.

## Scope

`type` for the *invoice* branch is untouched, and self-payments still resolve as
`incoming`: the invoice lookup is tried first and payments are only a fallback, so
nothing that resolves today changes.

Independent of #4269 and #4272. On its own this resolves payments by hash; with
#4272 (which resolves `lookup_invoice` by `invoice` as well) it also resolves them
by payment request. All three append to the end of
`utils/NostrConnectUtils.test.ts`, so whichever lands last needs a trivial rebase
there — happy to do that in whatever order you prefer.

Still open after this, handled separately in #4276: `lookup_invoice` fails on
`cln-rest` and `lndhub`. Correcting something I wrote earlier — the two fail for
*different* reasons. CLNRest defines no `lookupInvoice`, so `BackendUtils.call`
returns `false`. LndHub `extends LND` and therefore inherits `lookupInvoice`,
which requests `/v1/invoice/{hash}` against an LndHub server that serves no such
route. Same `NOT_FOUND` for the client, different cause and different fix.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

Eleven cases in `utils/NostrConnectUtils.test.ts` cover the payment mapping
(outgoing type, no expiry, fee in msats, Core Lightning fee derivation, LndHub
buffer hash decoding, settled/failed/in-flight states) and the cache window
including the clock-moved-backwards case.

The payment mapping was extracted out of `convertLightningDataToNip47Transactions`
so `list_transactions` and `lookup_invoice` share one implementation; that part is
a pure refactor with no behavior change.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
