### PR TITLE
views: WalletConfiguration: lock interface for initialized LDK Node

### DIFF
--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -2935,6 +2935,22 @@ export default class WalletConfiguration extends React.Component<
                             </View>
                         )}
 
+                        {((implementation === 'embedded-lnd' &&
+                            adminMacaroon) ||
+                            (implementation === 'ldk-node' &&
+                                ldkNodeInitialized)) && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.Settings.WalletConfiguration.walletInterface'
+                                )}
+                                value={
+                                    INTERFACE_KEYS.find(
+                                        (k) => k.value === implementation
+                                    )?.key
+                                }
+                            />
+                        )}
+
                         {implementation === 'embedded-lnd' && adminMacaroon && (
                             <KeyValue
                                 keyValue={localeString('general.network')}

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -1678,7 +1678,9 @@ export default class WalletConfiguration extends React.Component<
                                 </View>
                             </View>
 
-                            {!adminMacaroon && <WalletInterface />}
+                            {!adminMacaroon && !ldkNodeInitialized && (
+                                <WalletInterface />
+                            )}
 
                             {!adminMacaroon &&
                                 implementation === 'embedded-lnd' && (
@@ -2954,6 +2956,20 @@ export default class WalletConfiguration extends React.Component<
                                 }
                             />
                         )}
+
+                        {implementation === 'ldk-node' &&
+                            ldkNodeInitialized && (
+                                <KeyValue
+                                    keyValue={localeString('general.network')}
+                                    value={localeString(
+                                        EMBEDDED_NODE_NETWORK_KEYS.find(
+                                            (k) =>
+                                                k.value ===
+                                                (ldkNetwork || 'mainnet')
+                                        )?.translateKey || 'network.mainnet'
+                                    )}
+                                />
+                            )}
 
                         {implementation === 'embedded-lnd' &&
                             recoveryCipherSeed && (


### PR DESCRIPTION
# Description

WalletConfiguration prevents Embedded LND wallets from having their implementation selection changed once the wallet has been created (gated on `adminMacaroon`). LDK Node wallets had no such guard: an initialized LDK Node wallet still showed the wallet interface dropdown, allowing the implementation to be switched out from under an existing wallet.

This PR:

- Hides the wallet interface dropdown when `ldkNodeInitialized` is set (derived from the presence of `ldkMnemonic`), matching the Embedded LND behavior
- Adds a read-only Network label for initialized LDK Node wallets, mirroring the Network/Database labels shown for initialized Embedded LND wallets. The value is rendered via `localeString` on the `EMBEDDED_NODE_NETWORK_KEYS` translate keys, so it displays capitalized and localized (e.g. "Mainnet"), consistent with the network dropdown
- Adds the Wallet interface label above the Network label

|Before|After|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-30 at 22 10 58" src="https://github.com/user-attachments/assets/2edba368-f525-4529-b333-414bbe604e97" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-30 at 22 14 45" src="https://github.com/user-attachments/assets/9121934b-58b5-4c81-9fa6-4ba582a015ca" />|

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
