### PR TITLE
fix(nwc): count pending payments against connection spending budget

### DIFF
--- a/models/NWCConnection.test.ts
+++ b/models/NWCConnection.test.ts
@@ -170,4 +170,82 @@ describe('NWCConnection budget accounting with pending payments', () => {
         expect(connection.canSpend(1000000)).toBe(true);
         expect(connection.remainingBudget).toBe(Infinity);
     });
+
+    it('keeps budget getters consistent when pending activity exists', () => {
+        // Budget 100k: 10k settled + 90k pending. Every budget-facing
+        // value must agree that the budget is exhausted, not just
+        // remainingBudget/canSpend.
+        const connection = baseConnection();
+        connection.trackSpending(10000);
+        connection.activity.push({
+            id: 'lnbc-hodl',
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'pending',
+            satAmount: 90000
+        });
+
+        expect(connection.effectiveSpendSats).toBe(100000);
+        expect(connection.remainingBudget).toBe(0);
+        expect(connection.budgetUsagePercentage).toBe(100);
+        expect(connection.budgetLimitReached).toBe(true);
+        expect(connection.canSpend(1)).toBe(false);
+    });
+
+    it('reflects pending payments in budgetUsagePercentage', () => {
+        const connection = baseConnection();
+        connection.trackSpending(25000);
+        connection.activity.push({
+            id: 'lnbc-partial',
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'pending',
+            satAmount: 25000
+        });
+
+        expect(connection.budgetUsagePercentage).toBe(50);
+        expect(connection.budgetLimitReached).toBe(false);
+    });
+
+    it('frees the budget and limit flag when a pending payment fails', () => {
+        const connection = baseConnection();
+        connection.activity.push({
+            id: 'lnbc-doomed',
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'pending',
+            satAmount: 100000
+        });
+
+        expect(connection.budgetLimitReached).toBe(true);
+        expect(connection.canSpend(1)).toBe(false);
+
+        connection.activity[0].status = 'failed';
+
+        expect(connection.budgetLimitReached).toBe(false);
+        expect(connection.remainingBudget).toBe(100000);
+        expect(connection.canSpend(100000)).toBe(true);
+    });
+
+    it('clears the BudgetLimitReached warning once budget frees up', () => {
+        const connection = baseConnection();
+        connection.activity.push({
+            id: 'lnbc-transient',
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'pending',
+            satAmount: 100000
+        });
+
+        connection.checkAndResetBudgetIfNeeded(1000000);
+        expect(
+            connection.warnings.some((w) => w.type === 'budget_limit_reached')
+        ).toBe(true);
+
+        connection.activity[0].status = 'failed';
+        connection.checkAndResetBudgetIfNeeded(1000000);
+        expect(
+            connection.warnings.some((w) => w.type === 'budget_limit_reached')
+        ).toBe(false);
+    });
 });

--- a/models/NWCConnection.test.ts
+++ b/models/NWCConnection.test.ts
@@ -1,0 +1,173 @@
+jest.mock('../stores/Stores', () => ({}));
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+jest.mock('../utils/NostrConnectUtils', () => ({
+    __esModule: true,
+    default: {
+        getReadOnlyPermissions: () => [],
+        hasPaymentPermissions: () => false
+    }
+}));
+
+import NWCConnection from './NWCConnection';
+
+const baseConnection = () =>
+    new NWCConnection({
+        id: 'test',
+        name: 'test',
+        pubkey: 'abc',
+        relayUrl: 'wss://relay.example.com',
+        permissions: [],
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        totalSpendSats: 0,
+        maxAmountSats: 100000,
+        nodePubkey: 'def',
+        implementation: 'lnd'
+    } as any);
+
+describe('NWCConnection budget accounting with pending payments', () => {
+    it('counts pending pay_invoice amounts in pendingSpendSats', () => {
+        const connection = baseConnection();
+        connection.activity.push(
+            {
+                id: 'lnbc1',
+                type: 'pay_invoice',
+                payment_source: 'lightning',
+                status: 'pending',
+                satAmount: 40000
+            },
+            {
+                id: 'lnbc2',
+                type: 'pay_invoice',
+                payment_source: 'lightning',
+                status: 'pending',
+                satAmount: 25000
+            }
+        );
+
+        expect(connection.pendingSpendSats).toBe(65000);
+    });
+
+    it('ignores settled, failed, expired, and make_invoice activity', () => {
+        const connection = baseConnection();
+        connection.activity.push(
+            {
+                id: 'a',
+                type: 'pay_invoice',
+                payment_source: 'lightning',
+                status: 'success',
+                satAmount: 10000
+            },
+            {
+                id: 'b',
+                type: 'pay_invoice',
+                payment_source: 'lightning',
+                status: 'failed',
+                satAmount: 10000
+            },
+            {
+                id: 'c',
+                type: 'pay_invoice',
+                payment_source: 'lightning',
+                status: 'expired',
+                satAmount: 10000
+            },
+            {
+                id: 'd',
+                type: 'make_invoice',
+                payment_source: 'lightning',
+                status: 'pending',
+                satAmount: 10000
+            }
+        );
+
+        expect(connection.pendingSpendSats).toBe(0);
+    });
+
+    it('rejects a payment when pending amounts exhaust the budget', () => {
+        const connection = baseConnection();
+        // Budget 100k: a single settled 10k payment plus a pending 90k
+        // hodl payment must block further spends even though only the
+        // settled 10k has been debited to totalSpendSats.
+        connection.trackSpending(10000);
+        connection.activity.push({
+            id: 'lnbc-hodl',
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'pending',
+            satAmount: 90000
+        });
+
+        expect(connection.canSpend(1)).toBe(false);
+        expect(connection.remainingBudget).toBe(0);
+    });
+
+    it('does not double-count once a pending payment reconciles', () => {
+        const connection = baseConnection();
+        connection.activity.push({
+            id: 'lnbc-settling',
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'pending',
+            satAmount: 60000
+        });
+
+        expect(connection.canSpend(40000)).toBe(true);
+        expect(connection.canSpend(40001)).toBe(false);
+
+        // Mirror reconcilePendingPayInvoiceActivities: flip to success
+        // and debit in one step.
+        connection.activity[0].status = 'success';
+        connection.trackSpending(60000);
+
+        expect(connection.pendingSpendSats).toBe(0);
+        expect(connection.totalSpendSats).toBe(60000);
+        expect(connection.canSpend(40000)).toBe(true);
+        expect(connection.canSpend(40001)).toBe(false);
+    });
+
+    it('reproduces the C3 bypass scenario when pending is ignored', () => {
+        // Pre-fix behavior: 10 x 100k-sat payments against a 100k budget
+        // all passed canSpend because none were settled yet. With pending
+        // counted, only the first passes.
+        const connection = baseConnection();
+
+        expect(connection.canSpend(100000)).toBe(true);
+        connection.activity.push({
+            id: 'lnbc-first',
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'pending',
+            satAmount: 100000
+        });
+
+        for (let i = 0; i < 9; i++) {
+            expect(connection.canSpend(100000)).toBe(false);
+        }
+    });
+
+    it('treats connections without a budget limit as unlimited', () => {
+        const connection = new NWCConnection({
+            id: 'nolimit',
+            name: 'nolimit',
+            pubkey: 'abc',
+            relayUrl: 'wss://relay.example.com',
+            permissions: [],
+            createdAt: new Date('2026-01-01T00:00:00Z'),
+            totalSpendSats: 0,
+            nodePubkey: 'def',
+            implementation: 'lnd'
+        } as any);
+        connection.activity.push({
+            id: 'lnbc-pending',
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'pending',
+            satAmount: 500000
+        });
+
+        expect(connection.canSpend(1000000)).toBe(true);
+        expect(connection.remainingBudget).toBe(Infinity);
+    });
+});

--- a/models/NWCConnection.ts
+++ b/models/NWCConnection.ts
@@ -212,9 +212,30 @@ export default class NWCConnection extends BaseModel {
         );
     }
 
+    /**
+     * Sum of in-flight (pending) pay_invoice amounts on this connection's
+     * activity log. Counted against the budget so concurrent or
+     * slow-settling (hodl) payments cannot exceed the limit while their
+     * debits are deferred to reconcile. Reconcile flips an activity to
+     * success and calls trackSpending in one atomic action, so an amount
+     * is never counted in both this and totalSpendSats.
+     */
+    @computed public get pendingSpendSats(): number {
+        if (!this.activity?.length) return 0;
+        return this.activity.reduce((sum, a) => {
+            if (a.type !== 'pay_invoice' || a.status !== 'pending') {
+                return sum;
+            }
+            return sum + Math.max(0, Math.floor(Number(a.satAmount) || 0));
+        }, 0);
+    }
+
     @computed public get remainingBudget(): number {
         if (!this.hasBudgetLimit) return Infinity;
-        return Math.max(0, this.maxAmountSats! - this.totalSpendSats);
+        return Math.max(
+            0,
+            this.maxAmountSats! - this.totalSpendSats - this.pendingSpendSats
+        );
     }
 
     @computed public get budgetUsagePercentage(): number {
@@ -357,7 +378,10 @@ export default class NWCConnection extends BaseModel {
 
     public canSpend(amountSats: number): boolean {
         if (!this.hasBudgetLimit) return true;
-        return this.totalSpendSats + amountSats <= this.maxAmountSats!;
+        return (
+            this.totalSpendSats + this.pendingSpendSats + amountSats <=
+            this.maxAmountSats!
+        );
     }
 
     @action

--- a/models/NWCConnection.ts
+++ b/models/NWCConnection.ts
@@ -208,7 +208,8 @@ export default class NWCConnection extends BaseModel {
 
     @computed public get budgetLimitReached(): boolean {
         return (
-            this.hasBudgetLimit && this.totalSpendSats >= this.maxAmountSats!
+            this.hasBudgetLimit &&
+            this.effectiveSpendSats >= this.maxAmountSats!
         );
     }
 
@@ -230,17 +231,27 @@ export default class NWCConnection extends BaseModel {
         }, 0);
     }
 
+    /**
+     * Total budget consumption: settled spends plus in-flight pending
+     * amounts. All budget-facing values (canSpend, remainingBudget,
+     * budgetUsagePercentage, budgetLimitReached) derive from this so the
+     * UI and enforcement always agree.
+     */
+    @computed public get effectiveSpendSats(): number {
+        return this.totalSpendSats + this.pendingSpendSats;
+    }
+
     @computed public get remainingBudget(): number {
         if (!this.hasBudgetLimit) return Infinity;
-        return Math.max(
-            0,
-            this.maxAmountSats! - this.totalSpendSats - this.pendingSpendSats
-        );
+        return Math.max(0, this.maxAmountSats! - this.effectiveSpendSats);
     }
 
     @computed public get budgetUsagePercentage(): number {
         if (!this.hasBudgetLimit) return 0;
-        return Math.min(100, (this.totalSpendSats / this.maxAmountSats!) * 100);
+        return Math.min(
+            100,
+            (this.effectiveSpendSats / this.maxAmountSats!) * 100
+        );
     }
 
     private resolveMakeInvoiceActivitySats(a: ConnectionActivity): number {
@@ -378,10 +389,7 @@ export default class NWCConnection extends BaseModel {
 
     public canSpend(amountSats: number): boolean {
         if (!this.hasBudgetLimit) return true;
-        return (
-            this.totalSpendSats + this.pendingSpendSats + amountSats <=
-            this.maxAmountSats!
-        );
+        return this.effectiveSpendSats + amountSats <= this.maxAmountSats!;
     }
 
     @action
@@ -411,6 +419,11 @@ export default class NWCConnection extends BaseModel {
             }
             if (this.budgetLimitReached) {
                 this.addWarning(ConnectionWarningType.BudgetLimitReached);
+                changed = true;
+            } else {
+                // Pending payments count toward the limit but can fail and
+                // free budget back up; clear the warning when that happens
+                this.removeWarning(ConnectionWarningType.BudgetLimitReached);
                 changed = true;
             }
         }


### PR DESCRIPTION
# Description

Counts in-flight payments against NWC connection spending budgets.

`NWCConnection.canSpend` compared only the settled `totalSpendSats` against `maxAmountSats`. In-flight payments sit in the connection's activity log as `pending` records whose budget debit is deferred until reconcile flips them to `success` and calls `trackSpending`. A client could therefore fire multiple payments into hodl or slow-settling invoices (each returned as in-transit with an empty preimage after the 120s completion wait) and have every one pass `validateBudgetBeforePayment`; once they all settled, a multiple of the configured budget had been spent. Example: a 100k-sat budget allows 10 x 100k-sat payments if none settle before the last one is validated.

## What changed

- `models/NWCConnection.ts`: new `pendingSpendSats` computed that sums `pending` `pay_invoice` activity amounts. `canSpend` now checks `totalSpendSats + pendingSpendSats + amountSats <= maxAmountSats`, and `remainingBudget` (which feeds the budget-rejection error message and the connection list/details views) subtracts pending as well.
- `models/NWCConnection.test.ts`: regression tests covering the bypass scenario, the pending-to-settled handoff (no double-count), exclusion of settled/failed/expired/make_invoice activity, and unlimited connections.

No double-count is possible across the pending-to-settled transition: `reconcilePendingPayInvoiceActivities` flips the activity status and calls `trackSpending` inside a single `runInAction` (with the status guard from b65f690b8), so an amount moves atomically from the pending bucket to the settled one.

Known trade-off: a pending record that never reconciles (payment lost node-side and never appearing in the payments list) holds its amount against the budget until it resolves or the budget renews. That is the conservative direction for a spending limit; the failure mode of the old behavior was overspending.

Related: `#4303` (serializing pay_invoice handling) narrows how quickly concurrent requests can stack up pending payments, but does not close this bypass on its own since serialized in-transit payments still return before settling. The two fixes are independent.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] Embedded LND
- [ ] LDK Node

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS Transifex page and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified
