### PR TITLE
Embedded LND restore: don't wipe seed when backing out of SCB entry

### DIFF
--- a/components/PreventRemove.tsx
+++ b/components/PreventRemove.tsx
@@ -1,0 +1,26 @@
+import { usePreventRemove } from '@react-navigation/native';
+
+interface PreventRemoveProps {
+    enabled: boolean;
+    onAttempt: () => void;
+}
+
+/**
+ * Blocks the screen from being popped while `enabled`, and runs `onAttempt`
+ * instead. Unlike a bare `beforeRemove` listener, this registers with
+ * react-navigation's prevent-remove context, which is what drives the native
+ * `preventNativeDismiss` prop - without it the iOS swipe-back gesture pops the
+ * screen natively before JS can call `preventDefault`.
+ *
+ * Renders nothing; mount it inside the screen it should guard, and toggle
+ * `enabled` rather than conditionally rendering it.
+ */
+function PreventRemove(props: PreventRemoveProps) {
+    const { enabled, onAttempt } = props;
+
+    usePreventRemove(enabled, onAttempt);
+
+    return null;
+}
+
+export default PreventRemove;

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -153,6 +153,7 @@ export default class SeedRecovery extends React.PureComponent<
     SeedRecoveryState
 > {
     textInput: React.RefObject<TextInputRN | null>;
+    private removeBeforeRemoveListener?: () => void;
     constructor(props: SeedRecoveryProps) {
         super(props);
 
@@ -230,6 +231,23 @@ export default class SeedRecovery extends React.PureComponent<
     }
 
     async componentDidMount() {
+        // Backing out of SCB entry (header arrow, iOS swipe, Android
+        // hardware back) must return to the seed grid, not pop the
+        // screen and discard the hand-entered seed
+        this.removeBeforeRemoveListener = this.props.navigation.addListener(
+            'beforeRemove',
+            (e) => {
+                if (
+                    this.state.selectedInputType === 'scb' &&
+                    (e.data.action.type === 'GO_BACK' ||
+                        e.data.action.type === 'POP')
+                ) {
+                    e.preventDefault();
+                    this.exitScbEntry();
+                }
+            }
+        );
+
         await this.initFromProps(this.props);
 
         const { SettingsStore, route } = this.props;
@@ -254,6 +272,18 @@ export default class SeedRecovery extends React.PureComponent<
             await this.initFromProps(this.props);
         }
     }
+
+    componentWillUnmount() {
+        this.removeBeforeRemoveListener?.();
+    }
+
+    exitScbEntry = () => {
+        Keyboard.dismiss();
+        this.setState({
+            selectedInputType: null,
+            selectedText: ''
+        });
+    };
 
     async initFromProps(props: SeedRecoveryProps) {
         const network = props.route.params?.network ?? 'mainnet';
@@ -1229,13 +1259,7 @@ export default class SeedRecovery extends React.PureComponent<
                                             title={localeString(
                                                 'general.confirm'
                                             )}
-                                            onPress={() => {
-                                                Keyboard.dismiss();
-                                                this.setState({
-                                                    selectedInputType: null,
-                                                    selectedText: ''
-                                                });
-                                            }}
+                                            onPress={() => this.exitScbEntry()}
                                             secondary
                                         />
                                     </View>

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -38,6 +38,7 @@ import ZeusText from '../../components/Text';
 import TextInput from '../../components/TextInput';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import DropdownSetting from '../../components/DropdownSetting';
+import PreventRemove from '../../components/PreventRemove';
 
 import { restartNeeded } from '../../utils/RestartUtils';
 import { themeColor } from '../../utils/ThemeUtils';
@@ -153,7 +154,6 @@ export default class SeedRecovery extends React.PureComponent<
     SeedRecoveryState
 > {
     textInput: React.RefObject<TextInputRN | null>;
-    private removeBeforeRemoveListener?: () => void;
     constructor(props: SeedRecoveryProps) {
         super(props);
 
@@ -231,23 +231,6 @@ export default class SeedRecovery extends React.PureComponent<
     }
 
     async componentDidMount() {
-        // Backing out of SCB entry (header arrow, iOS swipe, Android
-        // hardware back) must return to the seed grid, not pop the
-        // screen and discard the hand-entered seed
-        this.removeBeforeRemoveListener = this.props.navigation.addListener(
-            'beforeRemove',
-            (e) => {
-                if (
-                    this.state.selectedInputType === 'scb' &&
-                    (e.data.action.type === 'GO_BACK' ||
-                        e.data.action.type === 'POP')
-                ) {
-                    e.preventDefault();
-                    this.exitScbEntry();
-                }
-            }
-        );
-
         await this.initFromProps(this.props);
 
         const { SettingsStore, route } = this.props;
@@ -271,10 +254,6 @@ export default class SeedRecovery extends React.PureComponent<
         if (this.props.route.params !== prevProps.route.params) {
             await this.initFromProps(this.props);
         }
-    }
-
-    componentWillUnmount() {
-        this.removeBeforeRemoveListener?.();
     }
 
     exitScbEntry = () => {
@@ -1007,6 +986,13 @@ export default class SeedRecovery extends React.PureComponent<
 
         return (
             <Screen>
+                {/* Backing out of SCB entry (header arrow, iOS swipe, Android
+                    hardware back) must return to the seed grid, not pop the
+                    screen and discard the hand-entered seed */}
+                <PreventRemove
+                    enabled={selectedInputType === 'scb'}
+                    onAttempt={this.exitScbEntry}
+                />
                 <Header
                     leftComponent="Back"
                     centerComponent={{


### PR DESCRIPTION
# Description

Relates to issue: **#4302**

On the `SeedRecovery` screen, tapping the SCB ("Disaster Recovery Base64") tile switches the screen into an input mode whose only exit is the Confirm button. If the user instead leaves the natural way (header back arrow, iOS swipe-back, or Android hardware back), the whole `SeedRecovery` route is popped and the hand-entered 24-word seed, which lives only in component state, is discarded. The user has to type all 24 words again.

This PR guards the screen while SCB entry is active, so a back action returns to the seed grid instead of popping the route and discarding the entered seed. The SCB Confirm button was also deduped to use the same exit helper, so both exit paths behave identically.

The guard uses react-navigation's `usePreventRemove` rather than a raw `beforeRemove` listener. That distinction matters on iOS: in `native-stack`, the only thing that stops an interactive swipe-back is the native `preventNativeDismiss` prop, and that is fed solely from react-navigation's prevent-remove context, which only `usePreventRemove` writes to. With a bare listener, `preventNativeDismiss` stays `false`, UIKit pops the screen, and native-stack dispatches `StackActions.pop` only afterwards — so `preventDefault()` arrives after the screen is already gone, desyncing JS state from the native stack and logging react-navigation's "removed natively but didn't get removed from JS state" error. Thanks to @shubhamkmr04 for catching this on the first revision.

Since `SeedRecovery` is a class component, the hook lives in a small render-null `components/PreventRemove.tsx` wrapper, mounted unconditionally with `enabled` toggling rather than being conditionally rendered.

One behaviour note: `usePreventRemove` prevents *every* removal action while enabled, so there is no `GO_BACK`/`POP` filter. The only programmatic exit on this screen is the `popTo` after a completed restore, which cannot run while SCB entry is open.

Draft: opened for review of the approach; the manual platform/backend testing matrix below has not been completed yet.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

