### PR TITLE
fix(bolt12): show the actual payment outcome after LDK direct pay

### DIFF
--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -516,7 +516,15 @@ export default class Send extends React.Component<SendProps, SendState> {
                 timeoutSeconds
             );
             if (res.payment_hash) {
-                // LDK Node: payment already completed directly
+                // LDK Node: payment already completed directly. Feed the
+                // result through TransactionsStore so SendingLightning
+                // renders THIS payment's outcome; without it the screen
+                // shows whatever the previous payment left in the store
+                // (stale error, or the prior payment's preimage/fee/note).
+                // reset() first because handlePayment doesn't clear
+                // error/error_msg/payment_error on success.
+                this.props.TransactionsStore.reset();
+                this.props.TransactionsStore.handlePayment(res);
                 this.setState({ loading: false, error_msg: '' });
                 this.props.navigation.navigate('SendingLightning');
                 return;
@@ -1657,7 +1665,13 @@ export default class Send extends React.Component<SendProps, SendState> {
                             <Button
                                 title={localeString('general.proceed')}
                                 onPress={async () => await this.payBolt12()}
-                                disabled={!NodeInfoStore.supportsOffers}
+                                // loading: the offer payment executes
+                                // synchronously in payBolt12, so a second
+                                // tap mid-flight would fetch a fresh
+                                // invoice (new payment hash) and pay twice
+                                disabled={
+                                    !NodeInfoStore.supportsOffers || loading
+                                }
                             />
                         </View>
                     )}


### PR DESCRIPTION
# Description

Fixes the LDK Node BOLT 12 direct-pay path showing a previous payment's outcome, and closes a double-pay window on the same path.

On LDK Node, `fetchInvoiceFromOffer` does not fetch an invoice: it executes the offer payment (`bolt12SendUsingAmount` + `awaitPaymentCompletion`) and returns `{payment_hash, payment_preimage, status}`. `Send.payBolt12` then navigated to `SendingLightning` without writing anything to `TransactionsStore`, and that screen renders entirely from store observables. The result:

- If the previous payment failed, this successful BOLT 12 payment rendered as a failure. A retry fetches a fresh invoice with a new payment hash from the offer, so LDK's `DuplicatePayment` protection does not apply, and the user pays twice.
- If the previous payment succeeded, the screen showed the previous payment's preimage and fee, and "Add a note" attached to the previous payment's note key.
- In a fresh session, the screen had no state at all to render.

Separately, the BOLT 12 Proceed button was disabled only on `!NodeInfoStore.supportsOffers`, with no in-flight condition. The offer payment executes synchronously inside `payBolt12` (up to `timeoutSeconds`), so a second tap mid-flight started a second payment. This path never touches `TransactionsStore`, so the send-path double-submission guard (#4301) cannot cover it.

Scope is LDK Node only: CLN's `fetchinvoice` returns `{invoice}` with no `payment_hash` and takes the normal PaymentRequest flow, which is unchanged.

## What changed

- `views/Send.tsx` (`payBolt12`): in the direct-pay branch, `TransactionsStore.reset()` then `handlePayment(res)` before navigating, so `SendingLightning` renders this payment's true outcome (correct preimage, status, and note key; `reset()` first because `handlePayment` does not clear stale `error`/`payment_error` on success).
- `views/Send.tsx`: the BOLT 12 Proceed button is disabled while `state.loading`, closing the mid-flight double-tap.

Deliberately not included: routing the whole BOLT 12 flow through the store lifecycle (navigate to `SendingLightning` immediately with in-flight state, fee limit, confirmation screen). That restructuring belongs with the missing-fee-cap work, which has to touch this flow anyway.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] Embedded LND
- [ ] LDK Node

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS Transifex page and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified
