### PR TITLE
fix(CLN): include unpaid invoices in Activity

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -20,6 +20,7 @@ import {
     isOnionHttpsUrl,
     RequestMethod
 } from '../utils/TorUtils';
+import Bolt11Utils from '../utils/Bolt11Utils';
 
 const calls = new Map<string, Promise<any>>();
 
@@ -267,15 +268,26 @@ export default class CLNRest {
     getMyNodeInfo = () => this.postRequest('/v1/getinfo');
     getInvoices = (data?: any) =>
         this.postRequest('/v1/sql', {
-            query: `SELECT label, bolt11, bolt12, payment_hash, amount_msat, status, amount_received_msat, paid_at, payment_preimage, description, expires_at FROM invoices WHERE status = 'paid' ORDER BY created_index DESC LIMIT ${
+            query: `SELECT label, bolt11, bolt12, payment_hash, amount_msat, status, amount_received_msat, paid_at, payment_preimage, description, expires_at FROM invoices ORDER BY created_index DESC LIMIT ${
                 data?.limit ? data.limit : 150
             };`
         }).then((data: any) => {
             const invoiceList: any[] = [];
             data.rows.forEach((invoice: any) => {
+                const bolt11 = invoice[1];
+                let creation_date: string | undefined;
+                if (bolt11) {
+                    try {
+                        creation_date = String(
+                            Bolt11Utils.decode(bolt11).timestamp
+                        );
+                    } catch (_e) {
+                        // ignore decode errors; paid_at still sorts paid invoices
+                    }
+                }
                 invoiceList.push({
                     label: invoice[0],
-                    bolt11: invoice[1],
+                    bolt11,
                     payment_hash: invoice[3],
                     amount_msat: invoice[4],
                     status: invoice[5],
@@ -284,7 +296,8 @@ export default class CLNRest {
                     payment_preimage: invoice[8],
                     description: invoice[9],
                     expires_at: invoice[10],
-                    bolt12: invoice[2]
+                    bolt12: invoice[2],
+                    creation_date
                 });
             });
 

--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -241,7 +241,10 @@ export default class Invoice extends BaseModel {
         }
         return this.settled
             ? Number(this.amt_paid_sat)
-            : Number(this.value) || Number(this.amt) || 0;
+            : Number(this.value) ||
+                  Number(this.amt) ||
+                  this.getRequestAmount ||
+                  0;
     }
 
     // return amount in satoshis


### PR DESCRIPTION
# Description

In this PR, we fix CLN Activity only showing paid Lightning invoices. Unpaid and expired requests now appear with the correct amount and sort order, consistent with LND. 

## Problem
- **`CLNRest.getInvoices`** queried CLN's invoice table with `WHERE status = 'paid'`, so Activity only ever received settled invoices. Pending and expired requests never appeared.
- **Unpaid amounts showed as `0 sats`** because Activity uses `Invoice.getAmount`, which reads LND fields (`value`, `amt`) and received amounts (`amount_received_msat`). CLN unpaid invoices only expose the requested amount via `amount_msat`, which `getRequestAmount` already handles but `getAmount` did not.
- **Sorting** could be wrong for unpaid CLN invoices because CLN's SQL schema has no `created_at`; without a creation timestamp they would sort at `0` in Activity.
## Fix
- **`backends/CLNRest.ts`**
  - Remove the `WHERE status = 'paid'` filter so all invoice statuses (`unpaid`, `paid`, `expired`) are returned.
  - Derive `creation_date` from the BOLT11 timestamp so unpaid invoices sort correctly in Activity.
- **`models/Invoice.ts`**
  - Fall back to `getRequestAmount` in `getAmount` for unsettled invoices, so CLN `amount_msat` displays correctly without backend-specific mapping.
Paid invoice behavior is unchanged — received amounts are still resolved before the new fallback.


## Test plan
- [ ] Connect Zeus to a CLN REST node
- [ ] Create a Lightning invoice (e.g. 1,000 sats) and confirm it appears in **Activity** as **Requested Payment** with the correct amount
- [ ] Confirm expiry countdown displays for pending invoices
- [ ] Pay the invoice and confirm Activity updates to **You Received** after refresh
- [ ] Confirm expired unpaid invoices show as **Expired Request**
- [ ] Confirm existing paid invoice history still displays correctly with correct amounts and dates


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
