### PR TITLE
fix(nwc): serialize pay_invoice handling to prevent shared-store races

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1758,6 +1758,7 @@
     "stores.NostrWalletConnectStore.error.failedToStartService": "Failed to start service",
     "stores.NostrWalletConnectStore.error.connectionNameExists": "Connection name already exists",
     "stores.NostrWalletConnectStore.error.connectionNotFound": "Connection not found",
+    "stores.NostrWalletConnectStore.error.paymentQueueWaitExceeded": "Another payment was in progress and this request waited too long; it was not executed. Please try again.",
     "stores.NostrWalletConnectStore.error.failedToConnectRelay": "Failed to Connect {{relayUrl}}",
     "stores.NostrWalletConnectStore.error.failedToLoadConnections": "Failed to load connections",
     "stores.NostrWalletConnectStore.error.failedToSaveConnections": "Failed to save connections",

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -81,6 +81,13 @@ const SERVICE_START_DELAY_MS = 2000;
 const PAYMENT_TIMEOUT_SECONDS = 120;
 const PAYMENT_FEE_LIMIT_SATS = 1000;
 const PAYMENT_PROCESSING_DELAY_MS = 100;
+/**
+ * Max time a queued pay_invoice may wait behind another payment before it
+ * is rejected with RATE_LIMITED instead of executing late. Kept well under
+ * typical NWC client timeouts so we never pay an invoice whose client has
+ * already given up on the request.
+ */
+const MAX_PAYMENT_QUEUE_WAIT_MS = 30_000;
 const SAVE_CONNECTIONS_DEBOUNCE_MS = 500;
 /** Min time a pay_invoice must stay pending before getActivities polls the node */
 const PENDING_PAYMENT_STATUS_MIN_AGE_MS = 5_000;
@@ -1293,7 +1300,16 @@ export default class NostrWalletConnectStore {
                     : this.handleLightningPayInvoice.bind(this, connection);
                 handler.payInvoice = (request: Nip47PayInvoiceRequest) =>
                     this.withGlobalHandler(connection.id, () =>
-                        this.enqueuePayment(() => payHandler(request))
+                        this.enqueuePayment(
+                            () => payHandler(request),
+                            () =>
+                                NostrConnectUtils.createNip47Error(
+                                    localeString(
+                                        'stores.NostrWalletConnectStore.error.paymentQueueWaitExceeded'
+                                    ),
+                                    Nip47ErrorCode.RATE_LIMITED
+                                )
+                        )
                     );
             }
 
@@ -1499,8 +1515,20 @@ export default class NostrWalletConnectStore {
     // pay_invoice requests would clobber each other's state: one flow
     // can melt the other's quote, validate budget against the wrong
     // amount, or report the other payment's result/preimage.
-    private enqueuePayment<T>(task: () => Promise<T>): Promise<T> {
-        const result = this.paymentQueue.then(task);
+    // A request that waited past MAX_PAYMENT_QUEUE_WAIT_MS is not executed:
+    // its client has likely timed out already, and paying late would spend
+    // sats against a request the client reported as failed. `onStale`
+    // supplies the response for that case (RATE_LIMITED).
+    private enqueuePayment<T>(
+        task: () => Promise<T>,
+        onStale: () => T
+    ): Promise<T> {
+        const enqueuedAt = Date.now();
+        const result = this.paymentQueue.then(() =>
+            Date.now() - enqueuedAt > MAX_PAYMENT_QUEUE_WAIT_MS
+                ? onStale()
+                : task()
+        );
         this.paymentQueue = result.then(
             () => undefined,
             () => undefined

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -145,6 +145,8 @@ export default class NostrWalletConnectStore {
     @observable public iosAudioKeepAliveActive: boolean = false;
     @observable public iosAudioKeepAliveUptime: number = 0;
     @observable public iosAudioKeepAliveDisconnects: number = 0;
+    // Tail of the payment-handler queue; see enqueuePayment
+    private paymentQueue: Promise<unknown> = Promise.resolve();
     private iosAudioUptimeInterval: ReturnType<typeof setInterval> | null =
         null;
     private iosAudioInterruptedUnsub: (() => void) | null = null;
@@ -1291,7 +1293,7 @@ export default class NostrWalletConnectStore {
                     : this.handleLightningPayInvoice.bind(this, connection);
                 handler.payInvoice = (request: Nip47PayInvoiceRequest) =>
                     this.withGlobalHandler(connection.id, () =>
-                        payHandler(request)
+                        this.enqueuePayment(() => payHandler(request))
                     );
             }
 
@@ -1489,6 +1491,21 @@ export default class NostrWalletConnectStore {
     ): Promise<T> {
         await this.markConnectionUsed(connectionId);
         return await handler();
+    }
+
+    // Serializes payment handling across all connections. Payment flows
+    // read and mutate shared singleton stores (TransactionsStore,
+    // CashuStore payReq/meltQuote) across awaits, so two concurrent
+    // pay_invoice requests would clobber each other's state: one flow
+    // can melt the other's quote, validate budget against the wrong
+    // amount, or report the other payment's result/preimage.
+    private enqueuePayment<T>(task: () => Promise<T>): Promise<T> {
+        const result = this.paymentQueue.then(task);
+        this.paymentQueue = result.then(
+            () => undefined,
+            () => undefined
+        );
+        return result;
     }
     // NWC REQUEST HANDLERS
 


### PR DESCRIPTION
# Description

Serializes NWC `pay_invoice` handling so two concurrent requests can never interleave their reads and writes of the shared singleton stores.

Both payment handlers work through global store state across awaits, and Nostr relay events dispatch handlers concurrently with no queue anywhere:

- `handleCashuPayInvoice` calls `cashuStore.getPayReq(request.invoice)`, which mutates `CashuStore.payReq` / `paymentRequest` / `meltQuote`, then re-reads that state after further awaits (`payLnInvoiceFromEcash` reads `this.payReq?.getRequestAmount`, `this.selectedMintUrl`, `this.meltQuote.quote`).
- `handleLightningPayInvoice` does `transactionsStore.reset()` then `sendPayment()` then `waitForPaymentCompletion()`, reading result state off the same shared `TransactionsStore` the UI uses.

With two overlapping `pay_invoice` requests (same or different connections), connection A's flow can melt connection B's quote (paying B's payee with an amount that was budget-validated against A's smaller invoice), and both clients can receive the same result/preimage, so one believes it paid when it didn't.

## What changed

- `stores/NostrWalletConnectStore.ts`: a store-level promise queue (`paymentQueue` + `enqueuePayment`). The `payInvoice` handler registration routes through it, so payment requests are processed strictly one at a time across all connections. A rejected handler propagates its error to its own request; the queue continues regardless.

The queue is deliberately store-level rather than per-connection: cross-connection interleaving is exactly the dangerous case. Non-payment handlers (`get_info`, `get_balance`, `make_invoice`, `lookup_invoice`, `list_transactions`, `sign_message`) are not queued; they do not participate in this race.

Throughput note: a queued request waits for the one ahead of it, which for an in-transit lightning payment can be up to the 120s completion wait. That is the correct trade for a funds path; under normal single-client sequential use nothing changes.

Not addressed here (tracked separately): budget accounting for pending payments, and passing decoded state explicitly instead of via shared stores, which would be a larger refactor of the payment flows than a fix like this should carry.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] Embedded LND
- [ ] LDK Node

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS Transifex page and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified
