### PR TITLE
fix: payment timeout races on LND REST, CLNRest, LndHub, and Tor

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -99,7 +99,11 @@ export default class CLNRest {
             });
 
             const fetchPromise = ReactNativeBlobUtil.config({
-                trusty: !certVerification
+                trusty: !certVerification,
+                // RNBlobUtil's native default is 60s; without this a
+                // payment request holding the connection open longer than
+                // that dies natively no matter what the race below allows
+                timeout: timeout || this.defaultTimeout
             })
                 .fetch(method, url, headers, data ? JSON.stringify(data) : data)
                 .then((response: any) => {

--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -81,7 +81,10 @@ export default class CLNRest {
                     // self-signed certs can't match anyway).
                     // Clearnet-over-Tor: keep strict TLS because exit
                     // nodes can MITM.
-                    isOnionHttpsUrl(url)
+                    isOnionHttpsUrl(url),
+                    // undefined keeps doTorRequest's own default; only
+                    // request-scoped deadlines (payments) override it
+                    timeout
                 ).then((response: any) => {
                     calls.delete(id);
                     return response;
@@ -435,6 +438,45 @@ export default class CLNRest {
         return formatted;
     };
 
+    // cln blocks on /v1/pay, /v1/xpay, /v1/keysend, and /v1/xkeysend for
+    // up to retry_for seconds, so the request timeout needs headroom past
+    // that deadline or the definitive response is discarded as a generic
+    // transport timeout. Mirror LND's payLightningInvoice: race the call
+    // against the payment-timed-out shape so a slow payment surfaces as
+    // "may be in transit, check Activity" instead of a retryable-looking
+    // error (dangerous on keysend, where a retry double-sends).
+    // formatResult runs on the real response only, inside the race, so
+    // the timed-out shape is never marked status complete.
+    private payWithTimeout = (
+        route: string,
+        request: any,
+        data: any,
+        formatResult?: (result: any) => any
+    ) => {
+        const timeoutSeconds = Number(data.timeout_seconds) || 60;
+
+        const forcedTimeout = async (time_ms: number, response: any) => {
+            await new Promise((res) => setTimeout(res, time_ms));
+            return response;
+        };
+
+        let call = this.postRequest(
+            route,
+            request,
+            (timeoutSeconds + 5) * 1000
+        );
+        if (formatResult) call = call.then(formatResult);
+
+        return Promise.race([
+            forcedTimeout((timeoutSeconds + 1) * 1000, {
+                payment_error: localeString(
+                    'views.SendingLightning.paymentTimedOut'
+                )
+            }),
+            call
+        ]);
+    };
+
     payLightningInvoice = async (data: any) => {
         // pay is deprecated in CLN v26.06 and removed in v27.03; use xpay
         // (available since v24.11) when the node has it
@@ -453,11 +495,7 @@ export default class CLNRest {
             } else if (data.max_fee_percent) {
                 legacyRequest.maxfeepercent = data.max_fee_percent;
             }
-            return this.postRequest(
-                '/v1/pay',
-                legacyRequest,
-                data.timeout_seconds * 1000
-            );
+            return this.payWithTimeout('/v1/pay', legacyRequest, data);
         }
 
         const request: any = {
@@ -468,11 +506,12 @@ export default class CLNRest {
         const maxfee = this.getMaxFeeMsat(data);
         if (maxfee !== undefined) request.maxfee = maxfee;
 
-        return this.postRequest(
+        return this.payWithTimeout(
             '/v1/xpay',
             request,
-            data.timeout_seconds * 1000
-        ).then(this.formatXpayResult);
+            data,
+            this.formatXpayResult
+        );
     };
     sendKeysend = async (data: any) => {
         // keysend is deprecated in CLN v26.06 and removed in v27.03; use
@@ -502,11 +541,7 @@ export default class CLNRest {
                     ).toNumber();
                 }
             }
-            return this.postRequest(
-                '/v1/keysend',
-                legacyRequest,
-                data.timeout_seconds * 1000
-            );
+            return this.payWithTimeout('/v1/keysend', legacyRequest, data);
         }
 
         const request: any = {
@@ -517,11 +552,12 @@ export default class CLNRest {
         const maxfee = this.getMaxFeeMsat(data);
         if (maxfee !== undefined) request.maxfee = maxfee;
 
-        return this.postRequest(
+        return this.payWithTimeout(
             '/v1/xkeysend',
             request,
-            data.timeout_seconds * 1000
-        ).then(this.formatXpayResult);
+            data,
+            this.formatXpayResult
+        );
     };
     closeChannel = (urlParams?: Array<string>) => {
         const request = {

--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -81,7 +81,10 @@ export default class CLNRest {
                     // self-signed certs can't match anyway).
                     // Clearnet-over-Tor: keep strict TLS because exit
                     // nodes can MITM.
-                    isOnionHttpsUrl(url)
+                    isOnionHttpsUrl(url),
+                    // undefined keeps doTorRequest's own default; only
+                    // request-scoped deadlines (payments) override it
+                    timeout
                 ).then((response: any) => {
                     calls.delete(id);
                     return response;
@@ -407,8 +410,32 @@ export default class CLNRest {
             string: urlParams && urlParams[0]
         });
 
+    // cln blocks on /v1/pay and /v1/keysend for up to retry_for seconds,
+    // so the request timeout needs headroom past that deadline or the
+    // definitive response is discarded as a generic transport timeout.
+    // Mirror LND's payLightningInvoice: race the call against the
+    // payment-timed-out shape so a slow payment surfaces as "may be in
+    // transit, check Activity" instead of a retryable-looking error
+    // (dangerous on keysend, where a retry double-sends).
+    private payWithTimeout = (route: string, request: any, data: any) => {
+        const timeoutSeconds = Number(data.timeout_seconds) || 60;
+
+        const forcedTimeout = async (time_ms: number, response: any) => {
+            await new Promise((res) => setTimeout(res, time_ms));
+            return response;
+        };
+
+        return Promise.race([
+            forcedTimeout((timeoutSeconds + 1) * 1000, {
+                payment_error: localeString(
+                    'views.SendingLightning.paymentTimedOut'
+                )
+            }),
+            this.postRequest(route, request, (timeoutSeconds + 5) * 1000)
+        ]);
+    };
     payLightningInvoice = (data: any) =>
-        this.postRequest(
+        this.payWithTimeout(
             '/v1/pay',
             {
                 bolt11: data.payment_request,
@@ -416,10 +443,10 @@ export default class CLNRest {
                 maxfeepercent: data.max_fee_percent,
                 retry_for: data.timeout_seconds
             },
-            data.timeout_seconds * 1000
+            data
         );
     sendKeysend = (data: any) => {
-        return this.postRequest(
+        return this.payWithTimeout(
             '/v1/keysend',
             {
                 destination: data.pubkey,
@@ -427,7 +454,7 @@ export default class CLNRest {
                 maxfeepercent: data.max_fee_percent,
                 retry_for: data.timeout_seconds
             },
-            data.timeout_seconds * 1000
+            data
         );
     };
     closeChannel = (urlParams?: Array<string>) => {

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -84,7 +84,11 @@ export default class LND {
             });
 
             const fetchPromise = ReactNativeBlobUtil.config({
-                trusty: !certVerification
+                trusty: !certVerification,
+                // RNBlobUtil's native default is 60s; without this a
+                // payment request holding the connection open longer than
+                // that dies natively no matter what the race below allows
+                timeout: timeout || this.defaultTimeout
             })
                 .fetch(method, url, headers, data ? JSON.stringify(data) : data)
                 .then((response: any) => {

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -58,7 +58,10 @@ export default class LND {
                     // self-signed certs can't match anyway).
                     // Clearnet-over-Tor: keep strict TLS because exit
                     // nodes can MITM.
-                    isOnionHttpsUrl(url)
+                    isOnionHttpsUrl(url),
+                    // undefined keeps doTorRequest's own default; only
+                    // request-scoped deadlines (payments) override it
+                    timeout
                 )
                     .then((response: any) => {
                         calls.delete(id);
@@ -517,11 +520,17 @@ export default class LND {
     payLightningInvoice = async (data: any) => {
         if (data.pubkey) delete data.pubkey;
 
+        const timeoutSeconds = Number(data.timeout_seconds) || 60;
+
         const forcedTimeout = async (time_ms: number, response: any) => {
             await new Promise((res) => setTimeout(res, time_ms));
             return response;
         };
 
+        // The request timeout must exceed the forcedTimeout below, or the
+        // generic transport rejection wins the race and the user sees a
+        // retryable-looking error instead of the payment-timed-out shape
+        // (dangerous on keysend, where a retry double-sends).
         const call = () =>
             this.postRequest(
                 '/v2/router/send',
@@ -529,11 +538,11 @@ export default class LND {
                     ...data,
                     allow_self_payment: true
                 },
-                data.timeout_seconds * 1000
+                (timeoutSeconds + 5) * 1000
             );
 
         const result: any = await Promise.race([
-            forcedTimeout((data.timeout_seconds + 1) * 1000, {
+            forcedTimeout((timeoutSeconds + 1) * 1000, {
                 payment_error: localeString(
                     'views.SendingLightning.paymentTimedOut'
                 )

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -58,7 +58,10 @@ export default class LND {
                     // self-signed certs can't match anyway).
                     // Clearnet-over-Tor: keep strict TLS because exit
                     // nodes can MITM.
-                    isOnionHttpsUrl(url)
+                    isOnionHttpsUrl(url),
+                    // undefined keeps doTorRequest's own default; only
+                    // request-scoped deadlines (payments) override it
+                    timeout
                 ).then((response: any) => {
                     calls.delete(id);
                     return response;
@@ -509,11 +512,17 @@ export default class LND {
     payLightningInvoice = async (data: any) => {
         if (data.pubkey) delete data.pubkey;
 
+        const timeoutSeconds = Number(data.timeout_seconds) || 60;
+
         const forcedTimeout = async (time_ms: number, response: any) => {
             await new Promise((res) => setTimeout(res, time_ms));
             return response;
         };
 
+        // The request timeout must exceed the forcedTimeout below, or the
+        // generic transport rejection wins the race and the user sees a
+        // retryable-looking error instead of the payment-timed-out shape
+        // (dangerous on keysend, where a retry double-sends).
         const call = () =>
             this.postRequest(
                 '/v2/router/send',
@@ -521,11 +530,11 @@ export default class LND {
                     ...data,
                     allow_self_payment: true
                 },
-                data.timeout_seconds * 1000
+                (timeoutSeconds + 5) * 1000
             );
 
         const result: any = await Promise.race([
-            forcedTimeout((data.timeout_seconds + 1) * 1000, {
+            forcedTimeout((timeoutSeconds + 1) * 1000, {
                 payment_error: localeString(
                     'views.SendingLightning.paymentTimedOut'
                 )

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -76,7 +76,11 @@ export default class LND {
             });
 
             const fetchPromise = ReactNativeBlobUtil.config({
-                trusty: !certVerification
+                trusty: !certVerification,
+                // RNBlobUtil's native default is 60s; without this a
+                // payment request holding the connection open longer than
+                // that dies natively no matter what the race below allows
+                timeout: timeout || this.defaultTimeout
             })
                 .fetch(method, url, headers, data ? JSON.stringify(data) : data)
                 .then((response: any) => {

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -74,11 +74,12 @@ export default class LndHub extends LND {
     // LndHub servers (LNbits included) block on /payinvoice until the
     // payment resolves, which on slow routes exceeds the inherited 30s
     // restReq default; that surfaced as premature "Request timeout"
-    // failures for payments that later settled (#2761). LndHub gets no
-    // timeout_seconds plumbing, so use the app's default payment window
-    // and mirror LND's payLightningInvoice race: headroom past the
-    // deadline, and the payment-timed-out shape instead of a
-    // retryable-looking transport error.
+    // failures for payments that later settled (#2761). Unlike LND
+    // (timeout_seconds) and CLN (retry_for), the LndHub protocol has no
+    // server-side payment deadline at all, so this window is purely
+    // client-imposed: the server may well still be paying after we stop
+    // listening, which is exactly why the raced payment-timed-out shape
+    // (rather than a retryable-looking transport error) matters here.
     payLightningInvoice = (data: any) => {
         const timeoutSeconds = Number(data.timeout_seconds) || 60;
 

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -80,8 +80,10 @@ export default class LndHub extends LND {
     // client-imposed: the server may well still be paying after we stop
     // listening, which is exactly why the raced payment-timed-out shape
     // (rather than a retryable-looking transport error) matters here.
+    // Zeus's payment timeout setting is neither plumbed to this backend
+    // nor exposed in the UI for it, so the window is a fixed 60s.
     payLightningInvoice = (data: any) => {
-        const timeoutSeconds = Number(data.timeout_seconds) || 60;
+        const timeoutSeconds = 60;
 
         const forcedTimeout = async (time_ms: number, response: any) => {
             await new Promise((res) => setTimeout(res, time_ms));

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -71,11 +71,38 @@ export default class LndHub extends LND {
         Promise.resolve().then(() =>
             Bolt11Utils.decode((urlParams && urlParams[0]) || '')
         );
-    payLightningInvoice = (data: any) =>
-        this.postRequest('/payinvoice', {
-            invoice: data.payment_request,
-            amount: data.amt
-        });
+    // LndHub servers (LNbits included) block on /payinvoice until the
+    // payment resolves, which on slow routes exceeds the inherited 30s
+    // restReq default; that surfaced as premature "Request timeout"
+    // failures for payments that later settled (#2761). LndHub gets no
+    // timeout_seconds plumbing, so use the app's default payment window
+    // and mirror LND's payLightningInvoice race: headroom past the
+    // deadline, and the payment-timed-out shape instead of a
+    // retryable-looking transport error.
+    payLightningInvoice = (data: any) => {
+        const timeoutSeconds = Number(data.timeout_seconds) || 60;
+
+        const forcedTimeout = async (time_ms: number, response: any) => {
+            await new Promise((res) => setTimeout(res, time_ms));
+            return response;
+        };
+
+        return Promise.race([
+            forcedTimeout((timeoutSeconds + 1) * 1000, {
+                payment_error: localeString(
+                    'views.SendingLightning.paymentTimedOut'
+                )
+            }),
+            this.postRequest(
+                '/payinvoice',
+                {
+                    invoice: data.payment_request,
+                    amount: data.amt
+                },
+                (timeoutSeconds + 5) * 1000
+            )
+        ]);
+    };
     lnurlAuth = (message: string) => {
         const messageHash = new sha256Hash()
             .update(Base64Utils.stringToUint8Array(message))

--- a/utils/TorUtils.ts
+++ b/utils/TorUtils.ts
@@ -67,7 +67,11 @@ const doTorRequest = async (
     method: RequestMethod,
     data?: string,
     headers?: any,
-    trustInvalidCerts: boolean = false
+    trustInvalidCerts: boolean = false,
+    // Callers with a request-scoped deadline (e.g. payments, where the
+    // node holds the connection open for timeout_seconds) must pass a
+    // longer timeout or the request dies before the node can answer.
+    timeoutMs: number = REQUEST_TIMEOUT_MS
 ) => {
     await ensureTorStarted();
     const headerStr = headersToString(headers);
@@ -90,7 +94,7 @@ const doTorRequest = async (
             response = await RnTor.httpGet({
                 url,
                 headers: headerStr,
-                timeout_ms: REQUEST_TIMEOUT_MS,
+                timeout_ms: timeoutMs,
                 trust_invalid_certs: effectiveTrustInvalidCerts
             });
             break;
@@ -99,7 +103,7 @@ const doTorRequest = async (
                 url,
                 body: data || '',
                 headers: headerStr,
-                timeout_ms: REQUEST_TIMEOUT_MS,
+                timeout_ms: timeoutMs,
                 trust_invalid_certs: effectiveTrustInvalidCerts
             });
             break;
@@ -107,7 +111,7 @@ const doTorRequest = async (
             response = await RnTor.httpDelete({
                 url,
                 headers: headerStr,
-                timeout_ms: REQUEST_TIMEOUT_MS,
+                timeout_ms: timeoutMs,
                 trust_invalid_certs: effectiveTrustInvalidCerts
             });
             break;


### PR DESCRIPTION
# Description

Gives Lightning payment REST requests timeout headroom past the node-side payment deadline, so slow payments surface as the designed "Payment timed out. It may be in transit... Check the Activity view" message instead of a generic transport error that invites a retry. Retrying a payment that later settles is a double-send on keysend, where each attempt generates a fresh preimage and defeats node-side same-hash dedup.

Related issues:

- #3065 is this bug on LND (REST) clearnet verbatim: slow payment reported as timeout, later shown successful in Activity, funds received. The extra headroom here lets LND's real answer land in many of those cases, and the remainder now get the in-transit message instead of a failure claim. Full truthfulness would additionally need post-timeout reconciliation against `listPayments`, which is out of scope here.
- #2761 is the same premature-failure family across several interfaces, and both reported legs are covered here: the CLNRest leg (client timeout equal to `retry_for` discarded definitive responses) and the LndHub leg (`/payinvoice` failing at the inherited 30s transport default on slow LNbits/LndHub routes).

## The bug

**LND (REST):** `payLightningInvoice` races the REST call against a `forcedTimeout` that resolves the designed `{payment_error: paymentTimedOut}` shape at `timeout_seconds + 1`. But the REST call's own client timeout rejects with a generic `Error('Request timeout')` at exactly `timeout_seconds`, one second earlier, so the designed path was unreachable over clearnet. The fetch is never aborted, so the payment can still settle node-side after the UI reports failure.

**CLN (CLNRest):** `/v1/pay` and `/v1/keysend` block server-side for up to `retry_for` seconds, but the client timeout was exactly `retry_for * 1000` with zero headroom, so a definitive response arriving at the deadline was discarded as a generic timeout. CLN also had no in-transit message path at all.

**LndHub:** servers (LNbits included) block on `/payinvoice` until the payment resolves, but `payLightningInvoice` passed no timeout and inherited the 30s `restReq` default. Payments routing slower than 30s were reported as `Request timeout` and settled afterward (the primary interface reported in #2761). Note that unlike LND (`timeout_seconds`) and CLN (`retry_for`), the LndHub protocol has no server-side payment deadline parameter, and Zeus's payment timeout setting is neither plumbed to this backend nor exposed in its UI, so any window here is client-imposed.

**Tor:** since the react-native-nitro-tor swap, `doTorRequest` imposed a fixed 60s native timeout on every request. This reintroduced the same race over Tor for the default 60s payment timeout, and silently capped longer payment windows at 60s regardless of settings (the NWC service's 120s payment window included), losing success responses that arrive after 60s.

**Native transport (clearnet):** `ReactNativeBlobUtil` applies its own native default timeout of 60s when none is set in `config()` (OkHttp connect/read on Android, `timeoutIntervalForRequest` on iOS), and `restReq` only raced a JS-level timer. A payment holding the connection silent past 60s died natively no matter what the JS race allowed, which would beat the 61s in-transit shape at the default setting and capped longer windows at 60s on clearnet just as the Tor bug did.

## What changed

- `backends/LND.ts`: the payment REST call now gets `(timeout_seconds + 5) * 1000`, so the `forcedTimeout` shape at `+1s` reliably wins whenever the node has not answered; real responses before that still win the race. `timeout_seconds` is normalized locally (`Number(...) || 60`) as a NaN guard. `restReq` passes its `timeout` parameter through the Tor branch.
- `backends/CLNRest.ts`: `payLightningInvoice` and `sendKeysend` share a `payWithTimeout` helper mirroring the LND pattern: client timeout at `retry_for + 5` seconds, raced against the designed payment-timed-out shape at `+1s` (`handlePayment` already handles the `payment_error` field backend-agnostically). `restReq` passes its `timeout` through the Tor branch.
- `backends/LndHub.ts`: `payLightningInvoice` uses a fixed 60s payment window (65s client timeout) with the same raced payment-timed-out shape, replacing the silent 30s transport ceiling. Fixed rather than configurable because the payment timeout setting is not exposed for LndHub.
- `backends/LND.ts` / `backends/CLNRest.ts`: `restReq` passes its timeout into `ReactNativeBlobUtil.config()` so the native transport cap matches the JS race instead of silently enforcing 60s.
- `utils/TorUtils.ts`: `doTorRequest` accepts an optional per-request `timeoutMs`, defaulting to the existing 60s `REQUEST_TIMEOUT_MS`. Only the two `restReq` Tor branches pass an override, and only when a caller supplied an explicit timeout (payments); every other Tor call site keeps the 60s default.

`EmbeddedLND` and `LightningNodeConnect` override `payLightningInvoice`, so the LND change affects only remote LND (REST); LndHub's override is updated as described above.

## Behavior after the fix

| Path | Before | After |
|---|---|---|
| LND clearnet, no answer at deadline | generic "Request timeout" at 60s | designed in-transit message at 61s |
| LND Tor, default 60s timeout | generic Tor timeout at 60s | designed in-transit message at 61s |
| LND/NWC Tor, 120s timeout | request killed at 60s, late success lost | full 125s window |
| LND/NWC clearnet, 120s timeout | connection killed natively at ~60s of silence | full 125s window |
| CLN, response at the retry_for deadline | discarded as "Request timeout" | definitive result delivered |
| CLN, no answer at deadline | generic "Request timeout" | designed in-transit message |
| LndHub, payment routing longer than 30s | generic "Request timeout" at 30s | full 65s window |
| LndHub, no answer at 60s | generic "Request timeout" at 30s | designed in-transit message at 61s |

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] Embedded LND
- [ ] LDK Node

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS Transifex page and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified



