### PR TITLE
fix(CLN/LND): poll lookupInvoice in the Receive payment watcher

### DIFF
--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -1038,33 +1038,33 @@ export default class Receive extends React.Component<
         if (implementation === 'lnd') {
             if (rHash) {
                 this.lnInterval = setInterval(() => {
-                    // only fetch the last 10 invoices
-                    BackendUtils.getInvoices({ limit: 10 }).then(
-                        (response: any) => {
-                            const invoices = response.invoices;
-                            for (let i = 0; i < invoices.length; i++) {
-                                const result = invoices[i];
-                                if (
-                                    result.r_hash
-                                        .replace(/\+/g, '-')
-                                        .replace(/\//g, '_') === rHash &&
-                                    Number(result.amt_paid_sat) >=
-                                        Number(value) &&
-                                    Number(result.amt_paid_sat) !== 0
-                                ) {
-                                    this.handlePaymentReceived(
-                                        result.amt_paid_sat,
-                                        {
-                                            type: 'ln',
-                                            tx: result.payment_request
-                                        }
-                                    );
-                                    this.clearIntervals();
-                                    break;
-                                }
+                    // Look the invoice up directly by payment hash instead of
+                    // scanning the last 10 invoices: on busy nodes the watched
+                    // invoice can be pushed out of that window before it is
+                    // paid. LND's REST lookup endpoint expects a hex hash,
+                    // while rHash is base64url here
+                    BackendUtils.lookupInvoice({
+                        r_hash: Base64Utils.base64UrlToHex(rHash)
+                    })
+                        .then((result: any) => {
+                            const invoice = new Invoice(result);
+                            const amountPaid = invoice.getAmount;
+                            if (
+                                invoice.isPaid &&
+                                Number(amountPaid) >= Number(value) &&
+                                Number(amountPaid) !== 0
+                            ) {
+                                this.handlePaymentReceived(amountPaid, {
+                                    type: 'ln',
+                                    tx: invoice.getPaymentRequest
+                                });
+                                this.clearIntervals();
                             }
-                        }
-                    );
+                        })
+                        .catch(() => {
+                            // invoice not found or node unreachable;
+                            // retry on the next tick
+                        });
                 }, 5000);
             }
 

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -1124,34 +1124,30 @@ export default class Receive extends React.Component<
         if (implementation === 'cln-rest') {
             if (rHash) {
                 this.lnInterval = setInterval(() => {
-                    // only fetch the last 10 invoices
-                    BackendUtils.getInvoices({ limit: 10 }).then(
-                        (response: any) => {
-                            const invoices = response.invoices;
-                            for (let i = 0; i < invoices.length; i++) {
-                                const result = invoices[i];
-                                if (
-                                    result.payment_hash
-                                        .replace(/\+/g, '-')
-                                        .replace(/\//g, '_') === rHash &&
-                                    Number(
-                                        result.amount_received_msat / 1000
-                                    ) >= Number(value) &&
-                                    Number(result.amount_received_msat) !== 0
-                                ) {
-                                    this.handlePaymentReceived(
-                                        result.amount_received_msat / 1000,
-                                        {
-                                            type: 'ln',
-                                            tx: result.bolt11
-                                        }
-                                    );
-                                    this.clearIntervals();
-                                    break;
-                                }
+                    // Look the invoice up directly by payment hash instead of
+                    // scanning the last 10 invoices: getInvoices now includes
+                    // unpaid invoices, so on busy nodes the watched invoice
+                    // can be pushed out of that window before it is paid
+                    BackendUtils.lookupInvoice({ r_hash: rHash })
+                        .then((result: any) => {
+                            const invoice = new Invoice(result);
+                            const amountPaid = invoice.getAmount;
+                            if (
+                                invoice.isPaid &&
+                                Number(amountPaid) >= Number(value) &&
+                                Number(amountPaid) !== 0
+                            ) {
+                                this.handlePaymentReceived(amountPaid, {
+                                    type: 'ln',
+                                    tx: invoice.getPaymentRequest
+                                });
+                                this.clearIntervals();
                             }
-                        }
-                    );
+                        })
+                        .catch(() => {
+                            // invoice not found or node unreachable —
+                            // retry on the next tick
+                        });
                 }, 5000);
             }
         }


### PR DESCRIPTION
# Description

Fixes a regression introduced by #4291 (v13.1.4 milestone), plus a latent version of the same bug on LND (REST) flagged in review by @ajaysehwal.

The receive watcher in `views/Receive.tsx` polls `getInvoices({ limit: 10 })` every 5s and scans the list for the watched payment hash.

- **CLN**: before #4291, the CLN SQL query filtered `WHERE status = 'paid'`, so the window held the last 10 *paid* invoices and the watched invoice appeared at the top the moment it was paid. After #4291, the window holds the last 10 invoices of **any** status.
- **LND (REST)**: `/v1/invoices` has never filtered by paid status, so the same window problem has existed there all along.

On a busy node (POS, ZEUS Pay), if 10 or more invoices are created after the watched one before the payer pays, the watched invoice is pushed out of the result set. Every poll then returns the same 10 newer rows, the hash never matches, and `handlePaymentReceived` never fires; the success screen never shows even though the payment arrived. (The payment is still recorded correctly in Activity; only the real-time detection is missed.)

## Fix

Poll `lookupInvoice` instead, which filters natively by payment hash and includes unpaid invoices, eliminating the list window entirely rather than widening the limit.

- **CLN**: uses `CLNRest.lookupInvoice` (added in #4294), backed by `/v1/listinvoices`.
- **LND**: uses `/v1/invoice/{r_hash_str}`, which expects a hex payment hash; the watcher's `rHash` is base64url (from `getFormattedRhash`), so it is converted with `Base64Utils.base64UrlToHex`.
- Amount comparison goes through the `Invoice` model (`isPaid` / `getAmount`), which correctly handles both CLN's msat-suffixed amount strings and LND's `amt_paid_sat`.
- Lookup rejections (invoice not found, node unreachable) are swallowed so the next tick retries; the old code had no rejection handler at all.
- Match semantics (`amountPaid >= value`, `amountPaid !== 0`) and the `handlePaymentReceived` payload are unchanged.
- Embedded LND and Lightning Node Connect use invoice subscription streams and are unaffected.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
