### PR TITLE
refactor: move Receive payment watchers into backend classes

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -1,4 +1,5 @@
 import { settingsStore, nodeInfoStore } from '../stores/Stores';
+import Invoice from '../models/Invoice';
 import TransactionRequest from '../models/TransactionRequest';
 import OpenChannelRequest from '../models/OpenChannelRequest';
 import VersionUtils from '../utils/VersionUtils';
@@ -282,6 +283,42 @@ export default class CLNRest {
             }
             return invoice;
         });
+    // Poll lookupInvoice for the watched payment hash instead of scanning
+    // the invoice list: getInvoices includes unpaid invoices, so on busy
+    // nodes the watched invoice can be pushed out of the window before
+    // it is paid. rHash arrives hex encoded from the Receive view
+    watchInvoicePaid = (
+        { rHash, value }: { rHash: string; value?: string | number },
+        onPaid: (payload: {
+            amountSat: number;
+            tx?: string;
+            preimage?: string;
+        }) => void
+    ): (() => void) => {
+        const interval = setInterval(() => {
+            this.lookupInvoice({ r_hash: rHash })
+                .then((result: any) => {
+                    const invoice = new Invoice(result);
+                    const amountPaid = invoice.getAmount;
+                    if (
+                        invoice.isPaid &&
+                        Number(amountPaid) >= Number(value) &&
+                        Number(amountPaid) !== 0
+                    ) {
+                        clearInterval(interval);
+                        onPaid({
+                            amountSat: Number(amountPaid),
+                            tx: invoice.getPaymentRequest
+                        });
+                    }
+                })
+                .catch(() => {
+                    // invoice not found or node unreachable;
+                    // retry on the next tick
+                });
+        }, 5000);
+        return () => clearInterval(interval);
+    };
     getInvoices = (data?: any) =>
         this.postRequest('/v1/sql', {
             query: `SELECT label, bolt11, bolt12, payment_hash, amount_msat, status, amount_received_msat, paid_at, payment_preimage, description, expires_at FROM invoices ORDER BY created_index DESC LIMIT ${

--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -1,4 +1,5 @@
 import { settingsStore, nodeInfoStore } from '../stores/Stores';
+import Invoice from '../models/Invoice';
 import TransactionRequest from '../models/TransactionRequest';
 import OpenChannelRequest from '../models/OpenChannelRequest';
 import VersionUtils from '../utils/VersionUtils';
@@ -289,6 +290,42 @@ export default class CLNRest {
             }
             return invoice;
         });
+    // Poll lookupInvoice for the watched payment hash instead of scanning
+    // the invoice list: getInvoices includes unpaid invoices, so on busy
+    // nodes the watched invoice can be pushed out of the window before
+    // it is paid. rHash arrives hex encoded from the Receive view
+    watchInvoicePaid = (
+        { rHash, value }: { rHash: string; value?: string | number },
+        onPaid: (payload: {
+            amountSat: number;
+            tx?: string;
+            preimage?: string;
+        }) => void
+    ): (() => void) => {
+        const interval = setInterval(() => {
+            this.lookupInvoice({ r_hash: rHash })
+                .then((result: any) => {
+                    const invoice = new Invoice(result);
+                    const amountPaid = invoice.getAmount;
+                    if (
+                        invoice.isPaid &&
+                        Number(amountPaid) >= Number(value) &&
+                        Number(amountPaid) !== 0
+                    ) {
+                        clearInterval(interval);
+                        onPaid({
+                            amountSat: Number(amountPaid),
+                            tx: invoice.getPaymentRequest
+                        });
+                    }
+                })
+                .catch(() => {
+                    // invoice not found or node unreachable;
+                    // retry on the next tick
+                });
+        }, 5000);
+        return () => clearInterval(interval);
+    };
     getInvoices = (data?: any) =>
         this.postRequest('/v1/sql', {
             query: `SELECT label, bolt11, bolt12, payment_hash, amount_msat, status, amount_received_msat, paid_at, payment_preimage, description, expires_at FROM invoices ORDER BY created_index DESC LIMIT ${

--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -3,6 +3,7 @@ import OpenChannelRequest from '../models/OpenChannelRequest';
 import Base64Utils from './../utils/Base64Utils';
 
 import lndMobile from '../lndmobile/LndMobileInjection';
+import { decodeSubscribeTransactionsResult } from '../lndmobile/onchain';
 
 import {
     checkLndStreamErrorResponse,
@@ -418,10 +419,129 @@ export default class EmbeddedLND extends LND {
     terminateWatchtowerSession = async (sessionId: string) =>
         await WatchtowerClientTerminateSession(sessionId);
 
-    // TODO rewrite subscription logic, starting on Receive view
-    // subscribeInvoice = (r_hash: string) =>
-    //     this.getRequest(`/v2/invoices/subscribe/${r_hash}`);
-    // subscribeTransactions = () => this.getRequest('/v1/transactions/subscribe');
+    // rHash arrives hex encoded from the Receive view
+    watchInvoicePaid = (
+        { rHash }: { rHash: string; value?: string | number },
+        onPaid: (payload: {
+            amountSat: number;
+            tx?: string;
+            preimage?: string;
+        }) => void
+    ): (() => void) => {
+        const listener = LndMobileEventEmitter.addListener(
+            'SubscribeInvoices',
+            (e: any) => {
+                try {
+                    const error = checkLndStreamErrorResponse(
+                        'SubscribeInvoices',
+                        e
+                    );
+                    if (error === 'EOF') {
+                        listener.remove();
+                        return;
+                    } else if (error) {
+                        console.error('Got error from SubscribeInvoices', [
+                            error
+                        ]);
+                        listener.remove();
+                        return;
+                    }
+
+                    const invoice = lndMobile.wallet.decodeInvoiceResult(
+                        e.data
+                    );
+
+                    if (
+                        invoice.settled &&
+                        // @ts-ignore:next-line
+                        Base64Utils.bytesToHex(invoice.r_hash) === rHash
+                    ) {
+                        listener.remove();
+                        onPaid({
+                            amountSat: Number(invoice.amt_paid_sat),
+                            tx: invoice.payment_request,
+                            preimage: Base64Utils.bytesToHex(
+                                // @ts-ignore:next-line
+                                invoice.r_preimage
+                            )
+                        });
+                    }
+                } catch (error) {
+                    console.error(error);
+                    listener.remove();
+                }
+            }
+        );
+
+        lndMobile.wallet
+            .subscribeInvoices()
+            .catch((error) =>
+                console.error('subscribeInvoices error', [error])
+            );
+
+        return () => listener.remove();
+    };
+    watchOnchainReceived = (
+        {
+            address,
+            value,
+            numConfPreference
+        }: {
+            address: string;
+            value?: string | number;
+            numConfPreference: number;
+            blockHeight?: number;
+        },
+        onReceived: (payload: { amountSat: number; txid: string }) => void
+    ): (() => void) => {
+        const listener = LndMobileEventEmitter.addListener(
+            'SubscribeTransactions',
+            (e: any) => {
+                try {
+                    const error = checkLndStreamErrorResponse(
+                        'SubscribeTransactions',
+                        e
+                    );
+                    if (error === 'EOF') {
+                        listener.remove();
+                        return;
+                    } else if (error) {
+                        console.error('Got error from SubscribeTransactions', [
+                            error
+                        ]);
+                        listener.remove();
+                        return;
+                    }
+
+                    const transaction = decodeSubscribeTransactionsResult(
+                        e.data
+                    );
+                    if (
+                        transaction.dest_addresses.includes(address) &&
+                        transaction.num_confirmations > numConfPreference &&
+                        Number(transaction.amount) >= Number(value)
+                    ) {
+                        listener.remove();
+                        onReceived({
+                            amountSat: Number(transaction.amount),
+                            txid: transaction.tx_hash
+                        });
+                    }
+                } catch (error) {
+                    console.error(error);
+                    listener.remove();
+                }
+            }
+        );
+
+        lndMobile.onchain
+            .subscribeTransactions()
+            .catch((error) =>
+                console.error('subscribeTransactions error', [error])
+            );
+
+        return () => listener.remove();
+    };
     // initChannelAcceptor = async (callback: any) =>
     //     await channelAcceptor(callback);
     supportsWatchtowerClient = () => true;

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -5,6 +5,7 @@ import {
     isOnionHttpsUrl,
     RequestMethod
 } from '../utils/TorUtils';
+import Invoice from './../models/Invoice';
 import OpenChannelRequest from './../models/OpenChannelRequest';
 import Base64Utils from './../utils/Base64Utils';
 import VersionUtils from './../utils/VersionUtils';
@@ -751,6 +752,96 @@ export default class LND {
     subscribeInvoice = (r_hash: string) =>
         this.getRequest(`/v2/invoices/subscribe/${r_hash}`);
     subscribeTransactions = () => this.getRequest('/v1/transactions/subscribe');
+    // Poll lookupInvoice for the watched payment hash instead of scanning
+    // the invoice list, which can push the watched invoice out of the
+    // window on busy nodes. rHash arrives base64url encoded from the
+    // Receive view; the REST lookup endpoint expects hex
+    watchInvoicePaid = (
+        { rHash, value }: { rHash: string; value?: string | number },
+        onPaid: (payload: {
+            amountSat: number;
+            tx?: string;
+            preimage?: string;
+        }) => void
+    ): (() => void) => {
+        const interval = setInterval(() => {
+            this.lookupInvoice({
+                r_hash: Base64Utils.base64UrlToHex(rHash)
+            })
+                .then((result: any) => {
+                    const invoice = new Invoice(result);
+                    const amountPaid = invoice.getAmount;
+                    if (
+                        invoice.isPaid &&
+                        Number(amountPaid) >= Number(value) &&
+                        Number(amountPaid) !== 0
+                    ) {
+                        clearInterval(interval);
+                        onPaid({
+                            amountSat: Number(amountPaid),
+                            tx: invoice.getPaymentRequest
+                        });
+                    }
+                })
+                .catch(() => {
+                    // invoice not found or node unreachable;
+                    // retry on the next tick
+                });
+        }, 5000);
+        return () => clearInterval(interval);
+    };
+    watchOnchainReceived = (
+        {
+            address,
+            value,
+            numConfPreference,
+            blockHeight
+        }: {
+            address: string;
+            value?: string | number;
+            numConfPreference: number;
+            blockHeight?: number;
+        },
+        onReceived: (payload: { amountSat: number; txid: string }) => void
+    ): (() => void) => {
+        const interval = setInterval(() => {
+            // only look for transactions in the last 3 blocks
+            this.getTransactions(
+                blockHeight ? { start_height: blockHeight - 3 } : null
+            )
+                .then((response: any) => {
+                    const txs = response.transactions;
+                    for (let i = 0; i < txs.length; i++) {
+                        const result = txs[i];
+                        if (
+                            result.dest_addresses.includes(address) &&
+                            result.num_confirmations >= numConfPreference
+                        ) {
+                            // loop through outputs since amount is negative if unconfirmed
+                            const output_details = result.output_details;
+                            for (let j = 0; j < output_details.length; j++) {
+                                const output = output_details[j];
+                                if (
+                                    Number(output.amount) >= Number(value) &&
+                                    output.address === address
+                                ) {
+                                    clearInterval(interval);
+                                    onReceived({
+                                        amountSat: Number(output.amount),
+                                        txid: result.tx_hash
+                                    });
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                })
+                .catch(() => {
+                    // node unreachable; retry on the next tick
+                });
+        }, 7000);
+        return () => clearInterval(interval);
+    };
     initChanAcceptor = (data?: any) => {
         const { host, lndhubUrl, port, macaroonHex, accessToken } =
             settingsStore;

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -5,6 +5,7 @@ import {
     isOnionHttpsUrl,
     RequestMethod
 } from '../utils/TorUtils';
+import Invoice from './../models/Invoice';
 import OpenChannelRequest from './../models/OpenChannelRequest';
 import Base64Utils from './../utils/Base64Utils';
 import VersionUtils from './../utils/VersionUtils';
@@ -730,6 +731,96 @@ export default class LND {
     subscribeInvoice = (r_hash: string) =>
         this.getRequest(`/v2/invoices/subscribe/${r_hash}`);
     subscribeTransactions = () => this.getRequest('/v1/transactions/subscribe');
+    // Poll lookupInvoice for the watched payment hash instead of scanning
+    // the invoice list, which can push the watched invoice out of the
+    // window on busy nodes. rHash arrives base64url encoded from the
+    // Receive view; the REST lookup endpoint expects hex
+    watchInvoicePaid = (
+        { rHash, value }: { rHash: string; value?: string | number },
+        onPaid: (payload: {
+            amountSat: number;
+            tx?: string;
+            preimage?: string;
+        }) => void
+    ): (() => void) => {
+        const interval = setInterval(() => {
+            this.lookupInvoice({
+                r_hash: Base64Utils.base64UrlToHex(rHash)
+            })
+                .then((result: any) => {
+                    const invoice = new Invoice(result);
+                    const amountPaid = invoice.getAmount;
+                    if (
+                        invoice.isPaid &&
+                        Number(amountPaid) >= Number(value) &&
+                        Number(amountPaid) !== 0
+                    ) {
+                        clearInterval(interval);
+                        onPaid({
+                            amountSat: Number(amountPaid),
+                            tx: invoice.getPaymentRequest
+                        });
+                    }
+                })
+                .catch(() => {
+                    // invoice not found or node unreachable;
+                    // retry on the next tick
+                });
+        }, 5000);
+        return () => clearInterval(interval);
+    };
+    watchOnchainReceived = (
+        {
+            address,
+            value,
+            numConfPreference,
+            blockHeight
+        }: {
+            address: string;
+            value?: string | number;
+            numConfPreference: number;
+            blockHeight?: number;
+        },
+        onReceived: (payload: { amountSat: number; txid: string }) => void
+    ): (() => void) => {
+        const interval = setInterval(() => {
+            // only look for transactions in the last 3 blocks
+            this.getTransactions(
+                blockHeight ? { start_height: blockHeight - 3 } : null
+            )
+                .then((response: any) => {
+                    const txs = response.transactions;
+                    for (let i = 0; i < txs.length; i++) {
+                        const result = txs[i];
+                        if (
+                            result.dest_addresses.includes(address) &&
+                            result.num_confirmations >= numConfPreference
+                        ) {
+                            // loop through outputs since amount is negative if unconfirmed
+                            const output_details = result.output_details;
+                            for (let j = 0; j < output_details.length; j++) {
+                                const output = output_details[j];
+                                if (
+                                    Number(output.amount) >= Number(value) &&
+                                    output.address === address
+                                ) {
+                                    clearInterval(interval);
+                                    onReceived({
+                                        amountSat: Number(output.amount),
+                                        txid: result.tx_hash
+                                    });
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                })
+                .catch(() => {
+                    // node unreachable; retry on the next tick
+                });
+        }, 7000);
+        return () => clearInterval(interval);
+    };
     initChanAcceptor = (data?: any) => {
         const { host, lndhubUrl, port, macaroonHex, accessToken } =
             settingsStore;

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -124,6 +124,31 @@ export default class LdkNode {
         };
     };
 
+    // rHash arrives hex encoded from the Receive view
+    watchInvoicePaid = (
+        { rHash }: { rHash: string; value?: string | number },
+        onPaid: (payload: {
+            amountSat: number;
+            tx?: string;
+            preimage?: string;
+        }) => void
+    ): (() => void) => {
+        const unsubscribe = this.subscribeToEvents((event) => {
+            if (
+                event.type === 'paymentReceived' &&
+                rHash &&
+                event.paymentHash === rHash
+            ) {
+                unsubscribe();
+                onPaid({
+                    amountSat: Math.floor(event.amountMsat / 1000),
+                    tx: event.paymentHash
+                });
+            }
+        });
+        return unsubscribe;
+    };
+
     /**
      * Start the event loop
      */

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -625,6 +625,98 @@ export default class LightningNodeConnect {
     subscribeInvoices = () => this.lnc.lnd.lightning.subscribeInvoices();
     subscribeTransactions = () =>
         this.lnc.lnd.lightning.subscribeTransactions();
+    watchInvoicePaid = (
+        { rHash }: { rHash: string; value?: string | number },
+        onPaid: (payload: {
+            amountSat: number;
+            tx?: string;
+            preimage?: string;
+        }) => void
+    ): (() => void) => {
+        const { LncModule } = NativeModules;
+        const eventName = this.subscribeInvoice(rHash);
+        const eventEmitter = new NativeEventEmitter(LncModule);
+        const listener = eventEmitter.addListener(eventName, (event: any) => {
+            if (event.result) {
+                if (
+                    typeof event.result === 'string' &&
+                    event.result.includes('rpc error: code = Canceled')
+                ) {
+                    listener.remove();
+                    return;
+                }
+                try {
+                    const result = JSON.parse(event.result);
+                    if (result === 'EOF') {
+                        listener.remove();
+                        return;
+                    }
+                    if (result.settled) {
+                        listener.remove();
+                        onPaid({
+                            amountSat: Number(result.amt_paid_sat),
+                            tx: result.payment_request,
+                            preimage: result.r_preimage
+                        });
+                    }
+                } catch (error) {
+                    console.error(error);
+                    listener.remove();
+                }
+            }
+        });
+        return () => listener.remove();
+    };
+    watchOnchainReceived = (
+        {
+            address,
+            value,
+            numConfPreference
+        }: {
+            address: string;
+            value?: string | number;
+            numConfPreference: number;
+            blockHeight?: number;
+        },
+        onReceived: (payload: { amountSat: number; txid: string }) => void
+    ): (() => void) => {
+        const { LncModule } = NativeModules;
+        const eventName = this.subscribeTransactions();
+        const eventEmitter = new NativeEventEmitter(LncModule);
+        const listener = eventEmitter.addListener(eventName, (event: any) => {
+            if (event.result) {
+                if (
+                    typeof event.result === 'string' &&
+                    event.result.includes('rpc error: code = Canceled')
+                ) {
+                    listener.remove();
+                    return;
+                }
+                try {
+                    const result = JSON.parse(event.result);
+                    if (result === 'EOF') {
+                        listener.remove();
+                        return;
+                    }
+                    if (
+                        result.dest_addresses.includes(address) &&
+                        result.num_confirmations >= numConfPreference &&
+                        Number(result.amount) >= Number(value)
+                    ) {
+                        listener.remove();
+                        onReceived({
+                            amountSat: Number(result.amount),
+                            txid: result.tx_hash
+                        });
+                    }
+                } catch (error) {
+                    console.error(error);
+                    listener.remove();
+                }
+            }
+        });
+        return () => listener.remove();
+    };
 
     supports = (minVersion: string, eosVersion?: string) => {
         const { nodeInfo } = nodeInfoStore;

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -695,6 +695,98 @@ export default class LightningNodeConnect {
     subscribeInvoices = () => this.lnc.lnd.lightning.subscribeInvoices();
     subscribeTransactions = () =>
         this.lnc.lnd.lightning.subscribeTransactions();
+    watchInvoicePaid = (
+        { rHash }: { rHash: string; value?: string | number },
+        onPaid: (payload: {
+            amountSat: number;
+            tx?: string;
+            preimage?: string;
+        }) => void
+    ): (() => void) => {
+        const { LncModule } = NativeModules;
+        const eventName = this.subscribeInvoice(rHash);
+        const eventEmitter = new NativeEventEmitter(LncModule);
+        const listener = eventEmitter.addListener(eventName, (event: any) => {
+            if (event.result) {
+                if (
+                    typeof event.result === 'string' &&
+                    event.result.includes('rpc error: code = Canceled')
+                ) {
+                    listener.remove();
+                    return;
+                }
+                try {
+                    const result = JSON.parse(event.result);
+                    if (result === 'EOF') {
+                        listener.remove();
+                        return;
+                    }
+                    if (result.settled) {
+                        listener.remove();
+                        onPaid({
+                            amountSat: Number(result.amt_paid_sat),
+                            tx: result.payment_request,
+                            preimage: result.r_preimage
+                        });
+                    }
+                } catch (error) {
+                    console.error(error);
+                    listener.remove();
+                }
+            }
+        });
+        return () => listener.remove();
+    };
+    watchOnchainReceived = (
+        {
+            address,
+            value,
+            numConfPreference
+        }: {
+            address: string;
+            value?: string | number;
+            numConfPreference: number;
+            blockHeight?: number;
+        },
+        onReceived: (payload: { amountSat: number; txid: string }) => void
+    ): (() => void) => {
+        const { LncModule } = NativeModules;
+        const eventName = this.subscribeTransactions();
+        const eventEmitter = new NativeEventEmitter(LncModule);
+        const listener = eventEmitter.addListener(eventName, (event: any) => {
+            if (event.result) {
+                if (
+                    typeof event.result === 'string' &&
+                    event.result.includes('rpc error: code = Canceled')
+                ) {
+                    listener.remove();
+                    return;
+                }
+                try {
+                    const result = JSON.parse(event.result);
+                    if (result === 'EOF') {
+                        listener.remove();
+                        return;
+                    }
+                    if (
+                        result.dest_addresses.includes(address) &&
+                        result.num_confirmations >= numConfPreference &&
+                        Number(result.amount) >= Number(value)
+                    ) {
+                        listener.remove();
+                        onReceived({
+                            amountSat: Number(result.amount),
+                            txid: result.tx_hash
+                        });
+                    }
+                } catch (error) {
+                    console.error(error);
+                    listener.remove();
+                }
+            }
+        });
+        return () => listener.remove();
+    };
 
     supports = (minVersion: string, eosVersion?: string) => {
         const { nodeInfo } = nodeInfoStore;

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -61,6 +61,49 @@ export default class LndHub extends LND {
             return invoice;
         });
 
+    // Scans the user's invoice list since LndHub has no per-invoice
+    // endpoint returning amount details. rHash arrives in whatever format
+    // getFormattedRhash produced when the invoice was created
+    watchInvoicePaid = (
+        { rHash, value }: { rHash: string; value?: string | number },
+        onPaid: (payload: {
+            amountSat: number;
+            tx?: string;
+            preimage?: string;
+        }) => void
+    ): (() => void) => {
+        const interval = setInterval(() => {
+            this.getInvoices()
+                .then((response: any) => {
+                    const invoices = response.invoices;
+                    for (let i = 0; i < invoices.length; i++) {
+                        const result = new Invoice(invoices[i]);
+                        if (
+                            result.getFormattedRhash === rHash &&
+                            result.ispaid &&
+                            Number(result.amt) >= Number(value) &&
+                            Number(result.amt) !== 0
+                        ) {
+                            clearInterval(interval);
+                            onPaid({
+                                amountSat: Number(result.amt),
+                                tx: result.payment_request,
+                                preimage: result.r_preimage
+                            });
+                            break;
+                        }
+                    }
+                })
+                .catch(() => {
+                    // node unreachable; retry on the next tick
+                });
+        }, 5000);
+        return () => clearInterval(interval);
+    };
+    // Block the inherited LND REST transaction poller; LndHub has no
+    // onchain receive support
+    watchOnchainReceived = () => () => {};
+
     createInvoice = (data: any) =>
         this.postRequest('/addinvoice', {
             amt: data.value,

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -142,6 +142,11 @@ class BackendUtils {
     bumpForceCloseFee = (...args: any[]) =>
         this.call('bumpForceCloseFee', args);
     lookupInvoice = (...args: any[]) => this.call('lookupInvoice', args);
+    // return an unsubscribe function, or false on backends
+    // with no real-time payment detection
+    watchInvoicePaid = (...args: any[]) => this.call('watchInvoicePaid', args);
+    watchOnchainReceived = (...args: any[]) =>
+        this.call('watchOnchainReceived', args);
     subscribeInvoice = (...args: any[]) => this.call('subscribeInvoice', args);
     subscribeInvoices = (...args: any[]) =>
         this.call('subscribeInvoices', args);

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import {
     Dimensions,
-    NativeEventEmitter,
-    NativeModules,
     ScrollView,
     StyleSheet,
     TouchableOpacity,
@@ -56,7 +54,6 @@ import TextInput from '../components/TextInput';
 import { Spacer } from '../components/layout/Spacer';
 import Accordion from '../components/Accordion';
 
-import Invoice from '../models/Invoice';
 import Channel from '../models/Channel';
 
 import ChannelsStore from '../stores/ChannelsStore';
@@ -75,7 +72,6 @@ import BalanceStore from '../stores/BalanceStore';
 
 import { localeString } from '../utils/LocaleUtils';
 import BackendUtils from '../utils/BackendUtils';
-import Base64Utils from '../utils/Base64Utils';
 import { scanNfcTag } from '../utils/NFCUtils';
 import { themeColor } from '../utils/ThemeUtils';
 import { SATS_PER_BTC } from '../utils/UnitsUtils';
@@ -87,13 +83,6 @@ import {
     expirySecondsFromInput,
     localizedExpiryDuration
 } from '../utils/ExpiryUtils';
-
-import lndMobile from '../lndmobile/LndMobileInjection';
-import { decodeSubscribeTransactionsResult } from '../lndmobile/onchain';
-import {
-    checkLndStreamErrorResponse,
-    LndMobileEventEmitter
-} from '../utils/LndMobileUtils';
 
 import CaretDown from '../assets/images/SVG/Caret Down.svg';
 import CaretRight from '../assets/images/SVG/Caret Right.svg';
@@ -243,11 +232,8 @@ export default class Receive extends React.Component<
         };
     }
 
-    listener: any;
-    listenerSecondary: any;
-    ldkUnsubscribe: (() => void) | null = null;
-    lnInterval: any;
-    onChainInterval: any;
+    unsubscribeInvoiceWatch: (() => void) | null = null;
+    unsubscribeOnchainWatch: (() => void) | null = null;
     hopPickerRef: HopPicker | null;
 
     private getDefaultIndex = (): number => {
@@ -540,27 +526,28 @@ export default class Receive extends React.Component<
         this.cleanup();
     }
 
-    clearListeners = () => {
-        if (this.listener && this.listener.stop) this.listener.stop();
-        if (this.listenerSecondary && this.listenerSecondary.stop)
-            this.listenerSecondary.stop();
-        if (this.ldkUnsubscribe) {
-            this.ldkUnsubscribe();
-            this.ldkUnsubscribe = null;
+    stopInvoiceWatcher = () => {
+        if (this.unsubscribeInvoiceWatch) {
+            this.unsubscribeInvoiceWatch();
+            this.unsubscribeInvoiceWatch = null;
         }
     };
 
-    clearIntervals = () => {
-        if (this.lnInterval) clearInterval(this.lnInterval);
-        if (this.onChainInterval) clearInterval(this.onChainInterval);
+    stopOnchainWatcher = () => {
+        if (this.unsubscribeOnchainWatch) {
+            this.unsubscribeOnchainWatch();
+            this.unsubscribeOnchainWatch = null;
+        }
+    };
+
+    stopWatchers = () => {
+        this.stopInvoiceWatcher();
+        this.stopOnchainWatcher();
     };
 
     cleanup = () => {
         // kill all listeners and pollers
-        if (this.listener && this.listener.stop) this.listener.stop();
-        if (this.listenerSecondary && this.listenerSecondary.stop)
-            this.listenerSecondary.stop();
-        this.clearIntervals();
+        this.stopWatchers();
 
         // clear invoice
         this.props.InvoicesStore.reset();
@@ -814,10 +801,10 @@ export default class Receive extends React.Component<
         }
     };
 
-    subscribeInvoice = async (rHash?: string, onChainAddress?: string) => {
+    subscribeInvoice = (rHash?: string, onChainAddress?: string) => {
         const { SettingsStore, NodeInfoStore } = this.props;
         const { value } = this.state;
-        const { implementation, settings } = SettingsStore;
+        const { settings } = SettingsStore;
         const { nodeInfo } = NodeInfoStore;
 
         const numConfPreference =
@@ -825,365 +812,52 @@ export default class Receive extends React.Component<
                 ? 1
                 : 0;
 
-        if (implementation === 'embedded-lnd') {
-            if (rHash) {
-                this.listener = LndMobileEventEmitter.addListener(
-                    'SubscribeInvoices',
-                    (e: any) => {
-                        try {
-                            const error = checkLndStreamErrorResponse(
-                                'SubscribeInvoices',
-                                e
-                            );
-                            if (error === 'EOF') {
-                                this.listener?.remove();
-                                return;
-                            } else if (error) {
-                                console.error(
-                                    'Got error from SubscribeInvoices',
-                                    [error]
-                                );
-                                this.listener?.remove();
-                                return;
-                            }
-
-                            const invoice =
-                                lndMobile.wallet.decodeInvoiceResult(e.data);
-
-                            if (
-                                invoice.settled &&
-                                // @ts-ignore:next-line
-                                Base64Utils.bytesToHex(invoice.r_hash) === rHash
-                            ) {
-                                this.handlePaymentReceived(
-                                    Number(invoice.amt_paid_sat),
-                                    {
-                                        type: 'ln',
-                                        tx: invoice.payment_request,
-                                        preimage: Base64Utils.bytesToHex(
-                                            // @ts-ignore:next-line
-                                            invoice.r_preimage
-                                        )
-                                    }
-                                );
-                                this.listener?.remove();
-                            }
-                        } catch (error) {
-                            console.error(error);
-                            this.listener?.remove();
-                        }
-                    }
-                );
-            }
-
-            if (onChainAddress) {
-                this.listenerSecondary = LndMobileEventEmitter.addListener(
-                    'SubscribeTransactions',
-                    (e: any) => {
-                        try {
-                            const error = checkLndStreamErrorResponse(
-                                'SubscribeTransactions',
-                                e
-                            );
-                            if (error === 'EOF') {
-                                this.listenerSecondary?.remove();
-                                return;
-                            } else if (error) {
-                                console.error(
-                                    'Got error from SubscribeTransactions',
-                                    [error]
-                                );
-                                this.listenerSecondary?.remove();
-                                return;
-                            }
-
-                            const transaction =
-                                decodeSubscribeTransactionsResult(e.data);
-                            if (
-                                onChainAddress &&
-                                transaction.dest_addresses.includes(
-                                    onChainAddress
-                                ) &&
-                                transaction.num_confirmations >
-                                    numConfPreference &&
-                                Number(transaction.amount) >= Number(value)
-                            ) {
-                                this.handlePaymentReceived(
-                                    Number(transaction.amount),
-                                    {
-                                        type: 'onchain',
-                                        tx: transaction.tx_hash
-                                    }
-                                );
-                                this.listenerSecondary?.remove();
-                            }
-                        } catch (error) {
-                            console.error(error);
-                            this.listenerSecondary?.remove();
-                        }
-                    }
-                );
-            }
-
-            await lndMobile.wallet.subscribeInvoices();
-            await lndMobile.onchain.subscribeTransactions();
-        }
-
-        if (implementation === 'lightning-node-connect') {
-            const { LncModule } = NativeModules;
-            if (rHash) {
-                const eventName = BackendUtils.subscribeInvoice(rHash);
-                const eventEmitter = new NativeEventEmitter(LncModule);
-                this.listener = eventEmitter.addListener(
-                    eventName,
-                    (event: any) => {
-                        if (event.result) {
-                            if (
-                                typeof event.result === 'string' &&
-                                event.result.includes(
-                                    'rpc error: code = Canceled'
-                                )
-                            ) {
-                                this.listener?.remove();
-                                return;
-                            }
-                            try {
-                                const result = JSON.parse(event.result);
-                                if (result === 'EOF') {
-                                    this.listener?.remove();
-                                    return;
-                                }
-                                if (result.settled) {
-                                    this.handlePaymentReceived(
-                                        result.amt_paid_sat,
-                                        {
-                                            type: 'ln',
-                                            tx: result.payment_request,
-                                            preimage: result.r_preimage
-                                        }
-                                    );
-                                    this.listener?.remove();
-                                }
-                            } catch (error) {
-                                console.error(error);
-                                this.listener?.remove();
-                            }
-                        }
-                    }
-                );
-            }
-
-            if (onChainAddress) {
-                const eventName2 = BackendUtils.subscribeTransactions();
-                const eventEmitter2 = new NativeEventEmitter(LncModule);
-                this.listenerSecondary = eventEmitter2.addListener(
-                    eventName2,
-                    (event: any) => {
-                        if (event.result) {
-                            if (
-                                typeof event.result === 'string' &&
-                                event.result.includes(
-                                    'rpc error: code = Canceled'
-                                )
-                            ) {
-                                this.listenerSecondary?.remove();
-                                return;
-                            }
-                            try {
-                                const result = JSON.parse(event.result);
-                                if (result === 'EOF') {
-                                    this.listenerSecondary?.remove();
-                                    return;
-                                }
-                                if (
-                                    result.dest_addresses.includes(
-                                        onChainAddress
-                                    ) &&
-                                    result.num_confirmations >=
-                                        numConfPreference &&
-                                    Number(result.amount) >= Number(value)
-                                ) {
-                                    this.handlePaymentReceived(result.amount, {
-                                        type: 'onchain',
-                                        tx: result.tx_hash
-                                    });
-                                    this.listenerSecondary?.remove();
-                                }
-                            } catch (error) {
-                                console.error(error);
-                                this.listenerSecondary?.remove();
-                            }
-                        }
-                    }
-                );
-            }
-        }
-
-        if (implementation === 'ldk-node') {
-            const ldkBackend = BackendUtils.ldkNode;
-
-            this.ldkUnsubscribe = ldkBackend.subscribeToEvents((event) => {
-                if (event.type === 'paymentReceived') {
-                    const amountSat = Math.floor(event.amountMsat / 1000);
-
-                    // Check if this is the invoice we're watching
-                    if (rHash && event.paymentHash === rHash) {
-                        this.handlePaymentReceived(amountSat, {
-                            type: 'ln',
-                            tx: event.paymentHash
-                        });
-
-                        if (this.ldkUnsubscribe) {
-                            this.ldkUnsubscribe();
-                            this.ldkUnsubscribe = null;
-                        }
-                    }
+        if (rHash) {
+            this.stopInvoiceWatcher();
+            const unsubscribe = BackendUtils.watchInvoicePaid(
+                { rHash, value },
+                ({
+                    amountSat,
+                    tx,
+                    preimage
+                }: {
+                    amountSat: number;
+                    tx?: string;
+                    preimage?: string;
+                }) => {
+                    this.stopWatchers();
+                    this.handlePaymentReceived(amountSat, {
+                        type: 'ln',
+                        tx: tx || '',
+                        preimage
+                    });
                 }
-            });
+            );
+            // backends without real-time payment detection return
+            // false from the dispatcher
+            if (typeof unsubscribe === 'function')
+                this.unsubscribeInvoiceWatch = unsubscribe;
         }
 
-        if (implementation === 'lnd') {
-            if (rHash) {
-                this.lnInterval = setInterval(() => {
-                    // Look the invoice up directly by payment hash instead of
-                    // scanning the last 10 invoices: on busy nodes the watched
-                    // invoice can be pushed out of that window before it is
-                    // paid. LND's REST lookup endpoint expects a hex hash,
-                    // while rHash is base64url here
-                    BackendUtils.lookupInvoice({
-                        r_hash: Base64Utils.base64UrlToHex(rHash)
-                    })
-                        .then((result: any) => {
-                            const invoice = new Invoice(result);
-                            const amountPaid = invoice.getAmount;
-                            if (
-                                invoice.isPaid &&
-                                Number(amountPaid) >= Number(value) &&
-                                Number(amountPaid) !== 0
-                            ) {
-                                this.handlePaymentReceived(amountPaid, {
-                                    type: 'ln',
-                                    tx: invoice.getPaymentRequest
-                                });
-                                this.clearIntervals();
-                            }
-                        })
-                        .catch(() => {
-                            // invoice not found or node unreachable;
-                            // retry on the next tick
-                        });
-                }, 5000);
-            }
-
-            // this is workaround that manually calls your transactions every 30 secs
-            if (onChainAddress) {
-                this.onChainInterval = setInterval(() => {
-                    // only look for transactions in the last 3 blocks
-                    BackendUtils.getTransactions(
-                        nodeInfo && nodeInfo.block_height
-                            ? {
-                                  start_height: nodeInfo.block_height - 3
-                              }
-                            : null
-                    ).then((response: any) => {
-                        const txs = response.transactions;
-                        for (let i = 0; i < txs.length; i++) {
-                            const result = txs[i];
-                            if (
-                                result.dest_addresses.includes(
-                                    onChainAddress
-                                ) &&
-                                result.num_confirmations >= numConfPreference
-                            ) {
-                                // loop through outputs since amount is negative if unconfirmed
-                                const output_details = result.output_details;
-                                for (
-                                    let j = 0;
-                                    j < output_details.length;
-                                    j++
-                                ) {
-                                    const output = output_details[j];
-                                    if (
-                                        Number(output.amount) >=
-                                            Number(value) &&
-                                        output.address === onChainAddress
-                                    ) {
-                                        this.handlePaymentReceived(
-                                            output.amount,
-                                            {
-                                                type: 'onchain',
-                                                tx: result.tx_hash
-                                            }
-                                        );
-                                        this.clearIntervals();
-                                        // break parent loop
-                                        i = txs.length;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
+        if (onChainAddress) {
+            this.stopOnchainWatcher();
+            const unsubscribe = BackendUtils.watchOnchainReceived(
+                {
+                    address: onChainAddress,
+                    value,
+                    numConfPreference,
+                    blockHeight: nodeInfo?.block_height
+                },
+                ({ amountSat, txid }: { amountSat: number; txid: string }) => {
+                    this.stopWatchers();
+                    this.handlePaymentReceived(amountSat, {
+                        type: 'onchain',
+                        tx: txid
                     });
-                }, 7000);
-            }
-        }
-
-        if (implementation === 'cln-rest') {
-            if (rHash) {
-                this.lnInterval = setInterval(() => {
-                    // Look the invoice up directly by payment hash instead of
-                    // scanning the last 10 invoices: getInvoices now includes
-                    // unpaid invoices, so on busy nodes the watched invoice
-                    // can be pushed out of that window before it is paid
-                    BackendUtils.lookupInvoice({ r_hash: rHash })
-                        .then((result: any) => {
-                            const invoice = new Invoice(result);
-                            const amountPaid = invoice.getAmount;
-                            if (
-                                invoice.isPaid &&
-                                Number(amountPaid) >= Number(value) &&
-                                Number(amountPaid) !== 0
-                            ) {
-                                this.handlePaymentReceived(amountPaid, {
-                                    type: 'ln',
-                                    tx: invoice.getPaymentRequest
-                                });
-                                this.clearIntervals();
-                            }
-                        })
-                        .catch(() => {
-                            // invoice not found or node unreachable —
-                            // retry on the next tick
-                        });
-                }, 5000);
-            }
-        }
-
-        if (implementation === 'lndhub') {
-            if (rHash) {
-                this.lnInterval = setInterval(() => {
-                    BackendUtils.getInvoices().then((response: any) => {
-                        const invoices = response.invoices;
-                        for (let i = 0; i < invoices.length; i++) {
-                            const result = new Invoice(invoices[i]);
-                            if (
-                                result.getFormattedRhash === rHash &&
-                                result.ispaid &&
-                                Number(result.amt) >= Number(value) &&
-                                Number(result.amt) !== 0
-                            ) {
-                                this.handlePaymentReceived(Number(result.amt), {
-                                    type: 'ln',
-                                    tx: result.payment_request,
-                                    preimage: result.r_preimage
-                                });
-                                this.clearIntervals();
-                                break;
-                            }
-                        }
-                    });
-                }, 5000);
-            }
+                }
+            );
+            if (typeof unsubscribe === 'function')
+                this.unsubscribeOnchainWatch = unsubscribe;
         }
     };
 

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import {
     Dimensions,
-    NativeEventEmitter,
-    NativeModules,
     ScrollView,
     StyleSheet,
     TouchableOpacity,
@@ -56,7 +54,6 @@ import TextInput from '../components/TextInput';
 import { Spacer } from '../components/layout/Spacer';
 import Accordion from '../components/Accordion';
 
-import Invoice from '../models/Invoice';
 import Channel from '../models/Channel';
 
 import ChannelsStore from '../stores/ChannelsStore';
@@ -75,7 +72,6 @@ import BalanceStore from '../stores/BalanceStore';
 
 import { localeString } from '../utils/LocaleUtils';
 import BackendUtils from '../utils/BackendUtils';
-import Base64Utils from '../utils/Base64Utils';
 import { scanNfcTag } from '../utils/NFCUtils';
 import { themeColor } from '../utils/ThemeUtils';
 import { SATS_PER_BTC } from '../utils/UnitsUtils';
@@ -87,13 +83,6 @@ import {
     expirySecondsFromInput,
     localizedExpiryDuration
 } from '../utils/ExpiryUtils';
-
-import lndMobile from '../lndmobile/LndMobileInjection';
-import { decodeSubscribeTransactionsResult } from '../lndmobile/onchain';
-import {
-    checkLndStreamErrorResponse,
-    LndMobileEventEmitter
-} from '../utils/LndMobileUtils';
 
 import CaretDown from '../assets/images/SVG/Caret Down.svg';
 import CaretRight from '../assets/images/SVG/Caret Right.svg';
@@ -243,11 +232,8 @@ export default class Receive extends React.Component<
         };
     }
 
-    listener: any;
-    listenerSecondary: any;
-    ldkUnsubscribe: (() => void) | null = null;
-    lnInterval: any;
-    onChainInterval: any;
+    unsubscribeInvoiceWatch: (() => void) | null = null;
+    unsubscribeOnchainWatch: (() => void) | null = null;
     hopPickerRef: HopPicker | null;
 
     private getDefaultIndex = (): number => {
@@ -540,27 +526,28 @@ export default class Receive extends React.Component<
         this.cleanup();
     }
 
-    clearListeners = () => {
-        if (this.listener && this.listener.stop) this.listener.stop();
-        if (this.listenerSecondary && this.listenerSecondary.stop)
-            this.listenerSecondary.stop();
-        if (this.ldkUnsubscribe) {
-            this.ldkUnsubscribe();
-            this.ldkUnsubscribe = null;
+    stopInvoiceWatcher = () => {
+        if (this.unsubscribeInvoiceWatch) {
+            this.unsubscribeInvoiceWatch();
+            this.unsubscribeInvoiceWatch = null;
         }
     };
 
-    clearIntervals = () => {
-        if (this.lnInterval) clearInterval(this.lnInterval);
-        if (this.onChainInterval) clearInterval(this.onChainInterval);
+    stopOnchainWatcher = () => {
+        if (this.unsubscribeOnchainWatch) {
+            this.unsubscribeOnchainWatch();
+            this.unsubscribeOnchainWatch = null;
+        }
+    };
+
+    stopWatchers = () => {
+        this.stopInvoiceWatcher();
+        this.stopOnchainWatcher();
     };
 
     cleanup = () => {
         // kill all listeners and pollers
-        if (this.listener && this.listener.stop) this.listener.stop();
-        if (this.listenerSecondary && this.listenerSecondary.stop)
-            this.listenerSecondary.stop();
-        this.clearIntervals();
+        this.stopWatchers();
 
         // clear invoice
         this.props.InvoicesStore.reset();
@@ -807,10 +794,10 @@ export default class Receive extends React.Component<
         }
     };
 
-    subscribeInvoice = async (rHash?: string, onChainAddress?: string) => {
+    subscribeInvoice = (rHash?: string, onChainAddress?: string) => {
         const { SettingsStore, NodeInfoStore } = this.props;
         const { value } = this.state;
-        const { implementation, settings } = SettingsStore;
+        const { settings } = SettingsStore;
         const { nodeInfo } = NodeInfoStore;
 
         const numConfPreference =
@@ -818,365 +805,52 @@ export default class Receive extends React.Component<
                 ? 1
                 : 0;
 
-        if (implementation === 'embedded-lnd') {
-            if (rHash) {
-                this.listener = LndMobileEventEmitter.addListener(
-                    'SubscribeInvoices',
-                    (e: any) => {
-                        try {
-                            const error = checkLndStreamErrorResponse(
-                                'SubscribeInvoices',
-                                e
-                            );
-                            if (error === 'EOF') {
-                                this.listener?.remove();
-                                return;
-                            } else if (error) {
-                                console.error(
-                                    'Got error from SubscribeInvoices',
-                                    [error]
-                                );
-                                this.listener?.remove();
-                                return;
-                            }
-
-                            const invoice =
-                                lndMobile.wallet.decodeInvoiceResult(e.data);
-
-                            if (
-                                invoice.settled &&
-                                // @ts-ignore:next-line
-                                Base64Utils.bytesToHex(invoice.r_hash) === rHash
-                            ) {
-                                this.handlePaymentReceived(
-                                    Number(invoice.amt_paid_sat),
-                                    {
-                                        type: 'ln',
-                                        tx: invoice.payment_request,
-                                        preimage: Base64Utils.bytesToHex(
-                                            // @ts-ignore:next-line
-                                            invoice.r_preimage
-                                        )
-                                    }
-                                );
-                                this.listener?.remove();
-                            }
-                        } catch (error) {
-                            console.error(error);
-                            this.listener?.remove();
-                        }
-                    }
-                );
-            }
-
-            if (onChainAddress) {
-                this.listenerSecondary = LndMobileEventEmitter.addListener(
-                    'SubscribeTransactions',
-                    (e: any) => {
-                        try {
-                            const error = checkLndStreamErrorResponse(
-                                'SubscribeTransactions',
-                                e
-                            );
-                            if (error === 'EOF') {
-                                this.listenerSecondary?.remove();
-                                return;
-                            } else if (error) {
-                                console.error(
-                                    'Got error from SubscribeTransactions',
-                                    [error]
-                                );
-                                this.listenerSecondary?.remove();
-                                return;
-                            }
-
-                            const transaction =
-                                decodeSubscribeTransactionsResult(e.data);
-                            if (
-                                onChainAddress &&
-                                transaction.dest_addresses.includes(
-                                    onChainAddress
-                                ) &&
-                                transaction.num_confirmations >
-                                    numConfPreference &&
-                                Number(transaction.amount) >= Number(value)
-                            ) {
-                                this.handlePaymentReceived(
-                                    Number(transaction.amount),
-                                    {
-                                        type: 'onchain',
-                                        tx: transaction.tx_hash
-                                    }
-                                );
-                                this.listenerSecondary?.remove();
-                            }
-                        } catch (error) {
-                            console.error(error);
-                            this.listenerSecondary?.remove();
-                        }
-                    }
-                );
-            }
-
-            await lndMobile.wallet.subscribeInvoices();
-            await lndMobile.onchain.subscribeTransactions();
-        }
-
-        if (implementation === 'lightning-node-connect') {
-            const { LncModule } = NativeModules;
-            if (rHash) {
-                const eventName = BackendUtils.subscribeInvoice(rHash);
-                const eventEmitter = new NativeEventEmitter(LncModule);
-                this.listener = eventEmitter.addListener(
-                    eventName,
-                    (event: any) => {
-                        if (event.result) {
-                            if (
-                                typeof event.result === 'string' &&
-                                event.result.includes(
-                                    'rpc error: code = Canceled'
-                                )
-                            ) {
-                                this.listener?.remove();
-                                return;
-                            }
-                            try {
-                                const result = JSON.parse(event.result);
-                                if (result === 'EOF') {
-                                    this.listener?.remove();
-                                    return;
-                                }
-                                if (result.settled) {
-                                    this.handlePaymentReceived(
-                                        result.amt_paid_sat,
-                                        {
-                                            type: 'ln',
-                                            tx: result.payment_request,
-                                            preimage: result.r_preimage
-                                        }
-                                    );
-                                    this.listener?.remove();
-                                }
-                            } catch (error) {
-                                console.error(error);
-                                this.listener?.remove();
-                            }
-                        }
-                    }
-                );
-            }
-
-            if (onChainAddress) {
-                const eventName2 = BackendUtils.subscribeTransactions();
-                const eventEmitter2 = new NativeEventEmitter(LncModule);
-                this.listenerSecondary = eventEmitter2.addListener(
-                    eventName2,
-                    (event: any) => {
-                        if (event.result) {
-                            if (
-                                typeof event.result === 'string' &&
-                                event.result.includes(
-                                    'rpc error: code = Canceled'
-                                )
-                            ) {
-                                this.listenerSecondary?.remove();
-                                return;
-                            }
-                            try {
-                                const result = JSON.parse(event.result);
-                                if (result === 'EOF') {
-                                    this.listenerSecondary?.remove();
-                                    return;
-                                }
-                                if (
-                                    result.dest_addresses.includes(
-                                        onChainAddress
-                                    ) &&
-                                    result.num_confirmations >=
-                                        numConfPreference &&
-                                    Number(result.amount) >= Number(value)
-                                ) {
-                                    this.handlePaymentReceived(result.amount, {
-                                        type: 'onchain',
-                                        tx: result.tx_hash
-                                    });
-                                    this.listenerSecondary?.remove();
-                                }
-                            } catch (error) {
-                                console.error(error);
-                                this.listenerSecondary?.remove();
-                            }
-                        }
-                    }
-                );
-            }
-        }
-
-        if (implementation === 'ldk-node') {
-            const ldkBackend = BackendUtils.ldkNode;
-
-            this.ldkUnsubscribe = ldkBackend.subscribeToEvents((event) => {
-                if (event.type === 'paymentReceived') {
-                    const amountSat = Math.floor(event.amountMsat / 1000);
-
-                    // Check if this is the invoice we're watching
-                    if (rHash && event.paymentHash === rHash) {
-                        this.handlePaymentReceived(amountSat, {
-                            type: 'ln',
-                            tx: event.paymentHash
-                        });
-
-                        if (this.ldkUnsubscribe) {
-                            this.ldkUnsubscribe();
-                            this.ldkUnsubscribe = null;
-                        }
-                    }
+        if (rHash) {
+            this.stopInvoiceWatcher();
+            const unsubscribe = BackendUtils.watchInvoicePaid(
+                { rHash, value },
+                ({
+                    amountSat,
+                    tx,
+                    preimage
+                }: {
+                    amountSat: number;
+                    tx?: string;
+                    preimage?: string;
+                }) => {
+                    this.stopWatchers();
+                    this.handlePaymentReceived(amountSat, {
+                        type: 'ln',
+                        tx: tx || '',
+                        preimage
+                    });
                 }
-            });
+            );
+            // backends without real-time payment detection return
+            // false from the dispatcher
+            if (typeof unsubscribe === 'function')
+                this.unsubscribeInvoiceWatch = unsubscribe;
         }
 
-        if (implementation === 'lnd') {
-            if (rHash) {
-                this.lnInterval = setInterval(() => {
-                    // Look the invoice up directly by payment hash instead of
-                    // scanning the last 10 invoices: on busy nodes the watched
-                    // invoice can be pushed out of that window before it is
-                    // paid. LND's REST lookup endpoint expects a hex hash,
-                    // while rHash is base64url here
-                    BackendUtils.lookupInvoice({
-                        r_hash: Base64Utils.base64UrlToHex(rHash)
-                    })
-                        .then((result: any) => {
-                            const invoice = new Invoice(result);
-                            const amountPaid = invoice.getAmount;
-                            if (
-                                invoice.isPaid &&
-                                Number(amountPaid) >= Number(value) &&
-                                Number(amountPaid) !== 0
-                            ) {
-                                this.handlePaymentReceived(amountPaid, {
-                                    type: 'ln',
-                                    tx: invoice.getPaymentRequest
-                                });
-                                this.clearIntervals();
-                            }
-                        })
-                        .catch(() => {
-                            // invoice not found or node unreachable;
-                            // retry on the next tick
-                        });
-                }, 5000);
-            }
-
-            // this is workaround that manually calls your transactions every 30 secs
-            if (onChainAddress) {
-                this.onChainInterval = setInterval(() => {
-                    // only look for transactions in the last 3 blocks
-                    BackendUtils.getTransactions(
-                        nodeInfo && nodeInfo.block_height
-                            ? {
-                                  start_height: nodeInfo.block_height - 3
-                              }
-                            : null
-                    ).then((response: any) => {
-                        const txs = response.transactions;
-                        for (let i = 0; i < txs.length; i++) {
-                            const result = txs[i];
-                            if (
-                                result.dest_addresses.includes(
-                                    onChainAddress
-                                ) &&
-                                result.num_confirmations >= numConfPreference
-                            ) {
-                                // loop through outputs since amount is negative if unconfirmed
-                                const output_details = result.output_details;
-                                for (
-                                    let j = 0;
-                                    j < output_details.length;
-                                    j++
-                                ) {
-                                    const output = output_details[j];
-                                    if (
-                                        Number(output.amount) >=
-                                            Number(value) &&
-                                        output.address === onChainAddress
-                                    ) {
-                                        this.handlePaymentReceived(
-                                            output.amount,
-                                            {
-                                                type: 'onchain',
-                                                tx: result.tx_hash
-                                            }
-                                        );
-                                        this.clearIntervals();
-                                        // break parent loop
-                                        i = txs.length;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
+        if (onChainAddress) {
+            this.stopOnchainWatcher();
+            const unsubscribe = BackendUtils.watchOnchainReceived(
+                {
+                    address: onChainAddress,
+                    value,
+                    numConfPreference,
+                    blockHeight: nodeInfo?.block_height
+                },
+                ({ amountSat, txid }: { amountSat: number; txid: string }) => {
+                    this.stopWatchers();
+                    this.handlePaymentReceived(amountSat, {
+                        type: 'onchain',
+                        tx: txid
                     });
-                }, 7000);
-            }
-        }
-
-        if (implementation === 'cln-rest') {
-            if (rHash) {
-                this.lnInterval = setInterval(() => {
-                    // Look the invoice up directly by payment hash instead of
-                    // scanning the last 10 invoices: getInvoices now includes
-                    // unpaid invoices, so on busy nodes the watched invoice
-                    // can be pushed out of that window before it is paid
-                    BackendUtils.lookupInvoice({ r_hash: rHash })
-                        .then((result: any) => {
-                            const invoice = new Invoice(result);
-                            const amountPaid = invoice.getAmount;
-                            if (
-                                invoice.isPaid &&
-                                Number(amountPaid) >= Number(value) &&
-                                Number(amountPaid) !== 0
-                            ) {
-                                this.handlePaymentReceived(amountPaid, {
-                                    type: 'ln',
-                                    tx: invoice.getPaymentRequest
-                                });
-                                this.clearIntervals();
-                            }
-                        })
-                        .catch(() => {
-                            // invoice not found or node unreachable —
-                            // retry on the next tick
-                        });
-                }, 5000);
-            }
-        }
-
-        if (implementation === 'lndhub') {
-            if (rHash) {
-                this.lnInterval = setInterval(() => {
-                    BackendUtils.getInvoices().then((response: any) => {
-                        const invoices = response.invoices;
-                        for (let i = 0; i < invoices.length; i++) {
-                            const result = new Invoice(invoices[i]);
-                            if (
-                                result.getFormattedRhash === rHash &&
-                                result.ispaid &&
-                                Number(result.amt) >= Number(value) &&
-                                Number(result.amt) !== 0
-                            ) {
-                                this.handlePaymentReceived(Number(result.amt), {
-                                    type: 'ln',
-                                    tx: result.payment_request,
-                                    preimage: result.r_preimage
-                                });
-                                this.clearIntervals();
-                                break;
-                            }
-                        }
-                    });
-                }, 5000);
-            }
+                }
+            );
+            if (typeof unsubscribe === 'function')
+                this.unsubscribeOnchainWatch = unsubscribe;
         }
     };
 


### PR DESCRIPTION
# Description

Stacked on #4300; that PR's two commits appear in this diff until it merges. Suggested by @ajaysehwal's review there, and fulfills the old `// TODO rewrite subscription logic, starting on Receive view` in `EmbeddedLND.ts`.

The Receive view's `subscribeInvoice` was a ~370 line method with six `implementation === '...'` branches mixing four different watch mechanisms (native stream, LNC event emitter, LDK event loop, REST polling) plus on-chain detection. This moves each backend's watcher into its backend class behind a uniform subscription API, so the view no longer branches on implementation strings.

## New API

Two methods on the backend classes, dispatched through `BackendUtils`, each returning an unsubscribe function:

- `watchInvoicePaid({ rHash, value }, onPaid)`
  - LND (REST) and CLNRest poll `lookupInvoice` every 5s (LND converts the base64url `rHash` to the hex its REST endpoint expects)
  - LndHub polls its invoice list scan
  - Embedded LND wraps the `SubscribeInvoices` native stream
  - Lightning Node Connect wraps its event emitter, including the `rpc error: code = Canceled` / `EOF` handling
  - LDK Node wraps `subscribeToEvents`
- `watchOnchainReceived({ address, value, numConfPreference, blockHeight }, onReceived)`
  - LND (REST) polls `getTransactions`; embedded LND and LNC wrap their transaction streams
  - LndHub gets an explicit no-op override so it does not silently inherit LND's REST poller (both `EmbeddedLND` and `LndHub` extend `LND`, so inherited watchers are overridden explicitly)

`Receive.tsx` drops 391 lines: the six-branch method becomes ~60 backend-agnostic lines, and the five watcher fields (`listener`, `listenerSecondary`, `lnInterval`, `onChainInterval`, `ldkUnsubscribe`) collapse into two unsubscribe handles. NWC still has no watcher; the view guards the dispatcher's `false` return for backends without one.

## Behavior notes

Behavior-preserving per backend (match conditions, poll intervals, payloads, and quirks like embedded LND's strict `>` confirmation check are unchanged), with three deliberate fixes:

- Unmount cleanup now actually detaches stream listeners: the old code guarded on `.stop()` but emitter subscriptions only expose `.remove()`, so embedded LND and LNC listeners leaked
- Re-subscribing replaces the previous watcher of the same kind instead of stacking intervals/listeners
- Receiving a payment stops both watchers on every backend (previously only the polling backends did this)

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Manual testing across the backend matrix is still pending, hence the draft. Every backend's watcher path was rewritten, so each of the six should get a receive smoke test (LN invoice, and on-chain for embedded LND, LNC, and LND REST) before this leaves draft.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
