### PR TITLE
fix: PeerItem: render stats with KeyValue to avoid Text crash

### DIFF
--- a/components/Channels/PeerItem.tsx
+++ b/components/Channels/PeerItem.tsx
@@ -25,50 +25,60 @@ export function PeerItem({
     showDisconnect
 }: PeerItemProps) {
     const title = displayName === peer.pubkey ? peer.pubkey : displayName;
-    const pingDisplay =
-        peer.ping_time != null && peer.ping_time >= 0
-            ? `${(peer.ping_time / 1000).toFixed(2)} ms`
-            : 'N/A';
 
-    const stats: Array<{ label: string; value: string | number }> = [];
-    if (pingDisplay !== 'N/A') {
+    const stats: Array<{ key: string; label: string; value: string | number }> =
+        [];
+    if (peer.ping_time != null && peer.ping_time >= 0) {
         stats.push({
+            key: 'pingTime',
             label: localeString('views.ChannelsPane.pingTime'),
-            value: pingDisplay
+            value: `${(peer.ping_time / 1000).toFixed(2)} ms`
         });
     }
     if (peer.sats_sent != null) {
-        stats.push({
-            label: localeString('views.ChannelsPane.satsSent'),
-            value: getFormattedAmount(peer.sats_sent, 'sats') ?? ''
-        });
+        const satsSent = getFormattedAmount(peer.sats_sent, 'sats');
+        if (satsSent) {
+            stats.push({
+                key: 'satsSent',
+                label: localeString('views.ChannelsPane.satsSent'),
+                value: satsSent
+            });
+        }
     }
     if (peer.sats_recv != null) {
-        stats.push({
-            label: localeString('views.ChannelsPane.satsRecv'),
-            value: getFormattedAmount(peer.sats_recv, 'sats') ?? ''
-        });
+        const satsRecv = getFormattedAmount(peer.sats_recv, 'sats');
+        if (satsRecv) {
+            stats.push({
+                key: 'satsRecv',
+                label: localeString('views.ChannelsPane.satsRecv'),
+                value: satsRecv
+            });
+        }
     }
     if (peer.num_channels != null) {
         stats.push({
+            key: 'numChannels',
             label: localeString('views.NetworkInfo.numChannels'),
             value: peer.num_channels
         });
     }
     if (peer.bytesSent) {
         stats.push({
+            key: 'bytesSent',
             label: localeString('views.ChannelsPane.bytesSent'),
             value: `${peer.bytesSent} B`
         });
     }
     if (peer.bytesRecv) {
         stats.push({
+            key: 'bytesRecv',
             label: localeString('views.ChannelsPane.bytesRecv'),
             value: `${peer.bytesRecv} B`
         });
     }
     if (peer.inbound !== undefined) {
         stats.push({
+            key: 'inbound',
             label: localeString('views.Channel.inbound'),
             value: peer.inbound
                 ? localeString('general.true')
@@ -77,6 +87,7 @@ export function PeerItem({
     }
     if (peer.connected !== undefined) {
         stats.push({
+            key: 'connected',
             label: localeString('views.ChannelsPane.connected'),
             value: peer.connected
                 ? localeString('general.true')
@@ -146,7 +157,7 @@ export function PeerItem({
                 <View style={styles.stats}>
                     {stats.map((stat) => (
                         <KeyValue
-                            key={stat.label}
+                            key={stat.key}
                             keyValue={stat.label}
                             value={stat.value}
                             disableCopy

--- a/components/Channels/PeerItem.tsx
+++ b/components/Channels/PeerItem.tsx
@@ -3,12 +3,13 @@ import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import Feather from '@react-native-vector-icons/feather';
 
 import { Row } from '../layout/Row';
+import KeyValue from '../KeyValue';
+import Text from '../Text';
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { getFormattedAmount } from '../../utils/AmountUtils';
 
 import Peer from '../../models/Peer';
-import Text from '../Text';
 
 interface PeerItemProps {
     peer: Peer;
@@ -24,12 +25,64 @@ export function PeerItem({
     showDisconnect
 }: PeerItemProps) {
     const title = displayName === peer.pubkey ? peer.pubkey : displayName;
-    const satsSent = peer.sats_sent;
-    const satsRecv = peer.sats_recv;
     const pingDisplay =
         peer.ping_time != null && peer.ping_time >= 0
             ? `${(peer.ping_time / 1000).toFixed(2)} ms`
             : 'N/A';
+
+    const stats: Array<{ label: string; value: string | number }> = [];
+    if (pingDisplay !== 'N/A') {
+        stats.push({
+            label: localeString('views.ChannelsPane.pingTime'),
+            value: pingDisplay
+        });
+    }
+    if (peer.sats_sent != null) {
+        stats.push({
+            label: localeString('views.ChannelsPane.satsSent'),
+            value: getFormattedAmount(peer.sats_sent, 'sats') ?? ''
+        });
+    }
+    if (peer.sats_recv != null) {
+        stats.push({
+            label: localeString('views.ChannelsPane.satsRecv'),
+            value: getFormattedAmount(peer.sats_recv, 'sats') ?? ''
+        });
+    }
+    if (peer.num_channels != null) {
+        stats.push({
+            label: localeString('views.NetworkInfo.numChannels'),
+            value: peer.num_channels
+        });
+    }
+    if (peer.bytesSent) {
+        stats.push({
+            label: localeString('views.ChannelsPane.bytesSent'),
+            value: `${peer.bytesSent} B`
+        });
+    }
+    if (peer.bytesRecv) {
+        stats.push({
+            label: localeString('views.ChannelsPane.bytesRecv'),
+            value: `${peer.bytesRecv} B`
+        });
+    }
+    if (peer.inbound !== undefined) {
+        stats.push({
+            label: localeString('views.Channel.inbound'),
+            value: peer.inbound
+                ? localeString('general.true')
+                : localeString('general.false')
+        });
+    }
+    if (peer.connected !== undefined) {
+        stats.push({
+            label: localeString('views.ChannelsPane.connected'),
+            value: peer.connected
+                ? localeString('general.true')
+                : localeString('general.false')
+        });
+    }
 
     return (
         <TouchableOpacity
@@ -77,7 +130,7 @@ export function PeerItem({
                     )}
                 </Row>
 
-                {peer.address && (
+                {!!peer.address && (
                     <View style={styles.address}>
                         <Text
                             style={{
@@ -91,184 +144,15 @@ export function PeerItem({
                 )}
 
                 <View style={styles.stats}>
-                    <View style={styles.statRow}>
-                        <Text
-                            style={{
-                                ...styles.statLabel,
-                                color: themeColor('secondaryText')
-                            }}
-                        >
-                            {localeString('views.ChannelsPane.pingTime')}
-                        </Text>
-                        <View style={styles.statValueWrap}>
-                            <Text
-                                style={{
-                                    ...styles.statValue,
-                                    color: themeColor('text')
-                                }}
-                            >
-                                {pingDisplay}
-                            </Text>
-                        </View>
-                    </View>
-                    {satsSent != null && (
-                        <View style={styles.statRow}>
-                            <Text
-                                style={{
-                                    ...styles.statLabel,
-                                    color: themeColor('secondaryText')
-                                }}
-                            >
-                                {localeString('views.ChannelsPane.satsSent')}
-                            </Text>
-                            <View style={styles.statValueWrap}>
-                                <Text
-                                    style={{
-                                        ...styles.statValue,
-                                        color: themeColor('text')
-                                    }}
-                                >
-                                    {getFormattedAmount(satsSent, 'sats')}
-                                </Text>
-                            </View>
-                        </View>
-                    )}
-                    {satsRecv != null && (
-                        <View style={styles.statRow}>
-                            <Text
-                                style={{
-                                    ...styles.statLabel,
-                                    color: themeColor('secondaryText')
-                                }}
-                            >
-                                {localeString('views.ChannelsPane.satsRecv')}
-                            </Text>
-                            <View style={styles.statValueWrap}>
-                                <Text
-                                    style={{
-                                        ...styles.statValue,
-                                        color: themeColor('text')
-                                    }}
-                                >
-                                    {getFormattedAmount(satsRecv, 'sats')}
-                                </Text>
-                            </View>
-                        </View>
-                    )}
-                    {peer.num_channels && (
-                        <View style={styles.statRow}>
-                            <Text
-                                style={{
-                                    ...styles.statLabel,
-                                    color: themeColor('secondaryText')
-                                }}
-                            >
-                                {localeString('views.NetworkInfo.numChannels')}
-                            </Text>
-                            <View style={styles.statValueWrap}>
-                                <Text
-                                    style={{
-                                        ...styles.statValue,
-                                        color: themeColor('text')
-                                    }}
-                                >
-                                    {String(peer.num_channels)}
-                                </Text>
-                            </View>
-                        </View>
-                    )}
-                    {peer.bytesSent && (
-                        <View style={styles.statRow}>
-                            <Text
-                                style={{
-                                    ...styles.statLabel,
-                                    color: themeColor('secondaryText')
-                                }}
-                            >
-                                {localeString('views.ChannelsPane.bytesSent')}
-                            </Text>
-                            <View style={styles.statValueWrap}>
-                                <Text
-                                    style={{
-                                        ...styles.statValue,
-                                        color: themeColor('text')
-                                    }}
-                                >
-                                    {`${peer.bytesSent} B`}
-                                </Text>
-                            </View>
-                        </View>
-                    )}
-                    {peer.bytesRecv && (
-                        <View style={styles.statRow}>
-                            <Text
-                                style={{
-                                    ...styles.statLabel,
-                                    color: themeColor('secondaryText')
-                                }}
-                            >
-                                {localeString('views.ChannelsPane.bytesRecv')}
-                            </Text>
-                            <View style={styles.statValueWrap}>
-                                <Text
-                                    style={{
-                                        ...styles.statValue,
-                                        color: themeColor('text')
-                                    }}
-                                >
-                                    {`${peer.bytesRecv} B`}
-                                </Text>
-                            </View>
-                        </View>
-                    )}
-                    {peer.inbound !== undefined && (
-                        <View style={styles.statRow}>
-                            <Text
-                                style={{
-                                    ...styles.statLabel,
-                                    color: themeColor('secondaryText')
-                                }}
-                            >
-                                {localeString('views.Channel.inbound')}
-                            </Text>
-                            <View style={styles.statValueWrap}>
-                                <Text
-                                    style={{
-                                        ...styles.statValue,
-                                        color: themeColor('text')
-                                    }}
-                                >
-                                    {peer.inbound
-                                        ? localeString('general.true')
-                                        : localeString('general.false')}
-                                </Text>
-                            </View>
-                        </View>
-                    )}
-                    {peer.connected !== undefined && (
-                        <View style={styles.statRow}>
-                            <Text
-                                style={{
-                                    ...styles.statLabel,
-                                    color: themeColor('secondaryText')
-                                }}
-                            >
-                                {localeString('views.ChannelsPane.connected')}
-                            </Text>
-                            <View style={styles.statValueWrap}>
-                                <Text
-                                    style={{
-                                        ...styles.statValue,
-                                        color: themeColor('text')
-                                    }}
-                                >
-                                    {peer.connected
-                                        ? localeString('general.true')
-                                        : localeString('general.false')}
-                                </Text>
-                            </View>
-                        </View>
-                    )}
+                    {stats.map((stat) => (
+                        <KeyValue
+                            key={stat.label}
+                            keyValue={stat.label}
+                            value={stat.value}
+                            disableCopy
+                            containerStyle={styles.keyValue}
+                        />
+                    ))}
                 </View>
             </View>
         </TouchableOpacity>
@@ -301,30 +185,11 @@ const styles = StyleSheet.create({
         marginBottom: 6
     },
     stats: {
-        marginTop: 6,
-        gap: 2
+        marginTop: 6
     },
-    statRow: {
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        minHeight: 20
-    },
-    statLabel: {
-        fontFamily: 'PPNeueMontreal-Book',
-        fontSize: 14,
-        flexShrink: 0,
-        marginRight: 12
-    },
-    statValueWrap: {
-        flex: 1,
-        alignItems: 'flex-end',
-        minWidth: 0
-    },
-    statValue: {
-        fontFamily: 'PPNeueMontreal-Book',
-        fontSize: 14,
-        textAlign: 'right'
+    keyValue: {
+        paddingTop: 1,
+        paddingBottom: 1
     },
     disconnectButton: {
         padding: 4,

--- a/components/Channels/PeerItem.tsx
+++ b/components/Channels/PeerItem.tsx
@@ -62,14 +62,14 @@ export function PeerItem({
             value: peer.num_channels
         });
     }
-    if (peer.bytesSent) {
+    if (peer.bytesSent != null && peer.bytesSent !== '') {
         stats.push({
             key: 'bytesSent',
             label: localeString('views.ChannelsPane.bytesSent'),
             value: `${peer.bytesSent} B`
         });
     }
-    if (peer.bytesRecv) {
+    if (peer.bytesRecv != null && peer.bytesRecv !== '') {
         stats.push({
             key: 'bytesRecv',
             label: localeString('views.ChannelsPane.bytesRecv'),

--- a/components/KeyValue.tsx
+++ b/components/KeyValue.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import {
+    StyleProp,
     StyleSheet,
     Text,
     TouchableOpacity,
     Vibration,
-    View
+    View,
+    ViewStyle
 } from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { inject, observer } from 'mobx-react';
@@ -34,6 +36,7 @@ interface KeyValueProps {
     }>;
     mempoolLink?: () => void;
     disableCopy?: boolean;
+    containerStyle?: StyleProp<ViewStyle>;
     ModalStore?: ModalStore;
     SettingsStore?: SettingsStore;
 }
@@ -61,6 +64,7 @@ export default class KeyValue extends React.Component<KeyValueProps> {
             infoModalAdditionalButtons,
             mempoolLink,
             disableCopy,
+            containerStyle,
             ModalStore,
             SettingsStore
         } = this.props;
@@ -187,7 +191,9 @@ export default class KeyValue extends React.Component<KeyValueProps> {
         );
 
         return (
-            <View style={{ paddingTop: 10, paddingBottom: 10 }}>
+            <View
+                style={[{ paddingTop: 10, paddingBottom: 10 }, containerStyle]}
+            >
                 <KeyValueRow />
             </View>
         );


### PR DESCRIPTION
##  Description
Fixes a React Native crash on the Peers list: `Text strings must be rendered within a <Text> component`.
`PeerItem` used patterns like `{peer.num_channels && (...)}`. When `num_channels` was `0` (or string fields were `""`), RN tried to render that falsy value as a text child of a `View`.

This PR:
- Builds peer stats into an array (only push when a value is present), then renders each row with `KeyValue` so values are always inside `<Text>`
- Skips missing stats (including ping when unavailable) instead of showing `N/A`
- Adds an optional `containerStyle` prop to `KeyValue` so PeerItem can keep its compact spacing without changing default KeyValue padding elsewhere


<img width="350" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-03 at 19 55 37" src="https://github.com/user-attachments/assets/ef5c670d-b59f-4d1b-acc5-a51468314bbb" />
<img width="350" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-03 at 19 55 42" src="https://github.com/user-attachments/assets/75e8db75-fa68-4fba-aa7f-fd7217277440" />



This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
