### PR TITLE
fix(nwc): fix lookup_invoice, list_transactions, and backend invoice lookup

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -266,6 +266,22 @@ export default class CLNRest {
         return this.postRequest('/v1/withdraw', request);
     };
     getMyNodeInfo = () => this.postRequest('/v1/getinfo');
+    // listinvoices filters natively by payment hash, and unlike the SQL query
+    // used by getInvoices it is not restricted to paid invoices
+    lookupInvoice = (data: any) =>
+        this.postRequest('/v1/listinvoices', {
+            payment_hash: data.r_hash
+        }).then((response: any) => {
+            const invoice = response?.invoices?.[0];
+            if (!invoice) {
+                throw new Error(
+                    localeString(
+                        'stores.NostrWalletConnectStore.error.invoiceNotFound'
+                    )
+                );
+            }
+            return invoice;
+        });
     getInvoices = (data?: any) =>
         this.postRequest('/v1/sql', {
             query: `SELECT label, bolt11, bolt12, payment_hash, amount_msat, status, amount_received_msat, paid_at, payment_preimage, description, expires_at FROM invoices ORDER BY created_index DESC LIMIT ${

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -1246,8 +1246,13 @@ export default class LdkNode {
      */
     lookupInvoice = async (data: { r_hash: string }): Promise<any> => {
         const payments = await LdkNodeInjection.payments.listPayments();
+        // Inbound only — an outbound payment carries the same hash but is not
+        // an invoice, and formatting it as one mislabels it as incoming
         const payment = data?.r_hash
-            ? payments.find((p) => p.kind.hash === data.r_hash)
+            ? payments.find(
+                  (p) =>
+                      p.kind.hash === data.r_hash && p.direction === 'inbound'
+              )
             : undefined;
 
         if (payment) {

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -4,6 +4,7 @@ import LND from './LND';
 import LoginRequest from './../models/LoginRequest';
 import Base64Utils from './../utils/Base64Utils';
 import Bolt11Utils from './../utils/Bolt11Utils';
+import Invoice from './../models/Invoice';
 import { localeString } from './../utils/LocaleUtils';
 import { Hash as sha256Hash } from 'fast-sha256';
 import { ecdsaSignDERHex } from '../utils/SigningUtils';
@@ -47,7 +48,8 @@ export default class LndHub extends LND {
     lookupInvoice = (data: any) =>
         this.getRequest('/getuserinvoices').then((invoices: any) => {
             const invoice = (invoices || []).find(
-                (userInvoice: any) => userInvoice.payment_hash === data.r_hash
+                (userInvoice: any) =>
+                    new Invoice(userInvoice).getRHash === data.r_hash
             );
             if (!invoice) {
                 throw new Error(

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -4,6 +4,7 @@ import LND from './LND';
 import LoginRequest from './../models/LoginRequest';
 import Base64Utils from './../utils/Base64Utils';
 import Bolt11Utils from './../utils/Bolt11Utils';
+import { localeString } from './../utils/LocaleUtils';
 import { Hash as sha256Hash } from 'fast-sha256';
 import { ecdsaSignDERHex } from '../utils/SigningUtils';
 
@@ -40,6 +41,23 @@ export default class LndHub extends LND {
         this.getRequest('/getuserinvoices').then((data: any) => ({
             invoices: data
         }));
+    // Overrides LND's /v1/invoice/{r_hash}, a route LndHub does not serve.
+    // LndHub has no per-invoice endpoint returning details — /checkpayment only
+    // answers paid/unpaid — so the user's invoice list is searched by hash.
+    lookupInvoice = (data: any) =>
+        this.getRequest('/getuserinvoices').then((invoices: any) => {
+            const invoice = (invoices || []).find(
+                (userInvoice: any) => userInvoice.payment_hash === data.r_hash
+            );
+            if (!invoice) {
+                throw new Error(
+                    localeString(
+                        'stores.NostrWalletConnectStore.error.invoiceNotFound'
+                    )
+                );
+            }
+            return invoice;
+        });
 
     createInvoice = (data: any) =>
         this.postRequest('/addinvoice', {

--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -69,6 +69,8 @@ export default class Invoice extends BaseModel {
     public invoice_amount_msat: string | number;
     public bolt12: string;
     public payment_preimage: string;
+    // NIP-47 (Nostr Wallet Connect) transaction objects
+    public preimage?: string;
     // pay req
     public timestamp?: string | number;
     public destination?: string;
@@ -107,8 +109,11 @@ export default class Invoice extends BaseModel {
     }
 
     @computed public get getRPreimage(): string {
-        if (!this.r_preimage) return '';
-        const preimage = this.r_preimage.data || this.r_preimage;
+        // LND uses r_preimage, Core Lightning payment_preimage, NIP-47 preimage
+        const source =
+            this.r_preimage || this.payment_preimage || this.preimage;
+        if (!source) return '';
+        const preimage = source.data || source;
         return typeof preimage === 'object'
             ? Base64Utils.bytesToHex(preimage)
             : typeof preimage === 'string'
@@ -119,8 +124,10 @@ export default class Invoice extends BaseModel {
     }
 
     @computed public get getRHash(): string {
-        if (!this.r_hash) return '';
-        const hash = this.r_hash.data || this.r_hash;
+        // LND uses r_hash, Core Lightning and NIP-47 payment_hash
+        const source = this.r_hash || this.payment_hash;
+        if (!source) return '';
+        const hash = source.data || source;
         return typeof hash === 'object'
             ? Base64Utils.bytesToHex(hash)
             : typeof hash === 'string'

--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -359,7 +359,13 @@ export default class Invoice extends BaseModel {
     }
 
     @computed public get getCreationDate(): Date {
-        return DateTimeUtils.listDate(this.created_at || this.creation_date);
+        // CLN listinvoices omits created_at; fall back to the BOLT11 timestamp
+        return DateTimeUtils.listDate(
+            this.created_at ||
+                this.creation_date ||
+                this.decodedPaymentRequest?.timestamp ||
+                0
+        );
     }
 
     @computed public get formattedCreationDate(): string {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -86,6 +86,8 @@ const SAVE_CONNECTIONS_DEBOUNCE_MS = 500;
 const PENDING_PAYMENT_STATUS_MIN_AGE_MS = 5_000;
 /** Per-connection debounce for pending pay_invoice status refresh in getActivities */
 const PENDING_PAYMENT_STATUS_REFRESH_MS = 30_000;
+/** Debounce for lookup_invoice outgoing-payment fetches (NWC client polling) */
+const LOOKUP_PAYMENTS_CACHE_MS = 30_000;
 
 export const DEFAULT_NOSTR_RELAYS = [
     'wss://relay.getalby.com/v1',
@@ -164,6 +166,8 @@ export default class NostrWalletConnectStore {
         string,
         number
     >();
+    private lookupPaymentsCache: Payment[] | null = null;
+    private lookupPaymentsFetchedAt = 0;
 
     settingsStore: SettingsStore;
     balanceStore: BalanceStore;
@@ -1732,7 +1736,7 @@ export default class NostrWalletConnectStore {
                 isCashu: this.isCashuConfigured,
                 cashuInvoices: this.cashuStore.invoices || [],
                 cashuPayments: this.cashuStore.payments || [],
-                lightningPayments: this.paymentsStore.payments || []
+                getLightningPayments: () => this.getPaymentsForLookup()
             });
 
             if (!result) {
@@ -2344,6 +2348,40 @@ export default class NostrWalletConnectStore {
         this.lastPendingPaymentStatusFetchByConnection.set(connectionId, now);
         return this.paymentsStore.payments || [];
     }
+
+    /**
+     * Outgoing payments for lookup_invoice — fetched lazily after the invoice
+     * path misses, without touching paymentsStore (that overwrites the wallet
+     * activity list and toggles its loading flag).
+     */
+    private async getPaymentsForLookup(): Promise<Payment[]> {
+        const now = Date.now();
+        if (
+            this.lookupPaymentsCache &&
+            now - this.lookupPaymentsFetchedAt < LOOKUP_PAYMENTS_CACHE_MS
+        ) {
+            return this.lookupPaymentsCache;
+        }
+
+        try {
+            const data = await BackendUtils.getPayments({
+                maxPayments: 100,
+                // lndmobile spreads this conditionally; omitting it leaves the
+                // protobuf default of false and embedded LND returns the oldest page
+                reversed: true
+            });
+            if (!data?.payments) {
+                return this.lookupPaymentsCache || [];
+            }
+            const payments = data.payments.map((p: any) => new Payment(p));
+            this.lookupPaymentsCache = payments;
+            this.lookupPaymentsFetchedAt = now;
+            return payments;
+        } catch {
+            return this.lookupPaymentsCache || [];
+        }
+    }
+
     private findLightningInvoiceInStore(invoice: Invoice): Invoice | undefined {
         const rHash = invoice.getRHash;
         const paymentRequest = invoice.getPaymentRequest;

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1,11 +1,4 @@
-// Ensure TextDecoder is available before any nostr-tools imports
-if (typeof global !== 'undefined' && !global.TextDecoder) {
-    const TextEncodingPolyfill = require('text-encoding');
-    global.TextDecoder = TextEncodingPolyfill.TextDecoder;
-    global.TextEncoder = TextEncodingPolyfill.TextEncoder;
-}
 import { action, computed, observable, reaction, runInAction } from 'mobx';
-
 import {
     NWCWalletService,
     NWCWalletServiceKeyPair,

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1390,11 +1390,14 @@ export default class NostrWalletConnectStore {
      */
     private async reconcileAllPendingPayInvoiceActivities(): Promise<void> {
         try {
-            await Promise.all(
+            const changed = await Promise.all(
                 this.activeConnections.map((connection) =>
                     this.reconcilePendingPayInvoiceActivities(connection)
                 )
             );
+            if (changed.some(Boolean)) {
+                this.scheduleSave();
+            }
         } catch (error) {
             console.error('NWC: pending payment reconciliation failed:', error);
         }
@@ -1734,7 +1737,8 @@ export default class NostrWalletConnectStore {
             const result = await NostrConnectUtils.lookupInvoiceTransaction({
                 request,
                 isCashu: this.isCashuConfigured,
-                cashuInvoices: this.cashuStore.invoices || [],
+                getCashuInvoices: () =>
+                    Promise.resolve(this.cashuStore.invoices || []),
                 getCashuPayments: () =>
                     Promise.resolve(this.cashuStore.payments || []),
                 getLightningPayments: () => this.getPaymentsForLookup()
@@ -1766,7 +1770,11 @@ export default class NostrWalletConnectStore {
             let nip47Transactions: Nip47Transaction[] = [];
 
             if (connection.hasPaymentPermissions()) {
-                await this.reconcilePendingPayInvoiceActivities(connection);
+                const reconciled =
+                    await this.reconcilePendingPayInvoiceActivities(connection);
+                if (reconciled) {
+                    this.scheduleSave();
+                }
                 nip47Transactions = connection.activity
                     .map((activity) =>
                         NostrConnectUtils.convertConnectionActivityToNip47Transaction(
@@ -2282,19 +2290,20 @@ export default class NostrWalletConnectStore {
      */
     private async reconcilePendingPayInvoiceActivities(
         connection: NWCConnection
-    ): Promise<void> {
+    ): Promise<boolean> {
         const lightningPending = connection.activity.filter(
             (activity) =>
                 activity.type === 'pay_invoice' &&
                 activity.status === 'pending' &&
                 activity.payment_source !== 'cashu'
         );
-        if (lightningPending.length === 0) return;
+        if (lightningPending.length === 0) return false;
 
         const payments = await this.getPaymentsForPendingPayInvoiceRefresh(
             connection.id,
             lightningPending
         );
+        let changed = false;
         for (const activity of lightningPending) {
             const payment = payments.find(
                 (p) =>
@@ -2304,6 +2313,7 @@ export default class NostrWalletConnectStore {
             );
             if (!payment) continue;
 
+            changed = true;
             runInAction(() => {
                 activity.payment = new Payment(payment);
                 if (!payment.isIncomplete) {
@@ -2319,6 +2329,10 @@ export default class NostrWalletConnectStore {
                 }
             });
         }
+        if (changed) {
+            this.lookupPaymentsCache = null;
+        }
+        return changed;
     }
 
     private async getPaymentsForPendingPayInvoiceRefresh(
@@ -2673,6 +2687,8 @@ export default class NostrWalletConnectStore {
 
             this.findAndUpdateConnection(connection);
         });
+        this.lookupPaymentsCache = null;
+        this.scheduleSave();
     }
 
     private async recordFailedPayment({

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2313,8 +2313,10 @@ export default class NostrWalletConnectStore {
             );
             if (!payment) continue;
 
-            changed = true;
+            let reconciled = false;
             runInAction(() => {
+                if (activity.status !== 'pending') return;
+                reconciled = true;
                 activity.payment = new Payment(payment);
                 if (!payment.isIncomplete) {
                     activity.status = 'success';
@@ -2328,6 +2330,9 @@ export default class NostrWalletConnectStore {
                     activity.status = 'failed';
                 }
             });
+            if (reconciled) {
+                changed = true;
+            }
         }
         if (changed) {
             this.lookupPaymentsCache = null;

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -46,8 +46,6 @@ import NostrConnectUtils, {
 import IOSAudioKeepAliveUtils from '../utils/IOSAudioKeepAliveUtils';
 import { satsToMillisats, millisatsToSats } from '../utils/AmountUtils';
 import { retry } from '../utils/SleepUtils';
-import Base64Utils from '../utils/Base64Utils';
-
 import NWCConnection, {
     BudgetRenewalType,
     ConnectionActivity,
@@ -1704,55 +1702,21 @@ export default class NostrWalletConnectStore {
         request: Nip47LookupInvoiceRequest
     ): NWCWalletServiceResponsePromise<Nip47Transaction> {
         try {
-            if (this.isCashuConfigured) {
-                // lookup_invoice covers both directions, and a melt never lands
-                // in the invoice list, so payments have to be searched too
-                const cashuInvoice =
-                    await NostrConnectUtils.findCashuInvoiceForNwcLookup(
-                        this.cashuStore.invoices || [],
-                        request
-                    );
-                if (cashuInvoice) {
-                    const result =
-                        await NostrConnectUtils.buildNip47TransactionForCashuInvoiceLookup(
-                            this.cashuStore.invoices || [],
-                            request
-                        );
-                    return { result, error: undefined };
-                }
+            const result = await NostrConnectUtils.lookupInvoiceTransaction({
+                request,
+                isCashu: this.isCashuConfigured,
+                cashuInvoices: this.cashuStore.invoices || [],
+                cashuPayments: this.cashuStore.payments || [],
+                lightningPayments: this.paymentsStore.payments || []
+            });
 
-                const paymentResult =
-                    NostrConnectUtils.buildNip47TransactionForCashuPaymentLookup(
-                        this.cashuStore.payments || [],
-                        request
-                    );
-                if (paymentResult) {
-                    return { result: paymentResult, error: undefined };
-                }
-
+            if (!result) {
                 return NostrConnectUtils.createNip47Error(
-                    localeString(
-                        'stores.NostrWalletConnectStore.error.invoiceNotFound'
-                    ),
+                    NostrConnectUtils.invoiceNotFoundMessage(),
                     Nip47ErrorCode.NOT_FOUND
                 );
             }
-            const rHash =
-                request.payment_hash && request.payment_hash.includes('=')
-                    ? Base64Utils.base64ToHex(request.payment_hash)
-                    : request.payment_hash;
-            if (!rHash) {
-                return NostrConnectUtils.createNip47Error(
-                    localeString(
-                        'stores.NostrWalletConnectStore.error.invoiceNotFound'
-                    ),
-                    Nip47ErrorCode.NOT_FOUND
-                );
-            }
-            const result =
-                await NostrConnectUtils.buildNip47TransactionForLightningInvoiceLookup(
-                    rHash
-                );
+
             return { result, error: undefined };
         } catch (error) {
             return NostrConnectUtils.createNip47Error(

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -87,7 +87,7 @@ const PENDING_PAYMENT_STATUS_MIN_AGE_MS = 5_000;
 /** Per-connection debounce for pending pay_invoice status refresh in getActivities */
 const PENDING_PAYMENT_STATUS_REFRESH_MS = 30_000;
 /** Debounce for lookup_invoice outgoing-payment fetches (NWC client polling) */
-const LOOKUP_PAYMENTS_CACHE_MS = 30_000;
+const LOOKUP_PAYMENTS_CACHE_MS = 5_000;
 
 export const DEFAULT_NOSTR_RELAYS = [
     'wss://relay.getalby.com/v1',
@@ -1735,7 +1735,8 @@ export default class NostrWalletConnectStore {
                 request,
                 isCashu: this.isCashuConfigured,
                 cashuInvoices: this.cashuStore.invoices || [],
-                cashuPayments: this.cashuStore.payments || [],
+                getCashuPayments: () =>
+                    Promise.resolve(this.cashuStore.payments || []),
                 getLightningPayments: () => this.getPaymentsForLookup()
             });
 
@@ -1752,7 +1753,7 @@ export default class NostrWalletConnectStore {
         } catch (error) {
             return NostrConnectUtils.createNip47Error(
                 (error as Error).message,
-                Nip47ErrorCode.NOT_FOUND
+                Nip47ErrorCode.INTERNAL_ERROR
             );
         }
     }
@@ -2609,6 +2610,7 @@ export default class NostrWalletConnectStore {
             });
             this.findAndUpdateConnection(connection);
         });
+        this.lookupPaymentsCache = null;
         NostrConnectUtils.notifyOutgoingNwcPayment(amountSats, connection.name);
     }
 

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1705,12 +1705,37 @@ export default class NostrWalletConnectStore {
     ): NWCWalletServiceResponsePromise<Nip47Transaction> {
         try {
             if (this.isCashuConfigured) {
-                const result =
-                    await NostrConnectUtils.buildNip47TransactionForCashuInvoiceLookup(
+                // lookup_invoice covers both directions, and a melt never lands
+                // in the invoice list, so payments have to be searched too
+                const cashuInvoice =
+                    await NostrConnectUtils.findCashuInvoiceForNwcLookup(
                         this.cashuStore.invoices || [],
                         request
                     );
-                return { result, error: undefined };
+                if (cashuInvoice) {
+                    const result =
+                        await NostrConnectUtils.buildNip47TransactionForCashuInvoiceLookup(
+                            this.cashuStore.invoices || [],
+                            request
+                        );
+                    return { result, error: undefined };
+                }
+
+                const paymentResult =
+                    NostrConnectUtils.buildNip47TransactionForCashuPaymentLookup(
+                        this.cashuStore.payments || [],
+                        request
+                    );
+                if (paymentResult) {
+                    return { result: paymentResult, error: undefined };
+                }
+
+                return NostrConnectUtils.createNip47Error(
+                    localeString(
+                        'stores.NostrWalletConnectStore.error.invoiceNotFound'
+                    ),
+                    Nip47ErrorCode.NOT_FOUND
+                );
             }
             const rHash =
                 request.payment_hash && request.payment_hash.includes('=')

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1323,6 +1323,27 @@ export default class NostrWalletConnectStore {
         console.log(
             `NWC: Subscription results - ${connections.length} connection(s) processed (sequential pacing between relays)`
         );
+
+        // A payment can settle while the service is down, so catch up once the
+        // relays are back rather than waiting for a client to ask
+        void this.reconcileAllPendingPayInvoiceActivities();
+    }
+
+    /**
+     * Runs pending-payment reconciliation across every active connection.
+     * Cheap when nothing is pending: connections without pending pay_invoice
+     * activities return immediately, and node fetches stay rate limited.
+     */
+    private async reconcileAllPendingPayInvoiceActivities(): Promise<void> {
+        try {
+            await Promise.all(
+                this.activeConnections.map((connection) =>
+                    this.reconcilePendingPayInvoiceActivities(connection)
+                )
+            );
+        } catch (error) {
+            console.error('NWC: pending payment reconciliation failed:', error);
+        }
     }
     private unsubscribeFromConnection(connectionId: string): void {
         const unsub = this.activeSubscriptions.get(connectionId);
@@ -2875,6 +2896,12 @@ export default class NostrWalletConnectStore {
         this.appStateListener = AppState.addEventListener(
             'change',
             async (nextAppState: string) => {
+                // Independent of the persistent service: payments settle while
+                // the app is away on every platform, so catch up on return
+                if (nextAppState === 'active') {
+                    void this.reconcileAllPendingPayInvoiceActivities();
+                }
+
                 if (!this.persistentNWCServiceEnabled) {
                     return;
                 }
@@ -3032,6 +3059,12 @@ export default class NostrWalletConnectStore {
             'change',
             async (nextState: string) => {
                 if (!this.isServiceReady()) return;
+
+                // Mirrors the Android monitor: catch up on payments that
+                // settled while the app was away, regardless of keep-alive
+                if (nextState === 'active') {
+                    void this.reconcileAllPendingPayInvoiceActivities();
+                }
 
                 if (
                     nextState === 'background' &&

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1075,46 +1075,7 @@ export default class NostrWalletConnectStore {
             );
         }
 
-        const pendingPayInvoiceActivities = connection.activity.filter(
-            (activity) =>
-                activity.type === 'pay_invoice' && activity.status === 'pending'
-        );
-        if (pendingPayInvoiceActivities.length > 0) {
-            const lightningPending = pendingPayInvoiceActivities.filter(
-                (activity) => activity.payment_source !== 'cashu'
-            );
-            if (lightningPending.length > 0) {
-                const payments =
-                    await this.getPaymentsForPendingPayInvoiceRefresh(
-                        connectionId,
-                        lightningPending
-                    );
-                for (const activity of lightningPending) {
-                    const payment = payments.find(
-                        (p) =>
-                            p.getPaymentRequest === activity.id ||
-                            (!!activity.paymentHash &&
-                                p.paymentHash === activity.paymentHash)
-                    );
-                    if (!payment) continue;
-
-                    runInAction(() => {
-                        activity.payment = new Payment(payment);
-                        if (!payment.isIncomplete) {
-                            activity.status = 'success';
-                            const amountSats =
-                                Math.floor(Number(activity.satAmount)) ||
-                                Math.floor(Number(payment.getAmount) || 0);
-                            if (amountSats > 0) {
-                                connection.trackSpending(amountSats);
-                            }
-                        } else if (payment.isFailed) {
-                            activity.status = 'failed';
-                        }
-                    });
-                }
-            }
-        }
+        await this.reconcilePendingPayInvoiceActivities(connection);
 
         runInAction(() => {
             connection.activity = connection.activity.filter((activity) => {
@@ -1729,6 +1690,7 @@ export default class NostrWalletConnectStore {
             let nip47Transactions: Nip47Transaction[] = [];
 
             if (connection.hasPaymentPermissions()) {
+                await this.reconcilePendingPayInvoiceActivities(connection);
                 nip47Transactions = connection.activity
                     .map((activity) =>
                         NostrConnectUtils.convertConnectionActivityToNip47Transaction(
@@ -2234,6 +2196,53 @@ export default class NostrWalletConnectStore {
         }
 
         return true;
+    }
+
+    /**
+     * Promotes pending pay_invoice activities that have since settled or failed.
+     * Used by the activity screen and by list_transactions — without the latter,
+     * an NWC client sees a settled payment as pending until someone opens the
+     * screen. Node fetches are rate limited by the helper below.
+     */
+    private async reconcilePendingPayInvoiceActivities(
+        connection: NWCConnection
+    ): Promise<void> {
+        const lightningPending = connection.activity.filter(
+            (activity) =>
+                activity.type === 'pay_invoice' &&
+                activity.status === 'pending' &&
+                activity.payment_source !== 'cashu'
+        );
+        if (lightningPending.length === 0) return;
+
+        const payments = await this.getPaymentsForPendingPayInvoiceRefresh(
+            connection.id,
+            lightningPending
+        );
+        for (const activity of lightningPending) {
+            const payment = payments.find(
+                (p) =>
+                    p.getPaymentRequest === activity.id ||
+                    (!!activity.paymentHash &&
+                        p.paymentHash === activity.paymentHash)
+            );
+            if (!payment) continue;
+
+            runInAction(() => {
+                activity.payment = new Payment(payment);
+                if (!payment.isIncomplete) {
+                    activity.status = 'success';
+                    const amountSats =
+                        Math.floor(Number(activity.satAmount)) ||
+                        Math.floor(Number(payment.getAmount) || 0);
+                    if (amountSats > 0) {
+                        connection.trackSpending(amountSats);
+                    }
+                } else if (payment.isFailed) {
+                    activity.status = 'failed';
+                }
+            });
+        }
     }
 
     private async getPaymentsForPendingPayInvoiceRefresh(

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -895,6 +895,7 @@ export default class NostrWalletConnectStore {
         const connection = index !== -1 ? this.connections[index] : undefined;
         return { connection, index };
     };
+
     public getActivities = async (
         connectionId: string
     ): Promise<{ name: string; activity: ConnectionActivity[] }> => {
@@ -988,28 +989,25 @@ export default class NostrWalletConnectStore {
 
         if (pendingLightningInvoiceActivities.length > 0) {
             await Promise.all(
-                pendingLightningInvoiceActivities.map(async (activity) => {
-                    const invoice = activity.invoice as Invoice | undefined;
-                    if (!invoice) return;
+                pendingLightningInvoiceActivities.map((activity) =>
+                    this.reconcilePendingLightningMakeInvoice(activity)
+                )
+            );
+        }
 
-                    const applyPaidOrExpired = (backendSaysPaid: boolean) => {
-                        const settled = backendSaysPaid || invoice.isPaid;
-                        runInAction(() => {
-                            if (settled) {
-                                activity.status = 'success';
-                            } else if (invoice.isExpired) {
-                                activity.status = 'expired';
-                            }
-                        });
-                    };
-
-                    const isInvoicePaid =
-                        await NostrConnectUtils.lookupInvoicePaidFromNode({
-                            paymentRequest: invoice.getPaymentRequest,
-                            rHash: invoice.getRHash
-                        });
-                    applyPaidOrExpired(isInvoicePaid);
-                })
+        const stalePaidLightningInvoiceActivities = connection.activity.filter(
+            (activity) =>
+                activity.type === 'make_invoice' &&
+                activity.status === 'success' &&
+                activity.payment_source !== 'cashu' &&
+                activity.invoice instanceof Invoice &&
+                !activity.invoice.isPaid
+        );
+        if (stalePaidLightningInvoiceActivities.length > 0) {
+            await Promise.all(
+                stalePaidLightningInvoiceActivities.map((activity) =>
+                    this.backfillStalePaidLightningMakeInvoice(activity)
+                )
             );
         }
 
@@ -1088,6 +1086,58 @@ export default class NostrWalletConnectStore {
         this.scheduleSave();
         return { name: connection.name, activity: connection.activity };
     };
+
+    public refreshActivityInvoiceForNavigation = async (
+        activity: ConnectionActivity
+    ): Promise<Invoice | CashuInvoice | undefined> => {
+        if (activity.type !== 'make_invoice' || !activity.invoice) {
+            return activity.invoice ?? undefined;
+        }
+
+        if (
+            activity.payment_source === 'cashu' &&
+            activity.invoice instanceof CashuInvoice
+        ) {
+            const invoice = activity.invoice;
+            if (invoice.isPaid) return invoice;
+
+            const paid = this.cashuStore.invoices?.find(
+                (inv) =>
+                    inv.getPaymentRequest === invoice.getPaymentRequest &&
+                    inv.isPaid
+            );
+            if (!paid) return invoice;
+
+            runInAction(() => {
+                activity.invoice = paid;
+                activity.status = 'success';
+            });
+            this.scheduleSave();
+            return paid;
+        }
+
+        if (activity.invoice instanceof Invoice) {
+            const invoice = activity.invoice;
+            if (invoice.isPaid) return invoice;
+
+            const refreshed = await this.refreshLightningInvoiceFromNode(
+                invoice
+            );
+            if (!refreshed) return invoice;
+
+            runInAction(() => {
+                activity.invoice = refreshed;
+                if (refreshed.isPaid) {
+                    activity.status = 'success';
+                }
+            });
+            this.scheduleSave();
+            return refreshed;
+        }
+
+        return activity.invoice;
+    };
+
     @action
     private markConnectionUsed = async (connectionId: string) => {
         const { connection } = this.getConnection({ connectionId });
@@ -2293,6 +2343,95 @@ export default class NostrWalletConnectStore {
         await this.paymentsStore.getPayments();
         this.lastPendingPaymentStatusFetchByConnection.set(connectionId, now);
         return this.paymentsStore.payments || [];
+    }
+    private findLightningInvoiceInStore(invoice: Invoice): Invoice | undefined {
+        const rHash = invoice.getRHash;
+        const paymentRequest = invoice.getPaymentRequest;
+        return this.invoicesStore.invoices?.find(
+            (inv) =>
+                (rHash && inv.getRHash === rHash) ||
+                (paymentRequest && inv.getPaymentRequest === paymentRequest)
+        );
+    }
+
+    /** Store list first, then lookupInvoice — shared by activity refresh paths. */
+    private async refreshLightningInvoiceFromNode(
+        invoice: Invoice
+    ): Promise<Invoice | undefined> {
+        const fromStore = this.findLightningInvoiceInStore(invoice);
+        if (fromStore?.isPaid) {
+            return fromStore;
+        }
+
+        const rHash = invoice.getRHash;
+        if (!rHash) {
+            return fromStore;
+        }
+
+        try {
+            const raw = await BackendUtils.lookupInvoice({ r_hash: rHash });
+            if (raw && typeof raw === 'object') {
+                return new Invoice(raw);
+            }
+        } catch {
+            // lookupInvoice throws when the hash is unknown on this backend
+        }
+        return fromStore;
+    }
+
+    private async reconcilePendingLightningMakeInvoice(
+        activity: ConnectionActivity
+    ): Promise<void> {
+        const invoice = activity.invoice as Invoice | undefined;
+        if (!invoice) return;
+
+        const settled =
+            (await NostrConnectUtils.lookupInvoicePaidFromNode({
+                paymentRequest: invoice.getPaymentRequest,
+                rHash: invoice.getRHash
+            })) || invoice.isPaid;
+
+        if (settled) {
+            const refreshed = await this.refreshLightningInvoiceFromNode(
+                invoice
+            );
+            runInAction(() => {
+                activity.status = 'success';
+                if (refreshed) {
+                    activity.invoice = refreshed;
+                }
+            });
+            return;
+        }
+
+        if (invoice.isExpired) {
+            runInAction(() => {
+                activity.status = 'expired';
+            });
+        }
+    }
+
+    private async backfillStalePaidLightningMakeInvoice(
+        activity: ConnectionActivity
+    ): Promise<void> {
+        if (
+            activity.type !== 'make_invoice' ||
+            activity.status !== 'success' ||
+            activity.payment_source === 'cashu' ||
+            !(activity.invoice instanceof Invoice) ||
+            activity.invoice.isPaid
+        ) {
+            return;
+        }
+
+        const refreshed = await this.refreshLightningInvoiceFromNode(
+            activity.invoice
+        );
+        if (!refreshed?.isPaid) return;
+
+        runInAction(() => {
+            activity.invoice = refreshed;
+        });
     }
 
     private getTransactionsStorePaymentState() {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1705,7 +1705,9 @@ export default class NostrWalletConnectStore {
 
             if (!result) {
                 return NostrConnectUtils.createNip47Error(
-                    NostrConnectUtils.invoiceNotFoundMessage(),
+                    localeString(
+                        'stores.NostrWalletConnectStore.error.invoiceNotFound'
+                    ),
                     Nip47ErrorCode.NOT_FOUND
                 );
             }

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -41,6 +41,7 @@ import Invoice from '../models/Invoice';
 import Base64Utils from './Base64Utils';
 import BackendUtils from './BackendUtils';
 import type { ConnectionActivity } from '../models/NWCConnection';
+import CashuPayment from '../models/CashuPayment';
 
 // Stable hex values: repeat a hex digit 64 times to fill 32 bytes
 const hex64 = (c: string) => c.repeat(64);
@@ -866,6 +867,79 @@ describe('NostrConnectUtils', () => {
 
                 expect(tx.payment_hash).toBe(HASH_A);
             });
+        });
+    });
+
+    describe('buildNip47TransactionForCashuPaymentLookup', () => {
+        const TIMESTAMP = 1700000000;
+        const PREIMAGE = hex64('e');
+
+        /**
+         * Mirrors what CashuStore builds after a successful melt: the decoded
+         * payment request spread in, bolt11, amount, fee and the mint preimage
+         */
+        const cashuPayment = (overrides: object = {}) =>
+            new CashuPayment({
+                payment_hash: HASH_A,
+                timestamp: TIMESTAMP,
+                bolt11: INVOICE_A,
+                amount: 2000,
+                fee: 3,
+                payment_preimage: PREIMAGE,
+                mintUrl: 'https://mint.example.com',
+                ...overrides
+            });
+
+        const lookup = (request: object, payments?: CashuPayment[]) =>
+            NostrConnectUtils.buildNip47TransactionForCashuPaymentLookup(
+                payments ?? [cashuPayment()],
+                request as never
+            );
+
+        it('finds a melted payment by payment hash', () => {
+            const tx = lookup({ payment_hash: HASH_A });
+
+            expect(tx?.payment_hash).toBe(HASH_A);
+            expect(tx?.type).toBe('outgoing');
+        });
+
+        it('finds a melted payment by payment request', () => {
+            const tx = lookup({ invoice: INVOICE_A });
+
+            expect(tx?.type).toBe('outgoing');
+        });
+
+        it('reports the mint fee in msats and no expiry', () => {
+            const tx = lookup({ payment_hash: HASH_A });
+
+            expect(tx?.amount).toBe(2000000);
+            expect(tx?.fees_paid).toBe(3000);
+            expect(tx?.expires_at).toBe(0);
+        });
+
+        it('reports the mint preimage and a settled state', () => {
+            const tx = lookup({ payment_hash: HASH_A });
+
+            expect(tx?.state).toBe('settled');
+            expect(tx?.preimage).toBe(PREIMAGE);
+            expect(tx?.settled_at).toBe(TIMESTAMP);
+        });
+
+        it('leaves the preimage empty when the mint returned none', () => {
+            const tx = lookup({ payment_hash: HASH_A }, [
+                cashuPayment({ payment_preimage: '' })
+            ]);
+
+            expect(tx?.preimage).toBe('');
+            expect(tx?.state).toBe('settled');
+        });
+
+        it('does not match an unrelated hash', () => {
+            expect(lookup({ payment_hash: HASH_B })).toBeUndefined();
+        });
+
+        it('returns undefined when there are no payments', () => {
+            expect(lookup({ payment_hash: HASH_A }, [])).toBeUndefined();
         });
     });
 });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -1049,6 +1049,8 @@ describe('NostrConnectUtils', () => {
             jest.fn().mockResolvedValue(payments);
         const getCashuPayments = (payments: CashuPayment[] = []) =>
             jest.fn().mockResolvedValue(payments);
+        const getCashuInvoices = (invoices: CashuInvoice[] = []) =>
+            jest.fn().mockResolvedValue(invoices);
 
         it('finds a Lightning invoice from the node by payment hash', async () => {
             (BackendUtils as any).lookupInvoice = jest.fn().mockResolvedValue({
@@ -1064,7 +1066,7 @@ describe('NostrConnectUtils', () => {
             const tx = await NostrConnectUtils.lookupInvoiceTransaction({
                 request: { payment_hash: HASH_A },
                 isCashu: false,
-                cashuInvoices: [],
+                getCashuInvoices: getCashuInvoices(),
                 getCashuPayments: getCashuPayments(),
                 getLightningPayments: getPayments
             });
@@ -1089,7 +1091,7 @@ describe('NostrConnectUtils', () => {
             const tx = await NostrConnectUtils.lookupInvoiceTransaction({
                 request: { payment_hash: HASH_A },
                 isCashu: false,
-                cashuInvoices: [],
+                getCashuInvoices: getCashuInvoices(),
                 getCashuPayments: getCashuPayments(),
                 getLightningPayments: getPayments
             });
@@ -1116,7 +1118,7 @@ describe('NostrConnectUtils', () => {
             const tx = await NostrConnectUtils.lookupInvoiceTransaction({
                 request: { invoice: BOLT11 },
                 isCashu: false,
-                cashuInvoices: [],
+                getCashuInvoices: getCashuInvoices(),
                 getCashuPayments: getCashuPayments(),
                 getLightningPayments: getPayments
             });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -874,6 +874,23 @@ describe('NostrConnectUtils', () => {
 
                 expect(tx.payment_hash).toBe(HASH_A);
             });
+
+            it('reports the same expiry as lookup_invoice for activity', () => {
+                const activity: ConnectionActivity = {
+                    id: INVOICE_A,
+                    type: 'make_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    invoice: new Invoice(lndInvoice())
+                };
+
+                const tx =
+                    NostrConnectUtils.convertConnectionActivityToNip47Transaction(
+                        activity
+                    );
+
+                expect(tx.expires_at).toBe(CREATION_DATE + EXPIRY_SECONDS);
+            });
         });
     });
 
@@ -1030,6 +1047,8 @@ describe('NostrConnectUtils', () => {
         const TIMESTAMP = 1700000000;
         const getLightningPayments = (payments: Payment[] = []) =>
             jest.fn().mockResolvedValue(payments);
+        const getCashuPayments = (payments: CashuPayment[] = []) =>
+            jest.fn().mockResolvedValue(payments);
 
         it('finds a Lightning invoice from the node by payment hash', async () => {
             (BackendUtils as any).lookupInvoice = jest.fn().mockResolvedValue({
@@ -1046,7 +1065,7 @@ describe('NostrConnectUtils', () => {
                 request: { payment_hash: HASH_A },
                 isCashu: false,
                 cashuInvoices: [],
-                cashuPayments: [],
+                getCashuPayments: getCashuPayments(),
                 getLightningPayments: getPayments
             });
 
@@ -1071,7 +1090,7 @@ describe('NostrConnectUtils', () => {
                 request: { payment_hash: HASH_A },
                 isCashu: false,
                 cashuInvoices: [],
-                cashuPayments: [],
+                getCashuPayments: getCashuPayments(),
                 getLightningPayments: getPayments
             });
 
@@ -1098,7 +1117,7 @@ describe('NostrConnectUtils', () => {
                 request: { invoice: BOLT11 },
                 isCashu: false,
                 cashuInvoices: [],
-                cashuPayments: [],
+                getCashuPayments: getCashuPayments(),
                 getLightningPayments: getPayments
             });
 

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -37,6 +37,10 @@ import * as nostrTools from 'nostr-tools';
 
 import NostrConnectUtils from './NostrConnectUtils';
 import Payment from '../models/Payment';
+import Invoice from '../models/Invoice';
+import Base64Utils from './Base64Utils';
+import BackendUtils from './BackendUtils';
+import type { ConnectionActivity } from '../models/NWCConnection';
 
 // Stable hex values: repeat a hex digit 64 times to fill 32 bytes
 const hex64 = (c: string) => c.repeat(64);
@@ -740,6 +744,127 @@ describe('NostrConnectUtils', () => {
 
                     expect(result).toEqual({ inTransit: false });
                 });
+            });
+        });
+    });
+
+    describe('NIP-47 transaction field mapping', () => {
+        const CREATION_DATE = 1700000000;
+        const EXPIRY_SECONDS = 3600;
+        const SETTLE_DATE = 1700000500;
+        const PREIMAGE = hex64('a');
+
+        /** LND REST returns r_hash and r_preimage base64-encoded */
+        const lndInvoice = (overrides: object = {}) => ({
+            r_hash: Base64Utils.hexToBase64(HASH_A),
+            payment_request: INVOICE_A,
+            creation_date: String(CREATION_DATE),
+            expiry: String(EXPIRY_SECONDS),
+            value: '1000',
+            settled: false,
+            ...overrides
+        });
+
+        const lookupLightningInvoice = (rawInvoice: object) => {
+            (BackendUtils as any).lookupInvoice = jest
+                .fn()
+                .mockResolvedValue(rawInvoice);
+            return NostrConnectUtils.buildNip47TransactionForLightningInvoiceLookup(
+                HASH_A
+            );
+        };
+
+        describe('lookup_invoice', () => {
+            it('reads the payment hash from the LND r_hash field', async () => {
+                const tx = await lookupLightningInvoice(lndInvoice());
+
+                expect(tx.payment_hash).toBe(HASH_A);
+            });
+
+            it('reports expiry as creation plus expiry, not the creation date', async () => {
+                const tx = await lookupLightningInvoice(lndInvoice());
+
+                expect(tx.created_at).toBe(CREATION_DATE);
+                expect(tx.expires_at).toBe(CREATION_DATE + EXPIRY_SECONDS);
+            });
+
+            it('marks an unpaid invoice past its expiry as failed', async () => {
+                const tx = await lookupLightningInvoice(lndInvoice());
+
+                expect(tx.state).toBe('failed');
+            });
+
+            it('returns preimage and settle time for a settled invoice', async () => {
+                const tx = await lookupLightningInvoice(
+                    lndInvoice({
+                        settled: true,
+                        settle_date: String(SETTLE_DATE),
+                        r_preimage: Base64Utils.hexToBase64(PREIMAGE)
+                    })
+                );
+
+                expect(tx.state).toBe('settled');
+                expect(tx.preimage).toBe(PREIMAGE);
+                expect(tx.settled_at).toBe(SETTLE_DATE);
+            });
+
+            it('reads Core Lightning payment_hash and payment_preimage', async () => {
+                const tx = await lookupLightningInvoice({
+                    payment_hash: HASH_A,
+                    payment_preimage: PREIMAGE,
+                    bolt11: INVOICE_A,
+                    created_at: CREATION_DATE,
+                    expires_at: CREATION_DATE + EXPIRY_SECONDS,
+                    paid_at: SETTLE_DATE,
+                    status: 'paid',
+                    msatoshi: 1000000
+                });
+
+                expect(tx.payment_hash).toBe(HASH_A);
+                expect(tx.preimage).toBe(PREIMAGE);
+                expect(tx.expires_at).toBe(CREATION_DATE + EXPIRY_SECONDS);
+            });
+
+            it('does not report a settle time for an unpaid invoice', async () => {
+                const tx = await lookupLightningInvoice({
+                    payment_hash: HASH_A,
+                    bolt11: INVOICE_A,
+                    created_at: CREATION_DATE,
+                    timestamp: CREATION_DATE,
+                    expires_at: CREATION_DATE + EXPIRY_SECONDS,
+                    status: 'unpaid'
+                });
+
+                expect(tx.state).not.toBe('settled');
+                expect(tx.settled_at).toBe(0);
+            });
+        });
+
+        describe('list_transactions', () => {
+            it('derives payment_hash from r_hash for LND invoices', () => {
+                const [tx] =
+                    NostrConnectUtils.convertLightningDataToNip47Transactions({
+                        invoices: [new Invoice(lndInvoice())]
+                    });
+
+                expect(tx.payment_hash).toBe(HASH_A);
+            });
+
+            it('never reports the payment request as a payment hash', () => {
+                const activity: ConnectionActivity = {
+                    id: INVOICE_A,
+                    type: 'make_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    invoice: new Invoice(lndInvoice())
+                };
+
+                const tx =
+                    NostrConnectUtils.convertConnectionActivityToNip47Transaction(
+                        activity
+                    );
+
+                expect(tx.payment_hash).toBe(HASH_A);
             });
         });
     });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -42,6 +42,8 @@ import Base64Utils from './Base64Utils';
 import BackendUtils from './BackendUtils';
 import type { ConnectionActivity } from '../models/NWCConnection';
 import CashuPayment from '../models/CashuPayment';
+import CashuInvoice from '../models/CashuInvoice';
+import Base64Utils from './Base64Utils';
 
 // Stable hex values: repeat a hex digit 64 times to fill 32 bytes
 const hex64 = (c: string) => c.repeat(64);
@@ -940,6 +942,75 @@ describe('NostrConnectUtils', () => {
 
         it('returns undefined when there are no payments', () => {
             expect(lookup({ payment_hash: HASH_A }, [])).toBeUndefined();
+        });
+
+        it('matches a base64-encoded payment hash from the request', () => {
+            const tx = lookup({
+                payment_hash: Base64Utils.hexToBase64(HASH_A)
+            });
+
+            expect(tx?.payment_hash).toBe(HASH_A);
+        });
+    });
+
+    describe('payment hash normalization', () => {
+        // ZEUS's own NWC backend sends payment_hash base64-encoded, while
+        // stored hashes are hex — see backends/NostrWalletConnect.ts
+        const normalize = (hash?: string) =>
+            NostrConnectUtils.normalizePaymentHash(hash);
+
+        it('passes a hex hash through unchanged', () => {
+            expect(normalize(HASH_A)).toBe(HASH_A);
+        });
+
+        it('decodes a base64 hash to hex', () => {
+            expect(normalize(Base64Utils.hexToBase64(HASH_A))).toBe(HASH_A);
+        });
+
+        it('returns undefined for a missing or blank hash', () => {
+            expect(normalize(undefined)).toBeUndefined();
+            expect(normalize('   ')).toBeUndefined();
+        });
+    });
+
+    describe('findCashuInvoiceForNwcLookup', () => {
+        // BOLT11 spec reference vector; hash confirmed by decoding it
+        const BOLT11 =
+            'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr';
+        const BOLT11_HASH =
+            '0001020304050607080900010203040506070809000102030405060708090102';
+
+        const invoices = () => [
+            new CashuInvoice({ quote: 'quote-1', request: BOLT11 })
+        ];
+
+        it('matches a hex payment hash', async () => {
+            const found = await NostrConnectUtils.findCashuInvoiceForNwcLookup(
+                invoices(),
+                { payment_hash: BOLT11_HASH } as never
+            );
+
+            expect(found?.getPaymentRequest).toBe(BOLT11);
+        });
+
+        it('matches a base64-encoded payment hash', async () => {
+            const found = await NostrConnectUtils.findCashuInvoiceForNwcLookup(
+                invoices(),
+                {
+                    payment_hash: Base64Utils.hexToBase64(BOLT11_HASH)
+                } as never
+            );
+
+            expect(found?.getPaymentRequest).toBe(BOLT11);
+        });
+
+        it('does not match an unrelated hash', async () => {
+            const found = await NostrConnectUtils.findCashuInvoiceForNwcLookup(
+                invoices(),
+                { payment_hash: hex64('f') } as never
+            );
+
+            expect(found).toBeUndefined();
         });
     });
 });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -43,7 +43,6 @@ import BackendUtils from './BackendUtils';
 import type { ConnectionActivity } from '../models/NWCConnection';
 import CashuPayment from '../models/CashuPayment';
 import CashuInvoice from '../models/CashuInvoice';
-import Base64Utils from './Base64Utils';
 
 // Stable hex values: repeat a hex digit 64 times to fill 32 bytes
 const hex64 = (c: string) => c.repeat(64);
@@ -768,37 +767,34 @@ describe('NostrConnectUtils', () => {
             ...overrides
         });
 
-        const lookupLightningInvoice = (rawInvoice: object) => {
-            (BackendUtils as any).lookupInvoice = jest
-                .fn()
-                .mockResolvedValue(rawInvoice);
-            return NostrConnectUtils.buildNip47TransactionForLightningInvoiceLookup(
-                HASH_A
+        const lookupLightningInvoice = (rawInvoice: object) =>
+            NostrConnectUtils.lightningInvoiceToNip47Transaction(
+                new Invoice(rawInvoice),
+                { fallbackHash: HASH_A }
             );
-        };
 
         describe('lookup_invoice', () => {
-            it('reads the payment hash from the LND r_hash field', async () => {
-                const tx = await lookupLightningInvoice(lndInvoice());
+            it('reads the payment hash from the LND r_hash field', () => {
+                const tx = lookupLightningInvoice(lndInvoice());
 
                 expect(tx.payment_hash).toBe(HASH_A);
             });
 
-            it('reports expiry as creation plus expiry, not the creation date', async () => {
-                const tx = await lookupLightningInvoice(lndInvoice());
+            it('reports expiry as creation plus expiry, not the creation date', () => {
+                const tx = lookupLightningInvoice(lndInvoice());
 
                 expect(tx.created_at).toBe(CREATION_DATE);
                 expect(tx.expires_at).toBe(CREATION_DATE + EXPIRY_SECONDS);
             });
 
-            it('marks an unpaid invoice past its expiry as failed', async () => {
-                const tx = await lookupLightningInvoice(lndInvoice());
+            it('marks an unpaid invoice past its expiry as failed', () => {
+                const tx = lookupLightningInvoice(lndInvoice());
 
                 expect(tx.state).toBe('failed');
             });
 
-            it('returns preimage and settle time for a settled invoice', async () => {
-                const tx = await lookupLightningInvoice(
+            it('returns preimage and settle time for a settled invoice', () => {
+                const tx = lookupLightningInvoice(
                     lndInvoice({
                         settled: true,
                         settle_date: String(SETTLE_DATE),
@@ -811,8 +807,8 @@ describe('NostrConnectUtils', () => {
                 expect(tx.settled_at).toBe(SETTLE_DATE);
             });
 
-            it('reads Core Lightning payment_hash and payment_preimage', async () => {
-                const tx = await lookupLightningInvoice({
+            it('reads Core Lightning payment_hash and payment_preimage', () => {
+                const tx = lookupLightningInvoice({
                     payment_hash: HASH_A,
                     payment_preimage: PREIMAGE,
                     bolt11: INVOICE_A,
@@ -828,8 +824,8 @@ describe('NostrConnectUtils', () => {
                 expect(tx.expires_at).toBe(CREATION_DATE + EXPIRY_SECONDS);
             });
 
-            it('does not report a settle time for an unpaid invoice', async () => {
-                const tx = await lookupLightningInvoice({
+            it('does not report a settle time for an unpaid invoice', () => {
+                const tx = lookupLightningInvoice({
                     payment_hash: HASH_A,
                     bolt11: INVOICE_A,
                     created_at: CREATION_DATE,
@@ -853,6 +849,15 @@ describe('NostrConnectUtils', () => {
                 expect(tx.payment_hash).toBe(HASH_A);
             });
 
+            it('reports the same expiry as lookup_invoice', () => {
+                const [tx] =
+                    NostrConnectUtils.convertLightningDataToNip47Transactions({
+                        invoices: [new Invoice(lndInvoice())]
+                    });
+
+                expect(tx.expires_at).toBe(CREATION_DATE + EXPIRY_SECONDS);
+            });
+
             it('never reports the payment request as a payment hash', () => {
                 const activity: ConnectionActivity = {
                     id: INVOICE_A,
@@ -872,7 +877,7 @@ describe('NostrConnectUtils', () => {
         });
     });
 
-    describe('buildNip47TransactionForCashuPaymentLookup', () => {
+    describe('cashuPaymentToNip47Transaction', () => {
         const TIMESTAMP = 1700000000;
         const PREIMAGE = hex64('e');
 
@@ -892,11 +897,15 @@ describe('NostrConnectUtils', () => {
                 ...overrides
             });
 
-        const lookup = (request: object, payments?: CashuPayment[]) =>
-            NostrConnectUtils.buildNip47TransactionForCashuPaymentLookup(
+        const lookup = (request: object, payments?: CashuPayment[]) => {
+            const payment = NostrConnectUtils.findPaymentByLookupRequest(
                 payments ?? [cashuPayment()],
                 request as never
             );
+            return payment
+                ? NostrConnectUtils.cashuPaymentToNip47Transaction(payment)
+                : undefined;
+        };
 
         it('finds a melted payment by payment hash', () => {
             const tx = lookup({ payment_hash: HASH_A });
@@ -973,7 +982,7 @@ describe('NostrConnectUtils', () => {
         });
     });
 
-    describe('findCashuInvoiceForNwcLookup', () => {
+    describe('findCashuInvoiceByLookupRequest', () => {
         // BOLT11 spec reference vector; hash confirmed by decoding it
         const BOLT11 =
             'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr';
@@ -985,32 +994,112 @@ describe('NostrConnectUtils', () => {
         ];
 
         it('matches a hex payment hash', async () => {
-            const found = await NostrConnectUtils.findCashuInvoiceForNwcLookup(
-                invoices(),
-                { payment_hash: BOLT11_HASH } as never
-            );
+            const found =
+                await NostrConnectUtils.findCashuInvoiceByLookupRequest(
+                    invoices(),
+                    { payment_hash: BOLT11_HASH } as never
+                );
 
             expect(found?.getPaymentRequest).toBe(BOLT11);
         });
 
         it('matches a base64-encoded payment hash', async () => {
-            const found = await NostrConnectUtils.findCashuInvoiceForNwcLookup(
-                invoices(),
-                {
-                    payment_hash: Base64Utils.hexToBase64(BOLT11_HASH)
-                } as never
-            );
+            const found =
+                await NostrConnectUtils.findCashuInvoiceByLookupRequest(
+                    invoices(),
+                    {
+                        payment_hash: Base64Utils.hexToBase64(BOLT11_HASH)
+                    } as never
+                );
 
             expect(found?.getPaymentRequest).toBe(BOLT11);
         });
 
         it('does not match an unrelated hash', async () => {
-            const found = await NostrConnectUtils.findCashuInvoiceForNwcLookup(
-                invoices(),
-                { payment_hash: hex64('f') } as never
-            );
+            const found =
+                await NostrConnectUtils.findCashuInvoiceByLookupRequest(
+                    invoices(),
+                    { payment_hash: hex64('f') } as never
+                );
 
             expect(found).toBeUndefined();
+        });
+    });
+
+    describe('lookupInvoiceTransaction', () => {
+        const TIMESTAMP = 1700000000;
+
+        it('finds a Lightning invoice from the node by payment hash', async () => {
+            (BackendUtils as any).lookupInvoice = jest.fn().mockResolvedValue({
+                r_hash: Base64Utils.hexToBase64(HASH_A),
+                payment_request: INVOICE_A,
+                creation_date: String(TIMESTAMP),
+                expiry: '3600',
+                value: '1000',
+                settled: false
+            });
+
+            const tx = await NostrConnectUtils.lookupInvoiceTransaction({
+                request: { payment_hash: HASH_A },
+                isCashu: false,
+                cashuInvoices: [],
+                cashuPayments: [],
+                lightningPayments: []
+            });
+
+            expect(tx?.type).toBe('incoming');
+            expect(tx?.payment_hash).toBe(HASH_A);
+        });
+
+        it('falls back to an outgoing Lightning payment when the node has no invoice', async () => {
+            (BackendUtils as any).lookupInvoice = jest
+                .fn()
+                .mockRejectedValue(new Error('not found'));
+            const payment = new Payment({
+                payment_hash: HASH_A,
+                timestamp: TIMESTAMP,
+                payment_request: INVOICE_A,
+                value: '2000',
+                fee: '2'
+            });
+
+            const tx = await NostrConnectUtils.lookupInvoiceTransaction({
+                request: { payment_hash: HASH_A },
+                isCashu: false,
+                cashuInvoices: [],
+                cashuPayments: [],
+                lightningPayments: [payment]
+            });
+
+            expect(tx?.type).toBe('outgoing');
+            expect(tx?.payment_hash).toBe(HASH_A);
+            expect(BackendUtils.lookupInvoice).toHaveBeenCalled();
+        });
+
+        it('resolves an invoice-only Lightning request from the BOLT11 string', async () => {
+            const BOLT11 =
+                'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr';
+            (BackendUtils as any).lookupInvoice = jest.fn().mockResolvedValue({
+                payment_hash:
+                    '0001020304050607080900010203040506070809000102030405060708090102',
+                bolt11: BOLT11,
+                created_at: TIMESTAMP,
+                expires_at: TIMESTAMP + 3600,
+                status: 'unpaid'
+            });
+
+            const tx = await NostrConnectUtils.lookupInvoiceTransaction({
+                request: { invoice: BOLT11 },
+                isCashu: false,
+                cashuInvoices: [],
+                cashuPayments: [],
+                lightningPayments: []
+            });
+
+            expect(tx?.type).toBe('incoming');
+            expect(BackendUtils.lookupInvoice).toHaveBeenCalledWith({
+                r_hash: '0001020304050607080900010203040506070809000102030405060708090102'
+            });
         });
     });
 });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -1102,4 +1102,74 @@ describe('NostrConnectUtils', () => {
             });
         });
     });
+
+    describe('list_transactions unpaid filter', () => {
+        // NIP-47: "unpaid: include unpaid invoices, optional, default false"
+        const transaction = (
+            state: 'settled' | 'pending' | 'failed',
+            type: 'incoming' | 'outgoing',
+            createdAt: number
+        ) =>
+            NostrConnectUtils.createNip47Transaction({
+                type,
+                state,
+                invoice: '',
+                payment_hash: '',
+                amount: 1000,
+                created_at: createdAt
+            });
+
+        const settledInvoice = transaction('settled', 'incoming', 400);
+        const pendingInvoice = transaction('pending', 'incoming', 300);
+        const settledPayment = transaction('settled', 'outgoing', 200);
+        const failedPayment = transaction('failed', 'outgoing', 100);
+        const all = [
+            settledInvoice,
+            pendingInvoice,
+            settledPayment,
+            failedPayment
+        ];
+
+        const filter = (request: object) =>
+            NostrConnectUtils.filterAndPaginateTransactions(
+                all,
+                request as never
+            );
+
+        it('returns only settled transactions when unpaid is not requested', () => {
+            const { transactions, totalCount } = filter({});
+
+            expect(transactions).toEqual([settledInvoice, settledPayment]);
+            expect(totalCount).toBe(2);
+        });
+
+        it('returns only settled transactions when unpaid is false', () => {
+            const { transactions } = filter({ unpaid: false });
+
+            expect(transactions).toEqual([settledInvoice, settledPayment]);
+        });
+
+        it('includes every state when unpaid is true', () => {
+            const { transactions, totalCount } = filter({ unpaid: true });
+
+            expect(transactions).toHaveLength(4);
+            expect(totalCount).toBe(4);
+        });
+
+        it('does not drop settled transactions when unpaid is true', () => {
+            const { transactions } = filter({ unpaid: true });
+
+            expect(transactions).toContain(settledInvoice);
+            expect(transactions).toContain(settledPayment);
+        });
+
+        it('still applies the type filter alongside unpaid', () => {
+            const { transactions } = filter({
+                unpaid: true,
+                type: 'outgoing'
+            });
+
+            expect(transactions).toEqual([settledPayment, failedPayment]);
+        });
+    });
 });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -1058,7 +1058,6 @@ describe('NostrConnectUtils', () => {
             const payment = new Payment({
                 payment_hash: HASH_A,
                 timestamp: TIMESTAMP,
-                payment_request: INVOICE_A,
                 value: '2000',
                 fee: '2'
             });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -837,6 +837,27 @@ describe('NostrConnectUtils', () => {
                 expect(tx.state).not.toBe('settled');
                 expect(tx.settled_at).toBe(0);
             });
+
+            it('derives created_at from BOLT11 when CLN listinvoices omits a creation timestamp', () => {
+                // Real CLN listinvoices shape: no created_at/creation_date
+                const BOLT11 =
+                    'lnbcrt1230n1pj429x7pp57t97q4awqj3f529snr0pa6senk83sq5pp760qf5a4jzvd7xgwcksdqqcqzzsxqrrsssp57eqtv7vxr46arupna3w4ct0lkf2mqmz9wt044cwkks0rwlnhfr5s9qyyssqragwpwav7nfwv2xyuuamxxj4pnnpzv2hlw7j473repd3sq7st698ta9kmzmygt0w7tmncl56a6mnma0w7e5dlpqd0wy6x3v35rssldspjhh8p0';
+                const BOLT11_TIMESTAMP = 1700074718;
+                const tx = lookupLightningInvoice({
+                    label: 'zeus.123456',
+                    bolt11: BOLT11,
+                    payment_hash:
+                        'f2cbe056ae04a29a28b098de1eea199d8f1802900fb4f0269dac84c6f8c8762d',
+                    amount_msat: 123000,
+                    status: 'unpaid',
+                    description: 'test invoice',
+                    expires_at: BOLT11_TIMESTAMP + EXPIRY_SECONDS,
+                    created_index: 7
+                });
+
+                expect(tx.created_at).toBe(BOLT11_TIMESTAMP);
+                expect(tx.expires_at).toBe(BOLT11_TIMESTAMP + EXPIRY_SECONDS);
+            });
         });
 
         describe('list_transactions', () => {

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -1028,6 +1028,8 @@ describe('NostrConnectUtils', () => {
 
     describe('lookupInvoiceTransaction', () => {
         const TIMESTAMP = 1700000000;
+        const getLightningPayments = (payments: Payment[] = []) =>
+            jest.fn().mockResolvedValue(payments);
 
         it('finds a Lightning invoice from the node by payment hash', async () => {
             (BackendUtils as any).lookupInvoice = jest.fn().mockResolvedValue({
@@ -1038,17 +1040,19 @@ describe('NostrConnectUtils', () => {
                 value: '1000',
                 settled: false
             });
+            const getPayments = getLightningPayments();
 
             const tx = await NostrConnectUtils.lookupInvoiceTransaction({
                 request: { payment_hash: HASH_A },
                 isCashu: false,
                 cashuInvoices: [],
                 cashuPayments: [],
-                lightningPayments: []
+                getLightningPayments: getPayments
             });
 
             expect(tx?.type).toBe('incoming');
             expect(tx?.payment_hash).toBe(HASH_A);
+            expect(getPayments).not.toHaveBeenCalled();
         });
 
         it('falls back to an outgoing Lightning payment when the node has no invoice', async () => {
@@ -1061,18 +1065,20 @@ describe('NostrConnectUtils', () => {
                 value: '2000',
                 fee: '2'
             });
+            const getPayments = getLightningPayments([payment]);
 
             const tx = await NostrConnectUtils.lookupInvoiceTransaction({
                 request: { payment_hash: HASH_A },
                 isCashu: false,
                 cashuInvoices: [],
                 cashuPayments: [],
-                lightningPayments: [payment]
+                getLightningPayments: getPayments
             });
 
             expect(tx?.type).toBe('outgoing');
             expect(tx?.payment_hash).toBe(HASH_A);
             expect(BackendUtils.lookupInvoice).toHaveBeenCalled();
+            expect(getPayments).toHaveBeenCalledTimes(1);
         });
 
         it('resolves an invoice-only Lightning request from the BOLT11 string', async () => {
@@ -1086,19 +1092,21 @@ describe('NostrConnectUtils', () => {
                 expires_at: TIMESTAMP + 3600,
                 status: 'unpaid'
             });
+            const getPayments = getLightningPayments();
 
             const tx = await NostrConnectUtils.lookupInvoiceTransaction({
                 request: { invoice: BOLT11 },
                 isCashu: false,
                 cashuInvoices: [],
                 cashuPayments: [],
-                lightningPayments: []
+                getLightningPayments: getPayments
             });
 
             expect(tx?.type).toBe('incoming');
             expect(BackendUtils.lookupInvoice).toHaveBeenCalledWith({
                 r_hash: '0001020304050607080900010203040506070809000102030405060708090102'
             });
+            expect(getPayments).not.toHaveBeenCalled();
         });
     });
 

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -23,6 +23,7 @@ import CashuInvoice from '../models/CashuInvoice';
 import CashuToken from '../models/CashuToken';
 import Transaction from '../models/Transaction';
 
+import Base64Utils from './Base64Utils';
 import { localeString } from './LocaleUtils';
 import dateTimeUtils from './DateTimeUtils';
 import Bolt11Utils from './Bolt11Utils';
@@ -604,18 +605,21 @@ export default class NostrConnectUtils {
         invoices: CashuInvoice[],
         request: Nip47LookupInvoiceRequest
     ): Promise<CashuInvoice | undefined> {
+        const paymentHash = NostrConnectUtils.normalizePaymentHash(
+            request.payment_hash
+        );
         for (const inv of invoices) {
             if (inv.getPaymentRequest === request.invoice) {
                 return inv;
             }
-            if (!request.payment_hash) {
+            if (!paymentHash) {
                 continue;
             }
             try {
                 const decoded = await NostrConnectUtils.decodeInvoiceTags(
                     inv.getPaymentRequest
                 );
-                if (decoded.paymentHash === request.payment_hash) {
+                if (decoded.paymentHash === paymentHash) {
                     return inv;
                 }
             } catch {
@@ -678,6 +682,17 @@ export default class NostrConnectUtils {
     }
 
     /**
+     * NIP-47 payment hashes are hex, but some clients send them base64-encoded
+     * — ZEUS's own NWC backend does. Stored hashes are hex, so a request value
+     * has to be normalized before any exact comparison.
+     */
+    static normalizePaymentHash(paymentHash?: string): string | undefined {
+        const hash = paymentHash?.trim();
+        if (!hash) return undefined;
+        return hash.includes('=') ? Base64Utils.base64ToHex(hash) : hash;
+    }
+
+    /**
      * NIP-47 transaction for an outgoing Cashu payment matched by
      * lookup_invoice, by payment hash or by payment request. Answers with
      * undefined when nothing matches so the caller stays in control.
@@ -693,7 +708,7 @@ export default class NostrConnectUtils {
         const payment = NostrConnectUtils.findPaymentForInvoice(
             request.invoice || '',
             payments || [],
-            request.payment_hash
+            NostrConnectUtils.normalizePaymentHash(request.payment_hash)
         );
         if (!payment) return undefined;
 

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -649,20 +649,29 @@ export default class NostrConnectUtils {
             Number(invoice.expires_at) ||
             timestamp + DEFAULT_INVOICE_EXPIRY_SECONDS;
 
+        // The request may carry only the invoice, so recover the hash from it
+        let paymentHash = request.payment_hash || '';
+        if (!paymentHash) {
+            try {
+                const decoded = await NostrConnectUtils.decodeInvoiceTags(
+                    invoice.getPaymentRequest
+                );
+                paymentHash = decoded.paymentHash || '';
+            } catch {
+                // Undecodable mint quote — report an empty hash rather than a wrong one
+            }
+        }
+
         return NostrConnectUtils.createNip47Transaction({
             type: 'incoming',
             state: isPaid ? 'settled' : 'pending',
             invoice: invoice.getPaymentRequest,
-            payment_hash: request.payment_hash!,
+            payment_hash: paymentHash,
             amount: satsToMillisats(amtSat || 0),
-            ...(isPaid && {
-                preimage:
-                    invoice.getPaymentRequest ||
-                    request.invoice ||
-                    request.payment_hash
-            }),
             description: invoice.getMemo,
-            settled_at: isPaid ? invoice.settleDate.getTime() / 1000 : 0,
+            settled_at: isPaid
+                ? Math.floor(invoice.settleDate.getTime() / 1000)
+                : 0,
             created_at: timestamp,
             expires_at: expiresAt
         });
@@ -683,10 +692,16 @@ export default class NostrConnectUtils {
         }
         const invoice = new Invoice(rawInvoice);
         const now = Math.floor(Date.now() / 1000);
+        const createdAt = Math.floor(invoice.getCreationDate.getTime() / 1000);
+        // Core Lightning reports an absolute expires_at, LND expiry seconds
+        const expiresAt =
+            Number(invoice.expires_at) > 0
+                ? Number(invoice.expires_at)
+                : Number(invoice.expiry) > 0
+                ? createdAt + Number(invoice.expiry)
+                : 0;
 
-        const isExpired =
-            Number(invoice.expiry) > 0 &&
-            Number(invoice.timestamp) + Number(invoice.expiry) < now;
+        const isExpired = expiresAt > 0 && expiresAt < now;
 
         const state = invoice.isPaid
             ? 'settled'
@@ -705,9 +720,11 @@ export default class NostrConnectUtils {
                 preimage: invoice.getRPreimage
             }),
             description_hash: invoice.getDescriptionHash,
-            settled_at: invoice.settleDate.getTime() / 1000,
-            created_at: invoice.getCreationDate.getTime() / 1000,
-            expires_at: invoice.getCreationDate.getTime() / 1000
+            settled_at: invoice.isPaid
+                ? Math.floor(invoice.settleDate.getTime() / 1000)
+                : 0,
+            created_at: createdAt,
+            expires_at: expiresAt
         });
     }
 
@@ -1027,10 +1044,13 @@ export default class NostrConnectUtils {
             return activity.payment.paymentHash;
         }
         if (activity.invoice) {
-            const invoiceHash = (activity.invoice as Invoice).payment_hash;
+            const invoiceHash =
+                (activity.invoice as Invoice).getRHash ||
+                (activity.invoice as Invoice).payment_hash;
             if (invoiceHash) return invoiceHash;
         }
-        return activity.id || '';
+        // activity.id holds the payment request, which is not a payment hash
+        return '';
     }
 
     private static extractAmountFromActivity(
@@ -1409,7 +1429,8 @@ export default class NostrConnectUtils {
                     const amount = Number(invoice.getAmount) || 0;
                     const timestamp =
                         Number(invoice.getTimestamp) || Date.now() / 1000;
-                    const paymentHash = invoice.payment_hash || '';
+                    // LND returns r_hash, Core Lightning payment_hash
+                    const paymentHash = invoice.getRHash || '';
                     const invoiceString = invoice.getPaymentRequest || '';
                     const description = invoice.getMemo || '';
                     const expiresAt = Number(invoice.expires_at) || 0;

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -606,16 +606,6 @@ export default class NostrConnectUtils {
         }
     }
 
-    static invoiceNotFoundMessage(): string {
-        return localeString(
-            'stores.NostrWalletConnectStore.error.invoiceNotFound'
-        );
-    }
-
-    static invoiceNotFoundError(): Error {
-        return new Error(NostrConnectUtils.invoiceNotFoundMessage());
-    }
-
     /**
      * NIP-47 payment hashes are hex, but some clients send them base64-encoded
      * — ZEUS's own NWC backend does. Stored hashes are hex, so a request value

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -111,7 +111,7 @@ export const DEFAULT_INVOICE_EXPIRY_SECONDS = 3600;
 export interface Nip47LookupInvoiceContext {
     request: Nip47LookupInvoiceRequest;
     isCashu: boolean;
-    cashuInvoices: CashuInvoice[];
+    getCashuInvoices: () => Promise<CashuInvoice[]>;
     getCashuPayments: () => Promise<CashuPayment[]>;
     getLightningPayments: () => Promise<Payment[]>;
 }
@@ -857,7 +857,7 @@ export default class NostrConnectUtils {
         const { request } = ctx;
         const cashuInvoice =
             await NostrConnectUtils.findCashuInvoiceByLookupRequest(
-                ctx.cashuInvoices,
+                await ctx.getCashuInvoices(),
                 request
             );
         if (cashuInvoice) {

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -677,6 +677,45 @@ export default class NostrConnectUtils {
         });
     }
 
+    /**
+     * NIP-47 transaction for an outgoing Cashu payment matched by
+     * lookup_invoice, by payment hash or by payment request. Answers with
+     * undefined when nothing matches so the caller stays in control.
+     *
+     * A melt only reaches cashuStore.payments after it succeeded, so the state
+     * is settled. The mint's preimage is method-specific and optional per
+     * NUT-05, so it may legitimately be empty.
+     */
+    static buildNip47TransactionForCashuPaymentLookup(
+        payments: CashuPayment[],
+        request: Nip47LookupInvoiceRequest
+    ): Nip47Transaction | undefined {
+        const payment = NostrConnectUtils.findPaymentForInvoice(
+            request.invoice || '',
+            payments || [],
+            request.payment_hash
+        );
+        if (!payment) return undefined;
+
+        const timestamp = Math.floor(
+            Number(payment.getTimestamp) || dateTimeUtils.getCurrentTimestamp()
+        );
+
+        return NostrConnectUtils.createNip47Transaction({
+            type: 'outgoing',
+            state: 'settled',
+            invoice: payment.getPaymentRequest || '',
+            payment_hash: payment.paymentHash || '',
+            amount: satsToMillisats(Number(payment.getAmount) || 0),
+            description: payment.getMemo,
+            preimage: payment.getPreimage,
+            fees_paid: satsToMillisats(Number(payment.getFee) || 0),
+            settled_at: timestamp,
+            created_at: timestamp,
+            expires_at: 0
+        });
+    }
+
     static async buildNip47TransactionForLightningInvoiceLookup(
         r_hash: string
     ): Promise<Nip47Transaction> {

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -1656,13 +1656,10 @@ export default class NostrConnectUtils {
             filtered = filtered.filter((tx) => tx.created_at <= request.until!);
         }
 
-        // Filter by unpaid status
-        if (request.unpaid !== undefined) {
-            if (request.unpaid) {
-                filtered = filtered.filter((tx) => tx.state === 'pending');
-            } else {
-                filtered = filtered.filter((tx) => tx.state === 'settled');
-            }
+        // NIP-47 defines unpaid as "include unpaid invoices, default false", so
+        // it widens the result rather than selecting only unpaid ones
+        if (!request.unpaid) {
+            filtered = filtered.filter((tx) => tx.state === 'settled');
         }
 
         // Calculate pagination

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -113,7 +113,7 @@ export interface Nip47LookupInvoiceContext {
     isCashu: boolean;
     cashuInvoices: CashuInvoice[];
     cashuPayments: CashuPayment[];
-    lightningPayments: Payment[];
+    getLightningPayments: () => Promise<Payment[]>;
 }
 
 export enum Nip47ErrorCode {
@@ -904,7 +904,7 @@ export default class NostrConnectUtils {
         }
 
         const lightningPayment = NostrConnectUtils.findPaymentByLookupRequest(
-            ctx.lightningPayments,
+            await ctx.getLightningPayments(),
             request
         );
         return lightningPayment

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -112,7 +112,7 @@ export interface Nip47LookupInvoiceContext {
     request: Nip47LookupInvoiceRequest;
     isCashu: boolean;
     cashuInvoices: CashuInvoice[];
-    cashuPayments: CashuPayment[];
+    getCashuPayments: () => Promise<CashuPayment[]>;
     getLightningPayments: () => Promise<Payment[]>;
 }
 
@@ -600,6 +600,7 @@ export default class NostrConnectUtils {
         if (!hash) return false;
         try {
             const result = await BackendUtils.lookupInvoice({ r_hash: hash });
+            if (!result || typeof result !== 'object') return false;
             return new Invoice(result).isPaid;
         } catch {
             return false;
@@ -872,7 +873,7 @@ export default class NostrConnectUtils {
         }
 
         const cashuPayment = NostrConnectUtils.findPaymentByLookupRequest(
-            ctx.cashuPayments,
+            await ctx.getCashuPayments(),
             request
         );
         return cashuPayment
@@ -1333,6 +1334,15 @@ export default class NostrConnectUtils {
         }
 
         if (activity.invoice) {
+            if (activity.invoice instanceof Invoice) {
+                const createdAt = Math.floor(
+                    activity.invoice.getCreationDate.getTime() / 1000
+                );
+                return NostrConnectUtils.lightningInvoiceExpiresAt(
+                    activity.invoice,
+                    createdAt
+                );
+            }
             if (activity.invoice.expires_at) {
                 return Number(activity.invoice.expires_at);
             }

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -108,6 +108,14 @@ export function parseNwcActivityNotif(
 
 export const DEFAULT_INVOICE_EXPIRY_SECONDS = 3600;
 
+export interface Nip47LookupInvoiceContext {
+    request: Nip47LookupInvoiceRequest;
+    isCashu: boolean;
+    cashuInvoices: CashuInvoice[];
+    cashuPayments: CashuPayment[];
+    lightningPayments: Payment[];
+}
+
 export enum Nip47ErrorCode {
     INTERNAL_ERROR = 'INTERNAL_ERROR',
     RATE_LIMITED = 'RATE_LIMITED',
@@ -588,7 +596,7 @@ export default class NostrConnectUtils {
                 return false;
             }
         }
-        const hash = options.rHash?.trim();
+        const hash = NostrConnectUtils.normalizePaymentHash(options.rHash);
         if (!hash) return false;
         try {
             const result = await BackendUtils.lookupInvoice({ r_hash: hash });
@@ -598,87 +606,14 @@ export default class NostrConnectUtils {
         }
     }
 
-    /**
-     * Finds a Cashu invoice matching NIP-47 lookup_invoice (BOLT11 string and/or payment_hash).
-     */
-    static async findCashuInvoiceForNwcLookup(
-        invoices: CashuInvoice[],
-        request: Nip47LookupInvoiceRequest
-    ): Promise<CashuInvoice | undefined> {
-        const paymentHash = NostrConnectUtils.normalizePaymentHash(
-            request.payment_hash
+    static invoiceNotFoundMessage(): string {
+        return localeString(
+            'stores.NostrWalletConnectStore.error.invoiceNotFound'
         );
-        for (const inv of invoices) {
-            if (inv.getPaymentRequest === request.invoice) {
-                return inv;
-            }
-            if (!paymentHash) {
-                continue;
-            }
-            try {
-                const decoded = await NostrConnectUtils.decodeInvoiceTags(
-                    inv.getPaymentRequest
-                );
-                if (decoded.paymentHash === paymentHash) {
-                    return inv;
-                }
-            } catch {
-                // Skip malformed/undecodable invoices and continue lookup.
-            }
-        }
-        return undefined;
     }
 
-    /** NIP-47 transaction for a Cashu invoice matched by lookup_invoice. */
-    static async buildNip47TransactionForCashuInvoiceLookup(
-        invoices: CashuInvoice[],
-        request: Nip47LookupInvoiceRequest
-    ): Promise<Nip47Transaction> {
-        const invoice = await NostrConnectUtils.findCashuInvoiceForNwcLookup(
-            invoices || [],
-            request
-        );
-        if (!invoice) {
-            throw new Error(
-                localeString(
-                    'stores.NostrWalletConnectStore.error.invoiceNotFound'
-                )
-            );
-        }
-        const isPaid = invoice.isPaid || false;
-        const amtSat = invoice.getAmount;
-        const timestamp =
-            Number(invoice.getTimestamp) || dateTimeUtils.getCurrentTimestamp();
-        const expiresAt =
-            Number(invoice.expires_at) ||
-            timestamp + DEFAULT_INVOICE_EXPIRY_SECONDS;
-
-        // The request may carry only the invoice, so recover the hash from it
-        let paymentHash = request.payment_hash || '';
-        if (!paymentHash) {
-            try {
-                const decoded = await NostrConnectUtils.decodeInvoiceTags(
-                    invoice.getPaymentRequest
-                );
-                paymentHash = decoded.paymentHash || '';
-            } catch {
-                // Undecodable mint quote — report an empty hash rather than a wrong one
-            }
-        }
-
-        return NostrConnectUtils.createNip47Transaction({
-            type: 'incoming',
-            state: isPaid ? 'settled' : 'pending',
-            invoice: invoice.getPaymentRequest,
-            payment_hash: paymentHash,
-            amount: satsToMillisats(amtSat || 0),
-            description: invoice.getMemo,
-            settled_at: isPaid
-                ? Math.floor(invoice.settleDate.getTime() / 1000)
-                : 0,
-            created_at: timestamp,
-            expires_at: expiresAt
-        });
+    static invoiceNotFoundError(): Error {
+        return new Error(NostrConnectUtils.invoiceNotFoundMessage());
     }
 
     /**
@@ -692,29 +627,98 @@ export default class NostrConnectUtils {
         return hash.includes('=') ? Base64Utils.base64ToHex(hash) : hash;
     }
 
-    /**
-     * NIP-47 transaction for an outgoing Cashu payment matched by
-     * lookup_invoice, by payment hash or by payment request. Answers with
-     * undefined when nothing matches so the caller stays in control.
-     *
-     * A melt only reaches cashuStore.payments after it succeeded, so the state
-     * is settled. The mint's preimage is method-specific and optional per
-     * NUT-05, so it may legitimately be empty.
-     */
-    static buildNip47TransactionForCashuPaymentLookup(
-        payments: CashuPayment[],
+    /** Resolve a lookup hash from payment_hash and/or invoice on the request. */
+    static async resolveLookupPaymentHash(
+        request: Nip47LookupInvoiceRequest,
+        paymentRequest?: string
+    ): Promise<string | undefined> {
+        const fromRequest = NostrConnectUtils.normalizePaymentHash(
+            request.payment_hash
+        );
+        if (fromRequest) return fromRequest;
+
+        const invoice = request.invoice || paymentRequest;
+        if (!invoice) return undefined;
+
+        try {
+            const decoded = await NostrConnectUtils.decodeInvoiceTags(invoice);
+            return decoded.paymentHash || undefined;
+        } catch {
+            return undefined;
+        }
+    }
+
+    static findPaymentByLookupRequest<T extends Payment>(
+        payments: T[],
         request: Nip47LookupInvoiceRequest
-    ): Nip47Transaction | undefined {
-        const payment = NostrConnectUtils.findPaymentForInvoice(
+    ): T | undefined {
+        return NostrConnectUtils.findPaymentForInvoice(
             request.invoice || '',
-            payments || [],
+            payments,
             NostrConnectUtils.normalizePaymentHash(request.payment_hash)
         );
-        if (!payment) return undefined;
+    }
 
-        const timestamp = Math.floor(
-            Number(payment.getTimestamp) || dateTimeUtils.getCurrentTimestamp()
+    /** Whether a BOLT11 string matches a NIP-47 lookup request (invoice or hash). */
+    static async paymentRequestMatchesLookupRequest(
+        paymentRequest: string,
+        request: Nip47LookupInvoiceRequest,
+        normalizedHash?: string
+    ): Promise<boolean> {
+        if (request.invoice && paymentRequest === request.invoice) {
+            return true;
+        }
+        const hash =
+            normalizedHash ??
+            NostrConnectUtils.normalizePaymentHash(request.payment_hash);
+        if (!hash) return false;
+        try {
+            const decoded = await NostrConnectUtils.decodeInvoiceTags(
+                paymentRequest
+            );
+            return decoded.paymentHash === hash;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Finds a Cashu invoice matching NIP-47 lookup_invoice (BOLT11 and/or payment_hash).
+     */
+    static async findCashuInvoiceByLookupRequest(
+        invoices: CashuInvoice[],
+        request: Nip47LookupInvoiceRequest
+    ): Promise<CashuInvoice | undefined> {
+        const normalizedHash = NostrConnectUtils.normalizePaymentHash(
+            request.payment_hash
         );
+        for (const inv of invoices) {
+            if (
+                await NostrConnectUtils.paymentRequestMatchesLookupRequest(
+                    inv.getPaymentRequest,
+                    request,
+                    normalizedHash
+                )
+            ) {
+                return inv;
+            }
+        }
+        return undefined;
+    }
+
+    static cashuInvoicePaymentHash(invoice: CashuInvoice): string {
+        try {
+            const decoded = Bolt11Utils.decode(invoice.getPaymentRequest);
+            return decoded.payment_hash || '';
+        } catch {
+            return invoice.quote || '';
+        }
+    }
+
+    static cashuPaymentToNip47Transaction(
+        payment: CashuPayment
+    ): Nip47Transaction {
+        const timestamp = NostrConnectUtils.paymentTimestamp(payment);
 
         return NostrConnectUtils.createNip47Transaction({
             type: 'outgoing',
@@ -731,43 +735,79 @@ export default class NostrConnectUtils {
         });
     }
 
-    static async buildNip47TransactionForLightningInvoiceLookup(
-        r_hash: string
-    ): Promise<Nip47Transaction> {
-        const rawInvoice = await BackendUtils.lookupInvoice({
-            r_hash
-        });
-        if (!rawInvoice || typeof rawInvoice !== 'object') {
-            throw new Error(
-                localeString(
-                    'stores.NostrWalletConnectStore.error.invoiceNotFound'
-                )
-            );
-        }
-        const invoice = new Invoice(rawInvoice);
-        const now = Math.floor(Date.now() / 1000);
-        const createdAt = Math.floor(invoice.getCreationDate.getTime() / 1000);
-        // Core Lightning reports an absolute expires_at, LND expiry seconds
+    static cashuInvoiceToNip47Transaction(
+        invoice: CashuInvoice,
+        paymentHash?: string
+    ): Nip47Transaction {
+        const isPaid = invoice.isPaid || false;
+        const timestamp = Math.floor(
+            Number(invoice.getTimestamp) || dateTimeUtils.getCurrentTimestamp()
+        );
         const expiresAt =
-            Number(invoice.expires_at) > 0
-                ? Number(invoice.expires_at)
-                : Number(invoice.expiry) > 0
-                ? createdAt + Number(invoice.expiry)
-                : 0;
+            Number(invoice.expires_at) ||
+            timestamp + DEFAULT_INVOICE_EXPIRY_SECONDS;
 
-        const isExpired = expiresAt > 0 && expiresAt < now;
+        return NostrConnectUtils.createNip47Transaction({
+            type: 'incoming',
+            state: isPaid ? 'settled' : 'pending',
+            invoice: invoice.getPaymentRequest,
+            payment_hash:
+                NostrConnectUtils.normalizePaymentHash(paymentHash) ||
+                NostrConnectUtils.cashuInvoicePaymentHash(invoice),
+            amount: satsToMillisats(invoice.getAmount || 0),
+            description: invoice.getMemo,
+            settled_at: isPaid
+                ? Math.floor(invoice.settleDate.getTime() / 1000)
+                : 0,
+            created_at: timestamp,
+            expires_at: expiresAt
+        });
+    }
 
-        const state = invoice.isPaid
-            ? 'settled'
-            : isExpired
-            ? 'failed'
-            : 'pending';
+    static lightningInvoiceExpiresAt(
+        invoice: Invoice,
+        createdAt: number
+    ): number {
+        if (Number(invoice.expires_at) > 0) {
+            return Number(invoice.expires_at);
+        }
+        if (Number(invoice.expiry) > 0) {
+            return createdAt + Number(invoice.expiry);
+        }
+        return 0;
+    }
+
+    static lightningInvoiceState(
+        invoice: Invoice,
+        now: number,
+        expiresAt: number
+    ): 'settled' | 'pending' | 'failed' {
+        if (invoice.isPaid) return 'settled';
+        if (expiresAt > 0 && expiresAt < now) return 'failed';
+        return 'pending';
+    }
+
+    static lightningInvoiceToNip47Transaction(
+        invoice: Invoice,
+        opts?: { fallbackHash?: string; now?: number }
+    ): Nip47Transaction {
+        const now = opts?.now ?? Math.floor(Date.now() / 1000);
+        const createdAt = Math.floor(invoice.getCreationDate.getTime() / 1000);
+        const expiresAt = NostrConnectUtils.lightningInvoiceExpiresAt(
+            invoice,
+            createdAt
+        );
+        const state = NostrConnectUtils.lightningInvoiceState(
+            invoice,
+            now,
+            expiresAt
+        );
 
         return NostrConnectUtils.createNip47Transaction({
             type: 'incoming',
             state,
             invoice: invoice.getPaymentRequest,
-            payment_hash: invoice.getRHash || r_hash,
+            payment_hash: invoice.getRHash || opts?.fallbackHash || '',
             amount: satsToMillisats(invoice.getAmount),
             description: invoice.getMemo,
             ...(invoice.isPaid && {
@@ -780,6 +820,114 @@ export default class NostrConnectUtils {
             created_at: createdAt,
             expires_at: expiresAt
         });
+    }
+
+    static lightningPaymentToNip47Transaction(
+        payment: Payment
+    ): Nip47Transaction {
+        const timestamp = NostrConnectUtils.paymentTimestamp(payment);
+        let state: 'settled' | 'pending' | 'failed' = 'pending';
+        if (payment.isFailed) {
+            state = 'failed';
+        } else if (!payment.isIncomplete) {
+            state = 'settled';
+        }
+
+        return NostrConnectUtils.createNip47Transaction({
+            type: 'outgoing',
+            state,
+            invoice: payment.getPaymentRequest || '',
+            payment_hash: payment.paymentHash || '',
+            amount: satsToMillisats(Number(payment.getAmount) || 0),
+            description: payment.getMemo || '',
+            preimage: payment.getPreimage || '',
+            fees_paid: satsToMillisats(Number(payment.getFee) || 0),
+            settled_at: state === 'settled' ? timestamp : 0,
+            created_at: timestamp,
+            expires_at: 0
+        });
+    }
+
+    /**
+     * NIP-47 lookup_invoice: incoming invoice first, then outgoing payment.
+     * Returns undefined when nothing matches so the caller can emit NOT_FOUND.
+     */
+    static async lookupInvoiceTransaction(
+        ctx: Nip47LookupInvoiceContext
+    ): Promise<Nip47Transaction | undefined> {
+        return ctx.isCashu
+            ? NostrConnectUtils.lookupCashuInvoiceTransaction(ctx)
+            : NostrConnectUtils.lookupLightningInvoiceTransaction(ctx);
+    }
+
+    private static async lookupCashuInvoiceTransaction(
+        ctx: Nip47LookupInvoiceContext
+    ): Promise<Nip47Transaction | undefined> {
+        const { request } = ctx;
+        const cashuInvoice =
+            await NostrConnectUtils.findCashuInvoiceByLookupRequest(
+                ctx.cashuInvoices,
+                request
+            );
+        if (cashuInvoice) {
+            const paymentHash =
+                await NostrConnectUtils.resolveLookupPaymentHash(
+                    request,
+                    cashuInvoice.getPaymentRequest
+                );
+            return NostrConnectUtils.cashuInvoiceToNip47Transaction(
+                cashuInvoice,
+                paymentHash
+            );
+        }
+
+        const cashuPayment = NostrConnectUtils.findPaymentByLookupRequest(
+            ctx.cashuPayments,
+            request
+        );
+        return cashuPayment
+            ? NostrConnectUtils.cashuPaymentToNip47Transaction(cashuPayment)
+            : undefined;
+    }
+
+    private static async lookupLightningInvoiceTransaction(
+        ctx: Nip47LookupInvoiceContext
+    ): Promise<Nip47Transaction | undefined> {
+        const { request } = ctx;
+        const paymentHash = await NostrConnectUtils.resolveLookupPaymentHash(
+            request
+        );
+        if (paymentHash) {
+            try {
+                const rawInvoice = await BackendUtils.lookupInvoice({
+                    r_hash: paymentHash
+                });
+                if (rawInvoice && typeof rawInvoice === 'object') {
+                    return NostrConnectUtils.lightningInvoiceToNip47Transaction(
+                        new Invoice(rawInvoice),
+                        { fallbackHash: paymentHash }
+                    );
+                }
+            } catch {
+                // Outgoing payments share the hash but are not node invoices.
+            }
+        }
+
+        const lightningPayment = NostrConnectUtils.findPaymentByLookupRequest(
+            ctx.lightningPayments,
+            request
+        );
+        return lightningPayment
+            ? NostrConnectUtils.lightningPaymentToNip47Transaction(
+                  lightningPayment
+              )
+            : undefined;
+    }
+
+    private static paymentTimestamp(payment: Payment): number {
+        return Math.floor(
+            Number(payment.getTimestamp) || dateTimeUtils.getCurrentTimestamp()
+        );
     }
 
     static async decodeInvoiceTagsForMakeInvoice(
@@ -972,31 +1120,40 @@ export default class NostrConnectUtils {
         return hasInFlightStatus && payment.isIncomplete && !payment.isFailed;
     }
 
-    static findPaymentForInvoice(
+    static findPaymentForInvoice<T extends Payment>(
         invoice: string,
-        payments: Payment[],
+        payments: T[],
         paymentHash?: string | null
-    ): Payment | undefined {
-        return payments.find(
-            (p) =>
-                p.getPaymentRequest === invoice ||
-                (!!paymentHash && p.paymentHash === paymentHash)
+    ): T | undefined {
+        return payments.find((p) =>
+            NostrConnectUtils.matchesPaymentRequest(p, invoice, paymentHash)
         );
     }
 
-    static findInTransitPaymentForInvoice(
+    static findInTransitPaymentForInvoice<T extends Payment>(
         invoice: string,
-        payments: Payment[],
+        payments: T[],
         paymentHash?: string | null
-    ): Payment | undefined {
-        return payments.find((p) => {
-            const matchesInvoice =
-                p.getPaymentRequest === invoice ||
-                (!!paymentHash && p.paymentHash === paymentHash);
-            return (
-                matchesInvoice && NostrConnectUtils.isListedPaymentInTransit(p)
-            );
-        });
+    ): T | undefined {
+        return payments.find(
+            (p) =>
+                NostrConnectUtils.matchesPaymentRequest(
+                    p,
+                    invoice,
+                    paymentHash
+                ) && NostrConnectUtils.isListedPaymentInTransit(p)
+        );
+    }
+
+    private static matchesPaymentRequest(
+        payment: Payment,
+        invoice: string,
+        paymentHash?: string | null
+    ): boolean {
+        return (
+            payment.getPaymentRequest === invoice ||
+            (!!paymentHash && payment.paymentHash === paymentHash)
+        );
     }
 
     static isTransactionsStorePaymentInTransit(state: {
@@ -1318,51 +1475,20 @@ export default class NostrConnectUtils {
 
         // Convert Cashu payments
         if (cashuData.payments) {
-            const paymentTransactions = cashuData.payments.map((payment) => {
-                const timestamp =
-                    Number(payment.getTimestamp) || Date.now() / 1000;
-                return NostrConnectUtils.createNip47Transaction({
-                    type: 'outgoing',
-                    state: 'settled',
-                    invoice: payment.getPaymentRequest || '',
-                    payment_hash: payment.paymentHash || '',
-                    amount: satsToMillisats(Number(payment.getAmount) || 0),
-                    description: payment.getMemo,
-                    fees_paid: satsToMillisats(Number(payment.getFee) || 0),
-                    settled_at: Math.floor(timestamp),
-                    created_at: Math.floor(timestamp),
-                    expires_at: 0
-                });
-            });
-            transactions.push(...paymentTransactions);
+            transactions.push(
+                ...cashuData.payments.map(
+                    NostrConnectUtils.cashuPaymentToNip47Transaction
+                )
+            );
         }
 
         // Convert Cashu invoices
         if (cashuData.invoices) {
-            const invoiceTransactions = cashuData.invoices.map((invoice) => {
-                const timestamp =
-                    Number(invoice.getTimestamp) || Date.now() / 1000;
-                const expiresAt = Number(invoice.expires_at) || 0;
-                return NostrConnectUtils.createNip47Transaction({
-                    type: 'incoming',
-                    state: invoice.isPaid ? 'settled' : 'pending',
-                    invoice: invoice.getPaymentRequest || '',
-                    payment_hash: invoice.quote || '',
-                    amount: satsToMillisats(invoice.getAmount || 0),
-                    description: invoice.getMemo,
-                    settled_at: invoice.isPaid
-                        ? Math.floor(
-                              invoice.settleDate?.getTime()
-                                  ? invoice.settleDate.getTime() / 1000
-                                  : Number(invoice.getTimestamp) ||
-                                        Date.now() / 1000
-                          )
-                        : 0,
-                    created_at: Math.floor(timestamp),
-                    expires_at: Math.floor(expiresAt)
-                });
-            });
-            transactions.push(...invoiceTransactions);
+            transactions.push(
+                ...cashuData.invoices.map((invoice) =>
+                    NostrConnectUtils.cashuInvoiceToNip47Transaction(invoice)
+                )
+            );
         }
 
         // Convert received tokens
@@ -1437,78 +1563,22 @@ export default class NostrConnectUtils {
 
         // Convert Lightning payments
         if (lightningData.payments) {
-            const paymentTransactions = lightningData.payments.map(
-                (payment: Payment) => {
-                    const amount = Number(payment.getAmount) || 0;
-                    const timestamp =
-                        Number(payment.getTimestamp) || Date.now() / 1000;
-                    const paymentHash = payment.paymentHash || '';
-                    const invoice = payment.getPaymentRequest || '';
-                    const feesPaid = satsToMillisats(
-                        Number(payment.getFee) || 0
-                    );
-                    const description = payment.getMemo || '';
-                    const preimage = payment.getPreimage || '';
-
-                    // Determine state based on payment status
-                    let state: 'settled' | 'pending' | 'failed' = 'pending';
-                    if (payment.isFailed) {
-                        state = 'failed';
-                    } else if (!payment.isIncomplete) {
-                        state = 'settled';
-                    }
-
-                    return NostrConnectUtils.createNip47Transaction({
-                        type: 'outgoing',
-                        state,
-                        invoice,
-                        payment_hash: paymentHash,
-                        amount: satsToMillisats(amount),
-                        description,
-                        preimage,
-                        fees_paid: feesPaid,
-                        settled_at: state === 'settled' ? timestamp : 0,
-                        created_at: timestamp,
-                        expires_at: 0
-                    });
-                }
+            transactions.push(
+                ...lightningData.payments.map(
+                    NostrConnectUtils.lightningPaymentToNip47Transaction
+                )
             );
-            transactions.push(...paymentTransactions);
         }
 
         // Convert Lightning invoices
         if (lightningData.invoices) {
-            const invoiceTransactions = lightningData.invoices.map(
-                (invoice: Invoice) => {
-                    const amount = Number(invoice.getAmount) || 0;
-                    const timestamp =
-                        Number(invoice.getTimestamp) || Date.now() / 1000;
-                    // LND returns r_hash, Core Lightning payment_hash
-                    const paymentHash = invoice.getRHash || '';
-                    const invoiceString = invoice.getPaymentRequest || '';
-                    const description = invoice.getMemo || '';
-                    const expiresAt = Number(invoice.expires_at) || 0;
-
-                    let state: 'settled' | 'pending' | 'failed' = 'pending';
-                    if (invoice.isPaid) {
-                        state = 'settled';
-                    }
-
-                    return NostrConnectUtils.createNip47Transaction({
-                        type: 'incoming',
-                        state,
-                        invoice: invoiceString,
-                        payment_hash: paymentHash,
-                        amount: satsToMillisats(amount),
-                        description,
-                        fees_paid: 0,
-                        settled_at: state === 'settled' ? timestamp : 0,
-                        created_at: timestamp,
-                        expires_at: expiresAt
-                    });
-                }
+            transactions.push(
+                ...lightningData.invoices.map((invoice) =>
+                    NostrConnectUtils.lightningInvoiceToNip47Transaction(
+                        invoice
+                    )
+                )
             );
-            transactions.push(...invoiceTransactions);
         }
 
         return transactions;

--- a/views/Invoice.tsx
+++ b/views/Invoice.tsx
@@ -386,7 +386,7 @@ export default class InvoiceView extends React.Component<
                             />
                         )}
 
-                        {!!formattedTimeUntilExpiry && (
+                        {!!formattedTimeUntilExpiry && !isPaid && (
                             <KeyValue
                                 keyValue={localeString(
                                     'views.Invoice.expiration'

--- a/views/Settings/NostrWalletConnect/NWCConnectionActivity.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionActivity.tsx
@@ -471,7 +471,7 @@ export default class NWCConnectionActivity extends React.Component<
                         </View>
                     )}
 
-                    {showExpiry && (
+                    {showExpiry && item.invoice?.formattedTimeUntilExpiry && (
                         <View style={styles.row}>
                             <ListItem.Subtitle
                                 style={[

--- a/views/Settings/NostrWalletConnect/NWCConnectionActivity.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionActivity.tsx
@@ -352,19 +352,26 @@ export default class NWCConnectionActivity extends React.Component<
         }
     };
 
-    navigateToInvoiceDetails = (item: ConnectionActivity) => {
-        const { navigation } = this.props;
+    navigateToInvoiceDetails = async (item: ConnectionActivity) => {
+        const { navigation, NostrWalletConnectStore } = this.props;
+        if (!item.invoice) return;
 
         try {
-            if (!item.invoice) return;
+            const invoice =
+                await NostrWalletConnectStore.refreshActivityInvoiceForNavigation(
+                    item
+                );
+            if (!invoice) return;
 
-            if (
+            const screen =
                 item.payment_source === 'cashu' &&
-                item.invoice instanceof CashuInvoice
-            ) {
-                navigation.navigate('CashuInvoice', { invoice: item.invoice });
-            } else if (item.invoice instanceof Invoice) {
-                navigation.navigate('Invoice', { invoice: item.invoice });
+                invoice instanceof CashuInvoice
+                    ? 'CashuInvoice'
+                    : invoice instanceof Invoice
+                    ? 'Invoice'
+                    : undefined;
+            if (screen) {
+                navigation.navigate(screen, { invoice });
             }
         } catch (e) {
             console.error('Navigation to invoice failed:', e);
@@ -380,7 +387,7 @@ export default class NWCConnectionActivity extends React.Component<
         if (item.type === 'pay_invoice') {
             this.navigateToPaymentDetails(item);
         } else if (item.type === 'make_invoice') {
-            this.navigateToInvoiceDetails(item);
+            void this.navigateToInvoiceDetails(item);
         }
     };
 


### PR DESCRIPTION
## Summary

This PR fixes several issues in the Nostr Wallet Connect (NIP-47) implementation around invoice/payment lookup and transaction reporting.

Previously, NWC clients such as **Amethyst**, **Primal**, and others could receive incorrect transaction data or fail to find outgoing payments after sending or receiving Lightning payments. This PR ensures `lookup_invoice` and `list_transactions` return consistent and accurate `type`, `state`, `preimage`, payment hash, and expiry information across supported backends.

## Fixes

- Fix `lookup_invoice` failing to resolve outgoing Lightning and Cashu payments.
- Fix incorrect NIP-47 transaction mapping (`expires_at`, `payment_hash`, `preimage`, etc.).
- Fix `list_transactions` default `unpaid` filtering to match the NIP-47 specification.
- Fix pending `pay_invoice` activities remaining in a `pending` state until the NWC activity screen was opened.
- Add missing or incomplete `lookupInvoice` implementations across supported backends.
- Improve transaction lookup reliability by normalizing payment hashes and refreshing payment state when needed.

## Changes

### NIP-47 (`utils/NostrConnectUtils.ts`)

- Centralize invoice/payment lookup into `lookupInvoiceTransaction()`.
- Add shared transaction mappers for:
  - Lightning invoices
  - Lightning payments
  - Cashu payments
- Correctly calculate `expires_at` using `created_at + expiry`.
- Normalize payment hashes (hex ↔ base64) before matching.
- Update `lookup_invoice` to fall back to outgoing payment lookup when no invoice is found.
- Support Cashu outgoing payment lookup by payment hash or BOLT11 invoice.
- Fix `list_transactions` filtering so:
  - Default returns settled transactions only.
  - `unpaid: true` includes pending and failed transactions.

### NWC Store (`stores/NostrWalletConnectStore.ts`)

- Add lazy `getPaymentsForLookup()` with a fresh node fetch and a 5-second cache.
- Reconcile pending `pay_invoice` activities when:
  - Opening the activity screen.
  - Calling `list_transactions`.
  - The app returns to the foreground.
  - The relay reconnects.
- Persist reconciliation results and invalidate the lookup cache after payments.
- Refresh settled Lightning and Cashu invoices before opening transaction details.

### Backend Improvements

### CLNRest
- Implement `lookupInvoice` using `/v1/listinvoices` (including unpaid invoices).
### LndHub
- Implement `lookupInvoice` using `/getuserinvoices` with payment hash lookup.
### LDK Node
- Restrict `lookupInvoice` to inbound invoices only, preventing outgoing payments from being incorrectly returned as invoices.

### UI

- Hide invoice expiry after an invoice has been paid.
- Only display invoice expiry in NWC activity when a valid expiry exists.
- Remove the duplicate `TextEncoder` polyfill from the NWC store.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

Expanded `utils/NostrConnectUtils.test.ts` to nearly **100 tests**, covering:

- NIP-47 transaction mapping.
- Payment hash normalization.
- Lightning and Cashu lookup paths.
- `list_transactions` unpaid filtering.
- Backend compatibility and regression cases.


I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [x] LndHub / LNbits

---

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] N/A — no new strings

### Third Party Dependencies and Packages
- [ ] Contributors will need to run `yarn` after this PR is merged in
- [x] N/A — no dependency changes

### Other
- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding