### PR TITLE
fix(nwc): correct lookupInvoice on CLNRest, LndHub and LDK Node

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -265,6 +265,22 @@ export default class CLNRest {
         return this.postRequest('/v1/withdraw', request);
     };
     getMyNodeInfo = () => this.postRequest('/v1/getinfo');
+    // listinvoices filters natively by payment hash, and unlike the SQL query
+    // used by getInvoices it is not restricted to paid invoices
+    lookupInvoice = (data: any) =>
+        this.postRequest('/v1/listinvoices', {
+            payment_hash: data.r_hash
+        }).then((response: any) => {
+            const invoice = response?.invoices?.[0];
+            if (!invoice) {
+                throw new Error(
+                    localeString(
+                        'stores.NostrWalletConnectStore.error.invoiceNotFound'
+                    )
+                );
+            }
+            return invoice;
+        });
     getInvoices = (data?: any) =>
         this.postRequest('/v1/sql', {
             query: `SELECT label, bolt11, bolt12, payment_hash, amount_msat, status, amount_received_msat, paid_at, payment_preimage, description, expires_at FROM invoices WHERE status = 'paid' ORDER BY created_index DESC LIMIT ${

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -1246,8 +1246,13 @@ export default class LdkNode {
      */
     lookupInvoice = async (data: { r_hash: string }): Promise<any> => {
         const payments = await LdkNodeInjection.payments.listPayments();
+        // Inbound only — an outbound payment carries the same hash but is not
+        // an invoice, and formatting it as one mislabels it as incoming
         const payment = data?.r_hash
-            ? payments.find((p) => p.kind.hash === data.r_hash)
+            ? payments.find(
+                  (p) =>
+                      p.kind.hash === data.r_hash && p.direction === 'inbound'
+              )
             : undefined;
 
         if (payment) {

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -4,6 +4,7 @@ import LND from './LND';
 import LoginRequest from './../models/LoginRequest';
 import Base64Utils from './../utils/Base64Utils';
 import Bolt11Utils from './../utils/Bolt11Utils';
+import { localeString } from './../utils/LocaleUtils';
 import { Hash as sha256Hash } from 'fast-sha256';
 import { ecdsaSignDERHex } from '../utils/SigningUtils';
 
@@ -40,6 +41,23 @@ export default class LndHub extends LND {
         this.getRequest('/getuserinvoices').then((data: any) => ({
             invoices: data
         }));
+    // Overrides LND's /v1/invoice/{r_hash}, a route LndHub does not serve.
+    // LndHub has no per-invoice endpoint returning details — /checkpayment only
+    // answers paid/unpaid — so the user's invoice list is searched by hash.
+    lookupInvoice = (data: any) =>
+        this.getRequest('/getuserinvoices').then((invoices: any) => {
+            const invoice = (invoices || []).find(
+                (userInvoice: any) => userInvoice.payment_hash === data.r_hash
+            );
+            if (!invoice) {
+                throw new Error(
+                    localeString(
+                        'stores.NostrWalletConnectStore.error.invoiceNotFound'
+                    )
+                );
+            }
+            return invoice;
+        });
 
     createInvoice = (data: any) =>
         this.postRequest('/addinvoice', {


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

> Opened as a draft: on-device testing is still outstanding. This one genuinely
> needs a real CLN node and a real LndHub account — see the notes below for what
> I could and could not establish without them.

`lookup_invoice` over NWC is broken on three backends, each for a different
reason:

**CLNRest** defines no `lookupInvoice` at all. `BackendUtils.call` returns `false`
for a method a backend doesn't define, so `buildNip47TransactionForLightningInvoiceLookup`
receives `false`, throws, and the client gets `NOT_FOUND` — for paid invoices too.

**LndHub** `extends LND`, so it silently inherits `lookupInvoice = (data) =>
this.getRequest('/v1/invoice/' + data.r_hash)`. LndHub serves no such route; the
request 404s. This is the extends-LND hazard, same class of bug as the
`supportsChannelFundMax` / `supportsAddressMessageSigning` inheritance gaps.

**LDK Node** does not fail — it answers wrongly, which is worse. `lookupInvoice`
searches `listPayments()` unfiltered, so an *outbound* payment whose hash matches
is found and run through `formatPaymentAsInvoice`, which discards `direction`
entirely. A sent payment is then reported as `type: "incoming"` with
`fees_paid: 0` and an expiry.

## CLNRest

Uses `listinvoices` with a `payment_hash` filter rather than the raw SQL that
`getInvoices` uses. Per the `listinvoices` schema in the Core Lightning repo
(`doc/schemas/listinvoices.json`), the request accepts `label`, `invstring`,
`payment_hash`, `offer_id`, `index`, `start` and `limit`, and a `status: "paid"`
invoice additionally carries `payment_preimage`, `paid_at` and
`amount_received_msat` — which is exactly what `models/Invoice` reads, so no
reshaping is needed.

Two deliberate advantages over extending the existing SQL approach:

- **No string interpolation of a client-supplied value into a query.** The
  payment hash arrives from a remote NWC client; `listinvoices` takes it as a
  parameter.
- **Not restricted to paid invoices.** The `getInvoices` SQL is
  `WHERE status = 'paid'`, so a pending or expired invoice is invisible to it. A
  lookup has to be able to answer for those, and `listinvoices` returns all
  states.

It also avoids coupling another code path to CLN's internal `invoices` table
schema.

## LndHub

LndHub has no endpoint that returns invoice detail by hash. `GET
/checkpayment/:payment_hash` exists but answers only `{paid: boolean}` — no
amount, description, bolt11 or timestamps — so it cannot build a NIP-47
transaction. The override searches `/getuserinvoices` by hash instead.

Per LndHub's `User.getUserInvoices`, each entry carries `payment_request`,
`description`, `payment_hash` (hex), `ispaid`, `amt`, `expire_time` and
`timestamp`. **There is no preimage field**, so a settled invoice looked up on
LndHub will report an empty `preimage`. That is a limitation of the LndHub API,
not something this PR can fix; flagging it because NIP-47 clients use the
preimage as proof of payment.

## LDK Node

The search is restricted to `direction === 'inbound'`. `getPayments` in the same
file already filters on `direction === 'outbound'`, so the field is available and
in use; this simply stops the invoice lookup from claiming outbound payments.

Two effects:

- A sent payment is no longer mislabelled as an incoming invoice. It now misses
  the invoice lookup, which is what #4273 needs in order to resolve it through
  the payment path with the correct type and fee — without this line, that PR's
  fallback never runs on LDK Node.
- `lookupInvoicePaidFromNode` and the pending-invoice refresh in `getActivities`
  use `lookupInvoice` to answer "has this invoice been paid". On LDK Node an
  outbound payment sharing the hash could satisfy that question and mark a
  `make_invoice` activity as paid when nothing was received. That is now
  impossible.

## What I could not verify without a node

The shapes above are read from the Core Lightning schema file and the LndHub
source, not from live responses. Specifically worth confirming on real
infrastructure:

- that the clnrest plugin exposes `listinvoices` at `POST /v1/listinvoices` like
  the other RPCs Zeus already calls there, and that an unknown payment hash comes
  back as an empty `invoices` array rather than an error;
- that LndHub deployments in the wild (Alby, LNBits' LNDHub extension, LNbank)
  return `payment_hash` in the same hex form the lookup is queried with — Zeus's
  own `Payment` model notes LndHub encodes payment hashes as buffer objects on
  the `/gettxs` side, so the two sides may not agree.

- that LDK Node populates `direction` on inbound Lightning payments as
  `'inbound'`. The value is already relied on by `getPayments` and
  `formatOnchainTransaction` in the same file, so this is low risk, but if it
  were ever unset for inbound payments the lookup would start missing genuine
  invoices — worth one confirmation on device.

The CLN and LndHub failure modes are the status quo — `NOT_FOUND` — so a mismatch
there is no worse than today, though it would mean the fix silently doesn't take.
The LDK Node change is the one that could regress something that works, which is
why the `direction` check above is the single most useful thing to confirm.

## Scope

No new dispatcher wrapper or `supports*` flag: `lookupInvoice` already exists in
`utils/BackendUtils.ts` and is not capability-gated today. Adding a gate would
change behavior for the five backends that already implement it, so it is left
alone.

No unit tests — `backends/` has no test coverage in this repo and these are thin
request wrappers whose value is entirely in the live response shape.

Touches only `backends/`, so it merges independently of #4269, #4272 and #4273.
The LDK Node line is a genuine dependency in one direction though: #4273 resolves
outgoing payments through a fallback that only runs when the invoice lookup
misses, and on LDK Node it never missed. Either PR stands alone, but LDK Node is
only fully correct with both.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
