### PR TITLE
fix(nwc): reconcile pending payments and correct the unpaid filter

### DIFF
--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1084,46 +1084,7 @@ export default class NostrWalletConnectStore {
             );
         }
 
-        const pendingPayInvoiceActivities = connection.activity.filter(
-            (activity) =>
-                activity.type === 'pay_invoice' && activity.status === 'pending'
-        );
-        if (pendingPayInvoiceActivities.length > 0) {
-            const lightningPending = pendingPayInvoiceActivities.filter(
-                (activity) => activity.payment_source !== 'cashu'
-            );
-            if (lightningPending.length > 0) {
-                const payments =
-                    await this.getPaymentsForPendingPayInvoiceRefresh(
-                        connectionId,
-                        lightningPending
-                    );
-                for (const activity of lightningPending) {
-                    const payment = payments.find(
-                        (p) =>
-                            p.getPaymentRequest === activity.id ||
-                            (!!activity.paymentHash &&
-                                p.paymentHash === activity.paymentHash)
-                    );
-                    if (!payment) continue;
-
-                    runInAction(() => {
-                        activity.payment = new Payment(payment);
-                        if (!payment.isIncomplete) {
-                            activity.status = 'success';
-                            const amountSats =
-                                Math.floor(Number(activity.satAmount)) ||
-                                Math.floor(Number(payment.getAmount) || 0);
-                            if (amountSats > 0) {
-                                connection.trackSpending(amountSats);
-                            }
-                        } else if (payment.isFailed) {
-                            activity.status = 'failed';
-                        }
-                    });
-                }
-            }
-        }
+        await this.reconcilePendingPayInvoiceActivities(connection);
 
         runInAction(() => {
             connection.activity = connection.activity.filter((activity) => {
@@ -1745,6 +1706,7 @@ export default class NostrWalletConnectStore {
             let nip47Transactions: Nip47Transaction[] = [];
 
             if (connection.hasPaymentPermissions()) {
+                await this.reconcilePendingPayInvoiceActivities(connection);
                 nip47Transactions = connection.activity
                     .map((activity) =>
                         NostrConnectUtils.convertConnectionActivityToNip47Transaction(
@@ -2250,6 +2212,53 @@ export default class NostrWalletConnectStore {
         }
 
         return true;
+    }
+
+    /**
+     * Promotes pending pay_invoice activities that have since settled or failed.
+     * Used by the activity screen and by list_transactions — without the latter,
+     * an NWC client sees a settled payment as pending until someone opens the
+     * screen. Node fetches are rate limited by the helper below.
+     */
+    private async reconcilePendingPayInvoiceActivities(
+        connection: NWCConnection
+    ): Promise<void> {
+        const lightningPending = connection.activity.filter(
+            (activity) =>
+                activity.type === 'pay_invoice' &&
+                activity.status === 'pending' &&
+                activity.payment_source !== 'cashu'
+        );
+        if (lightningPending.length === 0) return;
+
+        const payments = await this.getPaymentsForPendingPayInvoiceRefresh(
+            connection.id,
+            lightningPending
+        );
+        for (const activity of lightningPending) {
+            const payment = payments.find(
+                (p) =>
+                    p.getPaymentRequest === activity.id ||
+                    (!!activity.paymentHash &&
+                        p.paymentHash === activity.paymentHash)
+            );
+            if (!payment) continue;
+
+            runInAction(() => {
+                activity.payment = new Payment(payment);
+                if (!payment.isIncomplete) {
+                    activity.status = 'success';
+                    const amountSats =
+                        Math.floor(Number(activity.satAmount)) ||
+                        Math.floor(Number(payment.getAmount) || 0);
+                    if (amountSats > 0) {
+                        connection.trackSpending(amountSats);
+                    }
+                } else if (payment.isFailed) {
+                    activity.status = 'failed';
+                }
+            });
+        }
     }
 
     private async getPaymentsForPendingPayInvoiceRefresh(

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1332,6 +1332,27 @@ export default class NostrWalletConnectStore {
         console.log(
             `NWC: Subscription results - ${connections.length} connection(s) processed (sequential pacing between relays)`
         );
+
+        // A payment can settle while the service is down, so catch up once the
+        // relays are back rather than waiting for a client to ask
+        void this.reconcileAllPendingPayInvoiceActivities();
+    }
+
+    /**
+     * Runs pending-payment reconciliation across every active connection.
+     * Cheap when nothing is pending: connections without pending pay_invoice
+     * activities return immediately, and node fetches stay rate limited.
+     */
+    private async reconcileAllPendingPayInvoiceActivities(): Promise<void> {
+        try {
+            await Promise.all(
+                this.activeConnections.map((connection) =>
+                    this.reconcilePendingPayInvoiceActivities(connection)
+                )
+            );
+        } catch (error) {
+            console.error('NWC: pending payment reconciliation failed:', error);
+        }
     }
     private unsubscribeFromConnection(connectionId: string): void {
         const unsub = this.activeSubscriptions.get(connectionId);
@@ -2891,6 +2912,12 @@ export default class NostrWalletConnectStore {
         this.appStateListener = AppState.addEventListener(
             'change',
             async (nextAppState: string) => {
+                // Independent of the persistent service: payments settle while
+                // the app is away on every platform, so catch up on return
+                if (nextAppState === 'active') {
+                    void this.reconcileAllPendingPayInvoiceActivities();
+                }
+
                 if (!this.persistentNWCServiceEnabled) {
                     return;
                 }
@@ -3048,6 +3075,12 @@ export default class NostrWalletConnectStore {
             'change',
             async (nextState: string) => {
                 if (!this.isServiceReady()) return;
+
+                // Mirrors the Android monitor: catch up on payments that
+                // settled while the app was away, regardless of keep-alive
+                if (nextState === 'active') {
+                    void this.reconcileAllPendingPayInvoiceActivities();
+                }
 
                 if (
                     nextState === 'background' &&

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -743,4 +743,74 @@ describe('NostrConnectUtils', () => {
             });
         });
     });
+
+    describe('list_transactions unpaid filter', () => {
+        // NIP-47: "unpaid: include unpaid invoices, optional, default false"
+        const transaction = (
+            state: 'settled' | 'pending' | 'failed',
+            type: 'incoming' | 'outgoing',
+            createdAt: number
+        ) =>
+            NostrConnectUtils.createNip47Transaction({
+                type,
+                state,
+                invoice: '',
+                payment_hash: '',
+                amount: 1000,
+                created_at: createdAt
+            });
+
+        const settledInvoice = transaction('settled', 'incoming', 400);
+        const pendingInvoice = transaction('pending', 'incoming', 300);
+        const settledPayment = transaction('settled', 'outgoing', 200);
+        const failedPayment = transaction('failed', 'outgoing', 100);
+        const all = [
+            settledInvoice,
+            pendingInvoice,
+            settledPayment,
+            failedPayment
+        ];
+
+        const filter = (request: object) =>
+            NostrConnectUtils.filterAndPaginateTransactions(
+                all,
+                request as never
+            );
+
+        it('returns only settled transactions when unpaid is not requested', () => {
+            const { transactions, totalCount } = filter({});
+
+            expect(transactions).toEqual([settledInvoice, settledPayment]);
+            expect(totalCount).toBe(2);
+        });
+
+        it('returns only settled transactions when unpaid is false', () => {
+            const { transactions } = filter({ unpaid: false });
+
+            expect(transactions).toEqual([settledInvoice, settledPayment]);
+        });
+
+        it('includes every state when unpaid is true', () => {
+            const { transactions, totalCount } = filter({ unpaid: true });
+
+            expect(transactions).toHaveLength(4);
+            expect(totalCount).toBe(4);
+        });
+
+        it('does not drop settled transactions when unpaid is true', () => {
+            const { transactions } = filter({ unpaid: true });
+
+            expect(transactions).toContain(settledInvoice);
+            expect(transactions).toContain(settledPayment);
+        });
+
+        it('still applies the type filter alongside unpaid', () => {
+            const { transactions } = filter({
+                unpaid: true,
+                type: 'outgoing'
+            });
+
+            expect(transactions).toEqual([settledPayment, failedPayment]);
+        });
+    });
 });

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -1521,13 +1521,10 @@ export default class NostrConnectUtils {
             filtered = filtered.filter((tx) => tx.created_at <= request.until!);
         }
 
-        // Filter by unpaid status
-        if (request.unpaid !== undefined) {
-            if (request.unpaid) {
-                filtered = filtered.filter((tx) => tx.state === 'pending');
-            } else {
-                filtered = filtered.filter((tx) => tx.state === 'settled');
-            }
+        // NIP-47 defines unpaid as "include unpaid invoices, default false", so
+        // it widens the result rather than selecting only unpaid ones
+        if (!request.unpaid) {
+            filtered = filtered.filter((tx) => tx.state === 'settled');
         }
 
         // Calculate pagination


### PR DESCRIPTION
# Description

Relates to issue: **#4216** (related), **ZEUS-0000**

> Opened as a draft: on-device testing is still outstanding.

Two `list_transactions` bugs that compound each other. Both were checked against
the NIP-47 spec text and against Alby Hub as the reference implementation, not
from memory.

## A settled payment can stay `pending` indefinitely

When a `pay_invoice` does not resolve inside `waitForPaymentCompletion`, it is
recorded with `status: 'pending'`. The only code that promotes it to `success`
lives in `getActivities`, which is called from exactly two places — the NWC
connection detail and activity screens. The NIP-47 handler never called it.

So over NWC the payment stays `pending` until a human opens that screen in the
app, while the wallet's own transaction list has shown it as paid all along.
This is a plausible part of what gets reported as delayed or stale NWC
transaction lists (#4216 covers the other half — events that arrive while the
wallet is closed).

The reconciliation block is lifted out of `getActivities` into
`reconcilePendingPayInvoiceActivities` and called from both. Behavior in the
existing UI path is unchanged; the nested filters simply collapse into one.

Reading is not the only trigger any more, because a payment that settles while
the app is closed produces no read either. Reconciliation now also runs when the
app returns to the foreground (both platform monitors) and after
`subscribeToAllConnections` finishes, so the state is caught up before a client
asks rather than because one did.

Node load is unchanged: every path goes through
`getPaymentsForPendingPayInvoiceRefresh`, which requires a pending activity to be
at least 5 s old and rate limits fetches to one per connection per 30 s, falling
back to the already-fetched payment list otherwise. A connection with nothing
pending returns immediately without touching the node, so the added triggers cost
nothing in the normal case.

## The `unpaid` filter had it backwards

NIP-47 documents the parameter as:

```
"unpaid": true, // include unpaid invoices, optional, default false
```

so it *widens* the result set. ZEUS treated it as a selector, and ignored the
documented default:

| `unpaid` | ZEUS before | NIP-47 + Alby Hub |
|---|---|---|
| absent | no filter — unpaid included | settled only |
| `true` | pending only | every state |
| `false` | settled only | settled only ✓ |

Alby Hub, as the reference wallet service, maps `unpaid` onto both
`unpaidOutgoing` and `unpaidIncoming` and then applies
`WHERE state = settled` only when neither is set, with no state filter at all
when both are (`transactions/transactions_service.go`,
`nip47/controllers/list_transactions_controller.go`). That matches the spec
reading and is what this implements.

**This changes default behavior**: a client that sends no `unpaid` parameter will
stop receiving pending and failed transactions. That is the documented default,
and it is also why the two fixes belong in one PR — with the filter corrected but
the reconciliation missing, a payment stuck at `pending` would become invisible
by default rather than merely mislabelled.

Alby Hub also accepts `unpaid_outgoing` and `unpaid_incoming` as finer-grained
extensions. Those are not in NIP-47, so they are not implemented here; happy to
add them if you want closer Alby client parity.

## What this still is not

Reconciliation on a trigger is a backstop, not a design. The wallet still learns
that a payment settled by asking afterwards rather than by being told at the
time. A proper fast path would be either a payment subscription per backend — no
backend in ZEUS has one today, only `subscribeInvoice`/`subscribeTransactions` —
or NIP-47 notifications, which ZEUS currently advertises in its info event and in
`get_info` but never publishes (#4287).

Neither removes the need for this code: the app can be killed, and a payment that
settles while it is not running produces no event for anyone to receive. So the
backstop stays either way; what is missing above it is the fast path.

## Deliberately not in this PR

For connections holding `pay_invoice`, `list_transactions` still answers from
that connection's own activity log, so payments made in the wallet UI, by other
connections, incoming invoices and on-chain transactions do not appear. That is
the larger deviation, but changing it is a permission-model decision rather than
a bug fix — it would expose the whole wallet history to any connection granted
`list_transactions`, which is what the spec implies but not necessarily what
existing users expect from the current behavior. It is also the area of #3432,
which was reverted. I would rather have that discussion separately than bundle it
into a revertible fix. Happy to open an issue for it if useful.

Worth noting for whoever picks that up: the node-backed branch calls
`paymentsStore.getPayments()`, which overwrites the shared payment list the
wallet UI renders from. Any redesign there should fetch without mutating the
store.

Independent of #4269, #4272, #4273 and #4276. All of them append to the end of
`utils/NostrConnectUtils.test.ts`, so whichever lands last needs a trivial rebase
there.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

Five cases cover the filter: the documented default, explicit `false`, explicit
`true` across all states, that settled transactions are not dropped when `true`,
and that the `type` filter still composes with it. Four of the five fail against
master; the one that passes is `unpaid: false`, which was already correct.

The reconciliation change is in a store, which has no test coverage in this repo,
so it is verified by review and device testing rather than by a test.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
