### PR TITLE
fix(swaps): enforce BIP39 checksum on rescue key restore

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,7 @@
     "testPathIgnorePatterns": [
       "check-styles.test.ts",
       "zeus_modules"
-    ],
-    "moduleNameMapper": {
-      "^@noble/hashes/_assert$": "<rootDir>/node_modules/@noble/hashes/_assert.js",
-      "^@noble/hashes/pbkdf2$": "<rootDir>/node_modules/@noble/hashes/pbkdf2.js",
-      "^@noble/hashes/sha256$": "<rootDir>/node_modules/@noble/hashes/sha256.js",
-      "^@noble/hashes/sha512$": "<rootDir>/node_modules/@noble/hashes/sha512.js",
-      "^@noble/hashes/utils$": "<rootDir>/node_modules/@noble/hashes/utils.js"
-    }
+    ]
   },
   "scripts": {
     "start": "react-native start",

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -4,11 +4,7 @@ import { ECPairAPI, ECPairFactory } from 'ecpair';
 import ecc from '@bitcoinerlab/secp256k1';
 import { crypto, initEccLib } from 'bitcoinjs-lib';
 import { HDKey } from '@scure/bip32';
-import {
-    validateMnemonic,
-    mnemonicToSeedSync,
-    generateMnemonic
-} from '@scure/bip39';
+import { mnemonicToSeedSync, generateMnemonic } from '@scure/bip39';
 
 import { themeColor } from '../utils/ThemeUtils';
 import { localeString } from '../utils/LocaleUtils';
@@ -17,7 +13,8 @@ import {
     SWAPS_KEY,
     REVERSE_SWAPS_KEY,
     SWAPS_RESCUE_KEY,
-    SWAPS_LAST_USED_KEY
+    SWAPS_LAST_USED_KEY,
+    isValidRescueKey
 } from '../utils/SwapUtils';
 
 import NodeInfoStore from './NodeInfoStore';
@@ -818,7 +815,7 @@ export default class SwapStore {
     }) => {
         const mnemonic = seedArray.join(' ');
 
-        if (!validateMnemonic(mnemonic, BIP39_WORD_LIST)) {
+        if (!isValidRescueKey(mnemonic)) {
             return {
                 success: false,
                 error: localeString('views.Swaps.rescueKey.invalid')

--- a/utils/SwapUtils.test.ts
+++ b/utils/SwapUtils.test.ts
@@ -5,7 +5,8 @@ import {
     calculateReceiveAmount,
     calculateServiceFeeOnSend,
     calculateSendAmount,
-    calculateLimit
+    calculateLimit,
+    isValidRescueKey
 } from './SwapUtils';
 
 describe('SwapUtils', () => {
@@ -119,6 +120,67 @@ describe('SwapUtils', () => {
         it('should return limit as-is when in reverse mode', () => {
             const result = calculateLimit(940, 1, 50, true);
             expect(result).toBe(940);
+        });
+    });
+
+    describe('isValidRescueKey', () => {
+        // BIP39 reference vector (128-bit entropy of all zeroes)
+        const validMnemonic =
+            'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+        it('should accept a valid 12-word mnemonic', () => {
+            expect(isValidRescueKey(validMnemonic)).toBe(true);
+            expect(
+                isValidRescueKey(
+                    'legal winner thank year wave sausage worth useful legal winner thank yellow'
+                )
+            ).toBe(true);
+        });
+
+        it('should tolerate surrounding and irregular whitespace', () => {
+            expect(
+                isValidRescueKey(`  ${validMnemonic.replace(/ /g, '   ')}  `)
+            ).toBe(true);
+        });
+
+        it('should reject 12 wordlist words with a bad checksum', () => {
+            // all-abandon fails the checksum (valid vector ends in 'about')
+            expect(isValidRescueKey('abandon '.repeat(12).trim())).toBe(false);
+        });
+
+        it('should reject a single-word typo to another valid word', () => {
+            expect(
+                isValidRescueKey(validMnemonic.replace(/about$/, 'zoo'))
+            ).toBe(false);
+        });
+
+        it('should reject a word-order transposition', () => {
+            expect(
+                isValidRescueKey(
+                    'about abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon'
+                )
+            ).toBe(false);
+        });
+
+        it('should reject words outside the BIP39 wordlist', () => {
+            expect(
+                isValidRescueKey(validMnemonic.replace(/about$/, 'notaword'))
+            ).toBe(false);
+        });
+
+        it('should reject wrong word counts, including valid 24-word seeds', () => {
+            expect(isValidRescueKey('')).toBe(false);
+            expect(
+                isValidRescueKey(
+                    validMnemonic.split(' ').slice(0, 11).join(' ')
+                )
+            ).toBe(false);
+            // valid BIP39 mnemonic, but rescue keys must be exactly 12 words
+            expect(
+                isValidRescueKey(
+                    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art'
+                )
+            ).toBe(false);
         });
     });
 });

--- a/utils/SwapUtils.ts
+++ b/utils/SwapUtils.ts
@@ -1,4 +1,7 @@
 import BigNumber from 'bignumber.js';
+import { validateMnemonic } from '@scure/bip39';
+
+import { BIP39_WORD_LIST } from './Bip39Utils';
 
 export const bigCeil = (big: BigNumber): BigNumber => {
     return big.integerValue(BigNumber.ROUND_CEIL);
@@ -12,6 +15,17 @@ export const SWAPS_KEY = 'swaps';
 export const REVERSE_SWAPS_KEY = 'reverse-swaps';
 export const SWAPS_RESCUE_KEY = 'swaps-rescue-key';
 export const SWAPS_LAST_USED_KEY = 'swaps-last-used-key';
+
+export const RESCUE_KEY_WORD_COUNT = 12;
+
+// Swap rescue keys are 12-word BIP39 mnemonics; the checksum must be
+// enforced before persisting, since refund keys derived from a corrupted
+// seed cannot be reproduced from the user's real backup.
+export const isValidRescueKey = (mnemonic: string): boolean => {
+    const words = mnemonic?.trim().split(/\s+/) || [];
+    if (words.length !== RESCUE_KEY_WORD_COUNT) return false;
+    return validateMnemonic(words.join(' '), BIP39_WORD_LIST);
+};
 
 export const calculateReceiveAmount = (
     sendAmount: BigNumber,

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -81,7 +81,7 @@ import SettingsStore, {
 } from '../../stores/SettingsStore';
 import NodeInfoStore from '../../stores/NodeInfoStore';
 import SwapStore from '../../stores/SwapStore';
-import { SWAPS_RESCUE_KEY } from '../../utils/SwapUtils';
+import { SWAPS_RESCUE_KEY, isValidRescueKey } from '../../utils/SwapUtils';
 
 import Storage from '../../storage';
 
@@ -1381,7 +1381,11 @@ export default class SeedRecovery extends React.PureComponent<
                                                         importedData.mnemonic
                                                             .trim()
                                                             .split(/\s+/);
-                                                    if (words.length === 12) {
+                                                    if (
+                                                        isValidRescueKey(
+                                                            words.join(' ')
+                                                        )
+                                                    ) {
                                                         this.setState({
                                                             seedArray: words
                                                         });
@@ -1474,21 +1478,22 @@ export default class SeedRecovery extends React.PureComponent<
                                                 }
                                             );
                                         } else if (restoreRescueKey) {
-                                            console.log(
-                                                'Verifying rescue key...'
-                                            );
-
                                             const mnemonic = seedArray
                                                 .join(' ')
                                                 .trim();
 
+                                            if (!isValidRescueKey(mnemonic)) {
+                                                this.setState({
+                                                    errorMsg: localeString(
+                                                        'views.Settings.SeedRecovery.invalidChecksum'
+                                                    )
+                                                });
+                                                return;
+                                            }
+
                                             await Storage.setItem(
                                                 SWAPS_RESCUE_KEY,
                                                 mnemonic
-                                            );
-
-                                            console.log(
-                                                'Rescue key verified and saved!'
                                             );
 
                                             navigation.goBack();


### PR DESCRIPTION
# Description

Restoring a submarine swap rescue key (Settings > Swaps > Rescue key > Restore) previously validated only that the 12 entered words exist in the BIP39 wordlist. The checksum was never verified before the phrase was persisted to storage, and the console logs claimed the key was "verified." A single mistyped word that is itself a valid wordlist word, or a word-order transposition, produces an invalid mnemonic with probability ~15/16 yet was accepted silently. All subsequent swap refund keys and reverse swap preimages would then be derived from a seed the user cannot reproduce from their real backup, making swap funds unrecoverable exactly when the rescue key is needed. The `rescue_key.json` file import path had the same gap (word count only), while `SwapStore.getRescuableSwaps` already validated correctly, an inconsistency that confirmed the gap was unintended.

Changes:

- Added `isValidRescueKey()` to `utils/SwapUtils.ts`: enforces exactly 12 words plus the BIP39 checksum, tolerant of irregular whitespace
- The rescue key restore button, the `rescue_key.json` import, and `SwapStore.getRescuableSwaps` now all share this single validator, so the three gates cannot drift apart again
- Invalid phrases are rejected with the existing `views.Settings.SeedRecovery.invalidChecksum` locale string instead of being silently saved; the misleading "Verifying rescue key..." / "Rescue key verified and saved!" logs are removed
- Added unit tests covering valid reference vectors, whitespace tolerance, bad checksum, single-word typo, transposition, non-wordlist words, and wrong word counts (including rejecting valid 24-word seeds, since rescue keys must be exactly 12 words)
- Removed the stale jest `moduleNameMapper` for `@noble/hashes` subpaths from `package.json`. It pinned imports to the hoisted root copy (1.7.2) while `@scure/bip39` resolves its other imports to its nested 1.8.0 copy; the version mix made `validateMnemonic` throw internally and return `false` for every input under jest, valid or not, which would have made these new tests fail. The mapper's original workaround is no longer needed: all 49 suites (1051 tests) pass without it. Metro never used this config, so runtime app behavior is unaffected.

No legitimate backup can be rejected by the new gate: `SwapStore.generateRescueKey` uses `generateMnemonic`, so every genuine ZEUS rescue key has a valid checksum.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
