### PR TITLE
fix: display PSBT outputs, amounts, and fee before finalize/broadcast

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2135,6 +2135,8 @@
     "views.PSBT.derivation": "Derivation",
     "views.PSBT.noData": "No data",
     "views.PSBT.couldNotDecode": "Could not decode PSBT",
+    "views.PSBT.script": "Script",
+    "views.PSBT.feeUnknown": "Unknown (PSBT is missing input UTXO data)",
     "views.TxHex.TxInfo": "Transaction Info",
     "views.TxHex.channelWarning": "No channel loaded in the channel funding flow engine. DO NOT PUBLISH if this transaction is for a channel open.",
     "views.TxHex.broadcast": "Broadcast TX",

--- a/utils/PsbtUtils.test.ts
+++ b/utils/PsbtUtils.test.ts
@@ -1,0 +1,140 @@
+import * as bitcoin from 'bitcoinjs-lib';
+
+import PsbtUtils from './PsbtUtils';
+
+// valid secp256k1 point (2G)
+const pubkey = Buffer.from(
+    '02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5',
+    'hex'
+);
+
+const prevTxid =
+    'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+
+const makePrevTx = (script: Buffer, value: number) => {
+    const tx = new bitcoin.Transaction();
+    tx.addInput(Buffer.alloc(32, 1), 0);
+    tx.addOutput(script, value);
+    return tx;
+};
+
+describe('PsbtUtils', () => {
+    describe('decodePsbtSummary', () => {
+        it('decodes outputs, input values, and fee when all inputs have UTXO data', () => {
+            const network = bitcoin.networks.bitcoin;
+            const p2wpkh = bitcoin.payments.p2wpkh({ pubkey, network });
+            const prevTx = makePrevTx(p2wpkh.output!, 50000);
+
+            const psbt = new bitcoin.Psbt({ network });
+            psbt.addInput({
+                hash: prevTxid,
+                index: 1,
+                witnessUtxo: { script: p2wpkh.output!, value: 60000 }
+            });
+            psbt.addInput({
+                hash: prevTx.getHash(),
+                index: 0,
+                nonWitnessUtxo: prevTx.toBuffer()
+            });
+            psbt.addOutput({ address: p2wpkh.address!, value: 100000 });
+
+            const summary = PsbtUtils.decodePsbtSummary(
+                psbt.toBase64(),
+                network
+            );
+
+            expect(summary).toBeDefined();
+            expect(summary!.outputs).toHaveLength(1);
+            expect(summary!.outputs[0].address).toEqual(p2wpkh.address);
+            expect(summary!.outputs[0].value).toEqual(100000);
+            expect(summary!.inputs).toHaveLength(2);
+            expect(summary!.inputs[0].outpoint).toEqual(`${prevTxid}:1`);
+            expect(summary!.inputs[0].value).toEqual(60000);
+            expect(summary!.inputs[1].outpoint).toEqual(`${prevTx.getId()}:0`);
+            expect(summary!.inputs[1].value).toEqual(50000);
+            expect(summary!.fee).toEqual(10000);
+        });
+
+        it('leaves fee undefined when any input lacks UTXO data', () => {
+            const network = bitcoin.networks.bitcoin;
+            const p2wpkh = bitcoin.payments.p2wpkh({ pubkey, network });
+
+            const psbt = new bitcoin.Psbt({ network });
+            psbt.addInput({
+                hash: prevTxid,
+                index: 0,
+                witnessUtxo: { script: p2wpkh.output!, value: 60000 }
+            });
+            // no witnessUtxo or nonWitnessUtxo
+            psbt.addInput({ hash: prevTxid, index: 1 });
+            psbt.addOutput({ address: p2wpkh.address!, value: 40000 });
+
+            const summary = PsbtUtils.decodePsbtSummary(
+                psbt.toBase64(),
+                network
+            );
+
+            expect(summary).toBeDefined();
+            expect(summary!.outputs).toHaveLength(1);
+            expect(summary!.outputs[0].value).toEqual(40000);
+            expect(summary!.inputs[1].value).toBeUndefined();
+            expect(summary!.fee).toBeUndefined();
+        });
+
+        it('derives addresses with the provided network', () => {
+            const network = bitcoin.networks.testnet;
+            const p2wpkh = bitcoin.payments.p2wpkh({ pubkey, network });
+
+            const psbt = new bitcoin.Psbt({ network });
+            psbt.addInput({
+                hash: prevTxid,
+                index: 0,
+                witnessUtxo: { script: p2wpkh.output!, value: 60000 }
+            });
+            psbt.addOutput({ address: p2wpkh.address!, value: 50000 });
+
+            const summary = PsbtUtils.decodePsbtSummary(
+                psbt.toBase64(),
+                network
+            );
+
+            expect(summary!.outputs[0].address).toEqual(p2wpkh.address);
+            expect(summary!.outputs[0].address!.startsWith('tb1')).toBe(true);
+        });
+
+        it('leaves address undefined for non-standard outputs', () => {
+            const network = bitcoin.networks.bitcoin;
+            const p2wpkh = bitcoin.payments.p2wpkh({ pubkey, network });
+            const opReturn = bitcoin.script.compile([
+                bitcoin.opcodes.OP_RETURN,
+                Buffer.from('zeus')
+            ]);
+
+            const psbt = new bitcoin.Psbt({ network });
+            psbt.addInput({
+                hash: prevTxid,
+                index: 0,
+                witnessUtxo: { script: p2wpkh.output!, value: 60000 }
+            });
+            psbt.addOutput({ script: opReturn, value: 0 });
+
+            const summary = PsbtUtils.decodePsbtSummary(
+                psbt.toBase64(),
+                network
+            );
+
+            expect(summary!.outputs[0].address).toBeUndefined();
+            expect(summary!.outputs[0].scriptHex).toEqual(
+                opReturn.toString('hex')
+            );
+        });
+
+        it('returns undefined for invalid input', () => {
+            expect(PsbtUtils.decodePsbtSummary('')).toBeUndefined();
+            expect(PsbtUtils.decodePsbtSummary('not a psbt')).toBeUndefined();
+            expect(
+                PsbtUtils.decodePsbtSummary('aGVsbG8gd29ybGQ=')
+            ).toBeUndefined();
+        });
+    });
+});

--- a/utils/PsbtUtils.ts
+++ b/utils/PsbtUtils.ts
@@ -1,0 +1,90 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import ecc from '../zeus_modules/noble_ecc';
+
+bitcoin.initEccLib(ecc);
+
+export interface PsbtSummaryOutput {
+    address?: string;
+    value: number;
+    scriptHex: string;
+}
+
+export interface PsbtSummaryInput {
+    outpoint: string;
+    value?: number;
+}
+
+export interface PsbtSummary {
+    outputs: PsbtSummaryOutput[];
+    inputs: PsbtSummaryInput[];
+    fee?: number;
+}
+
+class PsbtUtils {
+    decodePsbtSummary = (
+        psbtBase64: string,
+        network?: bitcoin.Network
+    ): PsbtSummary | undefined => {
+        try {
+            const psbt = bitcoin.Psbt.fromBase64(psbtBase64, {
+                network: network || bitcoin.networks.bitcoin
+            });
+
+            const outputs: PsbtSummaryOutput[] = psbt.txOutputs.map(
+                (output) => ({
+                    address: output.address,
+                    value: output.value,
+                    scriptHex: output.script.toString('hex')
+                })
+            );
+
+            const inputs: PsbtSummaryInput[] = psbt.txInputs.map(
+                (input, index) => {
+                    const hash = Buffer.from(input.hash).reverse();
+                    const outpoint = `${hash.toString('hex')}:${input.index}`;
+
+                    let value: number | undefined;
+                    const inputData = psbt.data.inputs[index];
+                    try {
+                        if (inputData?.witnessUtxo) {
+                            value = inputData.witnessUtxo.value;
+                        } else if (inputData?.nonWitnessUtxo) {
+                            const utxoTx = bitcoin.Transaction.fromBuffer(
+                                inputData.nonWitnessUtxo
+                            );
+                            value = utxoTx.outs[input.index]?.value;
+                        }
+                    } catch (e) {}
+
+                    return { outpoint, value };
+                }
+            );
+
+            // psbt.getFee() requires finalized inputs and silently
+            // undercounts inputs that lack UTXO data, so compute the fee
+            // from the extracted values, and only when every input's
+            // value is known
+            let fee: number | undefined;
+            if (inputs.every((input) => input.value !== undefined)) {
+                const inputTotal = inputs.reduce(
+                    (total, input) => total + (input.value || 0),
+                    0
+                );
+                const outputTotal = outputs.reduce(
+                    (total, output) => total + output.value,
+                    0
+                );
+                if (inputTotal >= outputTotal) {
+                    fee = inputTotal - outputTotal;
+                }
+            }
+
+            return { outputs, inputs, fee };
+        } catch (e) {
+            return undefined;
+        }
+    };
+}
+
+const psbtUtils = new PsbtUtils();
+export default psbtUtils;

--- a/views/PSBT.tsx
+++ b/views/PSBT.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+    ScrollView,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View
+} from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { ButtonGroup } from '@rneui/themed';
 import { Route } from '@react-navigation/native';
@@ -7,6 +13,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 const bitcoin = require('bitcoinjs-lib');
 
+import Amount from '../components/Amount';
 import AnimatedQRDisplay from '../components/AnimatedQRDisplay';
 import Button from '../components/Button';
 import Header from '../components/Header';
@@ -18,14 +25,19 @@ import { WarningMessage } from '../components/SuccessErrorMessage';
 import Base64Utils from '../utils/Base64Utils';
 import { getButtonGroupStyles } from '../utils/buttonGroupStyles';
 import { localeString } from '../utils/LocaleUtils';
+import PrivacyUtils from '../utils/PrivacyUtils';
+import PsbtUtils, { PsbtSummary } from '../utils/PsbtUtils';
 import { themeColor } from '../utils/ThemeUtils';
+import UrlUtils from '../utils/UrlUtils';
 
 import ChannelsStore from '../stores/ChannelsStore';
+import NodeInfoStore from '../stores/NodeInfoStore';
 import TransactionsStore from '../stores/TransactionsStore';
 
 interface PSBTProps {
     navigation: NativeStackNavigationProp<any, any>;
     ChannelsStore: ChannelsStore;
+    NodeInfoStore: NodeInfoStore;
     TransactionsStore: TransactionsStore;
     route: Route<'PSBT', { psbt: string }>;
 }
@@ -42,15 +54,17 @@ interface PSBTState {
     infoIndex: number;
     fundedPsbt: string;
     psbtDecoded?: PSBTDecoded;
+    psbtSummary?: PsbtSummary;
 }
 
-@inject('ChannelsStore', 'TransactionsStore')
+@inject('ChannelsStore', 'NodeInfoStore', 'TransactionsStore')
 @observer
 export default class PSBT extends React.Component<PSBTProps, PSBTState> {
     state: PSBTState = {
         infoIndex: 0,
         fundedPsbt: this.props.route.params?.psbt || '',
-        psbtDecoded: undefined
+        psbtDecoded: undefined,
+        psbtSummary: undefined
     };
 
     componentDidMount(): void {
@@ -69,20 +83,108 @@ export default class PSBT extends React.Component<PSBTProps, PSBTState> {
     }
 
     decodePsbt = () => {
+        const { NodeInfoStore } = this.props;
         const { fundedPsbt } = this.state;
+
+        const network = NodeInfoStore.regtest
+            ? bitcoin.networks.regtest
+            : NodeInfoStore.testnet
+            ? bitcoin.networks.testnet
+            : bitcoin.networks.bitcoin;
+
+        const psbtSummary = PsbtUtils.decodePsbtSummary(fundedPsbt, network);
+
         try {
             const psbtDecoded = bitcoin.Psbt.fromBase64(fundedPsbt);
-            this.setState({ psbtDecoded });
+            this.setState({ psbtDecoded, psbtSummary });
         } catch (e) {
-            this.setState({ psbtDecoded: undefined });
+            this.setState({ psbtDecoded: undefined, psbtSummary });
         }
     };
 
+    renderOutputsAndFee = (psbtSummary: PsbtSummary) => {
+        const { NodeInfoStore } = this.props;
+        const { testnet } = NodeInfoStore;
+
+        return (
+            <>
+                {psbtSummary.outputs.map((output, index) => (
+                    <View key={`summary-output-${index}`}>
+                        <KeyValue
+                            keyValue={`${localeString('views.PSBT.output')} ${
+                                index + 1
+                            }`}
+                        />
+                        {output.address ? (
+                            <KeyValue
+                                keyValue={localeString('general.address')}
+                                value={
+                                    <TouchableOpacity
+                                        onPress={() =>
+                                            UrlUtils.goToBlockExplorerAddress(
+                                                output.address!,
+                                                testnet
+                                            )
+                                        }
+                                    >
+                                        <Text
+                                            style={{
+                                                ...styles.text,
+                                                color: themeColor('highlight')
+                                            }}
+                                        >
+                                            {`${PrivacyUtils.sensitiveValue({
+                                                input: output.address
+                                            })}`}
+                                        </Text>
+                                    </TouchableOpacity>
+                                }
+                                sensitive
+                            />
+                        ) : (
+                            <KeyValue
+                                keyValue={localeString('views.PSBT.script')}
+                                value={output.scriptHex}
+                                sensitive
+                            />
+                        )}
+                        <KeyValue
+                            keyValue={localeString('views.Receive.amount')}
+                            value={
+                                <Amount
+                                    sats={output.value}
+                                    toggleable
+                                    sensitive
+                                />
+                            }
+                        />
+                    </View>
+                ))}
+                <KeyValue
+                    keyValue={localeString('views.Payment.fee')}
+                    value={
+                        psbtSummary.fee !== undefined ? (
+                            <Amount
+                                sats={psbtSummary.fee}
+                                toggleable
+                                sensitive
+                            />
+                        ) : (
+                            localeString('views.PSBT.feeUnknown')
+                        )
+                    }
+                />
+            </>
+        );
+    };
+
     render() {
-        const { ChannelsStore, TransactionsStore, navigation } = this.props;
+        const { ChannelsStore, NodeInfoStore, TransactionsStore, navigation } =
+            this.props;
         const { pending_chan_ids } = ChannelsStore;
+        const { testnet } = NodeInfoStore;
         const { loading } = TransactionsStore;
-        const { infoIndex, fundedPsbt, psbtDecoded } = this.state;
+        const { infoIndex, fundedPsbt, psbtDecoded, psbtSummary } = this.state;
 
         const qrButton = () => (
             <Text
@@ -177,6 +279,12 @@ export default class PSBT extends React.Component<PSBTProps, PSBTState> {
                             fontSize={13}
                         />
                     )}
+                    {!loading && pending_chan_ids.length === 0 && (
+                        <WarningMessage
+                            message={localeString('views.TxHex.channelWarning')}
+                            fontSize={13}
+                        />
+                    )}
                     {loading && (
                         <View style={{ margin: 15 }}>
                             <LoadingIndicator />
@@ -204,6 +312,13 @@ export default class PSBT extends React.Component<PSBTProps, PSBTState> {
                                         fileType="P"
                                         copyValue={fundedPsbt}
                                     />
+                                    {psbtSummary && (
+                                        <View style={{ marginHorizontal: 15 }}>
+                                            {this.renderOutputsAndFee(
+                                                psbtSummary
+                                            )}
+                                        </View>
+                                    )}
                                     <View style={styles.button}>
                                         <Button
                                             title={localeString(
@@ -304,191 +419,328 @@ export default class PSBT extends React.Component<PSBTProps, PSBTState> {
                                                 />
                                             )}
                                             {psbtDecoded?.data?.inputs?.map(
-                                                (input: any, index: number) => (
-                                                    <View
-                                                        key={`input-${index}`}
-                                                    >
-                                                        <KeyValue
-                                                            keyValue={`${localeString(
-                                                                'views.PSBT.input'
-                                                            )} ${index + 1}`}
-                                                        />
-                                                        {input?.bip32Derivation ? (
-                                                            input?.bip32Derivation.map(
-                                                                (
-                                                                    derivation: any,
-                                                                    d: number
-                                                                ) => (
-                                                                    <View
-                                                                        key={`d-${index}-${d}`}
-                                                                    >
-                                                                        <Text
-                                                                            style={{
-                                                                                ...styles.text,
-                                                                                color: themeColor(
-                                                                                    'secondaryText'
-                                                                                ),
-                                                                                alignSelf:
-                                                                                    'center',
-                                                                                marginBottom: 10
-                                                                            }}
-                                                                        >{`${localeString(
-                                                                            'views.PSBT.input'
-                                                                        )} ${
-                                                                            index +
-                                                                            1
-                                                                        } - ${localeString(
-                                                                            'views.PSBT.derivation'
-                                                                        )} ${
-                                                                            d +
-                                                                            1
-                                                                        }`}</Text>
-                                                                        {derivation.masterFingerprint && (
-                                                                            <KeyValue
-                                                                                keyValue={localeString(
-                                                                                    'views.ImportAccount.masterKeyFingerprint'
-                                                                                )}
-                                                                                value={Base64Utils.bytesToHex(
-                                                                                    derivation.masterFingerprint
-                                                                                ).toUpperCase()}
-                                                                            />
-                                                                        )}
-                                                                        {derivation.pubkey && (
-                                                                            <KeyValue
-                                                                                keyValue={localeString(
-                                                                                    'views.NodeInfo.pubkey'
-                                                                                )}
-                                                                                value={Base64Utils.bytesToHex(
-                                                                                    derivation.pubkey
-                                                                                ).toUpperCase()}
-                                                                            />
-                                                                        )}
-                                                                        {derivation.path && (
-                                                                            <KeyValue
-                                                                                keyValue={localeString(
-                                                                                    'views.ImportAccount.derivationPath'
-                                                                                )}
-                                                                                value={
-                                                                                    derivation.path
-                                                                                }
-                                                                            />
-                                                                        )}
-                                                                    </View>
+                                                (input: any, index: number) => {
+                                                    const summaryInput =
+                                                        psbtSummary?.inputs[
+                                                            index
+                                                        ];
+                                                    return (
+                                                        <View
+                                                            key={`input-${index}`}
+                                                        >
+                                                            <KeyValue
+                                                                keyValue={`${localeString(
+                                                                    'views.PSBT.input'
+                                                                )} ${
+                                                                    index + 1
+                                                                }`}
+                                                            />
+                                                            {summaryInput?.outpoint && (
+                                                                <KeyValue
+                                                                    keyValue={localeString(
+                                                                        'general.outpoint'
+                                                                    )}
+                                                                    value={
+                                                                        <TouchableOpacity
+                                                                            onPress={() =>
+                                                                                UrlUtils.goToBlockExplorerTXID(
+                                                                                    summaryInput.outpoint,
+                                                                                    testnet
+                                                                                )
+                                                                            }
+                                                                        >
+                                                                            <Text
+                                                                                style={{
+                                                                                    ...styles.text,
+                                                                                    color: themeColor(
+                                                                                        'highlight'
+                                                                                    )
+                                                                                }}
+                                                                            >
+                                                                                {`${PrivacyUtils.sensitiveValue(
+                                                                                    {
+                                                                                        input: summaryInput.outpoint
+                                                                                    }
+                                                                                )}`}
+                                                                            </Text>
+                                                                        </TouchableOpacity>
+                                                                    }
+                                                                />
+                                                            )}
+                                                            {summaryInput?.value !==
+                                                                undefined && (
+                                                                <KeyValue
+                                                                    keyValue={localeString(
+                                                                        'views.Receive.amount'
+                                                                    )}
+                                                                    value={
+                                                                        <Amount
+                                                                            sats={
+                                                                                summaryInput.value
+                                                                            }
+                                                                            toggleable
+                                                                            sensitive
+                                                                        />
+                                                                    }
+                                                                />
+                                                            )}
+                                                            {input?.bip32Derivation ? (
+                                                                input?.bip32Derivation.map(
+                                                                    (
+                                                                        derivation: any,
+                                                                        d: number
+                                                                    ) => (
+                                                                        <View
+                                                                            key={`d-${index}-${d}`}
+                                                                        >
+                                                                            <Text
+                                                                                style={{
+                                                                                    ...styles.text,
+                                                                                    color: themeColor(
+                                                                                        'secondaryText'
+                                                                                    ),
+                                                                                    alignSelf:
+                                                                                        'center',
+                                                                                    marginBottom: 10
+                                                                                }}
+                                                                            >{`${localeString(
+                                                                                'views.PSBT.input'
+                                                                            )} ${
+                                                                                index +
+                                                                                1
+                                                                            } - ${localeString(
+                                                                                'views.PSBT.derivation'
+                                                                            )} ${
+                                                                                d +
+                                                                                1
+                                                                            }`}</Text>
+                                                                            {derivation.masterFingerprint && (
+                                                                                <KeyValue
+                                                                                    keyValue={localeString(
+                                                                                        'views.ImportAccount.masterKeyFingerprint'
+                                                                                    )}
+                                                                                    value={Base64Utils.bytesToHex(
+                                                                                        derivation.masterFingerprint
+                                                                                    ).toUpperCase()}
+                                                                                />
+                                                                            )}
+                                                                            {derivation.pubkey && (
+                                                                                <KeyValue
+                                                                                    keyValue={localeString(
+                                                                                        'views.NodeInfo.pubkey'
+                                                                                    )}
+                                                                                    value={Base64Utils.bytesToHex(
+                                                                                        derivation.pubkey
+                                                                                    ).toUpperCase()}
+                                                                                />
+                                                                            )}
+                                                                            {derivation.path && (
+                                                                                <KeyValue
+                                                                                    keyValue={localeString(
+                                                                                        'views.ImportAccount.derivationPath'
+                                                                                    )}
+                                                                                    value={
+                                                                                        derivation.path
+                                                                                    }
+                                                                                />
+                                                                            )}
+                                                                        </View>
+                                                                    )
                                                                 )
-                                                            )
-                                                        ) : (
-                                                            <Text
-                                                                style={{
-                                                                    ...styles.text,
-                                                                    color: themeColor(
-                                                                        'secondaryText'
-                                                                    ),
-                                                                    alignSelf:
-                                                                        'center'
-                                                                }}
-                                                            >
-                                                                {localeString(
-                                                                    'views.PSBT.noData'
-                                                                )}
-                                                            </Text>
-                                                        )}
-                                                    </View>
-                                                )
+                                                            ) : (
+                                                                <Text
+                                                                    style={{
+                                                                        ...styles.text,
+                                                                        color: themeColor(
+                                                                            'secondaryText'
+                                                                        ),
+                                                                        alignSelf:
+                                                                            'center'
+                                                                    }}
+                                                                >
+                                                                    {localeString(
+                                                                        'views.PSBT.noData'
+                                                                    )}
+                                                                </Text>
+                                                            )}
+                                                        </View>
+                                                    );
+                                                }
                                             )}
                                             {psbtDecoded.data?.outputs?.map(
                                                 (
                                                     output: any,
                                                     index: number
-                                                ) => (
-                                                    <View
-                                                        key={`output-${index}`}
-                                                    >
-                                                        <KeyValue
-                                                            keyValue={`${localeString(
-                                                                'views.PSBT.output'
-                                                            )} ${index + 1}`}
-                                                        />
-                                                        {output?.bip32Derivation ? (
-                                                            output?.bip32Derivation.map(
-                                                                (
-                                                                    derivation: any,
-                                                                    d: number
-                                                                ) => (
-                                                                    <View
-                                                                        key={`d-${index}-${d}`}
-                                                                    >
-                                                                        <Text
-                                                                            style={{
-                                                                                ...styles.text,
-                                                                                color: themeColor(
-                                                                                    'secondaryText'
-                                                                                ),
-                                                                                alignSelf:
-                                                                                    'center',
-                                                                                marginBottom: 10
-                                                                            }}
-                                                                        >{`${localeString(
-                                                                            'views.PSBT.output'
-                                                                        )} ${
-                                                                            index +
-                                                                            1
-                                                                        } - ${localeString(
-                                                                            'views.PSBT.derivation'
-                                                                        )} ${
-                                                                            d +
-                                                                            1
-                                                                        }`}</Text>
-                                                                        {derivation.masterFingerprint && (
-                                                                            <KeyValue
-                                                                                keyValue={localeString(
-                                                                                    'views.ImportAccount.masterKeyFingerprint'
-                                                                                )}
-                                                                                value={Base64Utils.bytesToHex(
-                                                                                    derivation.masterFingerprint
-                                                                                ).toUpperCase()}
-                                                                            />
-                                                                        )}
-                                                                        {derivation.pubkey && (
-                                                                            <KeyValue
-                                                                                keyValue={localeString(
-                                                                                    'views.NodeInfo.pubkey'
-                                                                                )}
-                                                                                value={Base64Utils.bytesToHex(
-                                                                                    derivation.pubkey
-                                                                                ).toUpperCase()}
-                                                                            />
-                                                                        )}
-                                                                        {derivation.path && (
-                                                                            <KeyValue
-                                                                                keyValue={localeString(
-                                                                                    'views.ImportAccount.derivationPath'
-                                                                                )}
-                                                                                value={
-                                                                                    derivation.path
-                                                                                }
-                                                                            />
-                                                                        )}
-                                                                    </View>
+                                                ) => {
+                                                    const summaryOutput =
+                                                        psbtSummary?.outputs[
+                                                            index
+                                                        ];
+                                                    return (
+                                                        <View
+                                                            key={`output-${index}`}
+                                                        >
+                                                            <KeyValue
+                                                                keyValue={`${localeString(
+                                                                    'views.PSBT.output'
+                                                                )} ${
+                                                                    index + 1
+                                                                }`}
+                                                            />
+                                                            {summaryOutput?.address && (
+                                                                <KeyValue
+                                                                    keyValue={localeString(
+                                                                        'general.address'
+                                                                    )}
+                                                                    value={
+                                                                        <TouchableOpacity
+                                                                            onPress={() =>
+                                                                                UrlUtils.goToBlockExplorerAddress(
+                                                                                    summaryOutput.address!,
+                                                                                    testnet
+                                                                                )
+                                                                            }
+                                                                        >
+                                                                            <Text
+                                                                                style={{
+                                                                                    ...styles.text,
+                                                                                    color: themeColor(
+                                                                                        'highlight'
+                                                                                    )
+                                                                                }}
+                                                                            >
+                                                                                {`${PrivacyUtils.sensitiveValue(
+                                                                                    {
+                                                                                        input: summaryOutput.address
+                                                                                    }
+                                                                                )}`}
+                                                                            </Text>
+                                                                        </TouchableOpacity>
+                                                                    }
+                                                                    sensitive
+                                                                />
+                                                            )}
+                                                            {summaryOutput && (
+                                                                <KeyValue
+                                                                    keyValue={localeString(
+                                                                        'views.Receive.amount'
+                                                                    )}
+                                                                    value={
+                                                                        <Amount
+                                                                            sats={
+                                                                                summaryOutput.value
+                                                                            }
+                                                                            toggleable
+                                                                            sensitive
+                                                                        />
+                                                                    }
+                                                                />
+                                                            )}
+                                                            {output?.bip32Derivation ? (
+                                                                output?.bip32Derivation.map(
+                                                                    (
+                                                                        derivation: any,
+                                                                        d: number
+                                                                    ) => (
+                                                                        <View
+                                                                            key={`d-${index}-${d}`}
+                                                                        >
+                                                                            <Text
+                                                                                style={{
+                                                                                    ...styles.text,
+                                                                                    color: themeColor(
+                                                                                        'secondaryText'
+                                                                                    ),
+                                                                                    alignSelf:
+                                                                                        'center',
+                                                                                    marginBottom: 10
+                                                                                }}
+                                                                            >{`${localeString(
+                                                                                'views.PSBT.output'
+                                                                            )} ${
+                                                                                index +
+                                                                                1
+                                                                            } - ${localeString(
+                                                                                'views.PSBT.derivation'
+                                                                            )} ${
+                                                                                d +
+                                                                                1
+                                                                            }`}</Text>
+                                                                            {derivation.masterFingerprint && (
+                                                                                <KeyValue
+                                                                                    keyValue={localeString(
+                                                                                        'views.ImportAccount.masterKeyFingerprint'
+                                                                                    )}
+                                                                                    value={Base64Utils.bytesToHex(
+                                                                                        derivation.masterFingerprint
+                                                                                    ).toUpperCase()}
+                                                                                />
+                                                                            )}
+                                                                            {derivation.pubkey && (
+                                                                                <KeyValue
+                                                                                    keyValue={localeString(
+                                                                                        'views.NodeInfo.pubkey'
+                                                                                    )}
+                                                                                    value={Base64Utils.bytesToHex(
+                                                                                        derivation.pubkey
+                                                                                    ).toUpperCase()}
+                                                                                />
+                                                                            )}
+                                                                            {derivation.path && (
+                                                                                <KeyValue
+                                                                                    keyValue={localeString(
+                                                                                        'views.ImportAccount.derivationPath'
+                                                                                    )}
+                                                                                    value={
+                                                                                        derivation.path
+                                                                                    }
+                                                                                />
+                                                                            )}
+                                                                        </View>
+                                                                    )
                                                                 )
-                                                            )
+                                                            ) : (
+                                                                <Text
+                                                                    style={{
+                                                                        ...styles.text,
+                                                                        color: themeColor(
+                                                                            'secondaryText'
+                                                                        ),
+                                                                        alignSelf:
+                                                                            'center'
+                                                                    }}
+                                                                >
+                                                                    {localeString(
+                                                                        'views.PSBT.noData'
+                                                                    )}
+                                                                </Text>
+                                                            )}
+                                                        </View>
+                                                    );
+                                                }
+                                            )}
+                                            {psbtSummary && (
+                                                <KeyValue
+                                                    keyValue={localeString(
+                                                        'views.Payment.fee'
+                                                    )}
+                                                    value={
+                                                        psbtSummary.fee !==
+                                                        undefined ? (
+                                                            <Amount
+                                                                sats={
+                                                                    psbtSummary.fee
+                                                                }
+                                                                toggleable
+                                                                sensitive
+                                                            />
                                                         ) : (
-                                                            <Text
-                                                                style={{
-                                                                    ...styles.text,
-                                                                    color: themeColor(
-                                                                        'secondaryText'
-                                                                    ),
-                                                                    alignSelf:
-                                                                        'center'
-                                                                }}
-                                                            >
-                                                                {localeString(
-                                                                    'views.PSBT.noData'
-                                                                )}
-                                                            </Text>
-                                                        )}
-                                                    </View>
-                                                )
+                                                            localeString(
+                                                                'views.PSBT.feeUnknown'
+                                                            )
+                                                        )
+                                                    }
+                                                />
                                             )}
                                         </>
                                     )}

--- a/views/TxHex.tsx
+++ b/views/TxHex.tsx
@@ -140,9 +140,15 @@ export default class TxHex extends React.Component<TxHexProps, TxHexState> {
         const { ChannelsStore, NodeInfoStore, TransactionsStore, navigation } =
             this.props;
         const { pending_chan_ids } = ChannelsStore;
-        const { testnet } = NodeInfoStore;
+        const { testnet, regtest } = NodeInfoStore;
         const { loading } = TransactionsStore;
         const { infoIndex, txHex, txDecoded } = this.state;
+
+        const network = regtest
+            ? bitcoin.networks.regtest
+            : testnet
+            ? bitcoin.networks.testnet
+            : bitcoin.networks.bitcoin;
 
         const qrButton = () => (
             <Text
@@ -428,13 +434,17 @@ export default class TxHex extends React.Component<TxHexProps, TxHexState> {
                                                     output: any,
                                                     index: number
                                                 ) => {
-                                                    // const decodedOutputScript = bitcoin.script.toASM(output.script);
-
-                                                    // Extract address from the output script
-                                                    const address =
-                                                        bitcoin.address.fromOutputScript(
-                                                            output.script
-                                                        );
+                                                    // Extract address from the output script;
+                                                    // non-standard scripts (e.g. OP_RETURN)
+                                                    // have no address form
+                                                    let address;
+                                                    try {
+                                                        address =
+                                                            bitcoin.address.fromOutputScript(
+                                                                output.script,
+                                                                network
+                                                            );
+                                                    } catch (e) {}
                                                     return (
                                                         <View
                                                             key={`output-${index}`}
@@ -476,6 +486,17 @@ export default class TxHex extends React.Component<TxHexProps, TxHexState> {
                                                                             </Text>
                                                                         </TouchableOpacity>
                                                                     }
+                                                                    sensitive
+                                                                />
+                                                            )}
+                                                            {!address && (
+                                                                <KeyValue
+                                                                    keyValue={localeString(
+                                                                        'views.PSBT.script'
+                                                                    )}
+                                                                    value={output.script.toString(
+                                                                        'hex'
+                                                                    )}
                                                                     sensitive
                                                                 />
                                                             )}


### PR DESCRIPTION
# Description

Relates to internal security audit finding **FND-005** (no public issue number).

Scanning any PSBT routes to the PSBT view, whose info tab only showed input/output counts and BIP32 derivations. The "Finalize PSBT and Broadcast" button would then finalize any pre-signed inputs and broadcast on a single tap, with no display of destination addresses, amounts, or fee. The warning banner only rendered in the channel funding flow, so externally scanned PSBTs got no warning at all. A user in an external-signing workflow (watch-only account, sign elsewhere, scan back) had nothing on screen to distinguish a swapped or stale signed PSBT from the one they intended to broadcast.

Changes:

* New `utils/PsbtUtils.decodePsbtSummary()`: decodes output addresses (with the node's network params), output values, input outpoints and values, and the fee. The fee is computed as input total minus output total, and only when every input carries `witnessUtxo`/`nonWitnessUtxo` data. `psbt.getFee()` was not usable here: it requires finalized inputs and silently undercounts inputs that lack UTXO data.
* PSBT view: the QR tab now renders every output's address (block explorer linked, privacy masked) and amount plus the fee directly above the finalize/broadcast button, so a broadcast can no longer happen without amounts on screen. When the fee cannot be computed safely it shows "Unknown (PSBT is missing input UTXO data)" instead of a wrong number. The info tab gains outpoints, input amounts, and output addresses/amounts merged alongside the existing derivation rows. Externally scanned PSBTs (no `pending_chan_ids`) now get the same warning banner the TxHex view shows.
* TxHex view (separate commit): `fromOutputScript` was called without a network argument, showing mainnet-prefixed addresses on testnet/regtest, and threw during render for non-standard outputs like OP_RETURN, blanking the info tab. It now receives the node's network and falls back to raw script hex.

Screenshots to follow after on-device testing.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

Note: 4 pre-existing test suites and some tsc modules fail on the dev machine due to a stale local `node_modules` (missing `bolt11`); unrelated to this change and expected to pass on CI's fresh install.

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] Embedded LND
- [ ] LDK Node

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

Manual test plan before marking ready: scan a signed PSBT and verify addresses, amounts, fee, and warning banner render on both tabs; scan a PSBT with stripped UTXO data and verify the fee shows as unknown; regression check the channel open funding flow (warning still shows, funding still goes through `fundingStateStep`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
