### PR TITLE
fix(nwc): await signature so sign_message returns the right one

### DIFF
--- a/stores/MessageSignStore.ts
+++ b/stores/MessageSignStore.ts
@@ -169,13 +169,19 @@ export default class MessageSignStore {
     // reading the shared `signature` observable, which may still hold a
     // previous request's result. Resolves to null on error; the
     // observable is still updated for the reactive view.
+    // `mode` overrides the shared `signingMode` observable without
+    // mutating it, so background callers don't inherit (or clobber)
+    // the Sign/Verify screen's state.
     @action
-    public signMessage = (text: string): Promise<string | null> => {
+    public signMessage = (
+        text: string,
+        mode?: 'lightning' | 'onchain'
+    ): Promise<string | null> => {
         this.loading = true;
 
         try {
             const signOperation =
-                this.signingMode === 'lightning'
+                (mode ?? this.signingMode) === 'lightning'
                     ? BackendUtils.signMessage(text)
                     : BackendUtils.signMessageWithAddr(
                           text,

--- a/stores/MessageSignStore.ts
+++ b/stores/MessageSignStore.ts
@@ -164,8 +164,13 @@ export default class MessageSignStore {
             });
     };
 
+    // Resolves to the signature so awaiting callers (e.g. the NWC
+    // sign_message handler) get THIS request's signature instead of
+    // reading the shared `signature` observable, which may still hold a
+    // previous request's result. Resolves to null on error; the
+    // observable is still updated for the reactive view.
     @action
-    public signMessage = (text: string) => {
+    public signMessage = (text: string): Promise<string | null> => {
         this.loading = true;
 
         try {
@@ -179,12 +184,14 @@ export default class MessageSignStore {
 
             // Check if signOperation is a valid Promise
             if (signOperation && typeof signOperation.then === 'function') {
-                signOperation
+                return signOperation
                     .then((data: any) => {
                         if (data) {
-                            this.signature = data.zbase || data.signature;
+                            const signature = data.zbase || data.signature;
+                            this.signature = signature;
                             this.error = false;
                             this.errorMessage = '';
+                            return signature ?? null;
                         } else {
                             throw new Error(
                                 localeString(
@@ -195,6 +202,7 @@ export default class MessageSignStore {
                     })
                     .catch((error: any) => {
                         this.handleError(error, 'Unknown signing error', true);
+                        return null;
                     })
                     .finally(() => {
                         this.loading = false;
@@ -206,9 +214,11 @@ export default class MessageSignStore {
                     'views.Settings.SignMessage.signOperationFailed'
                 );
                 this.loading = false;
+                return Promise.resolve(null);
             }
         } catch (error: any) {
             this.handleError(error, 'Unknown signing error');
+            return Promise.resolve(null);
         }
     };
 

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1855,12 +1855,26 @@ export default class NostrWalletConnectStore {
                     );
                 }
             }
-            this.messageSignStore.signMessage(request.message);
-            const signature = this.messageSignStore.signature;
+            // Must await: signMessage resolves to this request's
+            // signature. Reading messageSignStore.signature synchronously
+            // returns the PREVIOUS request's signature (or none), pairing
+            // the wrong signature with this message.
+            const signature = await this.messageSignStore.signMessage(
+                request.message
+            );
+            if (!signature) {
+                return NostrConnectUtils.createNip47Error(
+                    this.messageSignStore.errorMessage ||
+                        localeString(
+                            'views.Settings.SignMessage.signOperationFailed'
+                        ),
+                    Nip47ErrorCode.INTERNAL_ERROR
+                );
+            }
             return {
                 result: {
                     message: request.message,
-                    signature: signature || ''
+                    signature
                 },
                 error: undefined
             };

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1859,8 +1859,12 @@ export default class NostrWalletConnectStore {
             // signature. Reading messageSignStore.signature synchronously
             // returns the PREVIOUS request's signature (or none), pairing
             // the wrong signature with this message.
+            // Force lightning mode: the shared signingMode observable may
+            // be left on 'onchain' by the Sign/Verify screen, which would
+            // sign with a wallet address instead of the node identity.
             const signature = await this.messageSignStore.signMessage(
-                request.message
+                request.message,
+                'lightning'
             );
             if (!signature) {
                 return NostrConnectUtils.createNip47Error(


### PR DESCRIPTION
# Description

Fixes the NWC `sign_message` handler returning the wrong signature.

`handleSignMessage` called `messageSignStore.signMessage(request.message)` and then synchronously read `messageSignStore.signature` on the next line. But `signMessage` is fire-and-forget: it dispatches the async backend call and sets the `signature` observable later, inside a `.then()`, returning nothing. So the value read back is whatever the *previous* `sign_message` request left in the store, an empty string on the first request, or a valid signature over a *different* message on later ones.

The response then pairs `message: request.message` with that stale signature, so a verifier checking the signature against the stated message fails, or the client attributes a signature over message A to message B. This undermines every signed NWC interaction, not just an occasional one.

## What changed

- `stores/MessageSignStore.ts`: `signMessage` now returns `Promise<string | null>` that resolves to this request's signature (or `null` on failure). The `signature` observable is still updated, so the reactive `SignVerifyMessage` view is unchanged.
- `stores/NostrWalletConnectStore.ts`: `handleSignMessage` awaits `signMessage` and returns the resolved value; a `null`/empty result yields a NIP-47 `INTERNAL_ERROR` instead of a bogus signature.

Reading the resolved value rather than the shared observable also removes a secondary race: two concurrent `sign_message` requests would otherwise clobber each other's `signature` observable. `sign_message` is not on the payment serialization queue (#4303), so this matters independently.

## Verification

Verified the only two callers of `MessageSignStore.signMessage` are this handler and `views/Tools/SignVerifyMessage.tsx`; the view is an `@observer` that ignores the return value and reacts to the `signature` observable, so its behavior is unchanged.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] Embedded LND
- [ ] LDK Node

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS Transifex page and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified
