### PR TITLE
crypto: random BIP340 aux data by default; unify secp256k1 adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "lint-fix": "eslint . --fix"
   },
   "dependencies": {
-    "@bitcoinerlab/secp256k1": "1.2.0",
     "@getalby/sdk": "8.0.3",
     "@keystonehq/bc-ur-registry": "0.8.0",
     "@lightninglabs/lnc-core": "file:zeus_modules/@lightninglabs/lnc-core",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "lint-fix": "eslint . --fix"
   },
   "dependencies": {
-    "@bitcoinerlab/secp256k1": "1.2.0",
     "@getalby/sdk": "8.0.3",
     "@keystonehq/bc-ur-registry": "0.8.0",
     "@lightninglabs/lnc-core": "file:zeus_modules/@lightninglabs/lnc-core",

--- a/stores/SwapStore.test.ts
+++ b/stores/SwapStore.test.ts
@@ -36,7 +36,6 @@ jest.mock('../storage', () => ({
 jest.mock('../utils/LocaleUtils', () => ({ localeString: (k: string) => k }));
 jest.mock('../utils/ThemeUtils', () => ({ themeColor: () => '#000' }));
 jest.mock('ecpair', () => ({ ECPairFactory: () => ({}) }));
-jest.mock('@bitcoinerlab/secp256k1', () => ({ __esModule: true, default: {} }));
 jest.mock('bitcoinjs-lib', () => ({
     crypto: { sha256: jest.fn() },
     initEccLib: jest.fn()

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -1,7 +1,7 @@
 import { action, observable, computed, runInAction, reaction } from 'mobx';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 import { ECPairAPI, ECPairFactory } from 'ecpair';
-import ecc from '@bitcoinerlab/secp256k1';
+import ecc from '../zeus_modules/noble_ecc';
 import { crypto, initEccLib } from 'bitcoinjs-lib';
 import { HDKey } from '@scure/bip32';
 import { mnemonicToSeedSync, generateMnemonic } from '@scure/bip39';

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -1,7 +1,7 @@
 import { action, observable, computed, runInAction, reaction } from 'mobx';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 import { ECPairAPI, ECPairFactory } from 'ecpair';
-import ecc from '@bitcoinerlab/secp256k1';
+import ecc from '../zeus_modules/noble_ecc';
 import { crypto, initEccLib } from 'bitcoinjs-lib';
 import { HDKey } from '@scure/bip32';
 import {

--- a/utils/NobleEcc.test.ts
+++ b/utils/NobleEcc.test.ts
@@ -1,0 +1,40 @@
+import ecc from '../zeus_modules/noble_ecc';
+
+describe('noble_ecc', () => {
+    describe('signSchnorr', () => {
+        const hash = Buffer.alloc(32, 0x01);
+        const privateKey = Buffer.alloc(32, 0x02);
+        const xOnlyPubkey = Buffer.from(
+            ecc.pointFromScalar(privateKey, true)!.slice(1)
+        );
+
+        it('uses fresh BIP340 aux randomness by default', () => {
+            const sig1 = ecc.signSchnorr!(hash, privateKey);
+            const sig2 = ecc.signSchnorr!(hash, privateKey);
+            expect(Buffer.from(sig1).equals(Buffer.from(sig2))).toBe(false);
+        });
+
+        it('produces valid signatures under the default aux randomness', () => {
+            const sig = ecc.signSchnorr!(hash, privateKey);
+            expect(ecc.verifySchnorr!(hash, xOnlyPubkey, sig)).toBe(true);
+        });
+
+        it('is deterministic when explicit aux data is supplied', () => {
+            const aux = Buffer.alloc(32, 0x03);
+            const sig1 = ecc.signSchnorr!(hash, privateKey, aux);
+            const sig2 = ecc.signSchnorr!(hash, privateKey, aux);
+            expect(Buffer.from(sig1).equals(Buffer.from(sig2))).toBe(true);
+            expect(ecc.verifySchnorr!(hash, xOnlyPubkey, sig1)).toBe(true);
+        });
+    });
+
+    describe('sign', () => {
+        it('produces deterministic RFC6979 signatures without extraEntropy', () => {
+            const hash = Buffer.alloc(32, 0x01);
+            const privateKey = Buffer.alloc(32, 0x02);
+            const sig1 = ecc.sign(hash, privateKey);
+            const sig2 = ecc.sign(hash, privateKey);
+            expect(Buffer.from(sig1).equals(Buffer.from(sig2))).toBe(true);
+        });
+    });
+});

--- a/views/Swaps/index.tsx
+++ b/views/Swaps/index.tsx
@@ -12,7 +12,7 @@ import { RouteProp } from '@react-navigation/native';
 import BigNumber from 'bignumber.js';
 import { initEccLib } from 'bitcoinjs-lib';
 import { ECPairFactory } from 'ecpair';
-import ecc from '@bitcoinerlab/secp256k1';
+import ecc from '../../zeus_modules/noble_ecc';
 
 import Amount from '../../components/Amount';
 import Button from '../../components/Button';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1332,13 +1332,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitcoinerlab/secp256k1@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@bitcoinerlab/secp256k1/-/secp256k1-1.2.0.tgz#429d043ef4218b9c71915b50172e9aa4a2a8fea4"
-  integrity sha512-jeujZSzb3JOZfmJYI0ph1PVpCRV5oaexCgy+RvCXV8XlY+XFB/2n3WOcvBsKLsOw78KYgnQrQWb2HrKE4be88Q==
-  dependencies:
-    "@noble/curves" "^1.7.0"
-
 "@eggjs/yauzl@^2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@eggjs/yauzl/-/yauzl-2.11.0.tgz#b8e4413f50fc7c51451f770f152de4c1137aa99b"
@@ -1885,13 +1878,6 @@
   dependencies:
     "@noble/hashes" "1.7.2"
 
-"@noble/curves@^1.7.0":
-  version "1.9.7"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
-  integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
-  dependencies:
-    "@noble/hashes" "1.8.0"
-
 "@noble/hashes@1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
@@ -1907,11 +1893,6 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.2.tgz#d53c65a21658fb02f3303e7ee3ba89d6754c64b4"
   integrity sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==
 
-"@noble/hashes@1.8.0", "@noble/hashes@~1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
-  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
-
 "@noble/hashes@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-2.0.1.tgz#fc1a928061d1232b0a52bb754393c37a5216c89e"
@@ -1921,6 +1902,11 @@
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
   integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
+
+"@noble/hashes@~1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
 "@noble/secp256k1@1.6.3":
   version "1.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,13 +1343,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitcoinerlab/secp256k1@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@bitcoinerlab/secp256k1/-/secp256k1-1.2.0.tgz#429d043ef4218b9c71915b50172e9aa4a2a8fea4"
-  integrity sha512-jeujZSzb3JOZfmJYI0ph1PVpCRV5oaexCgy+RvCXV8XlY+XFB/2n3WOcvBsKLsOw78KYgnQrQWb2HrKE4be88Q==
-  dependencies:
-    "@noble/curves" "^1.7.0"
-
 "@eggjs/yauzl@^2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@eggjs/yauzl/-/yauzl-2.11.0.tgz#b8e4413f50fc7c51451f770f152de4c1137aa99b"
@@ -1879,22 +1872,10 @@
   dependencies:
     "@noble/hashes" "1.7.2"
 
-"@noble/curves@^1.7.0":
-  version "1.9.7"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
-  integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
-  dependencies:
-    "@noble/hashes" "1.8.0"
-
 "@noble/hashes@1.7.2", "@noble/hashes@^1.2.0", "@noble/hashes@^1.5.0":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.2.tgz#d53c65a21658fb02f3303e7ee3ba89d6754c64b4"
   integrity sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==
-
-"@noble/hashes@1.8.0", "@noble/hashes@~1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
-  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
 "@noble/hashes@2.0.1":
   version "2.0.1"
@@ -1910,6 +1891,11 @@
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-2.4.0.tgz#e6a3e98edbed3c8659b28bb8f9b18ca02ec8ea4b"
   integrity sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==
+
+"@noble/hashes@~1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
 "@noble/secp256k1@1.6.3":
   version "1.6.3"

--- a/zeus_modules/noble_ecc.ts
+++ b/zeus_modules/noble_ecc.ts
@@ -124,10 +124,13 @@ const ecc: TinySecp256k1InterfaceExtended & TinySecp256k1Interface & TinySecp256
   privateNegate: (d: Uint8Array): Uint8Array => necc.utils.privateNegate(d),
 
   sign: (h: Uint8Array, d: Uint8Array, e?: Uint8Array): Uint8Array => {
+    // e is folded into the RFC6979 nonce seed and must never be attacker-influenced
     return necc.signSync(h, d, { der: false, extraEntropy: e });
   },
 
-  signSchnorr: (h: Uint8Array, d: Uint8Array, e: Uint8Array = Buffer.alloc(32, 0x00)): Uint8Array => {
+  signSchnorr: (h: Uint8Array, d: Uint8Array, e: Uint8Array = necc.utils.randomBytes(32)): Uint8Array => {
+    // fresh BIP340 aux randomness per signature; a fixed default (e.g. zeros) is
+    // spec-legal but forfeits fault-injection and side-channel defense in depth
     return necc.schnorr.signSync(h, d, e);
   },
 


### PR DESCRIPTION
# Description

Hardening from an internal signing audit of the vendored secp256k1 adapter (`zeus_modules/noble_ecc.ts`), in two commits:

**1. `fix(crypto)`: default `signSchnorr` BIP340 aux data to fresh randomness**

The adapter (inherited from the upstream BitGo `noble_ecc` shim) defaulted `signSchnorr`'s aux_rand to 32 zero bytes. Zero aux is BIP340-legal and the resulting nonces are still secure, but it makes Schnorr signatures over the same (key, message) fully deterministic and forfeits the defense in depth that random aux data provides against fault injection and side channels in the pure-JS implementation. The default is now `necc.utils.randomBytes(32)`, matching noble's own default (`react-native-get-random-values` is already loaded in `index.js`, so CSPRNG bytes are available at runtime; node crypto covers jest).

No in-tree caller uses `signSchnorr` today (taproot sweeps are explicitly unsupported), so there is no behavior change for existing flows. This closes the gap silently ahead of any future taproot signing through bitcoinjs-lib. The `sign()` path is untouched and remains plain RFC6979; its `extraEntropy` parameter is now documented as never-attacker-influenced.

New unit tests in `utils/NobleEcc.test.ts` prove the change: default signatures over the same (key, message) differ and verify, explicit aux data remains deterministic, and ECDSA stays RFC6979-deterministic. The first test fails against the old zero-aux default.

**2. `refactor(swaps)`: unify on the vendored noble_ecc adapter**

Swaps passed `@bitcoinerlab/secp256k1` to `initEccLib`/`ECPairFactory` while `utils/AddressUtils.ts` installed the vendored `noble_ecc` into the same global bitcoinjs-lib slot, so the ecc implementation used for taproot operations depended on module load order. The swap code only uses ECPair for key derivation (`fromPrivateKey` and pubkey/privkey extraction), which the vendored adapter fully supports, so all call sites now use `noble_ecc` and the now-unused `@bitcoinerlab/secp256k1` dependency is removed (it had no other dependents in `yarn.lock`).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Manual testing pending: swap rescue-key derivation (create swap, refund/rescue flow) and WIF sweep should be smoke tested on both platforms before merge. No backend-specific code paths are touched.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [x] Contributors will need to run `yarn` after this PR is merged in
- [x] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
