### PR TITLE
fix(donations): verify LNURL invoice before silent donation payment

### DIFF
--- a/utils/DonationUtils.test.ts
+++ b/utils/DonationUtils.test.ts
@@ -48,25 +48,40 @@ describe('DonationUtils', () => {
     });
 
     describe('loadDonationLnurl', () => {
+        const CALLBACK_URL =
+            'https://pay.zeusln.app/BTC/UILNURL/pay/lnaddress/tips';
+        const DONATION_METADATA =
+            '[["text/identifier","tips@pay.zeusln.app"],["text/plain","Paid to ZEUS (Order ID: )"]]';
+        // Real 21 sat (21000 msat) invoice issued by pay.zeusln.app whose
+        // description_hash is sha256(DONATION_METADATA)
+        const DONATION_INVOICE_21_SATS =
+            'lnbc210n1p48zdsvpp5jkksnqvq4dpf67e4u6n3d3e4hn7lee6wt2g9rquwgavxgca0wzhqhp5tlfzg0jpxjddu0htpe54lkrd5n0zqce9rqwwk24g0lrxqmkhhsdscqzzsxqzuzsp5sehyhye2sn5vlauqz6cnrw58qjz65yzy3782ruk22pyanehhvdgq9qxpqysgq98pyfpyajv4myx7rtcm8jhs8g7jqpgahjsvlsvjcznzx4ljy9gyzvtfca7dldwst0tlmuygshy7re60zfys0d94w8ym6jky6jax4ylcqg4uz05';
+        // BOLT11 spec reference vector with no amount
+        const NO_AMOUNT_INVOICE =
+            'lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq9qrsgq357wnc5r2ueh7ck6q93dj32dlqnls087fxdwk8qakdyafkq3yap2r09nt4ndd0unm3z9u5t48y6ucv4r5sg7lk98c77ctvjczkspk5qprc90gx';
+
+        const mockLnurlParams = (overrides: any = {}) => ({
+            json: () => ({
+                callback: CALLBACK_URL,
+                metadata: DONATION_METADATA,
+                ...overrides
+            })
+        });
+
         beforeEach(() => {
             jest.clearAllMocks();
         });
 
-        it('should fetch LNURL data and return a payment request', async () => {
-            const callbackUrl = 'https://pay.zeusln.app/callback';
-            const expectedPr = 'lnbc1000n1ptest...';
-
+        it('should fetch LNURL data and return a verified payment request', async () => {
             mockFetch
+                .mockResolvedValueOnce(mockLnurlParams())
                 .mockResolvedValueOnce({
-                    json: () => ({ callback: callbackUrl })
-                })
-                .mockResolvedValueOnce({
-                    json: () => ({ pr: expectedPr })
+                    json: () => ({ pr: DONATION_INVOICE_21_SATS })
                 });
 
-            const result = await loadDonationLnurl('1000');
+            const result = await loadDonationLnurl('21');
 
-            expect(result).toBe(expectedPr);
+            expect(result).toBe(DONATION_INVOICE_21_SATS);
             expect(mockFetch).toHaveBeenCalledTimes(2);
             expect(mockFetch).toHaveBeenNthCalledWith(
                 1,
@@ -76,17 +91,15 @@ describe('DonationUtils', () => {
             expect(mockFetch).toHaveBeenNthCalledWith(
                 2,
                 'GET',
-                `${callbackUrl}?amount=1000000`
+                `${CALLBACK_URL}?amount=21000`
             );
         });
 
         it('should convert donation amount to millisats', async () => {
             mockFetch
+                .mockResolvedValueOnce(mockLnurlParams())
                 .mockResolvedValueOnce({
-                    json: () => ({ callback: 'https://example.com/cb' })
-                })
-                .mockResolvedValueOnce({
-                    json: () => ({ pr: 'lnbc...' })
+                    json: () => ({ pr: DONATION_INVOICE_21_SATS })
                 });
 
             await loadDonationLnurl('500');
@@ -94,7 +107,7 @@ describe('DonationUtils', () => {
             expect(mockFetch).toHaveBeenNthCalledWith(
                 2,
                 'GET',
-                'https://example.com/cb?amount=500000'
+                `${CALLBACK_URL}?amount=500000`
             );
         });
 
@@ -112,9 +125,7 @@ describe('DonationUtils', () => {
 
         it('should return null when callback request fails', async () => {
             mockFetch
-                .mockResolvedValueOnce({
-                    json: () => ({ callback: 'https://example.com/cb' })
-                })
+                .mockResolvedValueOnce(mockLnurlParams())
                 .mockRejectedValueOnce(new Error('Callback failed'));
 
             const result = await loadDonationLnurl('1000');
@@ -125,11 +136,9 @@ describe('DonationUtils', () => {
 
         it('should handle decimal donation amounts', async () => {
             mockFetch
+                .mockResolvedValueOnce(mockLnurlParams())
                 .mockResolvedValueOnce({
-                    json: () => ({ callback: 'https://example.com/cb' })
-                })
-                .mockResolvedValueOnce({
-                    json: () => ({ pr: 'lnbc...' })
+                    json: () => ({ pr: DONATION_INVOICE_21_SATS })
                 });
 
             await loadDonationLnurl('21.5');
@@ -137,8 +146,104 @@ describe('DonationUtils', () => {
             expect(mockFetch).toHaveBeenNthCalledWith(
                 2,
                 'GET',
-                'https://example.com/cb?amount=21500'
+                `${CALLBACK_URL}?amount=21500`
             );
+        });
+
+        it('should reject an invoice whose amount does not match the request', async () => {
+            mockFetch
+                .mockResolvedValueOnce(mockLnurlParams())
+                .mockResolvedValueOnce({
+                    json: () => ({ pr: DONATION_INVOICE_21_SATS })
+                });
+
+            const result = await loadDonationLnurl('22');
+
+            expect(result).toBeNull();
+        });
+
+        it('should reject an invoice with no amount', async () => {
+            mockFetch
+                .mockResolvedValueOnce(mockLnurlParams())
+                .mockResolvedValueOnce({
+                    json: () => ({ pr: NO_AMOUNT_INVOICE })
+                });
+
+            const result = await loadDonationLnurl('21');
+
+            expect(result).toBeNull();
+        });
+
+        it('should reject an undecodable payment request', async () => {
+            mockFetch
+                .mockResolvedValueOnce(mockLnurlParams())
+                .mockResolvedValueOnce({
+                    json: () => ({ pr: 'not-an-invoice' })
+                });
+
+            const result = await loadDonationLnurl('21');
+
+            expect(result).toBeNull();
+        });
+
+        it('should reject a callback off the donation domain without calling it', async () => {
+            mockFetch.mockResolvedValueOnce(
+                mockLnurlParams({ callback: 'https://evil.com/cb' })
+            );
+
+            const result = await loadDonationLnurl('21');
+
+            expect(result).toBeNull();
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('should reject a lookalike callback domain', async () => {
+            mockFetch.mockResolvedValueOnce(
+                mockLnurlParams({
+                    callback: 'https://pay.zeusln.app.evil.com/cb'
+                })
+            );
+
+            const result = await loadDonationLnurl('21');
+
+            expect(result).toBeNull();
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('should reject an invoice whose description_hash does not commit to the metadata', async () => {
+            mockFetch
+                .mockResolvedValueOnce(
+                    mockLnurlParams({
+                        metadata:
+                            '[["text/plain","Tampered metadata for a different payee"]]'
+                    })
+                )
+                .mockResolvedValueOnce({
+                    json: () => ({ pr: DONATION_INVOICE_21_SATS })
+                });
+
+            const result = await loadDonationLnurl('21');
+
+            expect(result).toBeNull();
+        });
+
+        it('should reject when the LNURL params omit metadata', async () => {
+            mockFetch
+                .mockResolvedValueOnce(mockLnurlParams({ metadata: undefined }))
+                .mockResolvedValueOnce({
+                    json: () => ({ pr: DONATION_INVOICE_21_SATS })
+                });
+
+            const result = await loadDonationLnurl('21');
+
+            expect(result).toBeNull();
+        });
+
+        it('should reject invalid donation amounts without any network call', async () => {
+            expect(await loadDonationLnurl('0')).toBeNull();
+            expect(await loadDonationLnurl('-21')).toBeNull();
+            expect(await loadDonationLnurl('abc')).toBeNull();
+            expect(mockFetch).not.toHaveBeenCalled();
         });
     });
 });

--- a/utils/DonationUtils.ts
+++ b/utils/DonationUtils.ts
@@ -1,6 +1,10 @@
 // DonationUtils.ts
 import BigNumber from 'bignumber.js';
 import ReactNativeBlobUtil from 'react-native-blob-util';
+import { sha256 } from '@noble/hashes/sha256';
+
+import Base64Utils from './Base64Utils';
+import Bolt11Utils from './Bolt11Utils';
 
 const DONATION_ADDRESS = 'tips@pay.zeusln.app';
 
@@ -39,23 +43,81 @@ export const loadDonationLnurl = async (
     donationAmount: string
 ): Promise<string | null> => {
     const [username, bolt11Domain] = DONATION_ADDRESS.split('@');
-    const url = bolt11Domain.includes('.onion')
-        ? `http://${bolt11Domain}/.well-known/lnurlp/${username.toLowerCase()}`
-        : `https://${bolt11Domain}/.well-known/lnurlp/${username.toLowerCase()}`;
+    const protocol = bolt11Domain.includes('.onion') ? 'http' : 'https';
+    const url = `${protocol}://${bolt11Domain}/.well-known/lnurlp/${username.toLowerCase()}`;
 
     try {
+        const amountMsat = new BigNumber(donationAmount || 0).multipliedBy(
+            1000
+        );
+        if (!amountMsat.isInteger() || amountMsat.lte(0)) {
+            console.error(
+                'loadLnurl error: invalid donation amount:',
+                donationAmount
+            );
+            return null;
+        }
+
         const response = await ReactNativeBlobUtil.fetch('GET', url);
         const lnurlData = response.json();
-        const amount = parseFloat(donationAmount) * 1000;
-        const callbackUrl = `${lnurlData.callback}?amount=${amount}`;
+
+        // The invoice returned by this callback is paid silently, with no
+        // confirmation screen, so never follow it off the donation domain
+        const callback = lnurlData?.callback;
+        const origin = `${protocol}://${bolt11Domain}`;
+        if (
+            typeof callback !== 'string' ||
+            (callback !== origin && !callback.startsWith(`${origin}/`))
+        ) {
+            console.error('loadLnurl error: unexpected callback URL');
+            return null;
+        }
+
+        const callbackUrl = `${callback}?amount=${amountMsat.toString()}`;
 
         const invoiceResponse = await ReactNativeBlobUtil.fetch(
             'GET',
             callbackUrl
         );
         const invoiceData = invoiceResponse.json();
+        const pr = invoiceData?.pr;
+        if (typeof pr !== 'string') {
+            console.error('loadLnurl error: no payment request returned');
+            return null;
+        }
 
-        return invoiceData.pr;
+        // Since there is no confirmation screen, a compromised server must
+        // not be able to name its own price: enforce LUD-06 client-side by
+        // requiring an exact amount match and a description_hash committing
+        // to the served metadata
+        const decoded = Bolt11Utils.decode(pr);
+        if (!new BigNumber(decoded.num_msat).isEqualTo(amountMsat)) {
+            console.error(
+                'loadLnurl error: invoice amount mismatch:',
+                decoded.num_msat,
+                'msat !==',
+                amountMsat.toString(),
+                'msat'
+            );
+            return null;
+        }
+
+        const metadata = lnurlData?.metadata;
+        const expectedDescriptionHash =
+            typeof metadata === 'string'
+                ? Base64Utils.bytesToHex(
+                      Array.from(sha256(Base64Utils.utf8ToBytes(metadata)))
+                  )
+                : null;
+        if (
+            !expectedDescriptionHash ||
+            decoded.description_hash !== expectedDescriptionHash
+        ) {
+            console.error('loadLnurl error: description hash mismatch');
+            return null;
+        }
+
+        return pr;
     } catch (err) {
         console.error('loadLnurl error:', err);
         return null;


### PR DESCRIPTION
# Description

Fixes a funds-loss vector in the donation flow reported in an internal security review.

When donations are enabled, every successful Lightning payment is followed by an automatic background donation. `loadDonationLnurl` requested an invoice from the donation LNURL endpoint and returned `invoiceData.pr` with no verification, and all three donation flows (`SendingLightning`, `CashuSendingLightning`, `MultimintPayment`) then paid that invoice silently with no confirmation screen. A compromised or malicious LNURL server could therefore return an invoice for an arbitrary amount (up to the full wallet balance) and ZEUS would pay it in the background. The `fee_limit_sat` of 100 only bounds routing fees, not the principal. On the Cashu paths, `payLnInvoiceFromEcash` prefers the decoded invoice amount over the caller-supplied amount, so those paths were equally exposed.

This PR enforces LUD-06 client-side in `loadDonationLnurl`, the single choke point for all three flows. The donation is silently skipped (existing `null` handling in all callers) unless every check passes:

* the decoded invoice amount exactly matches the requested donation amount in msat
* the invoice `description_hash` equals sha256 of the served metadata
* the callback URL stays on the donation domain (lookalike domains like `pay.zeusln.app.evil.com` are rejected)
* the requested amount is a positive integer msat value (checked before any network call; also replaces `parseFloat * 1000` with BigNumber arithmetic)

The live `pay.zeusln.app` endpoint was verified to already satisfy all of these checks: the callback is on the same domain, a request for 21000 msat returned an `lnbc210n` invoice, and its `description_hash` matched sha256 of the metadata byte for byte. That server-issued invoice is used as the happy-path test fixture, so legitimate donations are unaffected.

The interactive LNURL-pay flow is not touched: it is already mitigated by the PaymentRequest confirmation screen.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

7 new rejection tests were added (amount mismatch, no-amount invoice, undecodable invoice, off-domain callback, lookalike callback domain, tampered metadata, missing metadata, invalid requested amounts), plus the happy path against a real invoice issued by pay.zeusln.app.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

On-device testing pending: the change is confined to a pure utility function exercised before any backend call, and is fully covered by unit tests. Will follow up with a mainnet donation test on both platforms before merge.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
