### PR TITLE
build: verify sha256 of FFI bindings and harden fetch-libraries.sh

### DIFF
--- a/.claude/skills/zeus-build-and-env/SKILL.md
+++ b/.claude/skills/zeus-build-and-env/SKILL.md
@@ -83,9 +83,7 @@ Versions pinned at time of writing:
 | zeus-cashu-restore (`ZeusLN/zeus-cashu-restore` release) | `0.1.0` | `android/zeus-restore/zeus-cashu-restore.aar` | `ios/ZeusRestore/zeusRestoreFFI.xcframework` |
 
 Behavior and caveats (all verified by reading the script):
-- **SHA256 enforcement**: embedded-LND and LDK Node downloads hard-fail (`exit 1`) on checksum mismatch, always.
-- **Empty-hash skip caveat**: for `cdk` and `zeus-cashu-restore` ONLY, the checksum check is wrapped in `[ -n "$SHA256" ]` — if the hash field in `fetch-libraries-versions.json` is an empty string, verification is **skipped** and the script just prints the downloaded file's hash. All four hash fields are currently non-empty; never blank one to "fix" a checksum failure.
-- **Unchecked binding-source downloads**: the script also `curl`s uniffi **source** bindings with NO checksum: `ios/CashuDevKit/CashuDevKit.swift` (from cdk-swift tag), `ios/CashuDevKit/zeus_cashu_restore.swift` and `android/app/src/main/java/uniffi/zeus_cashu_restore/zeus_cashu_restore.kt` (from zeus-cashu-restore tag). Known supply-chain gap — labeled open, not planned-fixed.
+- **SHA256 enforcement**: ALL downloads — binaries AND the uniffi source bindings (`ios/CashuDevKit/CashuDevKit.swift`, `ios/CashuDevKit/zeus_cashu_restore.swift`, `android/app/src/main/java/uniffi/zeus_cashu_restore/zeus_cashu_restore.kt`, pinned via the `*BindingsSha256` fields) — hard-fail (`exit 1`) on checksum mismatch, always. An empty or malformed hash field in `fetch-libraries-versions.json` fails closed up front (the script validates every hash is 64-char hex before any download, because macOS `sha256sum -c` exits 0 on improperly formatted lines); never blank one to "fix" a checksum failure. (Before this hardening the bindings were curl'd from raw.githubusercontent.com tag URLs with no checksum; that supply-chain gap is closed.)
 - **`jq()` is not jq**: the script defines a shell function literally named `jq()` that is a `python3 -c` one-liner reading the versions JSON. Don't grep-conclude the repo depends on the jq binary.
 - **Error noise is normal**: the script has no `set -e`; on a fresh clone you will see `sha256sum: ... No such file or directory` and failed `rm` messages before each download, and on re-runs `mkdir: ios/LndMobileLibZipFile: File exists` (the directory doesn't exist on a truly fresh clone — its contents are gitignored). Only an explicit "checksum failed" + exit 1 is a real failure.
 - If skipped: Android fails at Gradle time (missing `.aar`/`.so`); iOS fails at Xcode link time ("framework 'Lndmobile' not found" etc.).
@@ -116,15 +114,15 @@ The `pod-install` npm package runs CocoaPods for `ios/`. On non-macOS it prints 
 - Workspace: `ios/zeus.xcworkspace` (always open the workspace, not the .xcodeproj — pods live in a companion project).
 - **One `Lndmobile.xcframework`, shared by two modules, in a misleading directory**: fetch-libraries.sh unzips it to `ios/LncMobile/` (NOT `ios/LndMobile/`). The embedded-LND Swift layer (`ios/LndMobile/Lnd.swift`, `LndMobile.swift`: `import Lndmobile`) and the LNC layer (`ios/LncMobile/LncModule.mm`, which #imports the header straight out of the xcframework) both link against it; `zeus.xcodeproj` references it at path `LncMobile/Lndmobile.xcframework`.
 - **Podfile post_install** appends to every pod's `FRAMEWORK_SEARCH_PATHS`: `"$(SRCROOT)/Cdk"`, `"$(SRCROOT)/ZeusRestore"`, `"$(SRCROOT)/LncMobile"`, and floors `IPHONEOS_DEPLOYMENT_TARGET` at 13.4. Local podspecs `ios/CashuDevKit.podspec` and `ios/ZeusCashuRestore.podspec` are consumed as `pod 'CashuDevKit', :path => '.'` / `pod 'ZeusCashuRestore', :path => '.'`.
-- Other frameworks: `ios/LdkNodeMobile/LDKNodeFFI.xcframework` (with **checked-in** binding `ios/LdkNodeMobile/LDKNode.swift`), `ios/Cdk/cdkFFI.xcframework`, `ios/ZeusRestore/zeusRestoreFFI.xcframework`; downloaded Swift bindings land in `ios/CashuDevKit/`.
+- Other frameworks: `ios/LdkNodeMobile/LDKNodeFFI.xcframework` (with **checked-in** binding `ios/LdkNodeMobile/LDKNode.swift`), `ios/Cdk/cdkFFI.xcframework`, `ios/ZeusRestore/zeusRestoreFFI.xcframework`; downloaded (sha256-pinned) Swift bindings land in `ios/CashuDevKit/`.
 
 ### uniffi binding version-match rule
 
 uniffi generates wrapper source (Kotlin/Swift) whose function/type checksums must match the compiled Rust library. In Zeus the two halves arrive by different routes:
 - **Checked into git** (must be updated by hand when the binary version bumps): `ldk_node.kt`, `LDKNode.swift`.
-- **Downloaded by fetch-libraries.sh pinned to the same version tag as the binary** (auto-matching): `CashuDevKit.swift`, `zeus_cashu_restore.swift`, `zeus_cashu_restore.kt`.
+- **Downloaded by fetch-libraries.sh pinned to the same version tag AND sha256-pinned** via the `*BindingsSha256` fields in `fetch-libraries-versions.json`: `CashuDevKit.swift`, `zeus_cashu_restore.swift`, `zeus_cashu_restore.kt`. (CDK Android bindings ship inside the checksummed `cashudevkit.aar`.)
 
-If binding source and binary versions diverge you get runtime symbol/checksum errors (uniffi aborts on API-checksum mismatch), not compile errors. When bumping `ldk-node` in `fetch-libraries-versions.json`, regenerate/replace the two checked-in binding files from the same release.
+If binding source and binary versions diverge you get runtime symbol/checksum errors (uniffi aborts on API-checksum mismatch), not compile errors. When bumping `ldk-node` in `fetch-libraries-versions.json`, regenerate/replace the two checked-in binding files from the same release. When bumping `cdk` or `zeus-cashu-restore`, update the binary hashes AND the `*BindingsSha256` fields from the same release in the same commit.
 
 ### TypeScript wrapper layers (where JS meets native)
 
@@ -148,7 +146,7 @@ Tor support is `react-native-nitro-tor` **0.6.0** (normal npm dependency, autoli
 5. **Hermes + New Architecture are ON** (`android/gradle.properties`: `hermesEnabled=true`, `newArchEnabled=true`; New Arch since RN 0.83.1 upgrade, commit `d13ebc2cd`). Consequences: pre-2026 Animated/layout patterns can crash Fabric, and Hermes regexes need input length caps — details and incident hashes in **zeus-failure-archaeology** / **zeus-debugging-playbook**.
 6. **Never hand-edit** the `react-native`/`browser` alias maps in `package.json` or `shim.js` — rn-nodeify regenerates them (§2 step 2).
 7. **`pod install` didn't run automatically from the RN CLI**: expected — `automaticPodsInstallation: false` in `react-native.config.js`; run `npx pod-install` or `cd ios && pod install`.
-8. **Checksum failure on a binary**: means the release asset changed or the download was corrupted. Delete the cached artifact (paths in §2 step 3 table) and re-run `yarn fetch-libraries`. Do NOT blank the hash in `fetch-libraries-versions.json` (empty-hash skip caveat).
+8. **Checksum failure on a binary**: means the release asset changed or the download was corrupted. Delete the cached artifact (paths in §2 step 3 table) and re-run `yarn fetch-libraries`. Do NOT blank the hash in `fetch-libraries-versions.json` (an empty hash fails closed anyway).
 9. **`gradle.properties` sets `org.gradle.parallel=false`** — a reproducible-build requirement; don't flip it for speed in a PR.
 10. **New npm dependencies require maintainer discussion first** (CONTRIBUTING.md) — see **zeus-change-control** before adding anything.
 
@@ -196,7 +194,7 @@ Re-verification one-liners for every volatile fact:
 | Postinstall chain | `node -e "console.log(require('./package.json').scripts.postinstall)"` |
 | Patch list | `ls patches/` and read `patches/index.mjs` |
 | Native binary versions + hashes | `cat fetch-libraries-versions.json` |
-| Empty-hash skip + unchecked binding downloads | `grep -n -e 'if \[ -n' -e BINDINGS_URL fetch-libraries.sh` |
+| No unchecked downloads in fetch-libraries.sh | `grep -n -e 'if \[ -n' -e 'curl -L ' fetch-libraries.sh` (expect no hits; all curls are `-fL` and every download, bindings included, is sha256-checked) |
 | Android SDK/Kotlin/NDK | `sed -n '1,10p' android/build.gradle` |
 | Gradle version | `grep distributionUrl android/gradle/wrapper/gradle-wrapper.properties` |
 | Hermes / New Arch / parallel | `grep -n -e newArchEnabled -e hermesEnabled -e org.gradle.parallel android/gradle.properties` |
@@ -205,7 +203,7 @@ Re-verification one-liners for every volatile fact:
 | xcframework location | `grep -n 'LncMobile/Lndmobile.xcframework' ios/zeus.xcodeproj/project.pbxproj` |
 | lnc-rn not in package.json | `grep -c lnc-rn package.json` (expect 0); `grep -n lnc-rn backends/LightningNodeConnect.ts` |
 | Tooling excludes zeus_modules | `grep -n zeus_modules tsconfig.json eslint.config.js .prettierignore` |
-| Checked-in vs downloaded uniffi bindings | `git ls-files -- '*ldk_node.kt' '*LDKNode.swift' '*zeus_cashu_restore*' '*CashuDevKit.swift'` (only the first two are tracked) |
+| Checked-in vs downloaded uniffi bindings | `git ls-files -- '*ldk_node.kt' '*LDKNode.swift' '*zeus_cashu_restore*' '*CashuDevKit.swift'` (only the first two are tracked; the rest are downloaded sha256-pinned) |
 | Emulator host rule | `grep -n 10.0.2.2 CONTRIBUTING.md` |
 | CocoaPods constraint | `grep cocoapods Gemfile` |
 | nitro-tor migration commit | `git log --oneline --all --grep=nitro-tor` |

--- a/fetch-libraries-versions.json
+++ b/fetch-libraries-versions.json
@@ -12,11 +12,14 @@
     "cdk": {
         "version": "0.14.2",
         "androidSha256": "e8e9ee354cf21546e49946d351a6c482355f8b3800c60a8a9348c4ae40f529cb",
-        "iosSha256": "5c4a152cdcd6aaa6bbd1aef65c43eaeeb6ebde3f0f365fb2254cefbc49d5ea49"
+        "iosSha256": "5c4a152cdcd6aaa6bbd1aef65c43eaeeb6ebde3f0f365fb2254cefbc49d5ea49",
+        "iosBindingsSha256": "9e3d83af633cd615f50d4c0b71e4cbdcc357e08e12209a2160a5236ef3f9fa28"
     },
     "zeus-cashu-restore": {
         "version": "0.1.0",
         "androidSha256": "a067b281e99489cbfae66717b3c14196033fb864be6742f994a9ae71f886f85a",
-        "iosSha256": "a5b98ce83f242b670e492e914d51a96f05e27e7c3b4c6dbde2663bb5fa720ea5"
+        "iosSha256": "a5b98ce83f242b670e492e914d51a96f05e27e7c3b4c6dbde2663bb5fa720ea5",
+        "androidBindingsSha256": "0787300e17a95fb08b1dbf49b9666a5eb84aa7afa10058c43e4566031792e32f",
+        "iosBindingsSha256": "4745dc68822d18af6446bdf88acf73ad77a493ddcc4f585552f2dd2808a7b1f8"
     }
 }

--- a/fetch-libraries.sh
+++ b/fetch-libraries.sh
@@ -11,9 +11,27 @@ LDK_NODE_IOS_SHA256=$(jq "['ldk-node']['iosSha256']")
 CDK_VERSION=$(jq "['cdk']['version']")
 CDK_ANDROID_SHA256=$(jq "['cdk']['androidSha256']")
 CDK_IOS_SHA256=$(jq "['cdk']['iosSha256']")
+CDK_IOS_BINDINGS_SHA256=$(jq "['cdk']['iosBindingsSha256']")
 RESTORE_VERSION=$(jq "['zeus-cashu-restore']['version']")
 RESTORE_ANDROID_SHA256=$(jq "['zeus-cashu-restore']['androidSha256']")
 RESTORE_IOS_SHA256=$(jq "['zeus-cashu-restore']['iosSha256']")
+RESTORE_ANDROID_BINDINGS_SHA256=$(jq "['zeus-cashu-restore']['androidBindingsSha256']")
+RESTORE_IOS_BINDINGS_SHA256=$(jq "['zeus-cashu-restore']['iosBindingsSha256']")
+
+# Every hash must be 64-char lowercase hex. Fail closed on empty/malformed
+# values: macOS sha256sum -c exits 0 on improperly formatted lines, so a
+# blank hash would otherwise skip verification silently.
+for HASH in "$EMBEDDED_LND_ANDROID_SHA256" "$EMBEDDED_LND_IOS_SHA256" \
+            "$LDK_NODE_ANDROID_SHA256" "$LDK_NODE_IOS_SHA256" \
+            "$CDK_ANDROID_SHA256" "$CDK_IOS_SHA256" \
+            "$CDK_IOS_BINDINGS_SHA256" \
+            "$RESTORE_ANDROID_SHA256" "$RESTORE_IOS_SHA256" \
+            "$RESTORE_ANDROID_BINDINGS_SHA256" "$RESTORE_IOS_BINDINGS_SHA256"; do
+    if ! echo "$HASH" | grep -qE '^[0-9a-f]{64}$'; then
+        echo "Invalid or missing sha256 in $LV: '$HASH'" >&2
+        exit 1
+    fi
+done
 
 EMBEDDED_LND_ANDROID_FILE=Lndmobile.aar
 EMBEDDED_LND_IOS_FILE=Lndmobile.xcframework
@@ -53,7 +71,7 @@ if ! echo "$EMBEDDED_LND_ANDROID_SHA256 android/lndmobile/$EMBEDDED_LND_ANDROID_
     rm android/lndmobile/$EMBEDDED_LND_ANDROID_FILE
 
     # download Android LND library file
-    curl -L $EMBEDDED_LND_ANDROID_LINK > android/lndmobile/$EMBEDDED_LND_ANDROID_FILE
+    curl -fL $EMBEDDED_LND_ANDROID_LINK > android/lndmobile/$EMBEDDED_LND_ANDROID_FILE
 
     # check checksum
     if ! echo "$EMBEDDED_LND_ANDROID_SHA256 android/lndmobile/$EMBEDDED_LND_ANDROID_FILE" | sha256sum -c -; then
@@ -75,7 +93,7 @@ if ! echo "$EMBEDDED_LND_IOS_SHA256 ios/LndMobileLibZipFile/$EMBEDDED_LND_IOS_FI
     rm ios/LndMobileLibZipFile/$EMBEDDED_LND_IOS_FILE.zip
 
     # download iOS LND library file
-    curl -L $EMBEDDED_LND_IOS_LINK > ios/LndMobileLibZipFile/$EMBEDDED_LND_IOS_FILE.zip
+    curl -fL $EMBEDDED_LND_IOS_LINK > ios/LndMobileLibZipFile/$EMBEDDED_LND_IOS_FILE.zip
 
     # check checksum
     if ! echo "$EMBEDDED_LND_IOS_SHA256 ios/LndMobileLibZipFile/$EMBEDDED_LND_IOS_FILE.zip" | sha256sum -c -; then
@@ -109,28 +127,15 @@ CDK_IOS_LINK=$CDK_IOS_PATH$CDK_IOS_FILE.zip
 # Android CDK
 mkdir -p android/cdk
 
-NEED_CDK_ANDROID=false
-if [ ! -f "android/cdk/$CDK_ANDROID_FILE" ]; then
-    NEED_CDK_ANDROID=true
-elif [ -n "$CDK_ANDROID_SHA256" ]; then
-    if ! echo "$CDK_ANDROID_SHA256 android/cdk/$CDK_ANDROID_FILE" | sha256sum -c - 2>/dev/null; then
-        NEED_CDK_ANDROID=true
-    fi
-fi
+if ! echo "$CDK_ANDROID_SHA256 android/cdk/$CDK_ANDROID_FILE" | sha256sum -c -; then
+    echo "CDK Android library file missing or checksum failed" >&2
 
-if [ "$NEED_CDK_ANDROID" = true ]; then
-    echo "Downloading CDK Android library..." >&2
     rm -f android/cdk/$CDK_ANDROID_FILE
-    curl -L $CDK_ANDROID_LINK > android/cdk/$CDK_ANDROID_FILE
+    curl -fL $CDK_ANDROID_LINK > android/cdk/$CDK_ANDROID_FILE
 
-    if [ -n "$CDK_ANDROID_SHA256" ]; then
-        if ! echo "$CDK_ANDROID_SHA256 android/cdk/$CDK_ANDROID_FILE" | sha256sum -c -; then
-            echo "CDK Android checksum failed" >&2
-            exit 1
-        fi
-    else
-        echo "CDK Android downloaded (checksum verification skipped)"
-        echo "SHA256: $(sha256sum android/cdk/$CDK_ANDROID_FILE | cut -d' ' -f1)"
+    if ! echo "$CDK_ANDROID_SHA256 android/cdk/$CDK_ANDROID_FILE" | sha256sum -c -; then
+        echo "CDK Android checksum failed" >&2
+        exit 1
     fi
 fi
 
@@ -138,28 +143,15 @@ fi
 mkdir -p ios/CashuDevKitLibZipFile
 mkdir -p ios/Cdk
 
-NEED_CDK_IOS=false
-if [ ! -f "ios/CashuDevKitLibZipFile/$CDK_IOS_FILE.zip" ]; then
-    NEED_CDK_IOS=true
-elif [ -n "$CDK_IOS_SHA256" ]; then
-    if ! echo "$CDK_IOS_SHA256 ios/CashuDevKitLibZipFile/$CDK_IOS_FILE.zip" | sha256sum -c - 2>/dev/null; then
-        NEED_CDK_IOS=true
-    fi
-fi
+if ! echo "$CDK_IOS_SHA256 ios/CashuDevKitLibZipFile/$CDK_IOS_FILE.zip" | sha256sum -c -; then
+    echo "CDK iOS library file missing or checksum failed" >&2
 
-if [ "$NEED_CDK_IOS" = true ]; then
-    echo "Downloading CDK iOS library..." >&2
     rm -f ios/CashuDevKitLibZipFile/$CDK_IOS_FILE.zip
-    curl -L $CDK_IOS_LINK > ios/CashuDevKitLibZipFile/$CDK_IOS_FILE.zip
+    curl -fL $CDK_IOS_LINK > ios/CashuDevKitLibZipFile/$CDK_IOS_FILE.zip
 
-    if [ -n "$CDK_IOS_SHA256" ]; then
-        if ! echo "$CDK_IOS_SHA256 ios/CashuDevKitLibZipFile/$CDK_IOS_FILE.zip" | sha256sum -c -; then
-            echo "CDK iOS checksum failed" >&2
-            exit 1
-        fi
-    else
-        echo "CDK iOS downloaded (checksum verification skipped)"
-        echo "SHA256: $(sha256sum ios/CashuDevKitLibZipFile/$CDK_IOS_FILE.zip | cut -d' ' -f1)"
+    if ! echo "$CDK_IOS_SHA256 ios/CashuDevKitLibZipFile/$CDK_IOS_FILE.zip" | sha256sum -c -; then
+        echo "CDK iOS checksum failed" >&2
+        exit 1
     fi
 fi
 
@@ -170,14 +162,25 @@ unzip ios/CashuDevKitLibZipFile/$CDK_IOS_FILE.zip -d ios/Cdk
 
 echo "CashuDevKit iOS framework installed to ios/Cdk/$CDK_IOS_FILE"
 
-# Download matching Swift bindings from cdk-swift repo
+# Download matching Swift bindings from cdk-swift repo. When bumping the CDK
+# version, update iosBindingsSha256 in fetch-libraries-versions.json to the
+# hash of the file at the new tag.
 CDK_SWIFT_BINDINGS_URL="https://raw.githubusercontent.com/cashubtc/cdk-swift/v$CDK_VERSION/Sources/CashuDevKit/CashuDevKit.swift"
 mkdir -p ios/CashuDevKit
 
-echo "Downloading CDK Swift bindings..." >&2
-curl -L "$CDK_SWIFT_BINDINGS_URL" > ios/CashuDevKit/CashuDevKit.swift
+if ! echo "$CDK_IOS_BINDINGS_SHA256 ios/CashuDevKit/CashuDevKit.swift" | sha256sum -c -; then
+    echo "CDK Swift bindings missing or checksum failed" >&2
 
-echo "CashuDevKit Swift bindings updated to v$CDK_VERSION"
+    rm -f ios/CashuDevKit/CashuDevKit.swift
+    curl -fL "$CDK_SWIFT_BINDINGS_URL" > ios/CashuDevKit/CashuDevKit.swift
+
+    if ! echo "$CDK_IOS_BINDINGS_SHA256 ios/CashuDevKit/CashuDevKit.swift" | sha256sum -c -; then
+        echo "CDK Swift bindings checksum failed" >&2
+        exit 1
+    fi
+fi
+
+echo "CashuDevKit Swift bindings installed for v$CDK_VERSION"
 
 ######################
 # Zeus Cashu Restore #
@@ -196,28 +199,15 @@ RESTORE_KOTLIN_BINDINGS_URL="https://raw.githubusercontent.com/ZeusLN/zeus-cashu
 # Android Restore
 mkdir -p android/zeus-restore
 
-NEED_RESTORE_ANDROID=false
-if [ ! -f "android/zeus-restore/$RESTORE_ANDROID_FILE" ]; then
-    NEED_RESTORE_ANDROID=true
-elif [ -n "$RESTORE_ANDROID_SHA256" ]; then
-    if ! echo "$RESTORE_ANDROID_SHA256 android/zeus-restore/$RESTORE_ANDROID_FILE" | sha256sum -c - 2>/dev/null; then
-        NEED_RESTORE_ANDROID=true
-    fi
-fi
+if ! echo "$RESTORE_ANDROID_SHA256 android/zeus-restore/$RESTORE_ANDROID_FILE" | sha256sum -c -; then
+    echo "Restore Android library file missing or checksum failed" >&2
 
-if [ "$NEED_RESTORE_ANDROID" = true ]; then
-    echo "Downloading Zeus Cashu Restore Android library..." >&2
     rm -f android/zeus-restore/$RESTORE_ANDROID_FILE
-    curl -L $RESTORE_ANDROID_LINK > android/zeus-restore/$RESTORE_ANDROID_FILE
+    curl -fL $RESTORE_ANDROID_LINK > android/zeus-restore/$RESTORE_ANDROID_FILE
 
-    if [ -n "$RESTORE_ANDROID_SHA256" ]; then
-        if ! echo "$RESTORE_ANDROID_SHA256 android/zeus-restore/$RESTORE_ANDROID_FILE" | sha256sum -c -; then
-            echo "Restore Android checksum failed" >&2
-            exit 1
-        fi
-    else
-        echo "Restore Android downloaded (checksum verification skipped)"
-        echo "SHA256: $(sha256sum android/zeus-restore/$RESTORE_ANDROID_FILE | cut -d' ' -f1)"
+    if ! echo "$RESTORE_ANDROID_SHA256 android/zeus-restore/$RESTORE_ANDROID_FILE" | sha256sum -c -; then
+        echo "Restore Android checksum failed" >&2
+        exit 1
     fi
 fi
 
@@ -225,28 +215,15 @@ fi
 mkdir -p ios/ZeusRestoreLibZipFile
 mkdir -p ios/ZeusRestore
 
-NEED_RESTORE_IOS=false
-if [ ! -f "ios/ZeusRestoreLibZipFile/$RESTORE_IOS_FILE.zip" ]; then
-    NEED_RESTORE_IOS=true
-elif [ -n "$RESTORE_IOS_SHA256" ]; then
-    if ! echo "$RESTORE_IOS_SHA256 ios/ZeusRestoreLibZipFile/$RESTORE_IOS_FILE.zip" | sha256sum -c - 2>/dev/null; then
-        NEED_RESTORE_IOS=true
-    fi
-fi
+if ! echo "$RESTORE_IOS_SHA256 ios/ZeusRestoreLibZipFile/$RESTORE_IOS_FILE.zip" | sha256sum -c -; then
+    echo "Restore iOS library file missing or checksum failed" >&2
 
-if [ "$NEED_RESTORE_IOS" = true ]; then
-    echo "Downloading Zeus Cashu Restore iOS library..." >&2
     rm -f ios/ZeusRestoreLibZipFile/$RESTORE_IOS_FILE.zip
-    curl -L $RESTORE_IOS_LINK > ios/ZeusRestoreLibZipFile/$RESTORE_IOS_FILE.zip
+    curl -fL $RESTORE_IOS_LINK > ios/ZeusRestoreLibZipFile/$RESTORE_IOS_FILE.zip
 
-    if [ -n "$RESTORE_IOS_SHA256" ]; then
-        if ! echo "$RESTORE_IOS_SHA256 ios/ZeusRestoreLibZipFile/$RESTORE_IOS_FILE.zip" | sha256sum -c -; then
-            echo "Restore iOS checksum failed" >&2
-            exit 1
-        fi
-    else
-        echo "Restore iOS downloaded (checksum verification skipped)"
-        echo "SHA256: $(sha256sum ios/ZeusRestoreLibZipFile/$RESTORE_IOS_FILE.zip | cut -d' ' -f1)"
+    if ! echo "$RESTORE_IOS_SHA256 ios/ZeusRestoreLibZipFile/$RESTORE_IOS_FILE.zip" | sha256sum -c -; then
+        echo "Restore iOS checksum failed" >&2
+        exit 1
     fi
 fi
 
@@ -256,22 +233,41 @@ unzip ios/ZeusRestoreLibZipFile/$RESTORE_IOS_FILE.zip -d ios/ZeusRestore
 
 echo "Zeus Cashu Restore iOS framework installed to ios/ZeusRestore/$RESTORE_IOS_FILE"
 
-# Download matching Swift bindings
+# Download matching uniffi bindings. When bumping the zeus-cashu-restore
+# version, update iosBindingsSha256 and androidBindingsSha256 in
+# fetch-libraries-versions.json to the hashes of the files at the new tag.
 mkdir -p ios/CashuDevKit
 
-echo "Downloading Zeus Cashu Restore Swift bindings..." >&2
-curl -L "$RESTORE_SWIFT_BINDINGS_URL" > ios/CashuDevKit/zeus_cashu_restore.swift
+if ! echo "$RESTORE_IOS_BINDINGS_SHA256 ios/CashuDevKit/zeus_cashu_restore.swift" | sha256sum -c -; then
+    echo "Restore Swift bindings missing or checksum failed" >&2
 
-echo "Zeus Cashu Restore Swift bindings updated to v$RESTORE_VERSION"
+    rm -f ios/CashuDevKit/zeus_cashu_restore.swift
+    curl -fL "$RESTORE_SWIFT_BINDINGS_URL" > ios/CashuDevKit/zeus_cashu_restore.swift
 
-# Download matching Kotlin bindings
+    if ! echo "$RESTORE_IOS_BINDINGS_SHA256 ios/CashuDevKit/zeus_cashu_restore.swift" | sha256sum -c -; then
+        echo "Restore Swift bindings checksum failed" >&2
+        exit 1
+    fi
+fi
+
+echo "Zeus Cashu Restore Swift bindings installed for v$RESTORE_VERSION"
+
 RESTORE_KOTLIN_DIR=android/app/src/main/java/uniffi/zeus_cashu_restore
 mkdir -p "$RESTORE_KOTLIN_DIR"
 
-echo "Downloading Zeus Cashu Restore Kotlin bindings..." >&2
-curl -L "$RESTORE_KOTLIN_BINDINGS_URL" > "$RESTORE_KOTLIN_DIR/zeus_cashu_restore.kt"
+if ! echo "$RESTORE_ANDROID_BINDINGS_SHA256 $RESTORE_KOTLIN_DIR/zeus_cashu_restore.kt" | sha256sum -c -; then
+    echo "Restore Kotlin bindings missing or checksum failed" >&2
 
-echo "Zeus Cashu Restore Kotlin bindings updated to v$RESTORE_VERSION"
+    rm -f "$RESTORE_KOTLIN_DIR/zeus_cashu_restore.kt"
+    curl -fL "$RESTORE_KOTLIN_BINDINGS_URL" > "$RESTORE_KOTLIN_DIR/zeus_cashu_restore.kt"
+
+    if ! echo "$RESTORE_ANDROID_BINDINGS_SHA256 $RESTORE_KOTLIN_DIR/zeus_cashu_restore.kt" | sha256sum -c -; then
+        echo "Restore Kotlin bindings checksum failed" >&2
+        exit 1
+    fi
+fi
+
+echo "Zeus Cashu Restore Kotlin bindings installed for v$RESTORE_VERSION"
 
 #####################
 # LDK Node Android  #
@@ -285,7 +281,7 @@ if ! echo "$LDK_NODE_ANDROID_SHA256 android/ldk-node/$LDK_NODE_ANDROID_FILE" | s
     rm -f android/ldk-node/$LDK_NODE_ANDROID_FILE
     mkdir -p android/ldk-node
 
-    curl -L $LDK_NODE_ANDROID_LINK > android/ldk-node/$LDK_NODE_ANDROID_FILE
+    curl -fL $LDK_NODE_ANDROID_LINK > android/ldk-node/$LDK_NODE_ANDROID_FILE
 
     if ! echo "$LDK_NODE_ANDROID_SHA256 android/ldk-node/$LDK_NODE_ANDROID_FILE" | sha256sum -c -; then
         echo "LDK Node Android checksum failed" >&2
@@ -312,7 +308,7 @@ if ! echo "$LDK_NODE_IOS_SHA256 ios/LdkNodeLibZipFile/$LDK_NODE_IOS_FILE.zip" | 
     rm -f ios/LdkNodeLibZipFile/$LDK_NODE_IOS_FILE.zip
 
     # download LDK Node iOS library file
-    curl -L $LDK_NODE_IOS_LINK > ios/LdkNodeLibZipFile/$LDK_NODE_IOS_FILE.zip
+    curl -fL $LDK_NODE_IOS_LINK > ios/LdkNodeLibZipFile/$LDK_NODE_IOS_FILE.zip
 
     # check checksum
     if ! echo "$LDK_NODE_IOS_SHA256 ios/LdkNodeLibZipFile/$LDK_NODE_IOS_FILE.zip" | sha256sum -c -; then


### PR DESCRIPTION
# Description

Supply-chain hardening for the native FFI layer.

`fetch-libraries.sh` pins sha256 hashes for every compiled native library, but the uniffi source bindings for CDK and zeus-cashu-restore were curl'd from raw.githubusercontent.com tag URLs on every install with no checksum and no signature. Git tags are mutable, so anyone with push access to cashubtc/cdk-swift or ZeusLN/zeus-cashu-restore could swap the glue code that handles the wallet mnemonic and seed without tripping any verification. Release builds were exposed too, since build.sh runs yarn install inside Docker.

This PR pins the bindings with sha256 hashes like every other artifact:

1. **New hash fields in fetch-libraries-versions.json**: `iosBindingsSha256` for cdk, `androidBindingsSha256` and `iosBindingsSha256` for zeus-cashu-restore, hashing the files at cdk-swift v0.14.2 (commit `d9959e1c53941533dce45f704193e10a12b2013e`) and zeus-cashu-restore v0.1.0 (commit `5cf5064c2adc6356aa53140519e85f2ac168a53b`). The pinned hashes match the files installs have been downloading, so there is no behavior change. Once a hash is pinned, tag mutability no longer matters: substituted content fails the build.

2. **Binding downloads use the same fail-closed verify-download-reverify structure as the binaries**, which also skips the network fetch when a verified copy is already present instead of re-downloading on every install.

3. **The rest of the script fails closed too:**
   - CDK and zeus-cashu-restore binaries are now verified unconditionally; the `[ -n "$SHA256" ]` branches that skipped verification on an empty hash field are gone
   - every hash field is validated as 64-char hex up front. This matters beyond the removed branches: macOS `sha256sum -c` exits 0 with only a warning on improperly formatted checksum lines, so a blank hash previously skipped verification silently for EVERY artifact, including LND and LDK Node
   - all curl calls now use `-f` so HTTP error pages are never written into target files

When bumping cdk or zeus-cashu-restore, update the binary hashes AND the `*BindingsSha256` fields from the same release in the same commit (comments in fetch-libraries.sh say this).

**Verification performed:**
- fresh run (bindings deleted first): all 11 checksummed artifacts download and report OK, exit 0
- tamper test: appending bytes to a downloaded binding is detected, the file is re-fetched and re-verified against the pin
- wrong-pin test (simulates a re-pointed tag): a valid-format but non-matching hash exits 1 with "CDK Swift bindings checksum failed"
- fail-closed tests: a blanked or missing sha256 field in fetch-libraries-versions.json exits 1 immediately (previously passed silently on macOS)
- `yarn verify` green (1044 tests, tsc, prettier, lint)

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

(App-level testing pending: this change only affects how build inputs are verified; all fetched files are byte-identical to current builds. Device builds on both platforms should still be done before merge per project policy.)

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
