### PR TITLE
fix(nwc): find outgoing Cashu payments in lookup_invoice

### DIFF
--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1705,12 +1705,37 @@ export default class NostrWalletConnectStore {
     ): NWCWalletServiceResponsePromise<Nip47Transaction> {
         try {
             if (this.isCashuConfigured) {
-                const result =
-                    await NostrConnectUtils.buildNip47TransactionForCashuInvoiceLookup(
+                // lookup_invoice covers both directions, and a melt never lands
+                // in the invoice list, so payments have to be searched too
+                const cashuInvoice =
+                    await NostrConnectUtils.findCashuInvoiceForNwcLookup(
                         this.cashuStore.invoices || [],
                         request
                     );
-                return { result, error: undefined };
+                if (cashuInvoice) {
+                    const result =
+                        await NostrConnectUtils.buildNip47TransactionForCashuInvoiceLookup(
+                            this.cashuStore.invoices || [],
+                            request
+                        );
+                    return { result, error: undefined };
+                }
+
+                const paymentResult =
+                    NostrConnectUtils.buildNip47TransactionForCashuPaymentLookup(
+                        this.cashuStore.payments || [],
+                        request
+                    );
+                if (paymentResult) {
+                    return { result: paymentResult, error: undefined };
+                }
+
+                return NostrConnectUtils.createNip47Error(
+                    localeString(
+                        'stores.NostrWalletConnectStore.error.invoiceNotFound'
+                    ),
+                    Nip47ErrorCode.NOT_FOUND
+                );
             }
             const rHash =
                 request.payment_hash && request.payment_hash.includes('=')

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -38,6 +38,8 @@ import * as nostrTools from 'nostr-tools';
 import NostrConnectUtils from './NostrConnectUtils';
 import Payment from '../models/Payment';
 import CashuPayment from '../models/CashuPayment';
+import CashuInvoice from '../models/CashuInvoice';
+import Base64Utils from './Base64Utils';
 
 // Stable hex values: repeat a hex digit 64 times to fill 32 bytes
 const hex64 = (c: string) => c.repeat(64);
@@ -815,6 +817,75 @@ describe('NostrConnectUtils', () => {
 
         it('returns undefined when there are no payments', () => {
             expect(lookup({ payment_hash: HASH_A }, [])).toBeUndefined();
+        });
+
+        it('matches a base64-encoded payment hash from the request', () => {
+            const tx = lookup({
+                payment_hash: Base64Utils.hexToBase64(HASH_A)
+            });
+
+            expect(tx?.payment_hash).toBe(HASH_A);
+        });
+    });
+
+    describe('payment hash normalization', () => {
+        // ZEUS's own NWC backend sends payment_hash base64-encoded, while
+        // stored hashes are hex — see backends/NostrWalletConnect.ts
+        const normalize = (hash?: string) =>
+            NostrConnectUtils.normalizePaymentHash(hash);
+
+        it('passes a hex hash through unchanged', () => {
+            expect(normalize(HASH_A)).toBe(HASH_A);
+        });
+
+        it('decodes a base64 hash to hex', () => {
+            expect(normalize(Base64Utils.hexToBase64(HASH_A))).toBe(HASH_A);
+        });
+
+        it('returns undefined for a missing or blank hash', () => {
+            expect(normalize(undefined)).toBeUndefined();
+            expect(normalize('   ')).toBeUndefined();
+        });
+    });
+
+    describe('findCashuInvoiceForNwcLookup', () => {
+        // BOLT11 spec reference vector; hash confirmed by decoding it
+        const BOLT11 =
+            'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr';
+        const BOLT11_HASH =
+            '0001020304050607080900010203040506070809000102030405060708090102';
+
+        const invoices = () => [
+            new CashuInvoice({ quote: 'quote-1', request: BOLT11 })
+        ];
+
+        it('matches a hex payment hash', async () => {
+            const found = await NostrConnectUtils.findCashuInvoiceForNwcLookup(
+                invoices(),
+                { payment_hash: BOLT11_HASH } as never
+            );
+
+            expect(found?.getPaymentRequest).toBe(BOLT11);
+        });
+
+        it('matches a base64-encoded payment hash', async () => {
+            const found = await NostrConnectUtils.findCashuInvoiceForNwcLookup(
+                invoices(),
+                {
+                    payment_hash: Base64Utils.hexToBase64(BOLT11_HASH)
+                } as never
+            );
+
+            expect(found?.getPaymentRequest).toBe(BOLT11);
+        });
+
+        it('does not match an unrelated hash', async () => {
+            const found = await NostrConnectUtils.findCashuInvoiceForNwcLookup(
+                invoices(),
+                { payment_hash: hex64('f') } as never
+            );
+
+            expect(found).toBeUndefined();
         });
     });
 });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -37,6 +37,7 @@ import * as nostrTools from 'nostr-tools';
 
 import NostrConnectUtils from './NostrConnectUtils';
 import Payment from '../models/Payment';
+import CashuPayment from '../models/CashuPayment';
 
 // Stable hex values: repeat a hex digit 64 times to fill 32 bytes
 const hex64 = (c: string) => c.repeat(64);
@@ -741,6 +742,79 @@ describe('NostrConnectUtils', () => {
                     expect(result).toEqual({ inTransit: false });
                 });
             });
+        });
+    });
+
+    describe('buildNip47TransactionForCashuPaymentLookup', () => {
+        const TIMESTAMP = 1700000000;
+        const PREIMAGE = hex64('e');
+
+        /**
+         * Mirrors what CashuStore builds after a successful melt: the decoded
+         * payment request spread in, bolt11, amount, fee and the mint preimage
+         */
+        const cashuPayment = (overrides: object = {}) =>
+            new CashuPayment({
+                payment_hash: HASH_A,
+                timestamp: TIMESTAMP,
+                bolt11: INVOICE_A,
+                amount: 2000,
+                fee: 3,
+                payment_preimage: PREIMAGE,
+                mintUrl: 'https://mint.example.com',
+                ...overrides
+            });
+
+        const lookup = (request: object, payments?: CashuPayment[]) =>
+            NostrConnectUtils.buildNip47TransactionForCashuPaymentLookup(
+                payments ?? [cashuPayment()],
+                request as never
+            );
+
+        it('finds a melted payment by payment hash', () => {
+            const tx = lookup({ payment_hash: HASH_A });
+
+            expect(tx?.payment_hash).toBe(HASH_A);
+            expect(tx?.type).toBe('outgoing');
+        });
+
+        it('finds a melted payment by payment request', () => {
+            const tx = lookup({ invoice: INVOICE_A });
+
+            expect(tx?.type).toBe('outgoing');
+        });
+
+        it('reports the mint fee in msats and no expiry', () => {
+            const tx = lookup({ payment_hash: HASH_A });
+
+            expect(tx?.amount).toBe(2000000);
+            expect(tx?.fees_paid).toBe(3000);
+            expect(tx?.expires_at).toBe(0);
+        });
+
+        it('reports the mint preimage and a settled state', () => {
+            const tx = lookup({ payment_hash: HASH_A });
+
+            expect(tx?.state).toBe('settled');
+            expect(tx?.preimage).toBe(PREIMAGE);
+            expect(tx?.settled_at).toBe(TIMESTAMP);
+        });
+
+        it('leaves the preimage empty when the mint returned none', () => {
+            const tx = lookup({ payment_hash: HASH_A }, [
+                cashuPayment({ payment_preimage: '' })
+            ]);
+
+            expect(tx?.preimage).toBe('');
+            expect(tx?.state).toBe('settled');
+        });
+
+        it('does not match an unrelated hash', () => {
+            expect(lookup({ payment_hash: HASH_B })).toBeUndefined();
+        });
+
+        it('returns undefined when there are no payments', () => {
+            expect(lookup({ payment_hash: HASH_A }, [])).toBeUndefined();
         });
     });
 });

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -668,6 +668,45 @@ export default class NostrConnectUtils {
         });
     }
 
+    /**
+     * NIP-47 transaction for an outgoing Cashu payment matched by
+     * lookup_invoice, by payment hash or by payment request. Answers with
+     * undefined when nothing matches so the caller stays in control.
+     *
+     * A melt only reaches cashuStore.payments after it succeeded, so the state
+     * is settled. The mint's preimage is method-specific and optional per
+     * NUT-05, so it may legitimately be empty.
+     */
+    static buildNip47TransactionForCashuPaymentLookup(
+        payments: CashuPayment[],
+        request: Nip47LookupInvoiceRequest
+    ): Nip47Transaction | undefined {
+        const payment = NostrConnectUtils.findPaymentForInvoice(
+            request.invoice || '',
+            payments || [],
+            request.payment_hash
+        );
+        if (!payment) return undefined;
+
+        const timestamp = Math.floor(
+            Number(payment.getTimestamp) || dateTimeUtils.getCurrentTimestamp()
+        );
+
+        return NostrConnectUtils.createNip47Transaction({
+            type: 'outgoing',
+            state: 'settled',
+            invoice: payment.getPaymentRequest || '',
+            payment_hash: payment.paymentHash || '',
+            amount: satsToMillisats(Number(payment.getAmount) || 0),
+            description: payment.getMemo,
+            preimage: payment.getPreimage,
+            fees_paid: satsToMillisats(Number(payment.getFee) || 0),
+            settled_at: timestamp,
+            created_at: timestamp,
+            expires_at: 0
+        });
+    }
+
     static async buildNip47TransactionForLightningInvoiceLookup(
         r_hash: string
     ): Promise<Nip47Transaction> {

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -23,6 +23,7 @@ import CashuInvoice from '../models/CashuInvoice';
 import CashuToken from '../models/CashuToken';
 import Transaction from '../models/Transaction';
 
+import Base64Utils from './Base64Utils';
 import { localeString } from './LocaleUtils';
 import dateTimeUtils from './DateTimeUtils';
 import Bolt11Utils from './Bolt11Utils';
@@ -604,18 +605,21 @@ export default class NostrConnectUtils {
         invoices: CashuInvoice[],
         request: Nip47LookupInvoiceRequest
     ): Promise<CashuInvoice | undefined> {
+        const paymentHash = NostrConnectUtils.normalizePaymentHash(
+            request.payment_hash
+        );
         for (const inv of invoices) {
             if (inv.getPaymentRequest === request.invoice) {
                 return inv;
             }
-            if (!request.payment_hash) {
+            if (!paymentHash) {
                 continue;
             }
             try {
                 const decoded = await NostrConnectUtils.decodeInvoiceTags(
                     inv.getPaymentRequest
                 );
-                if (decoded.paymentHash === request.payment_hash) {
+                if (decoded.paymentHash === paymentHash) {
                     return inv;
                 }
             } catch {
@@ -669,6 +673,17 @@ export default class NostrConnectUtils {
     }
 
     /**
+     * NIP-47 payment hashes are hex, but some clients send them base64-encoded
+     * — ZEUS's own NWC backend does. Stored hashes are hex, so a request value
+     * has to be normalized before any exact comparison.
+     */
+    static normalizePaymentHash(paymentHash?: string): string | undefined {
+        const hash = paymentHash?.trim();
+        if (!hash) return undefined;
+        return hash.includes('=') ? Base64Utils.base64ToHex(hash) : hash;
+    }
+
+    /**
      * NIP-47 transaction for an outgoing Cashu payment matched by
      * lookup_invoice, by payment hash or by payment request. Answers with
      * undefined when nothing matches so the caller stays in control.
@@ -684,7 +699,7 @@ export default class NostrConnectUtils {
         const payment = NostrConnectUtils.findPaymentForInvoice(
             request.invoice || '',
             payments || [],
-            request.payment_hash
+            NostrConnectUtils.normalizePaymentHash(request.payment_hash)
         );
         if (!payment) return undefined;
 


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

> Opened as a draft: on-device testing is still outstanding. This one needs a
> Cashu-configured wallet and a real melt.

On a Cashu-configured wallet, `lookup_invoice` can never resolve an outgoing
payment. `handleLookupInvoice` branches on `isCashuConfigured` before anything
else and searches `cashuStore.invoices` only — mint quotes, i.e. incoming. A
melted payment lives in `cashuStore.payments` and is never looked at. Because the
branch short-circuits, the Lightning path never runs either, so the fallbacks
that cover this for other backends do not apply.

NIP-47 defines `lookup_invoice` over both directions — `"incoming"` for invoices,
`"outgoing"` for payments — so a settled melt returning `NOT_FOUND` is a
spec violation, and it makes automated payment confirmation impossible for any
client talking to a Cashu wallet.

Payments are now searched by `payment_hash` or by payment request, reusing the
existing `findPaymentForInvoice` helper, and mapped as outgoing.

## Field mapping, and where the values come from

Checked against `stores/CashuStore.ts`, which constructs the record after a
successful melt, rather than assumed:

| NIP-47 field | Source |
|---|---|
| `payment_hash` | the decoded payment request spread into the record; `Bolt11Utils.decode` exposes it as top-level hex |
| `invoice` | `bolt11` |
| `amount` | `amount` from the melt result, scaled to msats |
| `fees_paid` | `fee` (the real `fee_paid` from the melt), scaled to msats |
| `preimage` | `payment_preimage`, set from `meltResult.preimage \|\| ''` |
| `created_at` / `settled_at` | the decoded invoice timestamp |
| `expires_at` | `0` — a payment does not expire |

Two deliberate choices:

**`state` is hardcoded to `settled`.** A melt only reaches `cashuStore.payments`
after it succeeded. Deriving the state from `Payment.isIncomplete` would be
wrong here, because that getter is preimage-based and a Cashu melt may have no
preimage at all — see below. This matches how `convertCashuDataToNip47Transactions`
already maps Cashu payments for `list_transactions`.

**An empty `preimage` is reported as empty.** Per NUT-05 the melt quote response
carries `payment_preimage` as a method-specific, optional field — ZEUS's own
`MeltQuote` interface types it `payment_preimage?: string | null` — so a mint may
legitimately return none. Reporting an empty string is correct; fabricating
something is not.

## Control flow

The Cashu branch checks the invoice list first via `findCashuInvoiceForNwcLookup`
and only then the payment list, mirroring the ordering on the Lightning side so
nothing that resolves today changes. Both checks answer with a value or
`undefined`; neither infers absence from an exception.

That means the invoice list is walked twice on a payment lookup — once to decide,
once inside the existing builder. It is an in-memory array and this keeps
`buildNip47TransactionForCashuInvoiceLookup` untouched, which avoids a conflict
with #4269. Happy to collapse it if you would rather have the extra pass gone.

## Scope

Only the Cashu lookup path. The remaining Cashu gap is the empty `payment_hash`
on `make_invoice` activities in `list_transactions`, which #4269 addresses on the
invoice side.

Independent of #4269, #4272, #4273, #4276 and #4285; all of them append to the end
of `utils/NostrConnectUtils.test.ts`, so whichever lands last needs a trivial
rebase there.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

Seven cases in `utils/NostrConnectUtils.test.ts` cover matching by hash and by
payment request, the fee and amount scaling, the absent-expiry, the preimage
present and absent, a non-matching hash, and an empty payment list. The fixture
mirrors the record `CashuStore` actually builds after a melt rather than an
idealised one.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
