### PR TITLE
fix(security): fully wipe wallet data on duress and lockout

### DIFF
--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -1,0 +1,215 @@
+// Regression coverage for the duress / failed-attempts wipe gap (KEY-005):
+// clearAllData() must stop and delete the on-disk LND/LDK node data
+// directories, not only the keychain/Cashu/settings entries. Lockscreen's
+// duress (`deleteNodes`) and lockout (`authenticationFailure`) handlers both
+// route through clearAllData(), so this guards that the seed-bearing node
+// directories are actually removed by a wipe.
+
+jest.mock('react-native-keychain', () => ({
+    resetInternetCredentials: jest.fn().mockResolvedValue(true)
+}));
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    clear: jest.fn().mockResolvedValue(undefined)
+}));
+jest.mock('react-native-encrypted-storage', () => ({
+    removeItem: jest.fn().mockResolvedValue(undefined),
+    clear: jest.fn().mockResolvedValue(undefined)
+}));
+jest.mock('react-native-blob-util', () => ({
+    fs: {
+        dirs: { LibraryDir: '/lib', DocumentDir: '/docs' },
+        exists: jest.fn().mockResolvedValue(false),
+        unlink: jest.fn().mockResolvedValue(undefined)
+    }
+}));
+
+jest.mock('../storage', () => ({
+    getItem: jest.fn().mockResolvedValue(null),
+    removeItem: jest.fn().mockResolvedValue(true),
+    setItem: jest.fn().mockResolvedValue(true)
+}));
+
+// The functions under regression - assert clearAllData delegates to them.
+jest.mock('./LndMobileUtils', () => ({
+    deleteLndWallet: jest.fn().mockResolvedValue(undefined)
+}));
+jest.mock('./LdkNodeUtils', () => ({
+    deleteLdkNodeWallet: jest.fn().mockResolvedValue(undefined),
+    stopLdkNode: jest.fn().mockResolvedValue(undefined)
+}));
+
+// Store modules are imported only for their storage-key constants; mock them
+// so the real (native-dependency-heavy) store modules are never loaded.
+jest.mock('../stores/SettingsStore', () => ({
+    STORAGE_KEY: 'zeus-settings-v2',
+    CURRENCY_CODES_KEY: 'zeus-currency-codes',
+    LEGACY_CURRENCY_CODES_KEY: 'currency-codes',
+    FAVORITE_CURRENCIES_KEY: 'favorite-currencies'
+}));
+jest.mock('../stores/NotesStore', () => ({
+    NOTES_KEY: 'notes-keys',
+    LEGACY_NOTES_KEY: 'noteKeys'
+}));
+jest.mock('../stores/ContactStore', () => ({
+    CONTACTS_KEY: 'zeus-contacts',
+    LEGACY_CONTACTS_KEY: 'contacts'
+}));
+jest.mock('../stores/ChannelBackupStore', () => ({
+    LAST_CHANNEL_BACKUP_STATUS: 'last-channel-backup-status',
+    LAST_CHANNEL_BACKUP_TIME: 'last-channel-backup-time',
+    LEGACY_LAST_CHANNEL_BACKUP_STATUS: 'lastChannelBackupStatus',
+    LEGACY_LAST_CHANNEL_BACKUP_TIME: 'lastChannelBackupTime'
+}));
+jest.mock('../stores/LightningAddressStore', () => ({
+    ADDRESS_ACTIVATED_STRING: 'address-activated',
+    HASHES_STORAGE_STRING: 'hashes',
+    LEGACY_ADDRESS_ACTIVATED_STRING: 'addressActivated',
+    LEGACY_HASHES_STORAGE_STRING: 'hashesStorage'
+}));
+jest.mock('../stores/PosStore', () => ({
+    POS_HIDDEN_KEY: 'pos-hidden',
+    POS_STANDALONE_KEY: 'pos-standalone',
+    LEGACY_POS_HIDDEN_KEY: 'posHidden',
+    LEGACY_POS_STANDALONE_KEY: 'posStandalone'
+}));
+jest.mock('../stores/InventoryStore', () => ({
+    CATEGORY_KEY: 'category',
+    PRODUCT_KEY: 'product',
+    LEGACY_CATEGORY_KEY: 'categoryLegacy',
+    LEGACY_PRODUCT_KEY: 'productLegacy'
+}));
+jest.mock('../stores/UnitsStore', () => ({
+    UNIT_KEY: 'unit',
+    LEGACY_UNIT_KEY: 'unitLegacy'
+}));
+jest.mock('../stores/UTXOsStore', () => ({
+    HIDDEN_ACCOUNTS_KEY: 'hidden-accounts',
+    LEGACY_HIDDEN_ACCOUNTS_KEY: 'hiddenAccounts'
+}));
+jest.mock('../stores/LSPStore', () => ({
+    LSPS_ORDERS_KEY: 'lsps-orders',
+    LEGACY_LSPS1_ORDERS_KEY: 'lsps1Orders'
+}));
+jest.mock('../stores/ActivityStore', () => ({
+    ACTIVITY_FILTERS_KEY: 'activity-filters',
+    LEGACY_ACTIVITY_FILTERS_KEY: 'activityFilters'
+}));
+jest.mock('../utils/MigrationUtils', () => ({
+    IS_BACKED_UP_KEY: 'is-backed-up'
+}));
+jest.mock('../utils/SwapUtils', () => ({
+    SWAPS_KEY: 'swaps',
+    REVERSE_SWAPS_KEY: 'reverse-swaps',
+    SWAPS_RESCUE_KEY: 'swaps-rescue-key',
+    SWAPS_LAST_USED_KEY: 'swaps-last-used-key'
+}));
+
+import Storage from '../storage';
+import { clearAllData } from './DataClearUtils';
+import { deleteLndWallet } from './LndMobileUtils';
+import { deleteLdkNodeWallet, stopLdkNode } from './LdkNodeUtils';
+
+const mockedDeleteLndWallet = deleteLndWallet as jest.Mock;
+const mockedDeleteLdkNodeWallet = deleteLdkNodeWallet as jest.Mock;
+const mockedStopLdkNode = stopLdkNode as jest.Mock;
+const mockedStorageGetItem = Storage.getItem as jest.Mock;
+
+// Keep test output clean
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+const settingsWithNodes = (nodes: any[]) => ({
+    getItem: (key: string) =>
+        key === 'zeus-settings-v2'
+            ? Promise.resolve(JSON.stringify({ nodes }))
+            : Promise.resolve(null)
+});
+
+describe('clearAllData node data directory wipe (KEY-005 regression)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedStorageGetItem.mockResolvedValue(null);
+    });
+
+    it('stops and deletes the data directory for an embedded-lnd node', async () => {
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([
+                { implementation: 'embedded-lnd', lndDir: 'lnd-abc' }
+            ]).getItem
+        );
+
+        await clearAllData();
+
+        expect(mockedDeleteLndWallet).toHaveBeenCalledWith('lnd-abc');
+    });
+
+    it('defaults the embedded-lnd directory to "lnd" when lndDir is absent', async () => {
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([{ implementation: 'embedded-lnd' }]).getItem
+        );
+
+        await clearAllData();
+
+        expect(mockedDeleteLndWallet).toHaveBeenCalledWith('lnd');
+    });
+
+    it('stops the LDK node before deleting its data directory', async () => {
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([
+                { implementation: 'ldk-node', ldkNodeDir: 'ldk-node-xyz' }
+            ]).getItem
+        );
+
+        await clearAllData();
+
+        expect(mockedStopLdkNode).toHaveBeenCalled();
+        expect(mockedDeleteLdkNodeWallet).toHaveBeenCalledWith('ldk-node-xyz');
+        // stop must be ordered before the unlink
+        expect(mockedStopLdkNode.mock.invocationCallOrder[0]).toBeLessThan(
+            mockedDeleteLdkNodeWallet.mock.invocationCallOrder[0]
+        );
+    });
+
+    it('wipes every configured node directory in a multi-node wallet', async () => {
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([
+                { implementation: 'embedded-lnd', lndDir: 'lnd-1' },
+                { implementation: 'ldk-node', ldkNodeDir: 'ldk-2' }
+            ]).getItem
+        );
+
+        await clearAllData();
+
+        expect(mockedDeleteLndWallet).toHaveBeenCalledWith('lnd-1');
+        expect(mockedDeleteLdkNodeWallet).toHaveBeenCalledWith('ldk-2');
+    });
+
+    it('does not delete an ldk-node directory when ldkNodeDir is missing', async () => {
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([{ implementation: 'ldk-node' }]).getItem
+        );
+
+        await clearAllData();
+
+        expect(mockedDeleteLdkNodeWallet).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op for node deletion when there are no configured nodes', async () => {
+        mockedStorageGetItem.mockImplementation(settingsWithNodes([]).getItem);
+
+        await clearAllData();
+
+        expect(mockedDeleteLndWallet).not.toHaveBeenCalled();
+        expect(mockedDeleteLdkNodeWallet).not.toHaveBeenCalled();
+        expect(mockedStopLdkNode).not.toHaveBeenCalled();
+    });
+
+    it('tolerates a missing / unreadable settings blob without throwing', async () => {
+        mockedStorageGetItem.mockResolvedValue(null);
+
+        await expect(clearAllData()).resolves.toBeUndefined();
+
+        expect(mockedDeleteLndWallet).not.toHaveBeenCalled();
+        expect(mockedDeleteLdkNodeWallet).not.toHaveBeenCalled();
+    });
+});

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -31,11 +31,16 @@ jest.mock('../storage', () => ({
 
 // The functions under regression - assert clearAllData delegates to them.
 jest.mock('./LndMobileUtils', () => ({
-    deleteLndWallet: jest.fn().mockResolvedValue(undefined)
+    deleteLndWallet: jest.fn().mockResolvedValue(true)
 }));
 jest.mock('./LdkNodeUtils', () => ({
     deleteLdkNodeWallet: jest.fn().mockResolvedValue(undefined),
     stopLdkNode: jest.fn().mockResolvedValue(undefined)
+}));
+
+// Retry backoff - keep the suite from actually waiting on it
+jest.mock('./SleepUtils', () => ({
+    sleep: jest.fn().mockResolvedValue(undefined)
 }));
 
 // Store modules are imported only for their storage-key constants; mock them
@@ -108,11 +113,13 @@ import Storage from '../storage';
 import { clearAllData } from './DataClearUtils';
 import { deleteLndWallet } from './LndMobileUtils';
 import { deleteLdkNodeWallet, stopLdkNode } from './LdkNodeUtils';
+import { sleep } from './SleepUtils';
 
 const mockedDeleteLndWallet = deleteLndWallet as jest.Mock;
 const mockedDeleteLdkNodeWallet = deleteLdkNodeWallet as jest.Mock;
 const mockedStopLdkNode = stopLdkNode as jest.Mock;
 const mockedStorageGetItem = Storage.getItem as jest.Mock;
+const mockedSleep = sleep as jest.Mock;
 
 // Keep test output clean
 jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -129,6 +136,8 @@ describe('clearAllData node data directory wipe (KEY-005 regression)', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockedStorageGetItem.mockResolvedValue(null);
+        mockedDeleteLndWallet.mockResolvedValue(true);
+        mockedDeleteLdkNodeWallet.mockResolvedValue(undefined);
     });
 
     it('stops and deletes the data directory for an embedded-lnd node', async () => {
@@ -211,5 +220,90 @@ describe('clearAllData node data directory wipe (KEY-005 regression)', () => {
 
         expect(mockedDeleteLndWallet).not.toHaveBeenCalled();
         expect(mockedDeleteLdkNodeWallet).not.toHaveBeenCalled();
+    });
+});
+
+// The wipe runs on the duress path, so a failed directory deletion must be
+// retried rather than surfaced: halting would leave the keychain and settings
+// blob unwiped, and an error in the UI would disclose the duress mechanism.
+describe('clearAllData node data directory retry', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedStorageGetItem.mockResolvedValue(null);
+        mockedDeleteLndWallet.mockResolvedValue(true);
+        mockedDeleteLdkNodeWallet.mockResolvedValue(undefined);
+    });
+
+    it('retries an embedded-lnd deletion that reports failure', async () => {
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([
+                { implementation: 'embedded-lnd', lndDir: 'lnd-abc' }
+            ]).getItem
+        );
+        mockedDeleteLndWallet
+            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce(true);
+
+        await clearAllData();
+
+        expect(mockedDeleteLndWallet).toHaveBeenCalledTimes(2);
+        expect(mockedSleep).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries an LDK deletion that throws', async () => {
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([
+                { implementation: 'ldk-node', ldkNodeDir: 'ldk-xyz' }
+            ]).getItem
+        );
+        mockedDeleteLdkNodeWallet
+            .mockRejectedValueOnce(new Error('EBUSY'))
+            .mockResolvedValueOnce(undefined);
+
+        await clearAllData();
+
+        expect(mockedDeleteLdkNodeWallet).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry a deletion that succeeded first time', async () => {
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([
+                { implementation: 'embedded-lnd', lndDir: 'lnd-abc' }
+            ]).getItem
+        );
+
+        await clearAllData();
+
+        expect(mockedDeleteLndWallet).toHaveBeenCalledTimes(1);
+        expect(mockedSleep).not.toHaveBeenCalled();
+    });
+
+    it('gives up after 3 attempts and still completes the wipe', async () => {
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([
+                { implementation: 'embedded-lnd', lndDir: 'lnd-abc' }
+            ]).getItem
+        );
+        mockedDeleteLndWallet.mockResolvedValue(false);
+
+        // never rejects - the caller must be free to restart
+        await expect(clearAllData()).resolves.toBeUndefined();
+
+        expect(mockedDeleteLndWallet).toHaveBeenCalledTimes(3);
+    });
+
+    it('still wipes later nodes after an earlier node exhausts its retries', async () => {
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([
+                { implementation: 'embedded-lnd', lndDir: 'lnd-1' },
+                { implementation: 'ldk-node', ldkNodeDir: 'ldk-2' }
+            ]).getItem
+        );
+        mockedDeleteLndWallet.mockResolvedValue(false);
+
+        await clearAllData();
+
+        expect(mockedDeleteLndWallet).toHaveBeenCalledTimes(3);
+        expect(mockedDeleteLdkNodeWallet).toHaveBeenCalledWith('ldk-2');
     });
 });

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -56,6 +56,7 @@ import {
 } from '../utils/SwapUtils';
 import { deleteLndWallet } from './LndMobileUtils';
 import { deleteLdkNodeWallet, stopLdkNode } from './LdkNodeUtils';
+import { sleep } from './SleepUtils';
 
 const KEY_PREFIX = 'zeus:';
 
@@ -249,27 +250,60 @@ async function clearCashuDataForNode(lndDir: string) {
     }
 }
 
+const NODE_DIR_DELETE_ATTEMPTS = 3;
+const NODE_DIR_RETRY_DELAY_MS = 500;
+
+/**
+ * Stops and deletes a single node's data directory. Never throws - returns
+ * whether the directory was removed so the caller can retry.
+ */
+async function deleteNodeDataDirectory(node: any): Promise<boolean> {
+    try {
+        if (node.implementation === 'embedded-lnd') {
+            // deleteLndWallet stops LND before unlinking the directory
+            return await deleteLndWallet(node.lndDir || 'lnd');
+        }
+        if (node.implementation === 'ldk-node' && node.ldkNodeDir) {
+            // deleteLdkNodeWallet does not stop the node itself
+            await stopLdkNode();
+            await deleteLdkNodeWallet(node.ldkNodeDir);
+        }
+        // no on-disk directory for remote implementations
+        return true;
+    } catch (e) {
+        console.warn('[ClearData] Error clearing node data directory:', e);
+        return false;
+    }
+}
+
 /**
  * Stops and deletes the on-disk node data directories (channel state, wallet
  * db) for every configured node. clearKey/clearCashuDataForNode only touch
  * keychain and Cashu storage; the LND/LDK node directories must be unlinked
  * separately or seed-bearing wallet state survives a "wipe".
+ *
+ * Deletion is retried: the likely cause of failure is a file handle still
+ * held by a node that hasn't finished shutting down, which clears on its own
+ * after a moment. A directory we still can't remove is logged and skipped -
+ * it never aborts the wipe and never reaches the UI. This runs on the duress
+ * path, where stopping mid-wipe would strand the user with the remaining
+ * steps (keychain, settings blob, pins) unwiped, and where showing an error
+ * would disclose the duress mechanism to a coercer.
  */
 async function clearNodeDataDirectories(settings: any): Promise<void> {
     if (!settings?.nodes || !Array.isArray(settings.nodes)) return;
 
     for (const node of settings.nodes) {
-        try {
-            if (node.implementation === 'embedded-lnd') {
-                // deleteLndWallet stops LND before unlinking the directory
-                await deleteLndWallet(node.lndDir || 'lnd');
-            } else if (node.implementation === 'ldk-node' && node.ldkNodeDir) {
-                // deleteLdkNodeWallet does not stop the node itself
-                await stopLdkNode();
-                await deleteLdkNodeWallet(node.ldkNodeDir);
+        for (let attempt = 1; attempt <= NODE_DIR_DELETE_ATTEMPTS; attempt++) {
+            if (await deleteNodeDataDirectory(node)) break;
+
+            if (attempt < NODE_DIR_DELETE_ATTEMPTS) {
+                await sleep(NODE_DIR_RETRY_DELAY_MS);
+            } else {
+                console.warn(
+                    `[ClearData] Gave up deleting node data directory after ${NODE_DIR_DELETE_ATTEMPTS} attempts`
+                );
             }
-        } catch (e) {
-            console.warn('[ClearData] Error clearing node data directory:', e);
         }
     }
 }

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -54,6 +54,8 @@ import {
     SWAPS_RESCUE_KEY,
     SWAPS_LAST_USED_KEY
 } from '../utils/SwapUtils';
+import { deleteLndWallet } from './LndMobileUtils';
+import { deleteLdkNodeWallet, stopLdkNode } from './LdkNodeUtils';
 
 const KEY_PREFIX = 'zeus:';
 
@@ -248,6 +250,31 @@ async function clearCashuDataForNode(lndDir: string) {
 }
 
 /**
+ * Stops and deletes the on-disk node data directories (channel state, wallet
+ * db) for every configured node. clearKey/clearCashuDataForNode only touch
+ * keychain and Cashu storage; the LND/LDK node directories must be unlinked
+ * separately or seed-bearing wallet state survives a "wipe".
+ */
+async function clearNodeDataDirectories(settings: any): Promise<void> {
+    if (!settings?.nodes || !Array.isArray(settings.nodes)) return;
+
+    for (const node of settings.nodes) {
+        try {
+            if (node.implementation === 'embedded-lnd') {
+                // deleteLndWallet stops LND before unlinking the directory
+                await deleteLndWallet(node.lndDir || 'lnd');
+            } else if (node.implementation === 'ldk-node' && node.ldkNodeDir) {
+                // deleteLdkNodeWallet does not stop the node itself
+                await stopLdkNode();
+                await deleteLdkNodeWallet(node.ldkNodeDir);
+            }
+        } catch (e) {
+            console.warn('[ClearData] Error clearing node data directory:', e);
+        }
+    }
+}
+
+/**
  * Clears all app data including:
  * - Storage (new zeus: namespace)
  * - Old keychain entries (local and cloud)
@@ -255,6 +282,7 @@ async function clearCashuDataForNode(lndDir: string) {
  * - EncryptedStorage
  * - Dynamic keys (notes, Cashu, LNC)
  * - CDK SQLite database (Cashu wallet state)
+ * - LND/LDK on-disk node data directories (channel + wallet state)
  *
  * After clearing, the app should be restarted.
  */
@@ -291,6 +319,11 @@ export async function clearAllData(): Promise<void> {
 
     // 2b. Clear CDK SQLite database (contains mints, proofs, transactions)
     await clearCDKDatabase();
+
+    // 2c. Stop and delete the on-disk LND/LDK node data directories. These
+    // hold channel + wallet state and are not covered by the keychain/Cashu
+    // clears above, so they must be unlinked explicitly.
+    await clearNodeDataDirectories(settings);
 
     // 3. Clear all known storage keys
     console.log('[ClearData] Clearing known storage keys...');

--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -323,13 +323,20 @@ const writeLndConfig = async ({
     await writeConfig({ lndDir, config });
 };
 
-export async function deleteLndWallet(lndDir: string) {
+/**
+ * Stops LND and deletes its data directory. Returns whether the deletion
+ * succeeded so callers that need to know (the duress/lockout wipe) can retry
+ * instead of assuming the directory is gone.
+ */
+export async function deleteLndWallet(lndDir: string): Promise<boolean> {
     log.d('Attempting to delete Embedded LND wallet');
     try {
         await stopLnd();
         await NativeModules.LndMobileTools.deleteLndDirectory(lndDir);
+        return true;
     } catch (error) {
         log.e('Embedded LND wallet deletion failed', [error]);
+        return false;
     }
 }
 

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -23,6 +23,7 @@ import ShowHideToggle from '../components/ShowHideToggle';
 import SettingsStore, { PosEnabled } from '../stores/SettingsStore';
 
 import { verifyBiometry } from '../utils/BiometricUtils';
+import { clearAllData } from '../utils/DataClearUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
 
@@ -436,9 +437,14 @@ export default class Lockscreen extends React.Component<
         });
     };
 
-    deleteNodes = () => {
+    deleteNodes = async () => {
         const { SettingsStore } = this.props;
         const { updateSettings } = SettingsStore;
+
+        // Fully wipe wallet data (node data dirs, Cashu seeds + CDK db, swap
+        // rescue key, keychain) so the duress action leaves no recoverable key
+        // material behind - not just the settings `nodes` pointer.
+        await clearAllData();
 
         updateSettings({
             nodes: undefined,
@@ -449,9 +455,14 @@ export default class Lockscreen extends React.Component<
         });
     };
 
-    authenticationFailure = () => {
+    authenticationFailure = async () => {
         const { SettingsStore } = this.props;
         const { updateSettings } = SettingsStore;
+
+        // Fully wipe wallet data on repeated failed logins, then clear the
+        // local auth secrets. clearAllData() removes the node data dirs, Cashu
+        // seeds + CDK db, and swap rescue key the settings wipe leaves behind.
+        await clearAllData();
 
         updateSettings({
             nodes: undefined,

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -446,8 +446,19 @@ export default class Lockscreen extends React.Component<
         // pre-wipe in-memory blob and re-persist it (pins, passphrases and
         // all), and a restart is also the only way to drop node credentials
         // still held in memory by the stores.
-        await clearAllData();
-        RNRestart.Restart();
+        try {
+            await clearAllData();
+        } catch (e) {
+            // never surface an error here: it would disclose the duress
+            // mechanism and there is no meaningful recovery mid-wipe
+            console.warn('[Lockscreen] wipe failed part-way', e);
+        } finally {
+            // the restart must run even after a partial wipe: the settings
+            // blob is cleared early, so a restart still lands on a fresh
+            // install state rather than stranding the user on a dead
+            // lockscreen
+            RNRestart.Restart();
+        }
     };
 
     authenticationFailure = async () => {
@@ -455,8 +466,14 @@ export default class Lockscreen extends React.Component<
         // removes the node data dirs, Cashu seeds + CDK db, swap rescue key
         // and the settings blob itself (including pins and passphrases).
         // Restart instead of writing settings back - see deleteNodes above.
-        await clearAllData();
-        RNRestart.Restart();
+        try {
+            await clearAllData();
+        } catch (e) {
+            // see deleteNodes: log only, never surface, always restart
+            console.warn('[Lockscreen] wipe failed part-way', e);
+        } finally {
+            RNRestart.Restart();
+        }
     };
 
     resetAuthenticationAttempts = () => {

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { Route } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import RNRestart from 'react-native-restart';
 
 import Button from '../components/Button';
 import Header from '../components/Header';
@@ -438,43 +439,24 @@ export default class Lockscreen extends React.Component<
     };
 
     deleteNodes = async () => {
-        const { SettingsStore } = this.props;
-        const { updateSettings } = SettingsStore;
-
         // Fully wipe wallet data (node data dirs, Cashu seeds + CDK db, swap
         // rescue key, keychain) so the duress action leaves no recoverable key
-        // material behind - not just the settings `nodes` pointer.
+        // material behind - not just the settings `nodes` pointer. Restart
+        // instead of writing settings: updateSettings() would merge into the
+        // pre-wipe in-memory blob and re-persist it (pins, passphrases and
+        // all), and a restart is also the only way to drop node credentials
+        // still held in memory by the stores.
         await clearAllData();
-
-        updateSettings({
-            nodes: undefined,
-            selectedNode: undefined,
-            authenticationAttempts: 0
-        }).then(() => {
-            this.proceed('IntroSplash');
-        });
+        RNRestart.Restart();
     };
 
     authenticationFailure = async () => {
-        const { SettingsStore } = this.props;
-        const { updateSettings } = SettingsStore;
-
-        // Fully wipe wallet data on repeated failed logins, then clear the
-        // local auth secrets. clearAllData() removes the node data dirs, Cashu
-        // seeds + CDK db, and swap rescue key the settings wipe leaves behind.
+        // Fully wipe wallet data on repeated failed logins. clearAllData()
+        // removes the node data dirs, Cashu seeds + CDK db, swap rescue key
+        // and the settings blob itself (including pins and passphrases).
+        // Restart instead of writing settings back - see deleteNodes above.
         await clearAllData();
-
-        updateSettings({
-            nodes: undefined,
-            selectedNode: undefined,
-            passphrase: '',
-            duressPassphrase: '',
-            pin: '',
-            duressPin: '',
-            authenticationAttempts: 0
-        }).then(() => {
-            this.proceed('IntroSplash');
-        });
+        RNRestart.Restart();
     };
 
     resetAuthenticationAttempts = () => {

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -348,7 +348,7 @@ export default class Lockscreen extends React.Component<
                 (duressPin && pinAttempt === duressPin))
         ) {
             SettingsStore.setLoginStatus(true);
-            this.deleteNodes();
+            await this.deleteNodes();
         } else {
             // need to fetch updated settings to get incremented value of
             // authenticationAttempts, in case there are multiple failed attempts in a row
@@ -364,7 +364,7 @@ export default class Lockscreen extends React.Component<
             if (authenticationAttempts >= maxAuthenticationAttempts) {
                 SettingsStore.setLoginStatus(true);
                 // wipe node configs, passwords, and pins
-                this.authenticationFailure();
+                await this.authenticationFailure();
             } else {
                 await updateSettings({ authenticationAttempts }).then(() => {
                     this.setState({


### PR DESCRIPTION
# Description

The duress PIN/passphrase wipe (`deleteNodes`) and the automatic 5-failed-attempts wipe (`authenticationFailure`) in `views/Lockscreen.tsx` only set `nodes: undefined` in the settings blob. Every piece of seed-bearing material survived the "wipe":

- the swap rescue key (`swaps-rescue-key`)
- the per-node Cashu seed phrase (`${nodeDir}-cashu-seed-phrase`), which is identical to the wallet mnemonic on 12-word LDK wallets
- the CDK ecash SQLite database (spendable bearer proofs)
- the on-disk LND/LDK node data directories (channel + wallet state)

An attacker who watches the user enter the duress PIN under coercion and then takes the device can recover the entire wallet from the keychain and on-disk state, even though the app shows an empty, wiped wallet. The feature provides false assurance to exactly the users who rely on it.

## Fix

Both wipe handlers now route through `clearAllData()`, which already cleared the keychain, Cashu seeds, CDK database, and swap rescue key. `clearAllData()` itself had the same node-directory gap (the Tools "Clear All Data" action left the node dirs behind too), so this adds node-data-directory deletion there, stopping the node first (`deleteLndWallet` stops LND internally; LDK is stopped via `stopLdkNode()` before unlinking). Routing both duress paths through the single `clearAllData()` avoids maintaining a second wipe list in `Lockscreen` that drifts out of sync.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Behavior change worth a maintainer decision

The 5-failed-attempts wipe is now genuinely destructive of on-disk wallet state, not just the settings pointer. That matches the security intent, but a user with no external seed backup now loses funds permanently on a lockout, whereas previously the data directory survived and was in principle recoverable. The 2026-08-01 audit listed "duress-wipe scope" as a known/accepted exclusion, so this crosses into keychain/settings-storage and security-feature territory that should get explicit sign-off before merge.

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

New `utils/DataClearUtils.test.ts` asserts `clearAllData()` stops and deletes each configured node's data directory (embedded-LND and LDK, single and multi-node, default `lndDir` fallback, ordering of stop-before-unlink, and the empty/missing-settings guards). Verified as a real regression guard: the positive-assertion tests fail when the node-directory deletion is removed.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

> Draft: not yet exercised on a device. Needs a two-platform run of the duress-PIN and 5-failed-attempts flows, asserting `swaps-rescue-key`, the `${nodeDir}-cashu-seed-phrase` entry, the CDK database, and the LDK/LND node directories are all gone afterward. The background-relock case (node actually running when the duress PIN is entered) is the most important path to exercise, since the startup lockscreen has no running node.

### Locales
- [ ] I've added new locale text that requires translations
- [x] N/A

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified