### PR TITLE
fix(sweep): collect UTXOs from all address types of a WIF key

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1139,6 +1139,7 @@
     "views.Wif.failedToDerivePubkey": "Failed to derive public key",
     "views.Wif.noUtxosFound": "No UTXOs found for the given private key",
     "views.Wif.addressTypeNotSupported": "This address type is not yet supported for sweeping",
+    "views.Wif.taprootFundsRemain": "This key also holds {{amount}} sats on a Taproot address, which cannot be swept yet. Those funds will NOT be included in this sweep. Keep the private key safe until Taproot sweeps are supported.",
     "views.Wif.insufficientFundsAfterFees": "Insufficient funds after fees",
     "views.Wif.failedToCreateTransaction": "Failed to create transaction. Please check your inputs and try again.",
     "views.Wif.errorFetchingUtxos": "Error fetching UTXOs",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1134,6 +1134,7 @@
     "views.Wif.failedToDerivePubkey": "Failed to derive public key",
     "views.Wif.noUtxosFound": "No UTXOs found for the given private key",
     "views.Wif.addressTypeNotSupported": "This address type is not yet supported for sweeping",
+    "views.Wif.taprootFundsRemain": "This key also holds {{amount}} sats on a Taproot address, which cannot be swept yet. Those funds will NOT be included in this sweep. Keep the private key safe until Taproot sweeps are supported.",
     "views.Wif.insufficientFundsAfterFees": "Insufficient funds after fees",
     "views.Wif.failedToCreateTransaction": "Failed to create transaction. Please check your inputs and try again.",
     "views.Wif.errorFetchingUtxos": "Error fetching UTXOs",

--- a/stores/SweepStore.test.ts
+++ b/stores/SweepStore.test.ts
@@ -1,0 +1,201 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import { toXOnly } from 'bitcoinjs-lib/src/psbt/bip371';
+import { getPublicKey } from '@noble/secp256k1';
+// @ts-ignore:next-line
+import { decode as wifDecode } from 'wif';
+
+import SweepStore from './SweepStore';
+
+jest.mock('./NodeInfoStore', () => ({
+    __esModule: true,
+    default: class {}
+}));
+
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+
+jest.mock('./Stores', () => ({
+    nodeInfoStore: {
+        nodeInfo: { isTestNet: false }
+    },
+    settingsStore: {
+        settings: { privacy: {} }
+    }
+}));
+
+jest.mock('react-native', () => ({
+    Linking: {
+        canOpenURL: jest.fn(),
+        openURL: jest.fn()
+    }
+}));
+
+jest.mock('./SettingsStore', () => ({
+    DEFAULT_MEMPOOL_INSTANCE: 'electrs.zeusln.com'
+}));
+
+// Private key 0x...01 (compressed, mainnet)
+const WIF = 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn';
+
+const network = bitcoin.networks.bitcoin;
+const { privateKey } = wifDecode(WIF);
+const publicKey = Buffer.from(getPublicKey(privateKey, true));
+
+const p2pkhAddress = bitcoin.payments.p2pkh({ pubkey: publicKey, network })
+    .address!;
+const p2wpkhAddress = bitcoin.payments.p2wpkh({ pubkey: publicKey, network })
+    .address!;
+const p2trAddress = bitcoin.payments.p2tr({
+    internalPubkey: toXOnly(publicKey),
+    network
+}).address!;
+
+// Build a real funding tx paying the p2pkh address, so the PSBT's
+// nonWitnessUtxo hash check passes
+const P2PKH_VALUE = 200_000_000;
+const fundingTx = new bitcoin.Transaction();
+fundingTx.version = 2;
+fundingTx.addInput(Buffer.alloc(32, 1), 0);
+fundingTx.addOutput(
+    bitcoin.address.toOutputScript(p2pkhAddress, network),
+    P2PKH_VALUE
+);
+const p2pkhTxid = fundingTx.getId();
+
+const P2WPKH_VALUE = 50_000_000;
+const p2wpkhTxid = '2'.repeat(64);
+
+const P2TR_VALUE = 30_000_000;
+
+const mockNodeInfoStore: any = { nodeInfo: { isTestNet: false } };
+
+function mockEsplora(balances: {
+    p2pkh?: boolean;
+    p2sh?: boolean;
+    p2wpkh?: boolean;
+    p2tr?: boolean;
+}) {
+    global.fetch = jest.fn(async (url: string) => {
+        const utxosFor = (address: string) => {
+            if (address === p2pkhAddress && balances.p2pkh)
+                return [{ txid: p2pkhTxid, vout: 0, value: P2PKH_VALUE }];
+            if (address === p2wpkhAddress && balances.p2wpkh)
+                return [{ txid: p2wpkhTxid, vout: 0, value: P2WPKH_VALUE }];
+            if (address === p2trAddress && balances.p2tr)
+                return [{ txid: '3'.repeat(64), vout: 0, value: P2TR_VALUE }];
+            return [];
+        };
+
+        const utxoMatch = url.match(/\/address\/([^/]+)\/utxo$/);
+        if (utxoMatch)
+            return {
+                ok: true,
+                json: async () => utxosFor(utxoMatch[1])
+            };
+
+        if (url.endsWith(`/tx/${p2pkhTxid}/hex`))
+            return {
+                ok: true,
+                text: async () => fundingTx.toHex()
+            };
+
+        if (url.endsWith(`/tx/${p2wpkhTxid}`))
+            return {
+                ok: true,
+                json: async () => ({
+                    vout: [
+                        {
+                            value: P2WPKH_VALUE,
+                            scriptpubkey: bitcoin.payments
+                                .p2wpkh({ pubkey: publicKey, network })
+                                .output!.toString('hex')
+                        }
+                    ]
+                })
+            };
+
+        throw new Error(`unexpected fetch: ${url}`);
+    }) as any;
+}
+
+describe('SweepStore', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('sweeps UTXOs from every address type of the key, not just the first', async () => {
+        mockEsplora({ p2pkh: true, p2wpkh: true });
+
+        const store = new SweepStore(mockNodeInfoStore);
+        await store.prepareSweepInputs(WIF);
+
+        expect(store.sweepError).toBe(false);
+        expect(store.sweptAddressTypes).toEqual(['p2pkh', 'p2wpkh']);
+        expect(store.psbt.inputCount).toBe(2);
+        expect(store.onChainBalance).toBe(P2PKH_VALUE + P2WPKH_VALUE);
+    });
+
+    it('signs and finalizes a mixed-input sweep transaction', async () => {
+        mockEsplora({ p2pkh: true, p2wpkh: true });
+
+        const store = new SweepStore(mockNodeInfoStore);
+        await store.prepareSweepInputs(WIF);
+        store.destination = p2wpkhAddress;
+        await store.finalizeSweepTransaction('2');
+
+        expect(store.sweepError).toBe(false);
+        expect(store.txHex).toBeTruthy();
+        const tx = bitcoin.Transaction.fromHex(store.txHex!);
+        expect(tx.ins.length).toBe(2);
+        expect(tx.outs[0].value).toBe(P2PKH_VALUE + P2WPKH_VALUE - store.fee);
+    });
+
+    it('warns about unswept taproot funds while sweeping supported types', async () => {
+        mockEsplora({ p2wpkh: true, p2tr: true });
+
+        const store = new SweepStore(mockNodeInfoStore);
+        await store.prepareSweepInputs(WIF);
+
+        expect(store.sweepError).toBe(false);
+        expect(store.sweptAddressTypes).toEqual(['p2wpkh']);
+        expect(store.onChainBalance).toBe(P2WPKH_VALUE);
+        expect(store.unsweptTaprootSats).toBe(P2TR_VALUE);
+    });
+
+    it('errors when funds are exclusively on an unsupported taproot address', async () => {
+        mockEsplora({ p2tr: true });
+
+        const store = new SweepStore(mockNodeInfoStore);
+        await store.prepareSweepInputs(WIF);
+
+        expect(store.sweepError).toBe(true);
+        expect(store.sweepErrorMsg).toBe('views.Wif.addressTypeNotSupported');
+        expect(store.unsweptTaprootSats).toBe(P2TR_VALUE);
+    });
+
+    it('errors when no address type has UTXOs', async () => {
+        mockEsplora({});
+
+        const store = new SweepStore(mockNodeInfoStore);
+        await store.prepareSweepInputs(WIF);
+
+        expect(store.sweepError).toBe(true);
+        expect(store.sweepErrorMsg).toBe('views.Wif.noUtxosFound');
+    });
+
+    it('resets stale balance and taproot warning between scans', async () => {
+        mockEsplora({ p2wpkh: true, p2tr: true });
+
+        const store = new SweepStore(mockNodeInfoStore);
+        await store.prepareSweepInputs(WIF);
+        expect(store.onChainBalance).toBe(P2WPKH_VALUE);
+        expect(store.unsweptTaprootSats).toBe(P2TR_VALUE);
+
+        mockEsplora({});
+        await store.prepareSweepInputs(WIF);
+        expect(store.sweepError).toBe(true);
+        expect(store.onChainBalance).toBe(0);
+        expect(store.unsweptTaprootSats).toBe(0);
+    });
+});

--- a/stores/SweepStore.test.ts
+++ b/stores/SweepStore.test.ts
@@ -1,0 +1,181 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import { toXOnly } from 'bitcoinjs-lib/src/psbt/bip371';
+import { getPublicKey } from '@noble/secp256k1';
+// @ts-ignore:next-line
+import { decode as wifDecode } from 'wif';
+
+import SweepStore from './SweepStore';
+
+jest.mock('./NodeInfoStore', () => ({
+    __esModule: true,
+    default: class {}
+}));
+
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+
+// Private key 0x...01 (compressed, mainnet)
+const WIF = 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn';
+
+const network = bitcoin.networks.bitcoin;
+const { privateKey } = wifDecode(WIF);
+const publicKey = Buffer.from(getPublicKey(privateKey, true));
+
+const p2pkhAddress = bitcoin.payments.p2pkh({ pubkey: publicKey, network })
+    .address!;
+const p2wpkhAddress = bitcoin.payments.p2wpkh({ pubkey: publicKey, network })
+    .address!;
+const p2trAddress = bitcoin.payments.p2tr({
+    internalPubkey: toXOnly(publicKey),
+    network
+}).address!;
+
+// Build a real funding tx paying the p2pkh address, so the PSBT's
+// nonWitnessUtxo hash check passes
+const P2PKH_VALUE = 200_000_000;
+const fundingTx = new bitcoin.Transaction();
+fundingTx.version = 2;
+fundingTx.addInput(Buffer.alloc(32, 1), 0);
+fundingTx.addOutput(
+    bitcoin.address.toOutputScript(p2pkhAddress, network),
+    P2PKH_VALUE
+);
+const p2pkhTxid = fundingTx.getId();
+
+const P2WPKH_VALUE = 50_000_000;
+const p2wpkhTxid = '2'.repeat(64);
+
+const P2TR_VALUE = 30_000_000;
+
+const mockNodeInfoStore: any = { nodeInfo: { isTestNet: false } };
+
+function mockEsplora(balances: {
+    p2pkh?: boolean;
+    p2sh?: boolean;
+    p2wpkh?: boolean;
+    p2tr?: boolean;
+}) {
+    global.fetch = jest.fn(async (url: string) => {
+        const utxosFor = (address: string) => {
+            if (address === p2pkhAddress && balances.p2pkh)
+                return [{ txid: p2pkhTxid, vout: 0, value: P2PKH_VALUE }];
+            if (address === p2wpkhAddress && balances.p2wpkh)
+                return [{ txid: p2wpkhTxid, vout: 0, value: P2WPKH_VALUE }];
+            if (address === p2trAddress && balances.p2tr)
+                return [{ txid: '3'.repeat(64), vout: 0, value: P2TR_VALUE }];
+            return [];
+        };
+
+        const utxoMatch = url.match(/\/address\/([^/]+)\/utxo$/);
+        if (utxoMatch)
+            return {
+                ok: true,
+                json: async () => utxosFor(utxoMatch[1])
+            };
+
+        if (url.endsWith(`/tx/${p2pkhTxid}/hex`))
+            return {
+                ok: true,
+                text: async () => fundingTx.toHex()
+            };
+
+        if (url.endsWith(`/tx/${p2wpkhTxid}`))
+            return {
+                ok: true,
+                json: async () => ({
+                    vout: [
+                        {
+                            value: P2WPKH_VALUE,
+                            scriptpubkey: bitcoin.payments
+                                .p2wpkh({ pubkey: publicKey, network })
+                                .output!.toString('hex')
+                        }
+                    ]
+                })
+            };
+
+        throw new Error(`unexpected fetch: ${url}`);
+    }) as any;
+}
+
+describe('SweepStore', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('sweeps UTXOs from every address type of the key, not just the first', async () => {
+        mockEsplora({ p2pkh: true, p2wpkh: true });
+
+        const store = new SweepStore(mockNodeInfoStore);
+        await store.prepareSweepInputs(WIF);
+
+        expect(store.sweepError).toBe(false);
+        expect(store.sweptAddressTypes).toEqual(['p2pkh', 'p2wpkh']);
+        expect(store.psbt.inputCount).toBe(2);
+        expect(store.onChainBalance).toBe(P2PKH_VALUE + P2WPKH_VALUE);
+    });
+
+    it('signs and finalizes a mixed-input sweep transaction', async () => {
+        mockEsplora({ p2pkh: true, p2wpkh: true });
+
+        const store = new SweepStore(mockNodeInfoStore);
+        await store.prepareSweepInputs(WIF);
+        store.destination = p2wpkhAddress;
+        await store.finalizeSweepTransaction('2');
+
+        expect(store.sweepError).toBe(false);
+        expect(store.txHex).toBeTruthy();
+        const tx = bitcoin.Transaction.fromHex(store.txHex!);
+        expect(tx.ins.length).toBe(2);
+        expect(tx.outs[0].value).toBe(P2PKH_VALUE + P2WPKH_VALUE - store.fee);
+    });
+
+    it('warns about unswept taproot funds while sweeping supported types', async () => {
+        mockEsplora({ p2wpkh: true, p2tr: true });
+
+        const store = new SweepStore(mockNodeInfoStore);
+        await store.prepareSweepInputs(WIF);
+
+        expect(store.sweepError).toBe(false);
+        expect(store.sweptAddressTypes).toEqual(['p2wpkh']);
+        expect(store.onChainBalance).toBe(P2WPKH_VALUE);
+        expect(store.unsweptTaprootSats).toBe(P2TR_VALUE);
+    });
+
+    it('errors when funds are exclusively on an unsupported taproot address', async () => {
+        mockEsplora({ p2tr: true });
+
+        const store = new SweepStore(mockNodeInfoStore);
+        await store.prepareSweepInputs(WIF);
+
+        expect(store.sweepError).toBe(true);
+        expect(store.sweepErrorMsg).toBe('views.Wif.addressTypeNotSupported');
+        expect(store.unsweptTaprootSats).toBe(P2TR_VALUE);
+    });
+
+    it('errors when no address type has UTXOs', async () => {
+        mockEsplora({});
+
+        const store = new SweepStore(mockNodeInfoStore);
+        await store.prepareSweepInputs(WIF);
+
+        expect(store.sweepError).toBe(true);
+        expect(store.sweepErrorMsg).toBe('views.Wif.noUtxosFound');
+    });
+
+    it('resets stale balance and taproot warning between scans', async () => {
+        mockEsplora({ p2wpkh: true, p2tr: true });
+
+        const store = new SweepStore(mockNodeInfoStore);
+        await store.prepareSweepInputs(WIF);
+        expect(store.onChainBalance).toBe(P2WPKH_VALUE);
+        expect(store.unsweptTaprootSats).toBe(P2TR_VALUE);
+
+        mockEsplora({});
+        await store.prepareSweepInputs(WIF);
+        expect(store.sweepError).toBe(true);
+        expect(store.onChainBalance).toBe(0);
+        expect(store.unsweptTaprootSats).toBe(0);
+    });
+});

--- a/stores/SweepStore.ts
+++ b/stores/SweepStore.ts
@@ -11,6 +11,8 @@ import wifUtils, { AddressType } from '../utils/WIFUtils';
 import { localeString } from '../utils/LocaleUtils';
 import ecc from '../zeus_modules/noble_ecc';
 
+bitcoin.initEccLib(ecc);
+
 export default class SweepStore {
     @observable sweepErrorMsg: string | null = null;
     @observable sweepError: boolean = false;
@@ -20,7 +22,8 @@ export default class SweepStore {
     @observable txId: string | null = null;
     @observable fee: number = 0;
     @observable feeRate: string = '';
-    @observable addressType: AddressType = 'p2wpkh';
+    @observable sweptAddressTypes: AddressType[] = [];
+    @observable unsweptTaprootSats: number = 0;
     @observable utxos: any[] = [];
     @observable psbt: bitcoin.Psbt;
     @observable privateKey: string;
@@ -53,11 +56,11 @@ export default class SweepStore {
         return utxos;
     }
 
-    async detectAddressWithUtxos(
+    async detectAddressesWithUtxos(
         publicKey: Buffer,
         network: bitcoin.Network,
         networkStr: string
-    ): Promise<{ address: string; type: AddressType; utxos: any[] }> {
+    ): Promise<{ address: string; type: AddressType; utxos: any[] }[]> {
         const addresses: { type: AddressType; address: string }[] = [];
 
         addresses.push({
@@ -90,19 +93,149 @@ export default class SweepStore {
             }).address!
         });
 
+        // A key may have received funds on multiple script types over its
+        // lifetime, so collect them all to avoid leaving funds behind
+        const detected: { address: string; type: AddressType; utxos: any[] }[] =
+            [];
         for (const { type, address } of addresses) {
             const utxos = await this.getUtxosFromAddress(address, networkStr);
             if (utxos && utxos.length > 0) {
-                return { type, address, utxos };
+                detected.push({ type, address, utxos });
             }
         }
 
-        throw new Error(localeString('views.Wif.noUtxosFound'));
+        if (detected.length === 0) {
+            throw new Error(localeString('views.Wif.noUtxosFound'));
+        }
+
+        return detected;
+    }
+
+    async addInputsForType(
+        type: AddressType,
+        utxos: any[],
+        networkStr: string,
+        publicKey: Buffer
+    ): Promise<number> {
+        let totalSats = 0;
+
+        if (type === 'p2pkh') {
+            for (const utxo of utxos) {
+                const { txid, vout } = utxo;
+                totalSats += utxo.value;
+                const res = await fetch(
+                    `${wifUtils.baseUrl(networkStr)}/tx/${txid}/hex`
+                );
+
+                if (!res.ok)
+                    throw new Error(
+                        localeString('views.Wif.failedToFetchTxHex', {
+                            txid
+                        })
+                    );
+
+                const rawTxHex = await res.text();
+
+                this.psbt.addInput({
+                    hash: txid,
+                    index: vout,
+                    nonWitnessUtxo: Buffer.from(rawTxHex, 'hex')
+                });
+            }
+        } else if (type === 'p2wpkh') {
+            for (const utxo of utxos) {
+                const { txid, vout } = utxo;
+
+                const res = await fetch(
+                    `${wifUtils.baseUrl(networkStr)}/tx/${txid}`
+                );
+                if (!res.ok)
+                    throw new Error(
+                        localeString('views.Wif.failedToFetchTxDetails', {
+                            txid
+                        })
+                    );
+
+                const tx = await res.json();
+                const output = tx.vout[vout];
+
+                if (!output)
+                    throw new Error(
+                        localeString('views.Sweep.outputIndexNotFound', {
+                            vout,
+                            txid
+                        })
+                    );
+
+                const value = Math.round(output.value);
+                totalSats += value;
+
+                const scriptPubKeyHex = output.scriptpubkey;
+                const script = Buffer.from(scriptPubKeyHex, 'hex');
+
+                this.psbt.addInput({
+                    hash: txid,
+                    index: vout,
+                    witnessUtxo: {
+                        script,
+                        value
+                    }
+                });
+            }
+        } else if (type === 'p2sh-p2wpkh') {
+            for (const utxo of utxos) {
+                const { txid, vout } = utxo;
+
+                const value = utxo.value;
+                totalSats += value;
+                const res = await fetch(
+                    `${wifUtils.baseUrl(networkStr)}/tx/${txid}`
+                );
+                if (!res.ok)
+                    throw new Error(
+                        localeString('views.Wif.failedToFetchTxDetails', {
+                            txid
+                        })
+                    );
+
+                const tx = await res.json();
+                const output = tx.vout[vout];
+
+                if (!output)
+                    throw new Error(
+                        localeString('views.Wif.outputNotFound', {
+                            vout,
+                            txid
+                        })
+                    );
+                const scriptPubKeyHex = output.scriptpubkey;
+                const script = Buffer.from(scriptPubKeyHex, 'hex');
+
+                this.psbt.addInput({
+                    hash: txid,
+                    index: vout,
+                    witnessUtxo: {
+                        script,
+                        value
+                    },
+                    redeemScript: bitcoin.payments.p2wpkh({
+                        pubkey: publicKey,
+                        network: this.network
+                    }).output
+                });
+            }
+        }
+
+        return totalSats;
     }
 
     @action
     async prepareSweepInputs(wif: string) {
         this.wif = wif;
+        this.onChainBalance = 0;
+        this.unsweptTaprootSats = 0;
+        this.sweptAddressTypes = [];
+        this.utxos = [];
         const { nodeInfo } = this.nodeInfoStore;
         const network = nodeInfo?.isTestNet
             ? nodeInfo?.isRegTest
@@ -118,20 +251,24 @@ export default class SweepStore {
             this.privateKey = Buffer.from(privateKey).toString('hex');
             const publicKey = Buffer.from(getPublicKey(privateKey, true));
 
-            const result = await this.detectAddressWithUtxos(
+            const detected = await this.detectAddressesWithUtxos(
                 publicKey,
                 this.network,
                 networkStr
             );
 
-            this.addressType = result.type;
-            this.utxos = result.utxos;
-            let totalSats = 0;
-
-            this.psbt = new bitcoin.Psbt({ network: this.network });
-
             // P2TR sweeps are not yet supported — ZEUS-3276
-            if (this.addressType === 'p2tr') {
+            const taproot = detected.find(({ type }) => type === 'p2tr');
+            const supported = detected.filter(({ type }) => type !== 'p2tr');
+
+            this.unsweptTaprootSats = taproot
+                ? taproot.utxos.reduce(
+                      (sum: number, utxo: any) => sum + utxo.value,
+                      0
+                  )
+                : 0;
+
+            if (supported.length === 0) {
                 this.sweepError = true;
                 this.sweepErrorMsg = localeString(
                     'views.Wif.addressTypeNotSupported'
@@ -139,122 +276,19 @@ export default class SweepStore {
                 return;
             }
 
-            if (this.addressType === 'p2pkh') {
-                for (const utxo of this.utxos) {
-                    const { txid, vout } = utxo;
-                    totalSats += utxo.value;
-                    const res = await fetch(
-                        `${wifUtils.baseUrl(networkStr)}/tx/${txid}/hex`
-                    );
+            this.sweptAddressTypes = supported.map(({ type }) => type);
+            this.utxos = supported.flatMap(({ utxos }) => utxos);
+            let totalSats = 0;
 
-                    if (!res.ok)
-                        throw new Error(
-                            localeString('views.Wif.failedToFetchTxHex', {
-                                txid
-                            })
-                        );
+            this.psbt = new bitcoin.Psbt({ network: this.network });
 
-                    const rawTxHex = await res.text();
-
-                    this.psbt.addInput({
-                        hash: txid,
-                        index: vout,
-                        nonWitnessUtxo: Buffer.from(rawTxHex, 'hex')
-                    });
-                }
-            } else if (this.addressType === 'p2wpkh') {
-                for (const utxo of this.utxos) {
-                    const { txid, vout } = utxo;
-
-                    const res = await fetch(
-                        `${wifUtils.baseUrl(networkStr)}/tx/${txid}`
-                    );
-                    if (!res.ok)
-                        throw new Error(
-                            localeString('views.Wif.failedToFetchTxDetails', {
-                                txid
-                            })
-                        );
-
-                    const tx = await res.json();
-                    const output = tx.vout[vout];
-
-                    if (!output)
-                        throw new Error(
-                            localeString('views.Sweep.outputIndexNotFound', {
-                                vout,
-                                txid
-                            })
-                        );
-
-                    const value = Math.round(output.value);
-                    totalSats += value;
-
-                    const scriptPubKeyHex = output.scriptpubkey;
-                    const script = Buffer.from(scriptPubKeyHex, 'hex');
-
-                    this.psbt.addInput({
-                        hash: txid,
-                        index: vout,
-                        witnessUtxo: {
-                            script,
-                            value
-                        }
-                    });
-                }
-            } else if (this.addressType === 'p2sh-p2wpkh') {
-                for (const utxo of this.utxos) {
-                    const { txid, vout } = utxo;
-
-                    const value = utxo.value;
-                    totalSats += value;
-                    const res = await fetch(
-                        `${wifUtils.baseUrl(networkStr)}/tx/${txid}`
-                    );
-                    if (!res.ok)
-                        throw new Error(
-                            localeString('views.Wif.failedToFetchTxDetails', {
-                                txid
-                            })
-                        );
-
-                    const tx = await res.json();
-                    const output = tx.vout[vout];
-
-                    if (!output)
-                        throw new Error(
-                            localeString('views.Wif.outputNotFound', {
-                                vout,
-                                txid
-                            })
-                        );
-                    const scriptPubKeyHex = output.scriptpubkey;
-                    const script = Buffer.from(scriptPubKeyHex, 'hex');
-
-                    const privKeyBuf = Buffer.from(this.privateKey, 'hex');
-                    const fullPub = ecc.pointFromScalar(privKeyBuf, true);
-
-                    if (!fullPub) {
-                        throw new Error(
-                            localeString('views.Wif.failedToDerivePubkey')
-                        );
-                    }
-
-                    const pubkey = Buffer.from(fullPub);
-
-                    this.psbt.addInput({
-                        hash: txid,
-                        index: vout,
-                        witnessUtxo: {
-                            script,
-                            value
-                        },
-                        redeemScript: bitcoin.payments.p2wpkh({
-                            pubkey,
-                            network: this.network
-                        }).output
-                    });
-                }
+            for (const { type, utxos } of supported) {
+                totalSats += await this.addInputsForType(
+                    type,
+                    utxos,
+                    networkStr,
+                    publicKey
+                );
             }
             this.onChainBalance = totalSats;
         } catch (err: any) {

--- a/stores/SweepStore.ts
+++ b/stores/SweepStore.ts
@@ -12,6 +12,8 @@ import { localeString } from '../utils/LocaleUtils';
 import UrlUtils from '../utils/UrlUtils';
 import ecc from '../zeus_modules/noble_ecc';
 
+bitcoin.initEccLib(ecc);
+
 export default class SweepStore {
     @observable sweepErrorMsg: string | null = null;
     @observable sweepError: boolean = false;
@@ -21,7 +23,8 @@ export default class SweepStore {
     @observable txId: string | null = null;
     @observable fee: number = 0;
     @observable feeRate: string = '';
-    @observable addressType: AddressType = 'p2wpkh';
+    @observable sweptAddressTypes: AddressType[] = [];
+    @observable unsweptTaprootSats: number = 0;
     @observable utxos: any[] = [];
     @observable psbt: bitcoin.Psbt;
     @observable privateKey: string;
@@ -56,10 +59,10 @@ export default class SweepStore {
         return utxos;
     }
 
-    async detectAddressWithUtxos(
+    async detectAddressesWithUtxos(
         publicKey: Buffer,
         network: bitcoin.Network
-    ): Promise<{ address: string; type: AddressType; utxos: any[] }> {
+    ): Promise<{ address: string; type: AddressType; utxos: any[] }[]> {
         const addresses: { type: AddressType; address: string }[] = [];
 
         addresses.push({
@@ -92,19 +95,154 @@ export default class SweepStore {
             }).address!
         });
 
+        // A key may have received funds on multiple script types over its
+        // lifetime, so collect them all to avoid leaving funds behind
+        const detected: { address: string; type: AddressType; utxos: any[] }[] =
+            [];
         for (const { type, address } of addresses) {
             const utxos = await this.getUtxosFromAddress(address);
             if (utxos && utxos.length > 0) {
-                return { type, address, utxos };
+                detected.push({ type, address, utxos });
             }
         }
 
-        throw new Error(localeString('views.Wif.noUtxosFound'));
+        if (detected.length === 0) {
+            throw new Error(localeString('views.Wif.noUtxosFound'));
+        }
+
+        return detected;
+    }
+
+    async addInputsForType(
+        type: AddressType,
+        utxos: any[],
+        publicKey: Buffer
+    ): Promise<number> {
+        let totalSats = 0;
+
+        if (type === 'p2pkh') {
+            for (const utxo of utxos) {
+                const { txid, vout } = utxo;
+                totalSats += utxo.value;
+                const res = await fetch(
+                    `${UrlUtils.getMempoolApiUrl(
+                        this.nodeInfoStore.nodeInfo
+                    )}/tx/${txid}/hex`
+                );
+
+                if (!res.ok)
+                    throw new Error(
+                        localeString('views.Wif.failedToFetchTxHex', {
+                            txid
+                        })
+                    );
+
+                const rawTxHex = await res.text();
+
+                this.psbt.addInput({
+                    hash: txid,
+                    index: vout,
+                    nonWitnessUtxo: Buffer.from(rawTxHex, 'hex')
+                });
+            }
+        } else if (type === 'p2wpkh') {
+            for (const utxo of utxos) {
+                const { txid, vout } = utxo;
+
+                const res = await fetch(
+                    `${UrlUtils.getMempoolApiUrl(
+                        this.nodeInfoStore.nodeInfo
+                    )}/tx/${txid}`
+                );
+                if (!res.ok)
+                    throw new Error(
+                        localeString('views.Wif.failedToFetchTxDetails', {
+                            txid
+                        })
+                    );
+
+                const tx = await res.json();
+                const output = tx.vout[vout];
+
+                if (!output)
+                    throw new Error(
+                        localeString('views.Sweep.outputIndexNotFound', {
+                            vout,
+                            txid
+                        })
+                    );
+
+                const value = Math.round(output.value);
+                totalSats += value;
+
+                const scriptPubKeyHex = output.scriptpubkey;
+                const script = Buffer.from(scriptPubKeyHex, 'hex');
+
+                this.psbt.addInput({
+                    hash: txid,
+                    index: vout,
+                    witnessUtxo: {
+                        script,
+                        value
+                    }
+                });
+            }
+        } else if (type === 'p2sh-p2wpkh') {
+            for (const utxo of utxos) {
+                const { txid, vout } = utxo;
+
+                const value = utxo.value;
+                totalSats += value;
+                const res = await fetch(
+                    `${UrlUtils.getMempoolApiUrl(
+                        this.nodeInfoStore.nodeInfo
+                    )}/tx/${txid}`
+                );
+                if (!res.ok)
+                    throw new Error(
+                        localeString('views.Wif.failedToFetchTxDetails', {
+                            txid
+                        })
+                    );
+
+                const tx = await res.json();
+                const output = tx.vout[vout];
+
+                if (!output)
+                    throw new Error(
+                        localeString('views.Wif.outputNotFound', {
+                            vout,
+                            txid
+                        })
+                    );
+                const scriptPubKeyHex = output.scriptpubkey;
+                const script = Buffer.from(scriptPubKeyHex, 'hex');
+
+                this.psbt.addInput({
+                    hash: txid,
+                    index: vout,
+                    witnessUtxo: {
+                        script,
+                        value
+                    },
+                    redeemScript: bitcoin.payments.p2wpkh({
+                        pubkey: publicKey,
+                        network: this.network
+                    }).output
+                });
+            }
+        }
+
+        return totalSats;
     }
 
     @action
     async prepareSweepInputs(wif: string) {
         this.wif = wif;
+        this.onChainBalance = 0;
+        this.unsweptTaprootSats = 0;
+        this.sweptAddressTypes = [];
+        this.utxos = [];
         const { nodeInfo } = this.nodeInfoStore;
         const network = nodeInfo?.isTestNet
             ? nodeInfo?.isRegTest
@@ -118,19 +256,23 @@ export default class SweepStore {
             this.privateKey = Buffer.from(privateKey).toString('hex');
             const publicKey = Buffer.from(getPublicKey(privateKey, true));
 
-            const result = await this.detectAddressWithUtxos(
+            const detected = await this.detectAddressesWithUtxos(
                 publicKey,
                 this.network
             );
 
-            this.addressType = result.type;
-            this.utxos = result.utxos;
-            let totalSats = 0;
-
-            this.psbt = new bitcoin.Psbt({ network: this.network });
-
             // P2TR sweeps are not yet supported — ZEUS-3276
-            if (this.addressType === 'p2tr') {
+            const taproot = detected.find(({ type }) => type === 'p2tr');
+            const supported = detected.filter(({ type }) => type !== 'p2tr');
+
+            this.unsweptTaprootSats = taproot
+                ? taproot.utxos.reduce(
+                      (sum: number, utxo: any) => sum + utxo.value,
+                      0
+                  )
+                : 0;
+
+            if (supported.length === 0) {
                 this.sweepError = true;
                 this.sweepErrorMsg = localeString(
                     'views.Wif.addressTypeNotSupported'
@@ -138,128 +280,18 @@ export default class SweepStore {
                 return;
             }
 
-            if (this.addressType === 'p2pkh') {
-                for (const utxo of this.utxos) {
-                    const { txid, vout } = utxo;
-                    totalSats += utxo.value;
-                    const res = await fetch(
-                        `${UrlUtils.getMempoolApiUrl(
-                            this.nodeInfoStore.nodeInfo
-                        )}/tx/${txid}/hex`
-                    );
+            this.sweptAddressTypes = supported.map(({ type }) => type);
+            this.utxos = supported.flatMap(({ utxos }) => utxos);
+            let totalSats = 0;
 
-                    if (!res.ok)
-                        throw new Error(
-                            localeString('views.Wif.failedToFetchTxHex', {
-                                txid
-                            })
-                        );
+            this.psbt = new bitcoin.Psbt({ network: this.network });
 
-                    const rawTxHex = await res.text();
-
-                    this.psbt.addInput({
-                        hash: txid,
-                        index: vout,
-                        nonWitnessUtxo: Buffer.from(rawTxHex, 'hex')
-                    });
-                }
-            } else if (this.addressType === 'p2wpkh') {
-                for (const utxo of this.utxos) {
-                    const { txid, vout } = utxo;
-
-                    const res = await fetch(
-                        `${UrlUtils.getMempoolApiUrl(
-                            this.nodeInfoStore.nodeInfo
-                        )}/tx/${txid}`
-                    );
-                    if (!res.ok)
-                        throw new Error(
-                            localeString('views.Wif.failedToFetchTxDetails', {
-                                txid
-                            })
-                        );
-
-                    const tx = await res.json();
-                    const output = tx.vout[vout];
-
-                    if (!output)
-                        throw new Error(
-                            localeString('views.Sweep.outputIndexNotFound', {
-                                vout,
-                                txid
-                            })
-                        );
-
-                    const value = Math.round(output.value);
-                    totalSats += value;
-
-                    const scriptPubKeyHex = output.scriptpubkey;
-                    const script = Buffer.from(scriptPubKeyHex, 'hex');
-
-                    this.psbt.addInput({
-                        hash: txid,
-                        index: vout,
-                        witnessUtxo: {
-                            script,
-                            value
-                        }
-                    });
-                }
-            } else if (this.addressType === 'p2sh-p2wpkh') {
-                for (const utxo of this.utxos) {
-                    const { txid, vout } = utxo;
-
-                    const value = utxo.value;
-                    totalSats += value;
-                    const res = await fetch(
-                        `${UrlUtils.getMempoolApiUrl(
-                            this.nodeInfoStore.nodeInfo
-                        )}/tx/${txid}`
-                    );
-                    if (!res.ok)
-                        throw new Error(
-                            localeString('views.Wif.failedToFetchTxDetails', {
-                                txid
-                            })
-                        );
-
-                    const tx = await res.json();
-                    const output = tx.vout[vout];
-
-                    if (!output)
-                        throw new Error(
-                            localeString('views.Wif.outputNotFound', {
-                                vout,
-                                txid
-                            })
-                        );
-                    const scriptPubKeyHex = output.scriptpubkey;
-                    const script = Buffer.from(scriptPubKeyHex, 'hex');
-
-                    const privKeyBuf = Buffer.from(this.privateKey, 'hex');
-                    const fullPub = ecc.pointFromScalar(privKeyBuf, true);
-
-                    if (!fullPub) {
-                        throw new Error(
-                            localeString('views.Wif.failedToDerivePubkey')
-                        );
-                    }
-
-                    const pubkey = Buffer.from(fullPub);
-
-                    this.psbt.addInput({
-                        hash: txid,
-                        index: vout,
-                        witnessUtxo: {
-                            script,
-                            value
-                        },
-                        redeemScript: bitcoin.payments.p2wpkh({
-                            pubkey,
-                            network: this.network
-                        }).output
-                    });
-                }
+            for (const { type, utxos } of supported) {
+                totalSats += await this.addInputsForType(
+                    type,
+                    utxos,
+                    publicKey
+                );
             }
             this.onChainBalance = totalSats;
         } catch (err: any) {

--- a/views/Tools/WIFSweeper.tsx
+++ b/views/Tools/WIFSweeper.tsx
@@ -9,7 +9,10 @@ import InvoicesStore from '../../stores/InvoicesStore';
 import SweepStore from '../../stores/SweepStore';
 
 import Button from '../../components/Button';
-import { ErrorMessage } from '../../components/SuccessErrorMessage';
+import {
+    ErrorMessage,
+    WarningMessage
+} from '../../components/SuccessErrorMessage';
 import Header from '../../components/Header';
 import Screen from '../../components/Screen';
 import TextInput from '../../components/TextInput';
@@ -145,6 +148,21 @@ export default class WIFSweeper extends React.Component<
                             />
                         </View>
                     )}
+
+                    {!sweepError &&
+                        !error &&
+                        SweepStore.unsweptTaprootSats > 0 && (
+                            <View>
+                                <WarningMessage
+                                    message={localeString(
+                                        'views.Wif.taprootFundsRemain',
+                                        {
+                                            amount: SweepStore.unsweptTaprootSats.toString()
+                                        }
+                                    )}
+                                />
+                            </View>
+                        )}
 
                     <View style={{ padding: 20, flex: 1 }}>
                         <Text style={{ color: themeColor('secondaryText') }}>


### PR DESCRIPTION
# Description

The WIF Sweeper (Tools > WIF Sweeper) derives four address candidates from the scanned key (p2pkh, p2sh-p2wpkh, p2wpkh, p2tr), probes each for UTXOs, and stops at the first type that has any. A key that received funds on multiple script types over its lifetime (e.g. legacy p2pkh and native segwit p2wpkh) was only partially swept, and the UI presented the partial sum as the key's full balance. A user who discarded the WIF after the "successful" sweep would permanently lose the funds remaining on the other script types. Dust on an earlier probe type could also hide a large balance on a later one.

This PR fixes that:

- `detectAddressesWithUtxos` now probes all four address types and returns every type holding UTXOs, instead of returning on the first match
- `prepareSweepInputs` builds a single mixed-input PSBT covering all supported types (p2pkh, p2sh-p2wpkh, p2wpkh), so `onChainBalance` reflects the key's full sweepable balance; all inputs share one key, so the existing single-signer finalize path handles the mixed PSBT unchanged
- Taproot (not yet sweepable): if funds exist only on p2tr, the existing `addressTypeNotSupported` error still surfaces; if p2tr funds coexist with sweepable types, the sweep proceeds and a warning shows the unswept taproot amount and tells the user to keep the private key
- Stale state (`onChainBalance`, `utxos`, taproot warning) is reset at the start of each scan so a failed second scan can't display the previous key's balance
- `SweepStore` now calls `bitcoin.initEccLib(ecc)` itself; previously its p2tr address derivation only worked because `utils/AddressUtils.ts` happened to be imported first

Added `stores/SweepStore.test.ts` with mocked esplora responses covering: multi-type UTXO collection, signing and finalizing a mixed p2pkh + p2wpkh sweep into a valid 2-input transaction, the taproot warning and taproot-only error paths, the no-UTXO error, and stale-state reset between scans.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Note: manual on-device testing is still pending. The sweep construction logic is backend-independent (mempool.space esplora), but the destination invoice generation should be exercised against at least one backend on each platform before merge.

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
