### PR TITLE
build: run prettier on generated proto types after gen-proto

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint . && yarn run test check-styles.test.ts --testPathIgnorePatterns=",
     "prettier": "prettier --check \"**/*.ts*\"",
     "prettier-write": "prettier --check --write \"**/*.ts*\"",
-    "gen-proto": "pbjs -p proto -t static-module --keep-case -w es6 --force-long -o proto/lightning.js proto/*.proto proto/*/*.proto && pbts -o proto/lightning.d.ts proto/lightning.js",
+    "gen-proto": "pbjs -p proto -t static-module --keep-case -w es6 --force-long -o proto/lightning.js proto/*.proto proto/*/*.proto && pbts -o proto/lightning.d.ts proto/lightning.js && prettier --write proto/lightning.d.ts",
     "gradlew": "cd android && ./gradlew",
     "android:clean": "rm -rf android/app/.cxx android/build && yarn gradlew clean",
     "fetch-libraries": "bash fetch-libraries.sh",


### PR DESCRIPTION
# Description

Relates to issue: **N/A**

`pbts` emits `proto/lightning.d.ts` unformatted, so every regeneration of the
proto bindings leaves the repo failing `yarn prettier` (which globs `**/*.ts*`)
until someone manually runs prettier over it. This appends a
`prettier --write proto/lightning.d.ts` step to the `gen-proto` script so the
output is formatted as part of generation.

`proto/lightning.js` is deliberately left exactly as `pbjs` emits it — it isn't
covered by the prettier check, and formatting it would produce a large one-time
diff that would bury real proto changes in future regenerations.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
