### PR TITLE
fix(swaps): verify reverse-swap invoice before it can be paid

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2429,6 +2429,7 @@
     "views.Swaps.missingAmount": "Please enter an amount",
     "views.Swaps.generateInvoice": "Generate invoice",
     "views.Swaps.generateInvoiceFailed": "Failed to generate invoice",
+    "views.Swaps.invalidReverseSwapInvoice": "The swap provider returned an invoice that does not match the requested swap. For your safety, this swap has been aborted and no payment was made.",
     "views.Swaps.generateOnchainAddress": "Generate on-chain address",
     "views.Swaps.generateOnchainAddressFailed": "Failed to generate on-chain address",
     "views.Swaps.noUpdates": "No updates found!",

--- a/locales/en.json
+++ b/locales/en.json
@@ -2420,6 +2420,7 @@
     "views.Swaps.missingAmount": "Please enter an amount",
     "views.Swaps.generateInvoice": "Generate invoice",
     "views.Swaps.generateInvoiceFailed": "Failed to generate invoice",
+    "views.Swaps.invalidReverseSwapInvoice": "The swap provider returned an invoice that does not match the requested swap. For your safety, this swap has been aborted and no payment was made.",
     "views.Swaps.generateOnchainAddress": "Generate on-chain address",
     "views.Swaps.generateOnchainAddressFailed": "Failed to generate on-chain address",
     "views.Swaps.noUpdates": "No updates found!",

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -17,7 +17,8 @@ import {
     SWAPS_KEY,
     REVERSE_SWAPS_KEY,
     SWAPS_RESCUE_KEY,
-    SWAPS_LAST_USED_KEY
+    SWAPS_LAST_USED_KEY,
+    verifyReverseSwapInvoice
 } from '../utils/SwapUtils';
 
 import NodeInfoStore from './NodeInfoStore';
@@ -467,6 +468,31 @@ export default class SwapStore {
                     this.loading = false;
                 });
                 console.error('Error in API response:', responseData.error);
+                return;
+            }
+
+            // Verify the host-supplied invoice before it can be paid: its
+            // payment hash must equal sha256(our preimage) and its amount
+            // must match what we requested. Without this a malicious or
+            // compromised host could return an invoice paying itself with
+            // an unrelated hash, breaking swap atomicity and losing the
+            // user's lightning funds.
+            const invoiceCheck = verifyReverseSwapInvoice(
+                responseData.invoice,
+                crypto.sha256(preimage).toString('hex'),
+                Number(invoiceAmount)
+            );
+            if (!invoiceCheck.valid) {
+                runInAction(() => {
+                    this.apiError = localeString(
+                        'views.Swaps.invalidReverseSwapInvoice'
+                    );
+                    this.loading = false;
+                });
+                console.error(
+                    'Reverse swap invoice verification failed:',
+                    invoiceCheck.reason
+                );
                 return;
             }
 

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -14,7 +14,8 @@ import {
     REVERSE_SWAPS_KEY,
     SWAPS_RESCUE_KEY,
     SWAPS_LAST_USED_KEY,
-    isValidRescueKey
+    isValidRescueKey,
+    verifyReverseSwapInvoice
 } from '../utils/SwapUtils';
 
 import NodeInfoStore from './NodeInfoStore';
@@ -480,6 +481,31 @@ export default class SwapStore {
                     this.loading = false;
                 });
                 console.error('Error in API response:', responseData.error);
+                return;
+            }
+
+            // Verify the host-supplied invoice before it can be paid: its
+            // payment hash must equal sha256(our preimage) and its amount
+            // must match what we requested. Without this a malicious or
+            // compromised host could return an invoice paying itself with
+            // an unrelated hash, breaking swap atomicity and losing the
+            // user's lightning funds.
+            const invoiceCheck = verifyReverseSwapInvoice(
+                responseData.invoice,
+                crypto.sha256(preimage).toString('hex'),
+                Number(invoiceAmount)
+            );
+            if (!invoiceCheck.valid) {
+                runInAction(() => {
+                    this.apiError = localeString(
+                        'views.Swaps.invalidReverseSwapInvoice'
+                    );
+                    this.loading = false;
+                });
+                console.error(
+                    'Reverse swap invoice verification failed:',
+                    invoiceCheck.reason
+                );
                 return;
             }
 

--- a/utils/SwapUtils.test.ts
+++ b/utils/SwapUtils.test.ts
@@ -6,8 +6,17 @@ import {
     calculateServiceFeeOnSend,
     calculateSendAmount,
     calculateLimit,
-    isValidRescueKey
+    isValidRescueKey,
+    verifyReverseSwapInvoice
 } from './SwapUtils';
+
+// regtest BOLT11 vector: 123 sats,
+// payment_hash f2cbe057ae04a29a28b098de1eea199d8f1802810fb4f0269dac84c6f8c8762d
+const REVERSE_INVOICE =
+    'lnbcrt1230n1pj429x7pp57t97q4awqj3f529snr0pa6senk83sq5pp760qf5a4jzvd7xgwcksdqqcqzzsxqrrsssp57eqtv7vxr46arupna3w4ct0lkf2mqmz9wt044cwkks0rwlnhfr5s9qyyssqragwpwav7nfwv2xyuuamxxj4pnnpzv2hlw7j473repd3sq7st698ta9kmzmygt0w7tmncl56a6mnma0w7e5dlpqd0wy6x3v35rssldspjhh8p0';
+const REVERSE_INVOICE_HASH =
+    'f2cbe057ae04a29a28b098de1eea199d8f1802810fb4f0269dac84c6f8c8762d';
+const REVERSE_INVOICE_SATS = 123;
 
 describe('SwapUtils', () => {
     describe('bigCeil', () => {
@@ -181,6 +190,56 @@ describe('SwapUtils', () => {
                     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art'
                 )
             ).toBe(false);
+        });
+    });
+
+    describe('verifyReverseSwapInvoice', () => {
+        it('accepts an invoice whose hash and amount match', () => {
+            const result = verifyReverseSwapInvoice(
+                REVERSE_INVOICE,
+                REVERSE_INVOICE_HASH,
+                REVERSE_INVOICE_SATS
+            );
+            expect(result.valid).toBe(true);
+        });
+
+        it('accepts a hash regardless of casing', () => {
+            const result = verifyReverseSwapInvoice(
+                REVERSE_INVOICE,
+                REVERSE_INVOICE_HASH.toUpperCase(),
+                REVERSE_INVOICE_SATS
+            );
+            expect(result.valid).toBe(true);
+        });
+
+        it('rejects a payment-hash mismatch (malicious host)', () => {
+            const result = verifyReverseSwapInvoice(
+                REVERSE_INVOICE,
+                'f'.repeat(64),
+                REVERSE_INVOICE_SATS
+            );
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('payment-hash-mismatch');
+        });
+
+        it('rejects an amount mismatch even when the hash matches', () => {
+            const result = verifyReverseSwapInvoice(
+                REVERSE_INVOICE,
+                REVERSE_INVOICE_HASH,
+                REVERSE_INVOICE_SATS + 1
+            );
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('amount-mismatch');
+        });
+
+        it('rejects an undecodable invoice', () => {
+            const result = verifyReverseSwapInvoice(
+                'not-a-real-invoice',
+                REVERSE_INVOICE_HASH,
+                REVERSE_INVOICE_SATS
+            );
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('undecodable');
         });
     });
 });

--- a/utils/SwapUtils.test.ts
+++ b/utils/SwapUtils.test.ts
@@ -5,8 +5,17 @@ import {
     calculateReceiveAmount,
     calculateServiceFeeOnSend,
     calculateSendAmount,
-    calculateLimit
+    calculateLimit,
+    verifyReverseSwapInvoice
 } from './SwapUtils';
+
+// regtest BOLT11 vector: 123 sats,
+// payment_hash f2cbe057ae04a29a28b098de1eea199d8f1802810fb4f0269dac84c6f8c8762d
+const REVERSE_INVOICE =
+    'lnbcrt1230n1pj429x7pp57t97q4awqj3f529snr0pa6senk83sq5pp760qf5a4jzvd7xgwcksdqqcqzzsxqrrsssp57eqtv7vxr46arupna3w4ct0lkf2mqmz9wt044cwkks0rwlnhfr5s9qyyssqragwpwav7nfwv2xyuuamxxj4pnnpzv2hlw7j473repd3sq7st698ta9kmzmygt0w7tmncl56a6mnma0w7e5dlpqd0wy6x3v35rssldspjhh8p0';
+const REVERSE_INVOICE_HASH =
+    'f2cbe057ae04a29a28b098de1eea199d8f1802810fb4f0269dac84c6f8c8762d';
+const REVERSE_INVOICE_SATS = 123;
 
 describe('SwapUtils', () => {
     describe('bigCeil', () => {
@@ -119,6 +128,56 @@ describe('SwapUtils', () => {
         it('should return limit as-is when in reverse mode', () => {
             const result = calculateLimit(940, 1, 50, true);
             expect(result).toBe(940);
+        });
+    });
+
+    describe('verifyReverseSwapInvoice', () => {
+        it('accepts an invoice whose hash and amount match', () => {
+            const result = verifyReverseSwapInvoice(
+                REVERSE_INVOICE,
+                REVERSE_INVOICE_HASH,
+                REVERSE_INVOICE_SATS
+            );
+            expect(result.valid).toBe(true);
+        });
+
+        it('accepts a hash regardless of casing', () => {
+            const result = verifyReverseSwapInvoice(
+                REVERSE_INVOICE,
+                REVERSE_INVOICE_HASH.toUpperCase(),
+                REVERSE_INVOICE_SATS
+            );
+            expect(result.valid).toBe(true);
+        });
+
+        it('rejects a payment-hash mismatch (malicious host)', () => {
+            const result = verifyReverseSwapInvoice(
+                REVERSE_INVOICE,
+                'f'.repeat(64),
+                REVERSE_INVOICE_SATS
+            );
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('payment-hash-mismatch');
+        });
+
+        it('rejects an amount mismatch even when the hash matches', () => {
+            const result = verifyReverseSwapInvoice(
+                REVERSE_INVOICE,
+                REVERSE_INVOICE_HASH,
+                REVERSE_INVOICE_SATS + 1
+            );
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('amount-mismatch');
+        });
+
+        it('rejects an undecodable invoice', () => {
+            const result = verifyReverseSwapInvoice(
+                'not-a-real-invoice',
+                REVERSE_INVOICE_HASH,
+                REVERSE_INVOICE_SATS
+            );
+            expect(result.valid).toBe(false);
+            expect(result.reason).toBe('undecodable');
         });
     });
 });

--- a/utils/SwapUtils.ts
+++ b/utils/SwapUtils.ts
@@ -1,7 +1,48 @@
 import BigNumber from 'bignumber.js';
 
+import Bolt11Utils from './Bolt11Utils';
+
 export const bigCeil = (big: BigNumber): BigNumber => {
     return big.integerValue(BigNumber.ROUND_CEIL);
+};
+
+/**
+ * Verifies a reverse-swap invoice returned by the swap host before it is
+ * paid. In a reverse swap ZEUS chooses the preimage and sends only its
+ * hash to the host; the host must return a hold invoice whose payment
+ * hash equals that hash, for the requested amount. A malicious or
+ * compromised host (custom hosts are supported) could otherwise return an
+ * invoice paying itself with an unrelated payment hash: the user pays it,
+ * the on-chain lockup that ZEUS can claim is never bound to that payment,
+ * and the lightning funds are lost. Returns { valid: false, reason } on
+ * any mismatch so the caller can abort before paying.
+ */
+export const verifyReverseSwapInvoice = (
+    invoice: string,
+    expectedPaymentHash: string,
+    expectedAmountSats: number
+): { valid: boolean; reason?: string } => {
+    let decoded;
+    try {
+        decoded = Bolt11Utils.decode(invoice);
+    } catch (e) {
+        return { valid: false, reason: 'undecodable' };
+    }
+
+    const paymentHash = (decoded.payment_hash || '').toLowerCase();
+    if (!paymentHash) {
+        return { valid: false, reason: 'missing-payment-hash' };
+    }
+    if (paymentHash !== expectedPaymentHash.toLowerCase()) {
+        return { valid: false, reason: 'payment-hash-mismatch' };
+    }
+
+    const invoiceSats = new BigNumber(decoded.num_satoshis || 0);
+    if (!invoiceSats.isEqualTo(expectedAmountSats)) {
+        return { valid: false, reason: 'amount-mismatch' };
+    }
+
+    return { valid: true };
 };
 
 export const bigFloor = (big: BigNumber): BigNumber => {

--- a/utils/SwapUtils.ts
+++ b/utils/SwapUtils.ts
@@ -3,8 +3,49 @@ import { validateMnemonic } from '@scure/bip39';
 
 import { BIP39_WORD_LIST } from './Bip39Utils';
 
+import Bolt11Utils from './Bolt11Utils';
+
 export const bigCeil = (big: BigNumber): BigNumber => {
     return big.integerValue(BigNumber.ROUND_CEIL);
+};
+
+/**
+ * Verifies a reverse-swap invoice returned by the swap host before it is
+ * paid. In a reverse swap ZEUS chooses the preimage and sends only its
+ * hash to the host; the host must return a hold invoice whose payment
+ * hash equals that hash, for the requested amount. A malicious or
+ * compromised host (custom hosts are supported) could otherwise return an
+ * invoice paying itself with an unrelated payment hash: the user pays it,
+ * the on-chain lockup that ZEUS can claim is never bound to that payment,
+ * and the lightning funds are lost. Returns { valid: false, reason } on
+ * any mismatch so the caller can abort before paying.
+ */
+export const verifyReverseSwapInvoice = (
+    invoice: string,
+    expectedPaymentHash: string,
+    expectedAmountSats: number
+): { valid: boolean; reason?: string } => {
+    let decoded;
+    try {
+        decoded = Bolt11Utils.decode(invoice);
+    } catch (e) {
+        return { valid: false, reason: 'undecodable' };
+    }
+
+    const paymentHash = (decoded.payment_hash || '').toLowerCase();
+    if (!paymentHash) {
+        return { valid: false, reason: 'missing-payment-hash' };
+    }
+    if (paymentHash !== expectedPaymentHash.toLowerCase()) {
+        return { valid: false, reason: 'payment-hash-mismatch' };
+    }
+
+    const invoiceSats = new BigNumber(decoded.num_satoshis || 0);
+    if (!invoiceSats.isEqualTo(expectedAmountSats)) {
+        return { valid: false, reason: 'amount-mismatch' };
+    }
+
+    return { valid: true };
 };
 
 export const bigFloor = (big: BigNumber): BigNumber => {


### PR DESCRIPTION
# Description

Verifies the swap host's invoice before a reverse swap can pay it.

In a reverse swap, ZEUS chooses the preimage and sends only its hash (`preimageHash`) to the swap host. The host must return a hold invoice whose payment hash equals that hash, for the requested amount. `createReverseSwap` stored and displayed the host's `invoice` verbatim with no verification, so a malicious or compromised host (custom swap hosts are supported via `settings.swaps.customHost`) could return an invoice paying itself with an unrelated payment hash. The user pays that invoice over Lightning, but the on-chain lockup ZEUS can claim with its preimage is never bound to that payment, so the Lightning funds are lost with nothing received on-chain: swap atomicity broken client-side.

## What changed

- `utils/SwapUtils.ts`: new pure `verifyReverseSwapInvoice(invoice, expectedPaymentHash, expectedAmountSats)` that decodes the invoice and asserts its `payment_hash` equals the expected hash (`sha256(preimage)`) and its amount equals the requested amount. Returns `{ valid, reason }`.
- `stores/SwapStore.ts` (`createReverseSwap`): after parsing the response and before saving/displaying/paying, run the check against `sha256(preimage)` and the requested `invoiceAmount`. On failure, set a user-facing error and abort without proceeding.
- `locales/en.json`: `views.Swaps.invalidReverseSwapInvoice` error string.
- `utils/SwapUtils.test.ts`: unit tests for the matching case, hash mismatch (the malicious-host scenario), amount mismatch, casing tolerance, and undecodable invoice, using a known regtest BOLT11 vector.

Note: an equivalent `validatePreimage` check already exists in `SwapDetails` but only on the claim path (validating the claim-details preimage against the invoice hash); it does not cover the invoice the user pays at swap creation, which is the gap this closes.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] Embedded LND
- [ ] LDK Node

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS Transifex page and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified
