### PR TITLE
utils: disable REST proxy in embedded LND config

### DIFF
--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -249,6 +249,7 @@ const writeLndConfig = async ({
     const config = `[Application Options]
     debuglevel=info
     maxbackoff=2s
+    norest=1
     sync-freelist=1
     accept-keysend=1
     tlsdisableautofill=1
@@ -261,11 +262,9 @@ const writeLndConfig = async ({
     ${dbConfig}
     
     [Routing]
-    routing.assumechanvalid=1
     routing.strictgraphpruning=false
 
     [Bitcoin]
-    bitcoin.active=1
     bitcoin.mainnet=${isTestnet ? 0 : 1}
     bitcoin.testnet=${isTestnet ? 1 : 0}
     bitcoin.node=neutrino


### PR DESCRIPTION
# Description

A user reported embedded LND failing to start in a loop with:

```
[ERR] LTND: gRPC proxy unable to listen on 127.0.0.1:8080
[ERR] LTND: Shutting down due to error in main method err="listen tcp4 127.0.0.1:8080: bind: address already in use"
```

Embedded LND starts lnd's REST proxy on the default `restlisten` address (127.0.0.1:8080), but ZEUS never uses it: all communication with the daemon goes over gomobile/bufconn, and a repo-wide search finds no consumer of port 8080. If anything else on the device holds that port (another app, or a listener left behind by a previous lnd instance in the same app process), lnd aborts startup entirely and the wallet cannot connect.

This PR sets `norest=1` in the generated lnd.conf so the proxy is never bound, which eliminates this failure class and stops exposing an unused localhost port to other apps on the device.

It also removes two config options that lnd warns about on every start:

- `bitcoin.active`: deprecated and ignored, since Bitcoin is the only supported chain
- `routing.assumechanvalid`: deprecated in [lnd v0.13.0](https://github.com/lightningnetwork/lnd/releases/tag/v0.13.0-beta); assuming channel validity has been the default for Neutrino-backed nodes since then (the inverse flag is `neutrino.validatechannels`), so removing it preserves existing behavior

Expected log changes: the two deprecation warnings disappear and there is no gRPC proxy listen attempt. The "Listening on the p2p interface is disabled!" line remains, as it comes from the intentional `--nolisten` startup arg.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Manual testing on both platforms (embedded LND wallet start, sync, receive, pay) still pending; will update the matrix once complete.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
