### PR TITLE
fix: guard against payment double-submission in send path

### DIFF
--- a/components/SwipeButton.tsx
+++ b/components/SwipeButton.tsx
@@ -20,6 +20,7 @@ interface SwipeButtonProps {
     instructionText?: string;
     instructionsStyle?: object;
     containerStyle?: object;
+    disabled?: boolean;
 }
 
 const SwipeButton: React.FC<SwipeButtonProps> = ({
@@ -27,9 +28,14 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
     swipeButtonStyle,
     instructionText = '',
     instructionsStyle,
-    containerStyle
+    containerStyle,
+    disabled = false
 }) => {
     const pan = useRef(new Animated.Value(0)).current;
+    // The PanResponder is created once, so read `disabled` through a ref to
+    // always see its latest value (e.g. once a payment goes in flight).
+    const disabledRef = useRef(disabled);
+    disabledRef.current = disabled;
     const screenWidth = Dimensions.get('window').width;
 
     const containerWidth = screenWidth - 40;
@@ -67,8 +73,10 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
 
     const panResponder = useRef(
         PanResponder.create({
-            onStartShouldSetPanResponder: () => !completed.current,
-            onMoveShouldSetPanResponder: () => !completed.current,
+            onStartShouldSetPanResponder: () =>
+                !completed.current && !disabledRef.current,
+            onMoveShouldSetPanResponder: () =>
+                !completed.current && !disabledRef.current,
             onPanResponderGrant: () => {
                 pan.setValue(0);
             },
@@ -82,7 +90,10 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
                 _e: GestureResponderEvent,
                 gesture: PanResponderGestureState
             ) => {
-                if (gesture.dx > maxTranslation * 0.95) {
+                if (
+                    gesture.dx > maxTranslation * 0.95 &&
+                    !disabledRef.current
+                ) {
                     // lock the button in the completed position before
                     // kicking off any work, so it can't be dragged again or
                     // left hanging mid-track while navigation is pending
@@ -100,7 +111,13 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
     ).current;
 
     return (
-        <View style={[styles.container, containerStyle]}>
+        <View
+            style={[
+                styles.container,
+                containerStyle,
+                disabled && styles.disabled
+            ]}
+        >
             <Animated.View
                 style={[
                     styles.instructionsContainer,
@@ -159,6 +176,9 @@ const styles = StyleSheet.create({
     },
     textStyle: {
         fontSize: 18
+    },
+    disabled: {
+        opacity: 0.5
     }
 });
 

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1930,7 +1930,10 @@ export default class NostrWalletConnectStore {
         this.transactionsStore.sendPayment({
             payment_request: request.invoice,
             fee_limit_sat: PAYMENT_FEE_LIMIT_SATS.toString(),
-            timeout_seconds: PAYMENT_TIMEOUT_SECONDS.toString()
+            timeout_seconds: PAYMENT_TIMEOUT_SECONDS.toString(),
+            // service-initiated: don't set or clear the user-facing
+            // double-submission guard (paymentInFlight)
+            background: true
         });
         await this.waitForPaymentCompletion();
 

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -569,6 +569,15 @@ export default class TransactionsStore {
         amp,
         timeout_seconds
     }: SendPaymentReq) => {
+        // Guard against double-submission: if a payment is already in flight,
+        // ignore the new request. Without this a rapid double-tap (or a
+        // re-fired swipe) dispatches two payments, and keysend in particular
+        // generates a fresh preimage per call, defeating every backend's
+        // same-hash duplicate protection.
+        if (this.loading) {
+            return;
+        }
+
         this.paymentStartTime = Date.now();
         this.paymentDuration = null;
         this.loading = true;

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -43,6 +43,10 @@ export interface SendPaymentReq {
     message?: string;
     amp?: boolean;
     timeout_seconds?: string;
+    // service-initiated payments (e.g. the NWC service path) neither set nor
+    // clear paymentInFlight, so the double-submission guard stays scoped to
+    // user-initiated sends
+    background?: boolean;
 }
 
 export default class TransactionsStore {
@@ -79,9 +83,14 @@ export default class TransactionsStore {
     // coin control
     @observable funded_psbt: string = '';
 
-    // identifies the payment the in-flight backstop timer was armed for,
-    // so it never clears the flag on behalf of a later payment
+    // monotonic id assigned to each dispatched payment
     private paymentSequence = 0;
+    // sequence of the payment that set paymentInFlight (null when none);
+    // completion callbacks and the backstop timer only clear the flag on
+    // behalf of that payment, so overlapping payments (e.g. a background
+    // NWC payment finishing while a user payment is still in flight)
+    // can't disarm each other's guard
+    private inFlightOwnerSeq: number | null = null;
 
     settingsStore: SettingsStore;
     nodeInfoStore: NodeInfoStore;
@@ -107,6 +116,7 @@ export default class TransactionsStore {
     public reset = () => {
         this.loading = false;
         this.paymentInFlight = false;
+        this.inFlightOwnerSeq = null;
         this.error = false;
         this.error_msg = null;
         this.transactions = [];
@@ -576,18 +586,25 @@ export default class TransactionsStore {
         last_hop_pubkey,
         message,
         amp,
-        timeout_seconds
+        timeout_seconds,
+        background
     }: SendPaymentReq) => {
         // Guard against double-submission: if a payment is already in flight,
         // ignore the new request. Without this a rapid double-tap (or a
         // re-fired swipe) dispatches two payments, and keysend in particular
         // generates a fresh preimage per call, defeating every backend's
-        // same-hash duplicate protection.
-        if (this.paymentInFlight) {
+        // same-hash duplicate protection. Background (service-initiated)
+        // payments bypass the guard and never own the flag: their concurrency
+        // control lives in the service (e.g. the NWC payment queue).
+        if (this.paymentInFlight && !background) {
             return;
         }
 
-        this.paymentInFlight = true;
+        const seq = ++this.paymentSequence;
+        if (!background) {
+            this.paymentInFlight = true;
+            this.inFlightOwnerSeq = seq;
+        }
         this.paymentStartTime = Date.now();
         this.paymentDuration = null;
         this.loading = true;
@@ -679,15 +696,10 @@ export default class TransactionsStore {
         // that gets no timeout_seconds), the flag would otherwise stay set
         // and block all sends until the next reconnect. Clear it once the
         // payment's timeout plus a grace period has elapsed.
-        const seq = ++this.paymentSequence;
-        const backstopMs = ((data.timeout_seconds ?? 300) + 60) * 1000;
-        setTimeout(() => {
-            if (this.paymentInFlight && this.paymentSequence === seq) {
-                runInAction(() => {
-                    this.paymentInFlight = false;
-                });
-            }
-        }, backstopMs);
+        if (!background) {
+            const backstopMs = ((data.timeout_seconds ?? 300) + 60) * 1000;
+            setTimeout(() => this.clearPaymentInFlight(seq), backstopMs);
+        }
 
         const payFunc =
             (this.settingsStore.implementation === 'cln-rest' ||
@@ -703,12 +715,22 @@ export default class TransactionsStore {
             payFunc(data)
                 .then((response: any) => {
                     const result = response.result || response;
-                    this.handlePayment(result);
+                    this.handlePayment(result, seq);
                 })
                 .catch((err: Error) => {
-                    this.handlePaymentError(err);
+                    this.handlePaymentError(err, seq);
                 });
         }
+    };
+
+    // Clears the in-flight guard on behalf of payment `seq`. Callers that
+    // can't identify their payment (LNC view subscriptions) omit `seq` and
+    // clear unconditionally, matching the pre-ownership behavior.
+    @action
+    private clearPaymentInFlight = (seq?: number) => {
+        if (seq !== undefined && this.inFlightOwnerSeq !== seq) return;
+        this.paymentInFlight = false;
+        this.inFlightOwnerSeq = null;
     };
 
     public sendPaymentSilently = async ({
@@ -764,9 +786,9 @@ export default class TransactionsStore {
     };
 
     @action
-    public handlePayment = (result: any) => {
+    public handlePayment = (result: any, seq?: number) => {
         this.loading = false;
-        this.paymentInFlight = false;
+        this.clearPaymentInFlight(seq);
         this.payment_route = result.payment_route;
 
         const payment = new Payment(result);
@@ -837,10 +859,10 @@ export default class TransactionsStore {
     };
 
     @action
-    public handlePaymentError = (err: Error) => {
+    public handlePaymentError = (err: Error, seq?: number) => {
         this.error = true;
         this.loading = false;
-        this.paymentInFlight = false;
+        this.clearPaymentInFlight(seq);
         this.error_msg =
             errorToUserFriendly(err) || localeString('error.sendingPayment');
     };

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -47,6 +47,10 @@ export interface SendPaymentReq {
 
 export default class TransactionsStore {
     @observable loading = false;
+    // true only while a Lightning payment dispatched via sendPaymentInternal
+    // is in flight; `loading` is shared with other operations (getTransactions,
+    // sendCoins, broadcast) so it can't serve as the double-submission guard
+    @observable paymentInFlight = false;
     @observable crafting = false;
     @observable error = false;
     @observable error_msg: string | null;
@@ -98,6 +102,7 @@ export default class TransactionsStore {
     @action
     public reset = () => {
         this.loading = false;
+        this.paymentInFlight = false;
         this.error = false;
         this.error_msg = null;
         this.transactions = [];
@@ -574,10 +579,11 @@ export default class TransactionsStore {
         // re-fired swipe) dispatches two payments, and keysend in particular
         // generates a fresh preimage per call, defeating every backend's
         // same-hash duplicate protection.
-        if (this.loading) {
+        if (this.paymentInFlight) {
             return;
         }
 
+        this.paymentInFlight = true;
         this.paymentStartTime = Date.now();
         this.paymentDuration = null;
         this.loading = true;
@@ -741,6 +747,7 @@ export default class TransactionsStore {
     @action
     public handlePayment = (result: any) => {
         this.loading = false;
+        this.paymentInFlight = false;
         this.payment_route = result.payment_route;
 
         const payment = new Payment(result);
@@ -814,6 +821,7 @@ export default class TransactionsStore {
     public handlePaymentError = (err: Error) => {
         this.error = true;
         this.loading = false;
+        this.paymentInFlight = false;
         this.error_msg =
             errorToUserFriendly(err) || localeString('error.sendingPayment');
     };

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -79,6 +79,10 @@ export default class TransactionsStore {
     // coin control
     @observable funded_psbt: string = '';
 
+    // identifies the payment the in-flight backstop timer was armed for,
+    // so it never clears the flag on behalf of a later payment
+    private paymentSequence = 0;
+
     settingsStore: SettingsStore;
     nodeInfoStore: NodeInfoStore;
     channelsStore: ChannelsStore;
@@ -669,6 +673,21 @@ export default class TransactionsStore {
         ) {
             data.timeout_seconds = Number(timeout_seconds) || 60;
         }
+
+        // Backstop for the in-flight guard: if the completion callback is
+        // lost (e.g. a dropped LNC stream, or a hung request on a backend
+        // that gets no timeout_seconds), the flag would otherwise stay set
+        // and block all sends until the next reconnect. Clear it once the
+        // payment's timeout plus a grace period has elapsed.
+        const seq = ++this.paymentSequence;
+        const backstopMs = ((data.timeout_seconds ?? 300) + 60) * 1000;
+        setTimeout(() => {
+            if (this.paymentInFlight && this.paymentSequence === seq) {
+                runInAction(() => {
+                    this.paymentInFlight = false;
+                });
+            }
+        }, backstopMs);
 
         const payFunc =
             (this.settingsStore.implementation === 'cln-rest' ||

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -416,7 +416,17 @@ export default class PaymentRequest extends React.Component<
     };
 
     triggerPayment = () => {
-        const { InvoicesStore, LnurlPayStore, SettingsStore } = this.props;
+        const {
+            InvoicesStore,
+            LnurlPayStore,
+            SettingsStore,
+            TransactionsStore
+        } = this.props;
+
+        // Guard against double-submission: bail if a payment is already in
+        // flight so a rapid double-tap or re-fired swipe can't dispatch twice.
+        if (TransactionsStore.loading) return;
+
         const {
             enableMultiPathPayment,
             maxParts,
@@ -480,6 +490,7 @@ export default class PaymentRequest extends React.Component<
             LnurlPayStore,
             SettingsStore,
             NodeInfoStore,
+            TransactionsStore,
             navigation
         } = this.props;
         const {
@@ -1587,6 +1598,7 @@ export default class PaymentRequest extends React.Component<
                                 <SwipeButton
                                     key={this.state.swipeButtonKey}
                                     onSwipeSuccess={this.triggerPayment}
+                                    disabled={TransactionsStore.loading}
                                     instructionText={localeString(
                                         'views.PaymentRequest.slideToPay'
                                     )}
@@ -1613,7 +1625,10 @@ export default class PaymentRequest extends React.Component<
                                                 : undefined
                                         }
                                         onPress={this.triggerPayment}
-                                        disabled={!lightningReadyToSend}
+                                        disabled={
+                                            !lightningReadyToSend ||
+                                            TransactionsStore.loading
+                                        }
                                     />
                                 </View>
                             )}

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -425,7 +425,7 @@ export default class PaymentRequest extends React.Component<
 
         // Guard against double-submission: bail if a payment is already in
         // flight so a rapid double-tap or re-fired swipe can't dispatch twice.
-        if (TransactionsStore.loading) return;
+        if (TransactionsStore.paymentInFlight) return;
 
         const {
             enableMultiPathPayment,
@@ -1598,7 +1598,7 @@ export default class PaymentRequest extends React.Component<
                                 <SwipeButton
                                     key={this.state.swipeButtonKey}
                                     onSwipeSuccess={this.triggerPayment}
-                                    disabled={TransactionsStore.loading}
+                                    disabled={TransactionsStore.paymentInFlight}
                                     instructionText={localeString(
                                         'views.PaymentRequest.slideToPay'
                                     )}
@@ -1627,7 +1627,7 @@ export default class PaymentRequest extends React.Component<
                                         onPress={this.triggerPayment}
                                         disabled={
                                             !lightningReadyToSend ||
-                                            TransactionsStore.loading
+                                            TransactionsStore.paymentInFlight
                                         }
                                     />
                                 </View>

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -558,6 +558,10 @@ export default class Send extends React.Component<SendProps, SendState> {
             maxFeePercent
         } = this.state;
 
+        // Guard against double-submission: bail if a payment is already in
+        // flight so a rapid double-tap can't dispatch a second keysend.
+        if (TransactionsStore.loading) return;
+
         let streamingCall;
         if (enableAtomicMultiPathPayment) {
             streamingCall = TransactionsStore.sendPayment({
@@ -704,6 +708,7 @@ export default class Send extends React.Component<SendProps, SendState> {
             UTXOsStore,
             ContactStore,
             NodeInfoStore,
+            TransactionsStore,
             navigation
         } = this.props;
         const {
@@ -758,6 +763,7 @@ export default class Send extends React.Component<SendProps, SendState> {
             (contact: Contact) => contact.isFavourite
         );
         const isSendDisabled: boolean =
+            TransactionsStore.loading ||
             lightningBalance === 0 ||
             !satAmount ||
             satAmount === '0' ||

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -560,7 +560,7 @@ export default class Send extends React.Component<SendProps, SendState> {
 
         // Guard against double-submission: bail if a payment is already in
         // flight so a rapid double-tap can't dispatch a second keysend.
-        if (TransactionsStore.loading) return;
+        if (TransactionsStore.paymentInFlight) return;
 
         let streamingCall;
         if (enableAtomicMultiPathPayment) {
@@ -763,7 +763,7 @@ export default class Send extends React.Component<SendProps, SendState> {
             (contact: Contact) => contact.isFavourite
         );
         const isSendDisabled: boolean =
-            TransactionsStore.loading ||
+            TransactionsStore.paymentInFlight ||
             lightningBalance === 0 ||
             !satAmount ||
             satAmount === '0' ||


### PR DESCRIPTION
# Description

Adds an in-flight guard to the Lightning send path so a rapid double-tap (or a re-fired slide-to-pay) cannot dispatch a payment twice.

The keysend path is the most dangerous case: `TransactionsStore.sendPaymentInternal` generates a fresh random preimage on every invocation, so each duplicate submission has a different payment hash. That defeats every backend's same-hash duplicate protection (LND control tower, LDK `DuplicatePayment`, the REST `calls` dedup map), meaning a double-tap on a keysend can actually send the amount twice. Invoice payments were mostly saved by node-side same-hash dedup, but keysend had no protection on any backend, and neither the Send/Pay buttons nor the send path itself had any "payment in flight" condition.

## What changed

- `stores/TransactionsStore.ts`: a new dedicated `paymentInFlight` observable is set when `sendPaymentInternal` dispatches a payment, and `sendPaymentInternal` early-returns when it is already set. This is the authoritative choke point shared by every backend, so the guard holds regardless of which view initiates the payment. A dedicated flag is used instead of the pre-existing `loading` observable because `loading` is shared with unrelated operations (`getTransactions`, `sendCoins`, `broadcast`) that can run in the background (Activity refreshes, NWC `list_transactions`) and would otherwise disable the send buttons or silently drop a legitimate payment attempt.
- `views/Send.tsx` (`sendKeySendPayment`) and `views/PaymentRequest.tsx` (`triggerPayment`): bail when a payment is already in flight, which also prevents double navigation and a stale Lightning Node Connect event subscription.
- `views/Send.tsx` and `views/PaymentRequest.tsx`: disable their send buttons while `TransactionsStore.paymentInFlight`.
- `components/SwipeButton.tsx`: adds an optional `disabled` prop (read through a ref since the `PanResponder` is created once) so the slide-to-pay control is inert and dimmed while a payment is in flight. This composes with the existing `completed`-ref lock, which already prevents a second swipe after one succeeds.

`paymentInFlight` is cleared by `handlePayment`, `handlePaymentError`, and `reset()` (which runs when the wallet reconnects, not on every Wallet mount). Because a lost completion callback (for example a dropped Lightning Node Connect stream, or a hung request on a backend that gets no `timeout_seconds`) would otherwise leave the flag stuck and lock out all sends until the next reconnect, `sendPaymentInternal` also arms a timed backstop that clears the flag once the payment's timeout plus a grace period has elapsed. A sequence counter ensures the backstop only clears the payment it was armed for.

Note: the NWC service path calls `reset()` immediately before dispatching, so it intentionally bypasses the guard; the guard protects user-initiated UI sends.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] Embedded LND
- [ ] LDK Node

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS Transifex page and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified
