### PR TITLE
Receive: surface real LSP Flow errors, don't fall back to unwrapped invoice

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -882,6 +882,7 @@
     "views.Receive.lspExplainer": "LSP will take the following amount as a setup fee:",
     "views.Receive.lspExplainerRoutingUnified": "LSP will take the following amount as a fee, if paid over lightning:",
     "views.Receive.lspExplainerRouting": "LSP will take the following amount as a fee:",
+    "views.Receive.lspFeeOnTop": "Since the invoice amount doesn't cover the setup fee, the fee will be added on top.",
     "views.Receive.lspExplainerZeroFeeWrapper": "Zero-fee wrapped invoice",
     "views.Receive.goToLspSettings": "Go to LSP Settings",
     "views.Receive.lspSwitchExplainer1": "The LSP will provide you with 0-conf channels that will allow you to send and receive payments on the Lightning network.",

--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -457,16 +457,19 @@ export default class InvoicesStore {
                         );
                         jit_bolt11 = response as string;
                     } catch (e: any) {
-                        // Surface the LSP's rejection as a dismissable
-                        // warning, clearing the error state so the
-                        // unwrapped invoice can still be displayed
+                        // The LSP rejected the proposal: hard-fail rather
+                        // than falling back to the unwrapped invoice, which
+                        // could dead-end without the channel it needs. Clear
+                        // the fee quote so it isn't shown alongside the
+                        // error the LSP flow already surfaced.
                         runInAction(() => {
-                            this.lspStore.flow_warning_msg =
-                                this.lspStore.flow_error_msg;
-                            this.lspStore.flow_error = false;
-                            this.lspStore.flow_error_msg = '';
-                            this.lspStore.showLspSettings = false;
+                            this.lspStore.zeroConfFee = undefined;
+                            this.lspStore.feeId = undefined;
+                            this.payment_request = null;
+                            this.payment_request_amt = null;
+                            this.creatingInvoice = false;
                         });
+                        return;
                     }
                 }
 

--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -43,7 +43,6 @@ export default class LSPStore {
     @observable public error_msg: string = '';
     @observable public flow_error: boolean = false;
     @observable public flow_error_msg: string = '';
-    @observable public flow_warning_msg: string = '';
     @observable public showLspSettings: boolean = false;
     @observable public channelAcceptor: any;
     @observable public customMessagesSubscriber: any;
@@ -125,7 +124,6 @@ export default class LSPStore {
         this.error_msg = '';
         this.flow_error = false;
         this.flow_error_msg = '';
-        this.flow_warning_msg = '';
         this.showLspSettings = false;
     };
 
@@ -135,7 +133,6 @@ export default class LSPStore {
         this.feeId = undefined;
         this.flow_error = false;
         this.flow_error_msg = '';
-        this.flow_warning_msg = '';
         this.showLspSettings = false;
     };
 
@@ -489,7 +486,6 @@ export default class LSPStore {
     public getZeroConfInvoice = (bolt11: string) => {
         this.flow_error = false;
         this.flow_error_msg = '';
-        this.flow_warning_msg = '';
         this.showLspSettings = false;
 
         const { settings } = this.settingsStore;

--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -251,6 +251,27 @@ export default class LSPStore {
 
     // Flow 2.0
 
+    // Prefer the LSP's own error message, then the raw response body,
+    // before settling for a bare HTTP status, so the real rejection
+    // reason isn't swallowed.
+    private formatFlowError = (response: any, status: number, data?: any) => {
+        const prefix = localeString('stores.LSPStore.error');
+        const message = data?.message || data?.error;
+        if (message) {
+            return `${prefix}: ${errorToUserFriendly(message)}`;
+        }
+        let body = '';
+        try {
+            body = response.text()?.toString().trim();
+        } catch (e) {}
+        // require some real content — an empty JSON body like `{}` tells
+        // the user nothing more than the status code does
+        if (body && body.length <= 200 && /[A-Za-z0-9]/.test(body)) {
+            return `${prefix}: ${body}`;
+        }
+        return `${prefix}: HTTP ${status}`;
+    };
+
     public getLSPInfo = () => {
         return new Promise((resolve, reject) => {
             ReactNativeBlobUtil.fetch(
@@ -266,9 +287,10 @@ export default class LSPStore {
                     } catch (jsonErr) {
                         runInAction(() => {
                             this.flow_error = true;
-                            this.flow_error_msg = `${localeString(
-                                'stores.LSPStore.error'
-                            )}: HTTP ${status}`;
+                            this.flow_error_msg = this.formatFlowError(
+                                response,
+                                status
+                            );
                         });
                         reject();
                         return;
@@ -294,15 +316,17 @@ export default class LSPStore {
                             );
                         } catch (e) {}
                     } else {
-                        const errorMsg = errorToUserFriendly(data.message);
+                        const errorMsg = this.formatFlowError(
+                            response,
+                            status,
+                            data
+                        );
                         runInAction(() => {
                             this.flow_error = true;
                             this.flow_error_msg = errorMsg;
                             // handle LSP geoblocking :(
                             if (
-                                this.error_msg.includes(
-                                    'unavailable in your country'
-                                )
+                                errorMsg.includes('unavailable in your country')
                             ) {
                                 this.showLspSettings = true;
                             }
@@ -350,9 +374,10 @@ export default class LSPStore {
                     } catch (jsonErr) {
                         runInAction(() => {
                             this.flow_error = true;
-                            this.flow_error_msg = `${localeString(
-                                'stores.LSPStore.error'
-                            )}: HTTP ${status}`;
+                            this.flow_error_msg = this.formatFlowError(
+                                response,
+                                status
+                            );
                         });
                         reject();
                         return;
@@ -375,13 +400,11 @@ export default class LSPStore {
                     } else {
                         runInAction(() => {
                             this.flow_error = true;
-                            this.flow_error_msg = data?.message
-                                ? `${localeString('stores.LSPStore.error')}: ${
-                                      data.message
-                                  }`
-                                : `${localeString(
-                                      'stores.LSPStore.error'
-                                  )}: HTTP ${status}`;
+                            this.flow_error_msg = this.formatFlowError(
+                                response,
+                                status,
+                                data
+                            );
                         });
                         reject();
                     }
@@ -498,9 +521,10 @@ export default class LSPStore {
                     } catch (jsonErr) {
                         runInAction(() => {
                             this.flow_error = true;
-                            this.flow_error_msg = `${localeString(
-                                'stores.LSPStore.error'
-                            )}: HTTP ${status}`;
+                            this.flow_error_msg = this.formatFlowError(
+                                response,
+                                status
+                            );
                         });
                         reject();
                         return;
@@ -510,13 +534,11 @@ export default class LSPStore {
                     } else {
                         runInAction(() => {
                             this.flow_error = true;
-                            this.flow_error_msg = data?.message
-                                ? `${localeString('stores.LSPStore.error')}: ${
-                                      data.message
-                                  }`
-                                : `${localeString(
-                                      'stores.LSPStore.error'
-                                  )}: HTTP ${status}`;
+                            this.flow_error_msg = this.formatFlowError(
+                                response,
+                                status,
+                                data
+                            );
                             if (
                                 data?.message &&
                                 data.message.includes('access key')

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -1311,6 +1311,19 @@ export default class Receive extends React.Component<
             watchedInvoicePaidAmt,
             clearUnified
         } = InvoicesStore;
+
+        // when the invoice amount doesn't cover the LSP's fee, the fee is
+        // added on top of the wrapped invoice and charged to the sender
+        const feeOnTop =
+            !!zeroConfFee &&
+            !!payment_request_amt &&
+            !new BigNumber(payment_request_amt).gt(zeroConfFee);
+        // the wrapped invoice is for amount + fee, so display the total
+        // the sender will actually pay
+        const displaySatAmount = feeOnTop
+            ? new BigNumber(satAmount).plus(zeroConfFee).toString()
+            : satAmount;
+
         const { implementation, posStatus, settings, updateSettings } =
             SettingsStore;
         const loading =
@@ -1976,6 +1989,22 @@ export default class Receive extends React.Component<
                                                     sats={zeroConfFee}
                                                     fixedUnits="sats"
                                                 />
+                                                {feeOnTop && (
+                                                    <Text
+                                                        style={{
+                                                            fontFamily:
+                                                                'PPNeueMontreal-Medium',
+                                                            color: themeColor(
+                                                                'text'
+                                                            ),
+                                                            marginTop: 5
+                                                        }}
+                                                    >
+                                                        {localeString(
+                                                            'views.Receive.lspFeeOnTop'
+                                                        )}
+                                                    </Text>
+                                                )}
                                                 <Text
                                                     style={{
                                                         fontFamily:
@@ -2069,7 +2098,7 @@ export default class Receive extends React.Component<
                                                             : ZIcon
                                                     }
                                                     nfcSupported={nfcSupported}
-                                                    satAmount={satAmount}
+                                                    satAmount={displaySatAmount}
                                                     displayAmount
                                                 />
                                             )}
@@ -2093,7 +2122,7 @@ export default class Receive extends React.Component<
                                                             : LightningIcon
                                                     }
                                                     nfcSupported={nfcSupported}
-                                                    satAmount={satAmount}
+                                                    satAmount={displaySatAmount}
                                                     displayAmount
                                                 />
                                             )}
@@ -2193,7 +2222,7 @@ export default class Receive extends React.Component<
                                                     textBottom
                                                     truncateLongValue
                                                     nfcSupported={nfcSupported}
-                                                    satAmount={satAmount}
+                                                    satAmount={displaySatAmount}
                                                     displayAmount
                                                 />
                                             )}

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -646,30 +646,34 @@ export default class Receive extends React.Component<
                     : undefined,
                 noLsp: !effectiveLspIsActive,
                 skipOnchain
-            }).then(
-                ({
-                    rHash,
-                    onChainAddress
-                }: {
-                    rHash: string;
-                    onChainAddress?: string;
-                }) => {
-                    // Store invoice for POS orders
-                    if (orderId && InvoicesStore.payment_request) {
-                        PosStore.recordInvoice({
-                            orderId,
-                            payment_request: InvoicesStore.payment_request,
-                            rHash,
-                            exchangeRate,
-                            amount: amount || '0',
-                            tip: orderTip,
-                            createdAt: Math.floor(Date.now() / 1000),
-                            expirySeconds: expirySeconds || '3600'
-                        });
+            })
+                .then(
+                    ({
+                        rHash,
+                        onChainAddress
+                    }: {
+                        rHash: string;
+                        onChainAddress?: string;
+                    }) => {
+                        // Store invoice for POS orders
+                        if (orderId && InvoicesStore.payment_request) {
+                            PosStore.recordInvoice({
+                                orderId,
+                                payment_request: InvoicesStore.payment_request,
+                                rHash,
+                                exchangeRate,
+                                amount: amount || '0',
+                                tip: orderTip,
+                                createdAt: Math.floor(Date.now() / 1000),
+                                expirySeconds: expirySeconds || '3600'
+                            });
+                        }
+                        this.subscribeInvoice(rHash, onChainAddress);
                     }
-                    this.subscribeInvoice(rHash, onChainAddress);
-                }
-            );
+                )
+                .catch(() => {
+                    // errors are surfaced via LSPStore/InvoicesStore observables
+                });
         });
     };
 
@@ -1822,12 +1826,6 @@ export default class Receive extends React.Component<
                             )}
                             {error_msg && (
                                 <ErrorMessage message={error_msg} dismissable />
-                            )}
-                            {LSPStore.flow_warning_msg && (
-                                <WarningMessage
-                                    message={LSPStore.flow_warning_msg}
-                                    dismissable
-                                />
                             )}
 
                             {showLspSettings && (
@@ -3203,20 +3201,24 @@ export default class Receive extends React.Component<
                                                                     : undefined,
                                                             noLsp: !lspIsActive,
                                                             skipOnchain
-                                                        }).then(
-                                                            ({
-                                                                rHash,
-                                                                onChainAddress
-                                                            }: {
-                                                                rHash: string;
-                                                                onChainAddress?: string;
-                                                            }) => {
-                                                                this.subscribeInvoice(
+                                                        })
+                                                            .then(
+                                                                ({
                                                                     rHash,
                                                                     onChainAddress
-                                                                );
-                                                            }
-                                                        );
+                                                                }: {
+                                                                    rHash: string;
+                                                                    onChainAddress?: string;
+                                                                }) => {
+                                                                    this.subscribeInvoice(
+                                                                        rHash,
+                                                                        onChainAddress
+                                                                    );
+                                                                }
+                                                            )
+                                                            .catch(() => {
+                                                                // errors are surfaced via LSPStore/InvoicesStore observables
+                                                            });
                                                     }}
                                                 />
                                             </View>

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -564,6 +564,9 @@ export default class Receive extends React.Component<
 
         // clear invoice
         this.props.InvoicesStore.reset();
+
+        // clear any LSP errors
+        this.props.LSPStore.reset(true);
     };
 
     onBack = () => {


### PR DESCRIPTION
# Description

When the Olympus Flow LSP rejects a request, the Receive view showed `LSP error: HTTP 400` with no reason, then displayed the unwrapped invoice anyway behind a dismissable warning.

Four changes:

1. **Surface the LSP's real error message.** `LSPStore` now has a `formatFlowError` helper used by all three Flow 2.0 calls (`/info`, `/fee`, `/proposal`). It prefers the response's `message`/`error` field (run through `errorToUserFriendly`), then falls back to the raw response body if it is short and has real content (an empty JSON body like `{}` is not shown), before settling for the bare HTTP status. Also fixes the geoblock check in `getLSPInfo`, which read `this.error_msg` (the LSPS1/7 field) instead of the message it had just computed, so the "go to LSP settings" prompt never appeared for geoblocked users.

2. **Hard-fail when the LSP rejects the wrapping proposal.** Previously the error was downgraded to a warning and the unwrapped invoice was displayed, and even submitted to LNURL-withdraw callbacks. Such an invoice can dead-end without the channel it needs and exposes the node pubkey. Now the flow error stays visible, the fee quote is cleared so a stale setup fee is not shown alongside the error, and no QR is displayed. The now-unused `flow_warning_msg` observable and its banner are removed.

3. **Display the full wrapped amount when the fee is added on top.** When the invoice amount doesn't cover the LSP's setup fee, the LSP wraps the invoice for amount plus fee and the sender pays the fee on top. The amount shown with the QR now displays the wrapped total the sender will actually pay, and the fee card notes that the fee is added on top.

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-03 at 14 26 07" src="https://github.com/user-attachments/assets/8dff0d5e-d613-4e6f-abd1-247b4ccdcdc4" />


4. **Clear LSP errors when leaving the view.** The LSP error state lives in `LSPStore` and survived navigation, so a stale error banner could reappear on the next visit to Receive. Errors are now cleared in `cleanup`, which runs on unmount and back navigation.

Server-side counterpart (returning real error messages instead of empty `{}` bodies): ZeusLN/olympus-flow#65

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS (iPhone Simulator)

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND (signet, against Olympus signet LSP)

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

