### PR TITLE
fix(receive): use plain decimal amounts in BIP21 URIs

### DIFF
--- a/utils/AddressUtils.test.ts
+++ b/utils/AddressUtils.test.ts
@@ -115,14 +115,15 @@ describe('AddressUtils', () => {
                 satAmount: '123456789000'
             });
 
-            // ambiguous comma decimal separator must not be misread
+            // ambiguous comma decimal separator must not be misread;
+            // invalid amounts are ignored but the address is kept
             expect(
                 AddressUtils.processBIP21Uri(
                     'bitcoin:bc1q7065ezyhcd3qtqlcvwcmp9t2weaxc4sguuvlwu?amount=1,5'
                 )
             ).toEqual({
                 value: 'bc1q7065ezyhcd3qtqlcvwcmp9t2weaxc4sguuvlwu',
-                satAmount: 'NaN'
+                satAmount: undefined
             });
 
             // without fee

--- a/utils/AddressUtils.test.ts
+++ b/utils/AddressUtils.test.ts
@@ -105,6 +105,26 @@ describe('AddressUtils', () => {
                 satAmount: '170003'
             });
 
+            // comma group separators (emitted by old ZEUS versions)
+            expect(
+                AddressUtils.processBIP21Uri(
+                    'bitcoin:bc1q7065ezyhcd3qtqlcvwcmp9t2weaxc4sguuvlwu?amount=1,234.56789'
+                )
+            ).toEqual({
+                value: 'bc1q7065ezyhcd3qtqlcvwcmp9t2weaxc4sguuvlwu',
+                satAmount: '123456789000'
+            });
+
+            // ambiguous comma decimal separator must not be misread
+            expect(
+                AddressUtils.processBIP21Uri(
+                    'bitcoin:bc1q7065ezyhcd3qtqlcvwcmp9t2weaxc4sguuvlwu?amount=1,5'
+                )
+            ).toEqual({
+                value: 'bc1q7065ezyhcd3qtqlcvwcmp9t2weaxc4sguuvlwu',
+                satAmount: 'NaN'
+            });
+
             // without fee
             expect(
                 AddressUtils.processBIP21Uri(

--- a/utils/AddressUtils.ts
+++ b/utils/AddressUtils.ts
@@ -103,13 +103,15 @@ const bitcoinQrParser = (input: string, prefix: string) => {
         // BIP21 amounts must be plain decimals, but some wallets (including
         // old ZEUS versions) emit comma group separators (e.g. 1,234.56789).
         // Only de-group unambiguous thousands formatting; anything else
-        // (e.g. a comma decimal separator like 1,5) is left to fail as NaN
-        // rather than risk misreading the amount.
+        // (e.g. a comma decimal separator like 1,5) is ignored rather than
+        // risk misreading the amount.
         if (/^\d{1,3}(,\d{3})+(\.\d+)?$/.test(amount)) {
             amount = amount.replace(/,/g, '');
         }
-        satAmount = new BigNumber(amount).multipliedBy(SATS_PER_BTC);
-        satAmount = satAmount.toString();
+        const parsedAmount = new BigNumber(amount).multipliedBy(SATS_PER_BTC);
+        if (!parsedAmount.isNaN()) {
+            satAmount = parsedAmount.toString();
+        }
     }
 
     if (result.lightning || result.LIGHTNING) {

--- a/utils/AddressUtils.ts
+++ b/utils/AddressUtils.ts
@@ -99,9 +99,16 @@ const bitcoinQrParser = (input: string, prefix: string) => {
 
     const value = btcAddress;
     if (result.amount || result.AMOUNT) {
-        satAmount = new BigNumber(result.amount || result.AMOUNT).multipliedBy(
-            SATS_PER_BTC
-        );
+        let amount = result.amount || result.AMOUNT;
+        // BIP21 amounts must be plain decimals, but some wallets (including
+        // old ZEUS versions) emit comma group separators (e.g. 1,234.56789).
+        // Only de-group unambiguous thousands formatting; anything else
+        // (e.g. a comma decimal separator like 1,5) is left to fail as NaN
+        // rather than risk misreading the amount.
+        if (/^\d{1,3}(,\d{3})+(\.\d+)?$/.test(amount)) {
+            amount = amount.replace(/,/g, '');
+        }
+        satAmount = new BigNumber(amount).multipliedBy(SATS_PER_BTC);
         satAmount = satAmount.toString();
     }
 

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -1503,7 +1503,7 @@ export default class Receive extends React.Component<
                 Number(satAmount) > 0
                     ? `&amount=${new BigNumber(satAmount)
                           .dividedBy(SATS_PER_BTC)
-                          .toFormat()}`
+                          .toFixed()}`
                     : ''
             }${memo ? `&message=${memo.replace(/ /g, '%20')}` : ''}`;
         }
@@ -1520,7 +1520,7 @@ export default class Receive extends React.Component<
                 Number(satAmount) > 0
                     ? `amount=${new BigNumber(satAmount)
                           .dividedBy(SATS_PER_BTC)
-                          .toFormat()}`
+                          .toFixed()}`
                     : ''
             }${
                 memo


### PR DESCRIPTION
# Description

When creating a receive request of 1000 BTC or more, the BIP21 URIs behind the unified and on-chain QRs are built with `BigNumber.toFormat()`, which applies the default FORMAT and inserts comma group separators. The QR then encodes:

```
bitcoin:BC1...?amount=1,234.56789
```

BIP21 requires a plain decimal amount. Consequences:

- ZEUS cannot re-scan its own QR: our parser feeds the amount to `new BigNumber('1,234.56789')`, which is NaN, so the send flow breaks
- Strict wallets reject the URI outright
- Lenient wallets that use `parseFloat`-style parsing stop at the comma and read **1 BTC** instead of 1,234.56789 BTC, a massive underpayment to the receiver

Fix:

1. `views/Receive.tsx`: build the `amount` parameter with `toFixed()` instead of `toFormat()`. `toFixed()` always emits a plain decimal with no separators and no exponent notation (verified for dust amounts, 1000+ BTC, and 21M BTC).
2. `utils/AddressUtils.ts`: harden the BIP21 parser to de-group amounts that match unambiguous thousands formatting (`1,234.56789` -> `1234.56789`) so QRs generated by old ZEUS versions still parse. Ambiguous comma-decimal forms like `1,5` (which some locales use to mean 1.5) deliberately do NOT match and continue to fail closed as NaN, since stripping that comma would misread 1.5 BTC as 15 BTC.
3. `utils/AddressUtils.test.ts`: regression tests for both parser behaviors.

No visual changes; screenshots N/A.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Not yet manually tested on device. The change is platform-independent string formatting; the parser paths are covered by unit tests. Will follow up with on-device verification of the receive QR round trip.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

The URI construction and parsing are backend-independent (pure string/BigNumber logic shared by all backends).

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding