### PR TITLE
fix(swaps): always generate an independent swap rescue key

### DIFF
--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -777,17 +777,11 @@ export default class SwapStore {
     @action
     public generateRescueKey = async () => {
         console.log('GENERATING RESCUE FILE...');
-        // A 12-word LDK Node wallet already has a 12-word BIP-39 mnemonic -
-        // reuse it instead of generating a separate rescue key. 24-word LDK
-        // wallets (and every other backend) get an independent 12-word key.
-        const { implementation, ldkMnemonic } = this.settingsStore;
-        const reuseLdkSeed =
-            implementation === 'ldk-node' &&
-            !!ldkMnemonic &&
-            ldkMnemonic.trim().split(/\s+/).length === 12;
-        const mnemonic = reuseLdkSeed
-            ? ldkMnemonic
-            : generateMnemonic(BIP39_WORD_LIST);
+        // Always generate an independent rescue key. Never reuse the wallet's
+        // BIP-39 mnemonic (e.g. an LDK Node seed): the swap master xpub is
+        // shared with the swap provider, so a rescue key derived from the
+        // wallet seed would expose the wallet's own key tree.
+        const mnemonic = generateMnemonic(BIP39_WORD_LIST);
         await Storage.setItem(SWAPS_RESCUE_KEY, mnemonic);
 
         return mnemonic;

--- a/views/Swaps/index.tsx
+++ b/views/Swaps/index.tsx
@@ -243,16 +243,7 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
 
         const checkAndShowModal = async () => {
             if (!SwapStore.loading) {
-                let mnemonic = await Storage.getItem(SWAPS_RESCUE_KEY);
-
-                // LDK Node: auto-populate rescue key from wallet seed
-                if (
-                    !mnemonic &&
-                    SettingsStore.implementation === 'ldk-node' &&
-                    SettingsStore.ldkMnemonic
-                ) {
-                    mnemonic = await SwapStore.generateRescueKey();
-                }
+                const mnemonic = await Storage.getItem(SWAPS_RESCUE_KEY);
 
                 if (mnemonic) {
                     this.setState({
@@ -288,16 +279,7 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
         const unsubFocus = this.props.navigation.addListener(
             'focus',
             async () => {
-                let mnemonic = await Storage.getItem(SWAPS_RESCUE_KEY);
-
-                // LDK Node: auto-populate rescue key from wallet seed
-                if (
-                    !mnemonic &&
-                    SettingsStore.implementation === 'ldk-node' &&
-                    SettingsStore.ldkMnemonic
-                ) {
-                    mnemonic = await SwapStore.generateRescueKey();
-                }
+                const mnemonic = await Storage.getItem(SWAPS_RESCUE_KEY);
 
                 if (mnemonic) {
                     this.setState({


### PR DESCRIPTION
# Description

Stops reusing the wallet's own BIP-39 mnemonic as the Boltz swap rescue key. Every backend now generates an independent 12-word rescue key.

## Why

Swap keys are derived from the rescue mnemonic on a fully non-hardened path (`m/44/0/0/0/i`), and during swap recovery the app sends the depth-0 **master** xpub of that mnemonic to the swap provider (`POST {host}/swap/restore`, host user-selectable including Custom).

Reusing the LDK Node wallet seed as the rescue key means:
- the provider receives the master xpub of the actual wallet's key tree (a privacy leak of the whole derivation tree), and
- because the path is non-hardened, the shared master xpub plus any single leaked child private key allows BIP-32 recovery of the wallet master key.

Verified the BIP-32 non-hardened parent-recovery against the repo's own `@scure/bip32`: master xpub + one child key at `m/44/0/0/0/i` reconstructs the master private key exactly.

## What changed

- `stores/SwapStore.ts` - `generateRescueKey()` no longer branches on the LDK Node seed; it always calls `generateMnemonic(...)`.
- `views/Swaps/index.tsx` - removed the two LDK-node blocks that silently auto-populated the rescue key from the wallet seed. LDK Node now falls through to the same intro-modal create/back-up flow every other backend uses.

Existing users are unaffected in place: both call sites still read `SWAPS_RESCUE_KEY` first, so any wallet that already has a rescue key keeps using it. The manual rescue-key restore path in `SeedRecovery.tsx` is untouched.

This pull request is categorized as a:

- [x] Bug fix

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly (no new errors in the changed files)
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly

## Testing

If you modified or added a utility file, did you add new unit tests?

- [x] N/A

The change removes a special case; no behavior change for wallets with an existing rescue key.

### Other:

Part of the swap key-handling hardening. The remaining items from the same finding (hardened derivation for new swap keys, sharing only a hardened account-level xpub instead of the depth-0 master) are provider-coordinated protocol changes and are intentionally out of scope for this PR.
