### PR TITLE
fix(security): purge orphaned key material on wallet deletion and wipe

### DIFF
--- a/android/app/src/main/java/com/zeus/LndMobileTools.java
+++ b/android/app/src/main/java/com/zeus/LndMobileTools.java
@@ -427,12 +427,18 @@ class LndMobileTools extends ReactContextBaseJavaModule {
     promise.resolve(null);
   }
 
-  void deleteRecursive(File fileOrDirectory) {
+  // Returns whether everything under fileOrDirectory was actually removed
+  boolean deleteRecursive(File fileOrDirectory) {
+    boolean success = true;
     if (fileOrDirectory.isDirectory()) {
-      for (File child : fileOrDirectory.listFiles()) {
-        deleteRecursive(child);
+      File[] children = fileOrDirectory.listFiles();
+      if (children != null) {
+        for (File child : children) {
+          success = deleteRecursive(child) && success;
+        }
       }
     }
+    return fileOrDirectory.delete() && success;
   }
 
   @ReactMethod
@@ -522,15 +528,32 @@ class LndMobileTools extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void deleteLndDirectory(String lndDir, Promise promise) {
-    String filename;
+    File filesDir = getReactApplicationContext().getFilesDir();
+    boolean success = true;
     if (lndDir.equals("lnd")) {
-      filename = "--lnddir=" + getReactApplicationContext().getFilesDir().getPath();
+      // Legacy wallets ran LND directly in the files-dir root, which also
+      // holds other wallets' directories, CDK databases, etc. Only delete
+      // LND's own artifacts there.
+      String[] lndArtifacts = { "data", "logs", "lnd.conf", "tls.cert", "tls.key" };
+      for (String artifact : lndArtifacts) {
+        File file = new File(filesDir, artifact);
+        if (file.exists()) {
+          success = deleteRecursive(file) && success;
+        }
+      }
     } else {
-      filename = "--lnddir=" + getReactApplicationContext().getFilesDir().getPath() + "/" + lndDir;
+      File file = new File(filesDir, lndDir);
+      if (file.exists()) {
+        success = deleteRecursive(file);
+      }
     }
-    File file = new File(filename);
-    deleteRecursive(file);
-    promise.resolve(null);
+    if (success) {
+      promise.resolve(null);
+    } else {
+      // Surface real failures so the JS-side retry logic (deleteLndWallet
+      // callers) does not treat a partial deletion as success
+      promise.reject("deleteLndDirectory", "Failed to fully delete LND directory: " + lndDir);
+    }
   }
 
   @ReactMethod

--- a/locales/en.json
+++ b/locales/en.json
@@ -375,6 +375,7 @@
     "views.Settings.WalletConfiguration.deleteWallet.channelsWarning": "This wallet has channels that are open or pending. We recommend exporting your channel backup file before proceeding to preserve your channels when restoring on another device.",
     "views.Settings.WalletConfiguration.deleteWallet.exportChannels": "Export Channels",
     "views.Settings.WalletConfiguration.deleteWallet.balanceWarning": "This wallet has an on-chain balance. Make sure you back up your seed before proceeding.",
+    "views.Settings.WalletConfiguration.deleteWallet.dataDirError": "Some of this wallet's data could not be removed from disk and may still contain wallet and channel state. Retry, or skip to leave the data behind.",
     "views.Settings.WalletConfiguration.duplicateWallet": "Duplicate Wallet Config",
     "views.Settings.WalletConfiguration.walletInterface": "Wallet interface",
     "views.Settings.AddEditNode.useTor": "Use Tor",

--- a/locales/en.json
+++ b/locales/en.json
@@ -979,6 +979,7 @@
     "views.Tools.clearStorage.message": "This will permanently delete all app data including settings, contacts, notes, and transaction history. The app will restart after clearing. Are you sure you want to continue?",
     "views.Tools.clearStorage.confirm": "Clear All Data",
     "views.Tools.clearStorage.error": "Failed to clear storage. Please try again.",
+    "views.Tools.clearStorage.clearing": "Clearing data...",
     "views.Tools.cashu": "Cashu Tools",
     "views.Tools.cashu.bumpWalletCounters": "Bump wallet counters",
     "views.Tools.cashu.bumpWalletCounters.subtitle": "Helpful if your wallet counters get out of sync and you encounter 'Outputs have already been signed before' errors.",

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -7,7 +7,7 @@ class Storage {
     // until the post-wipe restart lands, and any in-flight writer would
     // otherwise re-persist wiped data from memory (SettingsStore.updateSettings
     // merges the full in-memory settings on a storage miss, resurrecting every
-    // node config). The reload after RNRestart resets this naturally.
+    // node config). The post-wipe restart (restartApp) resets this naturally.
     private writesBlocked = false;
 
     blockWrites = () => {

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -3,6 +3,17 @@ import * as Keychain from 'react-native-keychain';
 const KEY_PREFIX = 'zeus:';
 
 class Storage {
+    // Set once a data wipe has started. The dying JS context keeps running
+    // until the post-wipe restart lands, and any in-flight writer would
+    // otherwise re-persist wiped data from memory (SettingsStore.updateSettings
+    // merges the full in-memory settings on a storage miss, resurrecting every
+    // node config). The reload after RNRestart resets this naturally.
+    private writesBlocked = false;
+
+    blockWrites = () => {
+        this.writesBlocked = true;
+    };
+
     private prefixKey = (key: string) => `${KEY_PREFIX}${key}`;
 
     getItem = async (key: string) => {
@@ -21,6 +32,11 @@ class Storage {
     };
 
     setItem = async (key: string, value: any) => {
+        if (this.writesBlocked) {
+            console.warn(`[Storage] Write blocked during data wipe: ${key}`);
+            return false;
+        }
+
         const prefixedKey = this.prefixKey(key);
         const stringValue =
             typeof value === 'string' ? value : JSON.stringify(value);

--- a/stores/NodeInfoStore.ts
+++ b/stores/NodeInfoStore.ts
@@ -5,6 +5,7 @@ import ChannelsStore from './ChannelsStore';
 import SettingsStore from './SettingsStore';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
 import BackendUtils from '../utils/BackendUtils';
+import Storage from '../storage';
 
 import Channel from '../models/Channel';
 
@@ -20,6 +21,8 @@ export default class NodeInfoStore {
     @observable public supportsListingOffers: boolean;
     channelsStore: ChannelsStore;
     settingsStore: SettingsStore;
+    // nodeIds whose legacy xprv cache has been purged this session
+    private purgedXprvCacheFor: string | null = null;
 
     constructor(channelsStore: ChannelsStore, settingsStore: SettingsStore) {
         this.channelsStore = channelsStore;
@@ -76,6 +79,21 @@ export default class NodeInfoStore {
                         this.supportsListingOffers =
                             BackendUtils.supportsListingOffers();
                     });
+                    // Purge the legacy '<pubkey>-extended-private-keys' xprv
+                    // cache written by older builds (KEY-006). Done here,
+                    // where the node pubkey is definitionally known: the
+                    // SeedQRExport read-site purge silently no-ops when
+                    // nodeInfo has not loaded yet (observed on-device), and
+                    // this also covers users who never open that screen.
+                    if (
+                        nodeInfo.nodeId &&
+                        this.purgedXprvCacheFor !== nodeInfo.nodeId
+                    ) {
+                        this.purgedXprvCacheFor = nodeInfo.nodeId;
+                        Storage.removeItem(
+                            `${nodeInfo.nodeId}-extended-private-keys`
+                        ).catch(() => {});
+                    }
                     resolve(nodeInfo);
                 })
                 .catch((error: any) => {

--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -160,6 +160,32 @@ describe('SettingsStore.updateSettings', () => {
         expect(StorageMock._backing[STORAGE_KEY]).not.toContain('hunter2');
     });
 
+    it('keeps memory consistent with disk when the write is blocked', async () => {
+        seedSettings({ fiat: 'USD', locale: 'en' });
+        const store = new SettingsStore();
+        // Load once so the store holds the seeded settings before the
+        // blocked write, mirroring a wipe that latches mid-session.
+        await store.getSettings();
+
+        // Storage.setItem returns false while the data-wipe write latch
+        // is engaged (storage/index.ts blockWrites).
+        StorageMock.setItem.mockImplementationOnce(async () => false);
+        const result = await store.updateSettings({ fiat: 'EUR' });
+
+        // The unpersisted update must not surface anywhere: not in the
+        // returned settings, not in memory, not in derived state.
+        expect(result.fiat).toEqual('USD');
+        expect(store.settings.fiat).toEqual('USD');
+        expect(store.triggerSettingsRefresh).toEqual(false);
+        expect(persistedSettings().fiat).toEqual('USD');
+
+        // Once writes land again, updates flow through as normal.
+        const after = await store.updateSettings({ fiat: 'CAD' });
+        expect(after.fiat).toEqual('CAD');
+        expect(store.settings.fiat).toEqual('CAD');
+        expect(persistedSettings().fiat).toEqual('CAD');
+    });
+
     it('keeps processing queued updates after one rejects', async () => {
         seedSettings({ fiat: 'USD' });
         const store = new SettingsStore();

--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -1,0 +1,178 @@
+// Regression coverage for the updateSettings lost-update race (KEY-006
+// review follow-up): updateSettings is a read-merge-write against the
+// persisted settings blob, so two concurrent callers could each read the
+// same snapshot and the later write would clobber the earlier one. The
+// worst case is a background settings write straddling a wallet deletion:
+// its stale snapshot still contains the deleted node, so committing it
+// resurrects the node config, seed phrase and wallet password included,
+// after the wallet's keychain material and data directories are gone.
+// updateSettings now serializes updates through an internal queue and
+// accepts a functional updater so deletion computes the new nodes array
+// inside the critical section.
+
+jest.mock('react-native-biometrics', () => ({ BiometryType: {} }));
+jest.mock('react-native-blob-util', () => ({
+    fs: {
+        dirs: { LibraryDir: '/lib', DocumentDir: '/docs' }
+    }
+}));
+jest.mock('react-native-encrypted-storage', () => ({
+    getItem: jest.fn().mockResolvedValue(null),
+    setItem: jest.fn().mockResolvedValue(undefined),
+    removeItem: jest.fn().mockResolvedValue(undefined)
+}));
+
+jest.mock('../utils/BackendUtils', () => ({}));
+jest.mock('../utils/BiometricUtils', () => ({
+    getSupportedBiometryType: jest.fn().mockResolvedValue(undefined)
+}));
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (s: string) => s
+}));
+jest.mock('../utils/MigrationUtils', () => ({
+    keychainCloudSyncMigration: jest.fn().mockResolvedValue(undefined),
+    migrateRgsDefaultToZeus: jest.fn().mockResolvedValue(undefined),
+    migrateInvoiceExpiryDisplay: jest.fn().mockResolvedValue(undefined),
+    legacySettingsMigrations: jest.fn().mockResolvedValue({}),
+    storageMigrationV2: jest.fn().mockResolvedValue(undefined)
+}));
+jest.mock('../utils/TorUtils', () => ({
+    doTorRequest: jest.fn(),
+    RequestMethod: {}
+}));
+jest.mock('../utils/LdkNodeUtils', () => ({
+    DEFAULT_SCORER_URL: '',
+    DEFAULT_VSS_SERVER: '',
+    getDefaultEsploraServer: jest.fn().mockReturnValue(''),
+    getDefaultRgsServer: jest.fn().mockReturnValue('')
+}));
+
+// In-memory keychain-backed storage: getItem returns the persisted string
+// or false, setItem stringifies objects, matching storage/index.ts. Every
+// call resolves through the microtask queue, so unserialized concurrent
+// read-merge-write cycles genuinely interleave (both reads complete before
+// either write) and the lost update reproduces without the queue.
+jest.mock('../storage', () => {
+    const backing: Record<string, string> = {};
+    return {
+        _backing: backing,
+        getItem: jest.fn(async (key: string) => backing[key] ?? false),
+        setItem: jest.fn(async (key: string, value: any) => {
+            backing[key] =
+                typeof value === 'string' ? value : JSON.stringify(value);
+            return true;
+        }),
+        removeItem: jest.fn(async (key: string) => {
+            delete backing[key];
+            return true;
+        })
+    };
+});
+
+import SettingsStore, { STORAGE_KEY } from './SettingsStore';
+
+const StorageMock: any = jest.requireMock('../storage');
+
+const seedSettings = (settings: any) => {
+    StorageMock._backing[STORAGE_KEY] = JSON.stringify(settings);
+};
+
+const persistedSettings = () => JSON.parse(StorageMock._backing[STORAGE_KEY]);
+
+let logSpy: jest.SpyInstance;
+
+beforeEach(() => {
+    for (const key of Object.keys(StorageMock._backing)) {
+        delete StorageMock._backing[key];
+    }
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    logSpy.mockRestore();
+});
+
+describe('SettingsStore.updateSettings', () => {
+    it('serializes concurrent updates so neither is lost', async () => {
+        seedSettings({ fiat: 'USD', locale: 'en' });
+        const store = new SettingsStore();
+
+        // Fired without awaiting in between: both would read the same
+        // snapshot if updates were not queued, and the later write would
+        // drop the earlier one's key.
+        const [first, second] = await Promise.all([
+            store.updateSettings({ fiat: 'EUR' }),
+            store.updateSettings({ locale: 'cs' })
+        ]);
+
+        expect(first.fiat).toEqual('EUR');
+        expect(second.fiat).toEqual('EUR');
+        expect(second.locale).toEqual('cs');
+
+        const persisted = persistedSettings();
+        expect(persisted.fiat).toEqual('EUR');
+        expect(persisted.locale).toEqual('cs');
+    });
+
+    it('does not resurrect a deleted node from a straddling write', async () => {
+        const embeddedNode = {
+            implementation: 'embedded-lnd',
+            lndDir: 'lnd',
+            seedPhrase: ['abandon', 'ability', 'able'],
+            walletPassword: 'hunter2',
+            certVerification: false,
+            dismissCustodialWarning: true
+        };
+        const remoteNode = {
+            implementation: 'lnd',
+            host: 'example.com',
+            certVerification: true,
+            dismissCustodialWarning: true
+        };
+        seedSettings({
+            nodes: [embeddedNode, remoteNode],
+            selectedNode: 1,
+            fiat: 'USD'
+        });
+        const store = new SettingsStore();
+
+        // A background write starts before the deletion and would finish
+        // after it; the deletion uses a functional updater so the new
+        // nodes array is computed inside the critical section.
+        await Promise.all([
+            store.updateSettings({ fiat: 'EUR' }),
+            store.updateSettings((currentSettings: any) => ({
+                nodes: (currentSettings.nodes || []).filter(
+                    (_: any, i: number) => i !== 0
+                ),
+                selectedNode: 0,
+                justDeletedWallet: false
+            }))
+        ]);
+
+        const persisted = persistedSettings();
+        expect(persisted.fiat).toEqual('EUR');
+        expect(persisted.nodes).toHaveLength(1);
+        expect(persisted.nodes[0].host).toEqual('example.com');
+        // The deleted node's key material must not survive anywhere in
+        // the persisted blob.
+        expect(StorageMock._backing[STORAGE_KEY]).not.toContain('abandon');
+        expect(StorageMock._backing[STORAGE_KEY]).not.toContain('hunter2');
+    });
+
+    it('keeps processing queued updates after one rejects', async () => {
+        seedSettings({ fiat: 'USD' });
+        const store = new SettingsStore();
+
+        await expect(
+            store.updateSettings(() => {
+                throw new Error('boom');
+            })
+        ).rejects.toThrow('boom');
+
+        const result = await store.updateSettings({ fiat: 'CAD' });
+        expect(result.fiat).toEqual('CAD');
+        expect(persistedSettings().fiat).toEqual('CAD');
+        expect(store.settingsUpdateInProgress).toEqual(false);
+    });
+});

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1973,28 +1973,60 @@ export default class SettingsStore {
         return settings;
     }
 
-    public updateSettings = async (newSetting: any) => {
+    // Serializes updateSettings calls. Each update is a read-merge-write
+    // against the persisted blob; without ordering, a caller that read
+    // before another's write can commit a stale snapshot over it, e.g. a
+    // background update straddling a wallet deletion writes the old nodes
+    // array back, resurrecting the deleted node's seed and password.
+    private updateSettingsQueue: Promise<unknown> = Promise.resolve();
+
+    public updateSettings = (
+        newSetting: any | ((currentSettings: Settings) => any)
+    ): Promise<Settings> => {
+        const task = this.updateSettingsQueue.then(() =>
+            this.applySettingsUpdate(newSetting)
+        );
+        // Keep the queue alive after a rejected update; the caller still
+        // sees the rejection through `task`.
+        this.updateSettingsQueue = task.catch(() => undefined);
+        return task;
+    };
+
+    private applySettingsUpdate = async (
+        newSetting: any | ((currentSettings: Settings) => any)
+    ) => {
         this.settingsUpdateInProgress = true;
-        const existingSettings = await this.getSettings();
-        const newSettings = {
-            ...existingSettings,
-            ...newSetting
-        };
+        try {
+            const existingSettings = await this.getSettings();
+            // Functional updates read the settings inside the critical
+            // section, so callers whose new value depends on the current
+            // one (delete node X from the array) cannot act on a snapshot
+            // taken before earlier queued writes landed.
+            const resolvedSetting =
+                typeof newSetting === 'function'
+                    ? newSetting(existingSettings)
+                    : newSetting;
+            const newSettings = {
+                ...existingSettings,
+                ...resolvedSetting
+            };
 
-        if (
-            newSetting.pos?.posEnabled &&
-            newSetting.pos.posEnabled !== PosEnabled.Disabled
-        ) {
-            this.posWasEnabled = true;
+            if (
+                resolvedSetting.pos?.posEnabled &&
+                resolvedSetting.pos.posEnabled !== PosEnabled.Disabled
+            ) {
+                this.posWasEnabled = true;
+            }
+
+            await this.setSettings(newSettings);
+            this.triggerSettingsRefresh = true;
+
+            // Update store's node properties from latest settings
+            this.updateNodeProperties(newSettings);
+            return newSettings;
+        } finally {
+            this.settingsUpdateInProgress = false;
         }
-
-        await this.setSettings(newSettings);
-        this.triggerSettingsRefresh = true;
-
-        // Update store's node properties from latest settings
-        this.updateNodeProperties(newSettings);
-        this.settingsUpdateInProgress = false;
-        return newSettings;
     };
 
     // LNDHub

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1965,12 +1965,20 @@ export default class SettingsStore {
         return this.settings;
     };
 
-    public async setSettings(settings: any) {
+    // Returns whether the settings were persisted. Storage.setItem returns
+    // false while the data-wipe write latch is engaged (and the keychain
+    // call itself is typed `false | Result`); in-memory settings only
+    // update when the write landed, so a blocked write cannot leave the
+    // store advertising state that will not survive the imminent restart.
+    public async setSettings(settings: any): Promise<boolean> {
         this.loading = true;
-        await Storage.setItem(STORAGE_KEY, settings);
-        this.settings = settings;
+        const persisted =
+            (await Storage.setItem(STORAGE_KEY, settings)) !== false;
+        if (persisted) {
+            this.settings = settings;
+        }
         this.loading = false;
-        return settings;
+        return persisted;
     }
 
     // Serializes updateSettings calls. Each update is a read-merge-write
@@ -2018,7 +2026,13 @@ export default class SettingsStore {
                 this.posWasEnabled = true;
             }
 
-            await this.setSettings(newSettings);
+            const persisted = await this.setSettings(newSettings);
+            if (!persisted) {
+                // Write latch engaged (data wipe in progress): nothing was
+                // persisted or kept in memory, so skip the derived-state
+                // updates that would advertise the unsaved settings.
+                return this.settings;
+            }
             this.triggerSettingsRefresh = true;
 
             // Update store's node properties from latest settings

--- a/utils/AezeedUtils.test.ts
+++ b/utils/AezeedUtils.test.ts
@@ -1,0 +1,61 @@
+// Golden vectors generated with lnd v0.19.2-beta Go code:
+// aezeed.CipherSeed.ToMnemonic / Mnemonic.ToCipherSeed for the entropy, and
+// hdkeychain.NewMaster(entropy) derived along m/1017'/coinType'/6'/0/0 (lnd's
+// node identity key, keychain.KeyFamilyNodeKey) for the node ids. This pins
+// the exact derivation DataClearUtils relies on to locate the legacy
+// '<pubkey>-extended-private-keys' keychain entry from a wallet's seed.
+
+import {
+    decodeAezeedEntropy,
+    deriveEmbeddedNodeId,
+    deriveNodeIdFromEntropy
+} from './AezeedUtils';
+
+const MNEMONIC = (
+    'absorb spawn orbit course shock genuine fitness speak horn entry ' +
+    'bean narrow leader amateur fatigue utility hard cactus abandon ' +
+    'abandon abandon feature hurdle rate'
+).split(' ');
+
+const ENTROPY_HEX = '00070e151c232a31383f464d545b6269';
+const NODE_ID_MAINNET =
+    '020b4e17f82873d40c1abff7a9140b6a56c04a845e1abe6ab71ef3269836d47abd';
+const NODE_ID_TESTNET =
+    '03b3447cd5aadff1b93dc1eec5124738e22378dc9eb5ab9f5378477534d1acb037';
+
+// scrypt (N=32768) runs for real in these tests
+jest.setTimeout(30000);
+
+describe('decodeAezeedEntropy', () => {
+    it('decrypts an lnd-generated aezeed mnemonic to its entropy', async () => {
+        const entropy = await decodeAezeedEntropy(MNEMONIC);
+        expect(entropy.toString('hex')).toBe(ENTROPY_HEX);
+    });
+
+    it('rejects a mnemonic with a bad checksum', async () => {
+        const tampered = [...MNEMONIC];
+        tampered[0] = 'ability';
+        await expect(decodeAezeedEntropy(tampered)).rejects.toThrow(
+            'Invalid seed checksum!'
+        );
+    });
+});
+
+describe('deriveNodeIdFromEntropy', () => {
+    const entropy = Buffer.from(ENTROPY_HEX, 'hex');
+
+    it('derives the mainnet node identity pubkey (coin type 0)', () => {
+        expect(deriveNodeIdFromEntropy(entropy, false)).toBe(NODE_ID_MAINNET);
+    });
+
+    it('derives the testnet node identity pubkey (coin type 1)', () => {
+        expect(deriveNodeIdFromEntropy(entropy, true)).toBe(NODE_ID_TESTNET);
+    });
+});
+
+describe('deriveEmbeddedNodeId', () => {
+    it('derives the node id straight from the mnemonic', async () => {
+        const nodeId = await deriveEmbeddedNodeId(MNEMONIC, false);
+        expect(nodeId).toBe(NODE_ID_MAINNET);
+    });
+});

--- a/utils/AezeedUtils.ts
+++ b/utils/AezeedUtils.ts
@@ -100,14 +100,15 @@ export async function decodeAezeedEntropy(
 /**
  * Derives the lnd node identity pubkey (hex-encoded, compressed) from wallet
  * entropy: BIP32 master -> m/1017'/coinType'/6'/0/0 (purpose 1017, key
- * family 6 = node key). Coin type is 0 on mainnet and 1 on testnet,
- * matching btcd's HDCoinType params.
+ * family 6 = node key). Coin type is 0 on mainnet and 1 on every other
+ * network: btcd's HDCoinType is 1 for testnet, signet (mutinynet), and
+ * regtest alike.
  */
 export function deriveNodeIdFromEntropy(
     entropy: Buffer,
-    isTestNet: boolean
+    nonMainnet: boolean
 ): string {
-    const coinType = isTestNet ? 1 : 0;
+    const coinType = nonMainnet ? 1 : 0;
     return bip32
         .fromSeed(entropy)
         .derivePath(`m/1017'/${coinType}'/6'/0/0`)
@@ -122,8 +123,8 @@ export function deriveNodeIdFromEntropy(
  */
 export async function deriveEmbeddedNodeId(
     seedPhrase: string[],
-    isTestNet: boolean
+    nonMainnet: boolean
 ): Promise<string> {
     const entropy = await decodeAezeedEntropy(seedPhrase);
-    return deriveNodeIdFromEntropy(entropy, isTestNet);
+    return deriveNodeIdFromEntropy(entropy, nonMainnet);
 }

--- a/utils/AezeedUtils.ts
+++ b/utils/AezeedUtils.ts
@@ -1,0 +1,129 @@
+import BIP32Factory from 'bip32';
+import ecc from '../zeus_modules/noble_ecc';
+
+import { BIP39_WORD_LIST } from './Bip39Utils';
+
+// You must wrap a tiny-secp256k1 compatible implementation
+const bip32 = BIP32Factory(ecc);
+
+const aez = require('aez');
+const crc32 = require('fast-crc32c/impls/js_crc32c');
+const scrypt = require('scrypt-js').scrypt;
+
+const AEZEED_DEFAULT_PASSPHRASE = 'aezeed',
+    AEZEED_VERSION = 0,
+    SCRYPT_N = 32768,
+    SCRYPT_R = 8,
+    SCRYPT_P = 1,
+    SCRYPT_KEY_LENGTH = 32,
+    ENCIPHERED_LENGTH = 33,
+    SALT_LENGTH = 5,
+    AD_LENGTH = SALT_LENGTH + 1,
+    AEZ_TAU = 4,
+    CHECKSUM_LENGTH = 4,
+    CHECKSUM_OFFSET = ENCIPHERED_LENGTH - CHECKSUM_LENGTH,
+    SALT_OFFSET = CHECKSUM_OFFSET - SALT_LENGTH;
+
+function lpad(str: string, padString: string, length: number) {
+    while (str.length < length) {
+        str = padString + str;
+    }
+    return str;
+}
+
+function getAD(salt: Buffer) {
+    const ad = Buffer.alloc(AD_LENGTH, AEZEED_VERSION);
+    salt.copy(ad, 1);
+    return ad;
+}
+
+/**
+ * Decrypts an aezeed cipher seed mnemonic (with the default passphrase) and
+ * returns the 16 bytes of wallet entropy, which lnd uses directly as the
+ * BIP32 master seed. Throws when the mnemonic is not a valid aezeed or was
+ * enciphered with a non-default passphrase.
+ */
+export async function decodeAezeedEntropy(
+    seedPhrase: string[]
+): Promise<Buffer> {
+    const bits = seedPhrase
+        .map((word: string) => {
+            const index = BIP39_WORD_LIST.indexOf(word);
+            return lpad(index.toString(2), '0', 11);
+        })
+        .join('');
+
+    const seedBytes = (bits.match(/(.{1,8})/g) || []).map((bin: string) =>
+        parseInt(bin, 2)
+    );
+    const seed = Buffer.from(seedBytes);
+
+    if (!seed || seed.length === 0 || seed[0] !== AEZEED_VERSION) {
+        throw new Error('Invalid seed or version!');
+    }
+
+    const salt = seed.slice(SALT_OFFSET, SALT_OFFSET + SALT_LENGTH);
+    const password = Buffer.from(AEZEED_DEFAULT_PASSPHRASE, 'utf8');
+    const cipherSeed = seed.slice(1, SALT_OFFSET);
+    const checksum = seed.slice(CHECKSUM_OFFSET);
+
+    const newChecksum = crc32.calculate(seed.slice(0, CHECKSUM_OFFSET));
+    if (newChecksum !== checksum.readUInt32BE(0)) {
+        throw new Error('Invalid seed checksum!');
+    }
+
+    const key = await scrypt(
+        password,
+        salt,
+        SCRYPT_N,
+        SCRYPT_R,
+        SCRYPT_P,
+        SCRYPT_KEY_LENGTH
+    );
+
+    const plainSeedBytes = aez.decrypt(
+        key,
+        null,
+        [getAD(salt)],
+        AEZ_TAU,
+        cipherSeed
+    );
+
+    if (plainSeedBytes == null) {
+        throw new Error('Decryption failed. Invalid passphrase?');
+    }
+
+    // plaintext layout: internal version (1) + birthday (2) + entropy (16)
+    return plainSeedBytes.slice(3);
+}
+
+/**
+ * Derives the lnd node identity pubkey (hex-encoded, compressed) from wallet
+ * entropy: BIP32 master -> m/1017'/coinType'/6'/0/0 (purpose 1017, key
+ * family 6 = node key). Coin type is 0 on mainnet and 1 on testnet,
+ * matching btcd's HDCoinType params.
+ */
+export function deriveNodeIdFromEntropy(
+    entropy: Buffer,
+    isTestNet: boolean
+): string {
+    const coinType = isTestNet ? 1 : 0;
+    return bip32
+        .fromSeed(entropy)
+        .derivePath(`m/1017'/${coinType}'/6'/0/0`)
+        .publicKey.toString('hex');
+}
+
+/**
+ * Derives an embedded LND wallet's node identity pubkey straight from its
+ * aezeed mnemonic. This is what NodeInfoStore reports as nodeId once the
+ * node is running, but computed offline, so key material namespaced by
+ * pubkey can be located after the wallet config is all that remains.
+ */
+export async function deriveEmbeddedNodeId(
+    seedPhrase: string[],
+    isTestNet: boolean
+): Promise<string> {
+    const entropy = await decodeAezeedEntropy(seedPhrase);
+    return deriveNodeIdFromEntropy(entropy, isTestNet);
+}

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -109,8 +109,10 @@ jest.mock('../utils/SwapUtils', () => ({
     SWAPS_LAST_USED_KEY: 'swaps-last-used-key'
 }));
 
+import hashjs from 'hash.js';
+
 import Storage from '../storage';
-import { clearAllData } from './DataClearUtils';
+import { clearAllData, clearNodeKeychainData } from './DataClearUtils';
 import { deleteLndWallet } from './LndMobileUtils';
 import { deleteLdkNodeWallet, stopLdkNode } from './LdkNodeUtils';
 import { sleep } from './SleepUtils';
@@ -120,6 +122,14 @@ const mockedDeleteLdkNodeWallet = deleteLdkNodeWallet as jest.Mock;
 const mockedStopLdkNode = stopLdkNode as jest.Mock;
 const mockedStorageGetItem = Storage.getItem as jest.Mock;
 const mockedSleep = sleep as jest.Mock;
+const mockedStorageRemoveItem = Storage.removeItem as jest.Mock;
+
+const lncHash = (value: string) => hashjs.sha256().update(value).digest('hex');
+
+// clearKey() clears each key via Storage.removeItem(rawKey); asserting on it is
+// the cleanest way to prove a namespaced key was targeted by a wipe.
+const removedKeys = () =>
+    mockedStorageRemoveItem.mock.calls.map((call) => call[0]);
 
 // Keep test output clean
 jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -305,5 +315,95 @@ describe('clearAllData node data directory retry', () => {
 
         expect(mockedDeleteLndWallet).toHaveBeenCalledTimes(3);
         expect(mockedDeleteLdkNodeWallet).toHaveBeenCalledWith('ldk-2');
+    });
+});
+
+describe('clearAllData orphaned key material (KEY-006 regression)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedStorageGetItem.mockResolvedValue(null);
+        mockedDeleteLndWallet.mockResolvedValue(true);
+        mockedDeleteLdkNodeWallet.mockResolvedValue(undefined);
+    });
+
+    it('clears the LDK-node-namespaced Cashu seed phrase (== wallet mnemonic)', async () => {
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([
+                { implementation: 'ldk-node', ldkNodeDir: 'ldk-node-xyz' }
+            ]).getItem
+        );
+
+        await clearAllData();
+
+        // Previously only lndDir was iterated, so this key survived a full wipe
+        expect(removedKeys()).toContain('ldk-node-xyz-cashu-seed-phrase');
+    });
+
+    it('clears the default "ldk" node dir Cashu data', async () => {
+        mockedStorageGetItem.mockImplementation(settingsWithNodes([]).getItem);
+
+        await clearAllData();
+
+        expect(removedKeys()).toContain('ldk-cashu-seed-phrase');
+    });
+
+    it('clears the hashed LNC pairing credentials for an LNC node', async () => {
+        const pairingPhrase = 'cherry truth mask employ box silver mass bunker';
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([
+                {
+                    implementation: 'lightning-node-connect',
+                    pairingPhrase
+                }
+            ]).getItem
+        );
+
+        await clearAllData();
+
+        const baseKey = `lnc-rn:${lncHash(pairingPhrase)}`;
+        expect(removedKeys()).toContain(baseKey);
+        expect(removedKeys()).toContain(`${baseKey}:host`);
+    });
+});
+
+describe('clearNodeKeychainData (single-wallet deletion helper)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedStorageGetItem.mockResolvedValue(null);
+    });
+
+    it('clears Cashu data for an embedded-lnd node dir', async () => {
+        await clearNodeKeychainData({
+            implementation: 'embedded-lnd',
+            lndDir: 'lnd-abc'
+        });
+
+        expect(removedKeys()).toContain('lnd-abc-cashu-seed-phrase');
+    });
+
+    it('clears Cashu data for an ldk-node dir', async () => {
+        await clearNodeKeychainData({
+            implementation: 'ldk-node',
+            ldkNodeDir: 'ldk-2'
+        });
+
+        expect(removedKeys()).toContain('ldk-2-cashu-seed-phrase');
+    });
+
+    it('clears hashed LNC credentials from the pairing phrase', async () => {
+        const pairingPhrase = 'over hover clever trigger';
+        await clearNodeKeychainData({
+            implementation: 'lightning-node-connect',
+            pairingPhrase
+        });
+
+        const baseKey = `lnc-rn:${lncHash(pairingPhrase)}`;
+        expect(removedKeys()).toContain(baseKey);
+        expect(removedKeys()).toContain(`${baseKey}:host`);
+    });
+
+    it('is a no-op for a null node', async () => {
+        await expect(clearNodeKeychainData(null)).resolves.toBeUndefined();
+        expect(mockedStorageRemoveItem).not.toHaveBeenCalled();
     });
 });

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -45,6 +45,17 @@ jest.mock('./SleepUtils', () => ({
     sleep: jest.fn().mockResolvedValue(undefined)
 }));
 
+// The real derivation runs scrypt (N=32768); its correctness is pinned by
+// AezeedUtils.test.ts against lnd-generated golden vectors. Here only the
+// wiring matters: the derived pubkey must be turned into a cleared key.
+jest.mock('./AezeedUtils', () => ({
+    deriveEmbeddedNodeId: jest
+        .fn()
+        .mockResolvedValue(
+            '020b4e17f82873d40c1abff7a9140b6a56c04a845e1abe6ab71ef3269836d47abd'
+        )
+}));
+
 // Store modules are imported only for their storage-key constants; mock them
 // so the real (native-dependency-heavy) store modules are never loaded.
 jest.mock('../stores/SettingsStore', () => ({
@@ -131,6 +142,7 @@ import fs from 'fs';
 import path from 'path';
 
 import Storage from '../storage';
+import { deriveEmbeddedNodeId } from './AezeedUtils';
 import {
     clearAllData,
     clearNodeKeychainData,
@@ -450,6 +462,121 @@ describe('clearNodeKeychainData (single-wallet deletion helper)', () => {
     it('is a no-op for a null node', async () => {
         await expect(clearNodeKeychainData(null)).resolves.toBeUndefined();
         expect(mockedStorageRemoveItem).not.toHaveBeenCalled();
+    });
+});
+
+// Reviewer follow-up on KEY-006: '<pubkey>-extended-private-keys' was not
+// removed by clearAllData / clearNodeKeychainData because the pubkey is not
+// in the node config. It is now re-derived from the embedded wallet's aezeed
+// so deletion and (iOS) full wipes can clear the entry.
+describe('legacy xprv cache purge (KEY-006 follow-up)', () => {
+    const mockedDerive = deriveEmbeddedNodeId as jest.Mock;
+    const NODE_ID =
+        '020b4e17f82873d40c1abff7a9140b6a56c04a845e1abe6ab71ef3269836d47abd';
+    const XPRV_KEY = `${NODE_ID}-extended-private-keys`;
+    const seedPhrase = ['absorb', 'spawn', 'orbit', 'course'];
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedStorageGetItem.mockResolvedValue(null);
+        mockedDeleteLndWallet.mockResolvedValue(true);
+        mockedDeleteLdkNodeWallet.mockResolvedValue(undefined);
+        mockedDerive.mockResolvedValue(NODE_ID);
+    });
+
+    it('clears the xprv cache on single-wallet deletion (mainnet)', async () => {
+        await clearNodeKeychainData({
+            implementation: 'embedded-lnd',
+            lndDir: 'lnd-abc',
+            seedPhrase,
+            embeddedLndNetwork: 'Mainnet'
+        });
+
+        expect(mockedDerive).toHaveBeenCalledWith(seedPhrase, false);
+        expect(removedKeys()).toContain(XPRV_KEY);
+    });
+
+    it('derives with coin type 1 for a Testnet wallet', async () => {
+        await clearNodeKeychainData({
+            implementation: 'embedded-lnd',
+            lndDir: 'lnd-abc',
+            seedPhrase,
+            embeddedLndNetwork: 'Testnet'
+        });
+
+        expect(mockedDerive).toHaveBeenCalledWith(seedPhrase, true);
+    });
+
+    it('does not attempt derivation without a seed phrase', async () => {
+        await clearNodeKeychainData({
+            implementation: 'embedded-lnd',
+            lndDir: 'lnd-abc'
+        });
+
+        expect(mockedDerive).not.toHaveBeenCalled();
+    });
+
+    it('does not attempt derivation for remote nodes', async () => {
+        await clearNodeKeychainData({
+            implementation: 'lnd',
+            seedPhrase
+        });
+
+        expect(mockedDerive).not.toHaveBeenCalled();
+    });
+
+    it('still clears the other node keys when derivation fails (custom aezeed passphrase)', async () => {
+        mockedDerive.mockRejectedValueOnce(
+            new Error('Decryption failed. Invalid passphrase?')
+        );
+
+        await expect(
+            clearNodeKeychainData({
+                implementation: 'embedded-lnd',
+                lndDir: 'lnd-abc',
+                seedPhrase
+            })
+        ).resolves.toBeUndefined();
+
+        expect(removedKeys()).toContain('lnd-abc-cashu-seed-phrase');
+        expect(removedKeys()).not.toContain(XPRV_KEY);
+    });
+
+    it('clears the xprv cache during a full wipe on iOS', async () => {
+        // Platform.OS is 'ios' by default under the react-native jest preset
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([
+                {
+                    implementation: 'embedded-lnd',
+                    lndDir: 'lnd-abc',
+                    seedPhrase,
+                    embeddedLndNetwork: 'Mainnet'
+                }
+            ]).getItem
+        );
+
+        await clearAllData();
+
+        expect(removedKeys()).toContain(XPRV_KEY);
+    });
+
+    it('skips the scrypt-heavy derivation on an Android full wipe (backing store deletion covers it)', async () => {
+        jest.replaceProperty(Platform, 'OS', 'android');
+        mockedStorageGetItem.mockImplementation(
+            settingsWithNodes([
+                {
+                    implementation: 'embedded-lnd',
+                    lndDir: 'lnd-abc',
+                    seedPhrase,
+                    embeddedLndNetwork: 'Mainnet'
+                }
+            ]).getItem
+        );
+
+        await clearAllData();
+
+        expect(mockedDerive).not.toHaveBeenCalled();
+        jest.restoreAllMocks();
     });
 });
 

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -113,13 +113,17 @@ jest.mock('../utils/SwapUtils', () => ({
 import hashjs from 'hash.js';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 
+import fs from 'fs';
+import path from 'path';
+
 import Storage from '../storage';
 import {
     clearAllData,
     clearNodeKeychainData,
     clearCDKDatabase,
     clearCDKDatabaseForNode,
-    deleteNodeDataDirectoryWithRetry
+    deleteNodeDataDirectoryWithRetry,
+    CASHU_KEY_SUFFIXES
 } from './DataClearUtils';
 import { deleteLndWallet } from './LndMobileUtils';
 import { deleteLdkNodeWallet, stopLdkNode } from './LdkNodeUtils';
@@ -432,6 +436,61 @@ describe('clearNodeKeychainData (single-wallet deletion helper)', () => {
     it('is a no-op for a null node', async () => {
         await expect(clearNodeKeychainData(null)).resolves.toBeUndefined();
         expect(mockedStorageRemoveItem).not.toHaveBeenCalled();
+    });
+});
+
+describe('Cashu key clearing completeness', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedStorageGetItem.mockResolvedValue(null);
+    });
+
+    // Found on-device: '<nodeDir>-cashu-original-seed-version' survived wallet
+    // deletion because CashuStore had grown keys the clear list never learned
+    // about. Scan the store's source so the next new key fails this test
+    // instead of surviving a wipe.
+    it('CASHU_KEY_SUFFIXES covers every -cashu- key CashuStore writes', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../stores/CashuStore.ts'),
+            'utf8'
+        );
+        const found = Array.from(
+            source.matchAll(/-cashu-([A-Za-z0-9-]+)/g),
+            (m) => m[1]
+        );
+        const missing = [...new Set(found)].filter(
+            (suffix) => !CASHU_KEY_SUFFIXES.includes(suffix)
+        );
+        expect(missing).toEqual([]);
+    });
+
+    it('clears the keys the on-device test found surviving', async () => {
+        await clearNodeKeychainData({
+            implementation: 'embedded-lnd',
+            lndDir: 'lnd-abc'
+        });
+
+        expect(removedKeys()).toContain('lnd-abc-cashu-original-seed-version');
+        expect(removedKeys()).toContain('lnd-abc-cashu-offline-pending-tokens');
+        expect(removedKeys()).toContain('lnd-abc-cashu-offline-spent-tokens');
+    });
+
+    it('clears legacy per-mint wallet keys using the mint list read before clearing', async () => {
+        mockedStorageGetItem.mockImplementation((key: string) =>
+            key === 'lnd-abc-cashu-mintUrls'
+                ? Promise.resolve(JSON.stringify(['https://mint.example']))
+                : Promise.resolve(null)
+        );
+
+        await clearNodeKeychainData({
+            implementation: 'embedded-lnd',
+            lndDir: 'lnd-abc'
+        });
+
+        expect(removedKeys()).toContain('lnd-abc==https://mint.example-proofs');
+        expect(removedKeys()).toContain(
+            'lnd-abc==https://mint.example-counter'
+        );
     });
 });
 

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -390,6 +390,25 @@ describe('clearNodeKeychainData (single-wallet deletion helper)', () => {
         expect(removedKeys()).toContain('ldk-2-cashu-seed-phrase');
     });
 
+    it('falls back to the "lnd" namespace for a legacy embedded-lnd node without lndDir', async () => {
+        await clearNodeKeychainData({ implementation: 'embedded-lnd' });
+
+        expect(removedKeys()).toContain('lnd-cashu-seed-phrase');
+    });
+
+    it('falls back to the "ldk" namespace for a legacy ldk-node without ldkNodeDir', async () => {
+        await clearNodeKeychainData({ implementation: 'ldk-node' });
+
+        expect(removedKeys()).toContain('ldk-cashu-seed-phrase');
+    });
+
+    it('never clears the default namespaces for a remote node without dirs', async () => {
+        await clearNodeKeychainData({ implementation: 'lnd' });
+
+        expect(removedKeys()).not.toContain('lnd-cashu-seed-phrase');
+        expect(removedKeys()).not.toContain('ldk-cashu-seed-phrase');
+    });
+
     it('clears hashed LNC credentials from the pairing phrase', async () => {
         const pairingPhrase = 'over hover clever trigger';
         await clearNodeKeychainData({

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -118,7 +118,8 @@ import {
     clearAllData,
     clearNodeKeychainData,
     clearCDKDatabase,
-    clearCDKDatabaseForNode
+    clearCDKDatabaseForNode,
+    deleteNodeDataDirectoryWithRetry
 } from './DataClearUtils';
 import { deleteLndWallet } from './LndMobileUtils';
 import { deleteLdkNodeWallet, stopLdkNode } from './LdkNodeUtils';
@@ -431,6 +432,55 @@ describe('clearNodeKeychainData (single-wallet deletion helper)', () => {
     it('is a no-op for a null node', async () => {
         await expect(clearNodeKeychainData(null)).resolves.toBeUndefined();
         expect(mockedStorageRemoveItem).not.toHaveBeenCalled();
+    });
+});
+
+describe('deleteNodeDataDirectoryWithRetry (single-wallet deletion path)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedSleep.mockResolvedValue(undefined);
+    });
+
+    it('retries a failed embedded-lnd directory deletion and reports success', async () => {
+        mockedDeleteLndWallet
+            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce(true);
+
+        const result = await deleteNodeDataDirectoryWithRetry({
+            implementation: 'embedded-lnd',
+            lndDir: 'lnd-abc'
+        });
+
+        expect(result).toBe(true);
+        expect(mockedDeleteLndWallet).toHaveBeenCalledTimes(3);
+        expect(mockedDeleteLndWallet).toHaveBeenCalledWith('lnd-abc');
+    });
+
+    it('gives up after the attempt limit and reports failure', async () => {
+        mockedDeleteLndWallet.mockResolvedValue(false);
+
+        const result = await deleteNodeDataDirectoryWithRetry({
+            implementation: 'embedded-lnd',
+            lndDir: 'lnd-abc'
+        });
+
+        expect(result).toBe(false);
+        expect(mockedDeleteLndWallet).toHaveBeenCalledTimes(3);
+    });
+
+    it('stops the LDK node before deleting its directory', async () => {
+        mockedStopLdkNode.mockResolvedValue(undefined);
+        mockedDeleteLdkNodeWallet.mockResolvedValue(undefined);
+
+        const result = await deleteNodeDataDirectoryWithRetry({
+            implementation: 'ldk-node',
+            ldkNodeDir: 'ldk-2'
+        });
+
+        expect(result).toBe(true);
+        expect(mockedStopLdkNode).toHaveBeenCalled();
+        expect(mockedDeleteLdkNodeWallet).toHaveBeenCalledWith('ldk-2');
     });
 });
 

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -110,6 +110,18 @@ jest.mock('../utils/SwapUtils', () => ({
     SWAPS_RESCUE_KEY: 'swaps-rescue-key',
     SWAPS_LAST_USED_KEY: 'swaps-last-used-key'
 }));
+jest.mock('../stores/NostrWalletConnectStore', () => ({
+    NWC_CONNECTIONS_KEY: 'zeus-nwc-connections',
+    NWC_CLIENT_KEYS: 'zeus-nwc-client-keys',
+    NWC_SERVICE_KEYS: 'zeus-nwc-service-keys',
+    NWC_CASHU_ENABLED: 'zeus-nwc-cashu-enabled',
+    NWC_LUD16_ENABLED: 'zeus-nwc-lud16-enabled',
+    NWC_PERSISTENT_SERVICE_ENABLED: 'persistentNWCServicesEnabled'
+}));
+jest.mock('../utils/RatingUtils', () => ({
+    PAYMENT_COUNT_KEY: 'successfulPaymentCount',
+    RATING_DISMISSED_KEY: 'ratingDismissedPermanently'
+}));
 
 import hashjs from 'hash.js';
 import ReactNativeBlobUtil from 'react-native-blob-util';
@@ -446,6 +458,19 @@ describe('clearAllData write latch (settings resurrection regression)', () => {
         mockedStorageGetItem.mockResolvedValue(null);
         mockedDeleteLndWallet.mockResolvedValue(true);
         mockedDeleteLdkNodeWallet.mockResolvedValue(undefined);
+    });
+
+    // Found on-device after a full wipe: NWC service keys (nostr secret key
+    // material) survived because NostrWalletConnectStore's keys were never in
+    // the wipe list.
+    it('clears NWC key material and rating state', async () => {
+        await clearAllData();
+
+        expect(removedKeys()).toContain('zeus-nwc-service-keys');
+        expect(removedKeys()).toContain('zeus-nwc-client-keys');
+        expect(removedKeys()).toContain('zeus-nwc-connections');
+        expect(removedKeys()).toContain('successfulPaymentCount');
+        expect(removedKeys()).toContain('lnurlpay:');
     });
 
     // Observed on-device: an async updateSettings landed ~20ms after the wipe

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -507,6 +507,27 @@ describe('legacy xprv cache purge (KEY-006 follow-up)', () => {
         expect(mockedDerive).toHaveBeenCalledWith(seedPhrase, true);
     });
 
+    it('derives with coin type 1 for any non-mainnet network (mutinynet)', async () => {
+        await clearNodeKeychainData({
+            implementation: 'embedded-lnd',
+            lndDir: 'lnd-abc',
+            seedPhrase,
+            embeddedLndNetwork: 'mutinynet'
+        });
+
+        expect(mockedDerive).toHaveBeenCalledWith(seedPhrase, true);
+    });
+
+    it('defaults a config without embeddedLndNetwork to mainnet (coin type 0)', async () => {
+        await clearNodeKeychainData({
+            implementation: 'embedded-lnd',
+            lndDir: 'lnd-abc',
+            seedPhrase
+        });
+
+        expect(mockedDerive).toHaveBeenCalledWith(seedPhrase, false);
+    });
+
     it('does not attempt derivation without a seed phrase', async () => {
         await clearNodeKeychainData({
             implementation: 'embedded-lnd',

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -27,7 +27,8 @@ jest.mock('react-native-blob-util', () => ({
 jest.mock('../storage', () => ({
     getItem: jest.fn().mockResolvedValue(null),
     removeItem: jest.fn().mockResolvedValue(true),
-    setItem: jest.fn().mockResolvedValue(true)
+    setItem: jest.fn().mockResolvedValue(true),
+    blockWrites: jest.fn()
 }));
 
 // The functions under regression - assert clearAllData delegates to them.
@@ -436,6 +437,29 @@ describe('clearNodeKeychainData (single-wallet deletion helper)', () => {
     it('is a no-op for a null node', async () => {
         await expect(clearNodeKeychainData(null)).resolves.toBeUndefined();
         expect(mockedStorageRemoveItem).not.toHaveBeenCalled();
+    });
+});
+
+describe('clearAllData write latch (settings resurrection regression)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedStorageGetItem.mockResolvedValue(null);
+        mockedDeleteLndWallet.mockResolvedValue(true);
+        mockedDeleteLdkNodeWallet.mockResolvedValue(undefined);
+    });
+
+    // Observed on-device: an async updateSettings landed ~20ms after the wipe
+    // finished and re-persisted the full in-memory settings blob (every node
+    // config) because getSettings falls back to memory on a storage miss.
+    it('blocks Storage writes before clearing anything', async () => {
+        const mockedBlockWrites = (Storage as any).blockWrites as jest.Mock;
+
+        await clearAllData();
+
+        expect(mockedBlockWrites).toHaveBeenCalled();
+        expect(mockedBlockWrites.mock.invocationCallOrder[0]).toBeLessThan(
+            mockedStorageRemoveItem.mock.invocationCallOrder[0]
+        );
     });
 });
 

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -135,7 +135,7 @@ jest.mock('../utils/RatingUtils', () => ({
 }));
 
 import hashjs from 'hash.js';
-import { Platform } from 'react-native';
+import { BackHandler, Platform } from 'react-native';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 
 import fs from 'fs';
@@ -144,6 +144,7 @@ import path from 'path';
 import Storage from '../storage';
 import { deriveEmbeddedNodeId } from './AezeedUtils';
 import {
+    blockNavigationDuringWipe,
     clearAllData,
     clearNodeKeychainData,
     clearCDKDatabase,
@@ -970,5 +971,83 @@ describe('CDK database deletion', () => {
 
             expect(mockedUnlink).not.toHaveBeenCalled();
         });
+    });
+});
+
+describe('blockNavigationDuringWipe (mid-wipe navigation guard)', () => {
+    // Reported on-device (PR #4328): during the wipe's loading state the user
+    // could still leave the screen - hardware/gesture back exits the app from
+    // the lockscreen or pops the Tools screen while the wipe runs beneath it.
+    const makeNavigation = () => {
+        const removeBeforeRemove = jest.fn();
+        const navigation = {
+            setOptions: jest.fn(),
+            addListener: jest.fn().mockReturnValue(removeBeforeRemove)
+        };
+        return { navigation, removeBeforeRemove };
+    };
+
+    let backSubscription: { remove: jest.Mock };
+    let backHandlerSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        backSubscription = { remove: jest.fn() };
+        backHandlerSpy = jest
+            .spyOn(BackHandler, 'addEventListener')
+            .mockReturnValue(backSubscription as any);
+    });
+
+    afterEach(() => {
+        backHandlerSpy.mockRestore();
+    });
+
+    it('swallows hardware back presses for the duration of the wipe', () => {
+        const { navigation } = makeNavigation();
+
+        blockNavigationDuringWipe(navigation);
+
+        expect(backHandlerSpy).toHaveBeenCalledWith(
+            'hardwareBackPress',
+            expect.any(Function)
+        );
+        // returning true stops the event before the App-level handler can
+        // exit the app (lockscreen) or pop the screen (Tools)
+        const handler = backHandlerSpy.mock.calls[0][1];
+        expect(handler()).toBe(true);
+    });
+
+    it('blocks removal of the screen from the navigation stack', () => {
+        const { navigation } = makeNavigation();
+
+        blockNavigationDuringWipe(navigation);
+
+        expect(navigation.addListener).toHaveBeenCalledWith(
+            'beforeRemove',
+            expect.any(Function)
+        );
+        const listener = navigation.addListener.mock.calls[0][1];
+        const event = { preventDefault: jest.fn() };
+        listener(event);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('disables the iOS back-swipe gesture', () => {
+        const { navigation } = makeNavigation();
+
+        blockNavigationDuringWipe(navigation);
+
+        expect(navigation.setOptions).toHaveBeenCalledWith({
+            gestureEnabled: false
+        });
+    });
+
+    it('releases every guard through the returned function', () => {
+        const { navigation, removeBeforeRemove } = makeNavigation();
+
+        const release = blockNavigationDuringWipe(navigation);
+        release();
+
+        expect(backSubscription.remove).toHaveBeenCalled();
+        expect(removeBeforeRemove).toHaveBeenCalled();
     });
 });

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -124,6 +124,7 @@ jest.mock('../utils/RatingUtils', () => ({
 }));
 
 import hashjs from 'hash.js';
+import { Platform } from 'react-native';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 
 import fs from 'fs';
@@ -449,6 +450,58 @@ describe('clearNodeKeychainData (single-wallet deletion helper)', () => {
     it('is a no-op for a null node', async () => {
         await expect(clearNodeKeychainData(null)).resolves.toBeUndefined();
         expect(mockedStorageRemoveItem).not.toHaveBeenCalled();
+    });
+});
+
+describe('clearAllData keychain backing store deletion (Android)', () => {
+    const mockedExists = ReactNativeBlobUtil.fs.exists as jest.Mock;
+    const mockedUnlink = ReactNativeBlobUtil.fs.unlink as jest.Mock;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedStorageGetItem.mockResolvedValue(null);
+        mockedExists.mockResolvedValue(true);
+        mockedUnlink.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('deletes the DataStore file and legacy prefs as the final clearing step on Android', async () => {
+        jest.replaceProperty(Platform, 'OS', 'android');
+
+        await clearAllData();
+
+        const unlinked = mockedUnlink.mock.calls.map((call) => call[0]);
+        const pbCall = unlinked.find((p: string) =>
+            p.endsWith('datastore/RN_KEYCHAIN.preferences_pb')
+        );
+        const xmlCall = unlinked.find((p: string) =>
+            p.endsWith('shared_prefs/RN_KEYCHAIN.xml')
+        );
+        expect(pbCall).toBeDefined();
+        expect(xmlCall).toBeDefined();
+
+        // Must be the LAST clearing action: any keychain write after this
+        // would re-persist react-native-keychain's cached map, resurrecting
+        // the orphans this deletion exists to kill.
+        const pbCallOrder =
+            mockedUnlink.mock.invocationCallOrder[unlinked.indexOf(pbCall)];
+        const lastRemoveItemOrder = Math.max(
+            ...mockedStorageRemoveItem.mock.invocationCallOrder
+        );
+        expect(pbCallOrder).toBeGreaterThan(lastRemoveItemOrder);
+    });
+
+    it('does not touch keychain files on iOS', async () => {
+        // Platform.OS is 'ios' by default under the react-native jest preset
+        await clearAllData();
+
+        const unlinked = mockedUnlink.mock.calls.map((call) => call[0]);
+        expect(unlinked.some((p: string) => p.includes('RN_KEYCHAIN'))).toBe(
+            false
+        );
     });
 });
 

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -173,6 +173,19 @@ const removedKeys = () =>
 jest.spyOn(console, 'log').mockImplementation(() => {});
 jest.spyOn(console, 'warn').mockImplementation(() => {});
 
+// Platform.OS overrides restore through a tracked handle rather than
+// jest.restoreAllMocks(): restoreAllMocks would also tear down the console
+// spies above for every subsequent test, and an in-test restore leaks the
+// replacement when an assertion throws before reaching it.
+let replacedPlatformOS: { restore: () => void } | undefined;
+const setPlatformOS = (os: typeof Platform.OS) => {
+    replacedPlatformOS = jest.replaceProperty(Platform, 'OS', os);
+};
+afterEach(() => {
+    replacedPlatformOS?.restore();
+    replacedPlatformOS = undefined;
+});
+
 const settingsWithNodes = (nodes: any[]) => ({
     getItem: (key: string) =>
         key === 'zeus-settings-v2'
@@ -582,7 +595,7 @@ describe('legacy xprv cache purge (KEY-006 follow-up)', () => {
     });
 
     it('skips the scrypt-heavy derivation on an Android full wipe (backing store deletion covers it)', async () => {
-        jest.replaceProperty(Platform, 'OS', 'android');
+        setPlatformOS('android');
         mockedStorageGetItem.mockImplementation(
             settingsWithNodes([
                 {
@@ -597,7 +610,6 @@ describe('legacy xprv cache purge (KEY-006 follow-up)', () => {
         await clearAllData();
 
         expect(mockedDerive).not.toHaveBeenCalled();
-        jest.restoreAllMocks();
     });
 });
 
@@ -612,12 +624,8 @@ describe('clearAllData keychain backing store deletion (Android)', () => {
         mockedUnlink.mockResolvedValue(undefined);
     });
 
-    afterEach(() => {
-        jest.restoreAllMocks();
-    });
-
     it('deletes the DataStore file and legacy prefs as the final clearing step on Android', async () => {
-        jest.replaceProperty(Platform, 'OS', 'android');
+        setPlatformOS('android');
 
         await clearAllData();
 
@@ -865,6 +873,66 @@ describe('CDK database deletion', () => {
             expect(paths.some((p) => p.endsWith(expected))).toBe(true);
             expect(paths.some((p) => p.endsWith(`${expected}-wal`))).toBe(true);
             expect(paths.some((p) => p.endsWith(`${expected}-shm`))).toBe(true);
+        });
+
+        // Like the CASHU_KEY_SUFFIXES guard above: clearCDKDatabaseForNode
+        // reconstructs filenames the native modules created, so the hashing
+        // convention (first 8 bytes of sha256(mnemonic) as hex) must stay in
+        // lockstep with CashuDevKitModule.kt/.swift. Scan both sources so a
+        // convention change fails here instead of silently orphaning dbs.
+        it('matches the Android CDK filename hashing convention', () => {
+            const source = fs.readFileSync(
+                path.join(
+                    __dirname,
+                    '../android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt'
+                ),
+                'utf8'
+            );
+            expect(source).toContain('MessageDigest.getInstance("SHA-256")');
+            expect(source).toContain('hashBytes.take(8)');
+            expect(source).toContain('"cashu_wallet_$hashHex.db"');
+        });
+
+        it('matches the iOS CDK filename hashing convention', () => {
+            const source = fs.readFileSync(
+                path.join(
+                    __dirname,
+                    '../ios/CashuDevKit/CashuDevKitModule.swift'
+                ),
+                'utf8'
+            );
+            expect(source).toContain('CC_SHA256(');
+            expect(source).toContain('hash.prefix(8)');
+            expect(source).toContain('cashu_wallet_\\(hashHex).db');
+        });
+
+        it('reconstructs the filename from a fixed vector, independent of hash.js', async () => {
+            // sha256('abandon ability able about') =
+            // 2364a17ff3507501df1e6385392fce14825bc0cf6e096543633d9df08c13bf8c
+            mockedStorageGetItem.mockImplementation((key: string) =>
+                key === 'lnd-abc-cashu-seed-phrase'
+                    ? Promise.resolve(
+                          JSON.stringify([
+                              'abandon',
+                              'ability',
+                              'able',
+                              'about'
+                          ])
+                      )
+                    : Promise.resolve(null)
+            );
+            mockedExists.mockResolvedValue(true);
+
+            await clearCDKDatabaseForNode({
+                implementation: 'embedded-lnd',
+                lndDir: 'lnd-abc'
+            });
+
+            expect(
+                unlinkedPaths().some((p) =>
+                    p.endsWith('cashu_wallet_2364a17ff3507501.db')
+                )
+            ).toBe(true);
         });
 
         it('uses the ldk default namespace for a legacy ldk-node config', async () => {

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -19,7 +19,8 @@ jest.mock('react-native-blob-util', () => ({
     fs: {
         dirs: { LibraryDir: '/lib', DocumentDir: '/docs' },
         exists: jest.fn().mockResolvedValue(false),
-        unlink: jest.fn().mockResolvedValue(undefined)
+        unlink: jest.fn().mockResolvedValue(undefined),
+        ls: jest.fn().mockResolvedValue([])
     }
 }));
 
@@ -110,9 +111,15 @@ jest.mock('../utils/SwapUtils', () => ({
 }));
 
 import hashjs from 'hash.js';
+import ReactNativeBlobUtil from 'react-native-blob-util';
 
 import Storage from '../storage';
-import { clearAllData, clearNodeKeychainData } from './DataClearUtils';
+import {
+    clearAllData,
+    clearNodeKeychainData,
+    clearCDKDatabase,
+    clearCDKDatabaseForNode
+} from './DataClearUtils';
 import { deleteLndWallet } from './LndMobileUtils';
 import { deleteLdkNodeWallet, stopLdkNode } from './LdkNodeUtils';
 import { sleep } from './SleepUtils';
@@ -424,5 +431,117 @@ describe('clearNodeKeychainData (single-wallet deletion helper)', () => {
     it('is a no-op for a null node', async () => {
         await expect(clearNodeKeychainData(null)).resolves.toBeUndefined();
         expect(mockedStorageRemoveItem).not.toHaveBeenCalled();
+    });
+});
+
+describe('CDK database deletion', () => {
+    const mockedLs = ReactNativeBlobUtil.fs.ls as jest.Mock;
+    const mockedExists = ReactNativeBlobUtil.fs.exists as jest.Mock;
+    const mockedUnlink = ReactNativeBlobUtil.fs.unlink as jest.Mock;
+    const unlinkedPaths = () => mockedUnlink.mock.calls.map((call) => call[0]);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedStorageGetItem.mockResolvedValue(null);
+        mockedLs.mockResolvedValue([]);
+        mockedExists.mockResolvedValue(false);
+        mockedUnlink.mockResolvedValue(undefined);
+    });
+
+    describe('clearCDKDatabase (full-wipe sweep)', () => {
+        it('sweeps legacy, per-wallet, and WAL/SHM sidecar files', async () => {
+            mockedLs.mockResolvedValue([
+                'cashu_wallet.db',
+                'cashu_wallet_0123456789abcdef.db',
+                'cashu_wallet_0123456789abcdef.db-wal',
+                'cashu_wallet_0123456789abcdef.db-shm',
+                'unrelated.db'
+            ]);
+
+            await clearCDKDatabase();
+
+            const paths = unlinkedPaths();
+            expect(paths).toHaveLength(4);
+            expect(paths.every((p) => p.includes('cashu_wallet'))).toBe(true);
+            expect(paths.some((p) => p.includes('unrelated'))).toBe(false);
+        });
+
+        it('keeps sweeping when one unlink fails', async () => {
+            mockedLs.mockResolvedValue([
+                'cashu_wallet_a.db',
+                'cashu_wallet_b.db'
+            ]);
+            mockedUnlink
+                .mockRejectedValueOnce(new Error('EBUSY'))
+                .mockResolvedValue(undefined);
+
+            await clearCDKDatabase();
+
+            expect(mockedUnlink).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('clearCDKDatabaseForNode (single-wallet deletion)', () => {
+        // Must match the native modules (CashuDevKitModule.kt/.swift):
+        // first 8 bytes of sha256(space-joined mnemonic) as hex
+        const walletDbHash = (mnemonic: string) =>
+            hashjs.sha256().update(mnemonic).digest('hex').slice(0, 16);
+
+        it('deletes the db and sidecars derived from the stored cashu seed', async () => {
+            const words = ['abandon', 'ability', 'able', 'about'];
+            mockedStorageGetItem.mockImplementation((key: string) =>
+                key === 'lnd-abc-cashu-seed-phrase'
+                    ? Promise.resolve(JSON.stringify(words))
+                    : Promise.resolve(null)
+            );
+            mockedExists.mockResolvedValue(true);
+
+            await clearCDKDatabaseForNode({
+                implementation: 'embedded-lnd',
+                lndDir: 'lnd-abc'
+            });
+
+            const expected = `cashu_wallet_${walletDbHash(words.join(' '))}.db`;
+            const paths = unlinkedPaths();
+            expect(paths.some((p) => p.endsWith(expected))).toBe(true);
+            expect(paths.some((p) => p.endsWith(`${expected}-wal`))).toBe(true);
+            expect(paths.some((p) => p.endsWith(`${expected}-shm`))).toBe(true);
+        });
+
+        it('uses the ldk default namespace for a legacy ldk-node config', async () => {
+            mockedStorageGetItem.mockImplementation((key: string) =>
+                key === 'ldk-cashu-seed-phrase'
+                    ? Promise.resolve(JSON.stringify(['some', 'words']))
+                    : Promise.resolve(null)
+            );
+            mockedExists.mockResolvedValue(true);
+
+            await clearCDKDatabaseForNode({ implementation: 'ldk-node' });
+
+            expect(mockedUnlink).toHaveBeenCalled();
+            expect(mockedStorageGetItem).toHaveBeenCalledWith(
+                'ldk-cashu-seed-phrase'
+            );
+        });
+
+        it('never deletes databases for a remote node (shared default namespace)', async () => {
+            mockedStorageGetItem.mockResolvedValue(
+                JSON.stringify(['some', 'words'])
+            );
+            mockedExists.mockResolvedValue(true);
+
+            await clearCDKDatabaseForNode({ implementation: 'lnd' });
+
+            expect(mockedUnlink).not.toHaveBeenCalled();
+        });
+
+        it('is a no-op when no cashu seed is stored', async () => {
+            await clearCDKDatabaseForNode({
+                implementation: 'embedded-lnd',
+                lndDir: 'lnd-abc'
+            });
+
+            expect(mockedUnlink).not.toHaveBeenCalled();
+        });
     });
 });

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -195,6 +195,45 @@ async function clearKey(key: string) {
 }
 
 /**
+ * Deletes react-native-keychain's Android backing stores wholesale: the
+ * Jetpack DataStore file (current versions) and the legacy shared-prefs XML
+ * (older versions). This is the only way to remove orphaned entries that
+ * config-driven clearing can never reach: keys from wallets deleted by older
+ * builds and unenumerable hash-keyed dynamic entries. Android-only; on iOS
+ * the keychain is system-managed with no file to delete.
+ *
+ * MUST run as the final step of a full wipe: react-native-keychain caches
+ * the full preference map in memory, and any keychain write after this
+ * deletion would re-persist that map, resurrecting the orphans. Storage's
+ * write latch blocks the known writers until the post-wipe restart.
+ */
+async function clearKeychainBackingStore(): Promise<void> {
+    if (Platform.OS !== 'android') return;
+    const dirs = ReactNativeBlobUtil.fs.dirs;
+    const appRoot = `${dirs.DocumentDir}/..`;
+    const targets = [
+        `${appRoot}/files/datastore/RN_KEYCHAIN.preferences_pb`,
+        `${appRoot}/shared_prefs/RN_KEYCHAIN.xml`
+    ];
+    for (const path of targets) {
+        try {
+            if (await ReactNativeBlobUtil.fs.exists(path)) {
+                await ReactNativeBlobUtil.fs.unlink(path);
+                console.log(
+                    '[ClearData] Keychain backing store deleted:',
+                    path
+                );
+            }
+        } catch (e) {
+            console.warn(
+                `[ClearData] Error deleting keychain backing store ${path}:`,
+                e
+            );
+        }
+    }
+}
+
+/**
  * Directory holding the CDK SQLite database files
  * iOS: Application Support; Android: files dir
  */
@@ -608,6 +647,11 @@ export async function clearAllData(): Promise<void> {
     for (const key of additionalKeys) {
         await clearKey(key);
     }
+
+    // 8. Android: delete the keychain backing stores wholesale, killing the
+    // orphaned entries no config-driven clear can reach. Keep this the LAST
+    // clearing action (see clearKeychainBackingStore).
+    await clearKeychainBackingStore();
 
     console.log('[ClearData] All data cleared successfully');
 }

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -312,6 +312,18 @@ export async function clearNodeKeychainData(node: any): Promise<void> {
     if (node.ldkNodeDir) {
         await clearCashuDataForNode(node.ldkNodeDir);
     }
+    // Legacy configs can predate explicit node dirs (see the `lndDir || 'lnd'`
+    // fallbacks in WalletConfiguration/getNodeDir). Mirror getNodeDir()'s
+    // defaults so those wallets' Cashu keys are cleared too. Gate on
+    // implementation: only one config can occupy a default namespace per
+    // implementation, and remote nodes must never clear the 'lnd'/'ldk'
+    // namespaces owned by embedded wallets.
+    if (node.implementation === 'embedded-lnd' && !node.lndDir) {
+        await clearCashuDataForNode('lnd');
+    }
+    if (node.implementation === 'ldk-node' && !node.ldkNodeDir) {
+        await clearCashuDataForNode('ldk');
+    }
     if (node.pairingPhrase) {
         await clearLncCredentials(node.pairingPhrase);
     }

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -2,7 +2,7 @@ import * as Keychain from 'react-native-keychain';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import EncryptedStorage from 'react-native-encrypted-storage';
 import ReactNativeBlobUtil from 'react-native-blob-util';
-import { Platform } from 'react-native';
+import { BackHandler, Platform } from 'react-native';
 import Storage from '../storage';
 
 import {
@@ -137,6 +137,34 @@ const STORAGE_KEYS = [
     'backup-complete',
     'backup-complete-v2'
 ];
+
+/**
+ * Pins the user to the current screen while a wipe runs. clearAllData()
+ * takes tens of seconds on device, and both wipe surfaces sit on screens
+ * the user can otherwise leave mid-wipe: hardware/gesture back either
+ * exits the app (Lockscreen, via the App-level loginRequired handler) or
+ * pops back into an app whose data is being destroyed underneath it
+ * (Tools). Swallows hardware back presses (registered after the App-level
+ * handler, so it runs first), blocks removal of the screen from the
+ * navigation stack, and disables the iOS back-swipe gesture. Returns a
+ * release function for unmount hygiene; in practice the guard holds until
+ * the post-wipe restart tears the JS context down.
+ */
+export function blockNavigationDuringWipe(navigation: any): () => void {
+    navigation.setOptions({ gestureEnabled: false });
+    const backSubscription = BackHandler.addEventListener(
+        'hardwareBackPress',
+        () => true
+    );
+    const removeBeforeRemove = navigation.addListener(
+        'beforeRemove',
+        (e: any) => e.preventDefault()
+    );
+    return () => {
+        backSubscription.remove();
+        removeBeforeRemove();
+    };
+}
 
 /**
  * Clears a key from all possible locations:

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -287,49 +287,74 @@ export async function clearCDKDatabaseForNode(node: any): Promise<void> {
 }
 
 /**
+ * Suffixes of every node-dir-namespaced Cashu storage key written by
+ * CashuStore (`<nodeDir>-cashu-<suffix>`). Kept complete by the drift guard
+ * in DataClearUtils.test.ts, which extracts the `-cashu-` literals from
+ * stores/CashuStore.ts and fails when a new key is written but not cleared.
+ */
+export const CASHU_KEY_SUFFIXES = [
+    'mintUrls',
+    'selectedMintUrl',
+    'selectedMintUrls',
+    'multiMintSelectedUrls',
+    'totalBalanceSats',
+    'invoices',
+    'payments',
+    'received-tokens',
+    'sent-tokens',
+    'offline-pending-tokens',
+    'offline-spent-tokens',
+    'seed-version',
+    'seed-phrase',
+    'seed',
+    'original-seed-version',
+    'v1-restore-done',
+    'dismissedUpgradeThreshold',
+    'randomizeMintSelection',
+    'nostrMintBackupTimestamp'
+];
+
+/**
  * Clears Cashu data for a specific node directory
  */
 async function clearCashuDataForNode(lndDir: string) {
-    // Clear app-level Cashu storage keys
-    const cashuKeys = [
-        `${lndDir}-cashu-mintUrls`,
-        `${lndDir}-cashu-selectedMintUrl`,
-        `${lndDir}-cashu-totalBalanceSats`,
-        `${lndDir}-cashu-invoices`,
-        `${lndDir}-cashu-payments`,
-        `${lndDir}-cashu-received-tokens`,
-        `${lndDir}-cashu-sent-tokens`,
-        `${lndDir}-cashu-seed-version`,
-        `${lndDir}-cashu-seed-phrase`,
-        `${lndDir}-cashu-seed`
-    ];
-
-    for (const key of cashuKeys) {
-        await clearKey(key);
-    }
-
-    // Try to clear per-mint wallet keys (legacy storage)
-    // Note: After CDK migration, mintUrls are stored in CDK database, not local storage
-    // These keys may still exist from before migration
+    // Read the legacy pre-CDK mint list BEFORE clearing: the loop below
+    // removes the mintUrls key this read depends on
+    let legacyMintUrls: string[] = [];
     try {
         const mintUrlsJson = await Storage.getItem(`${lndDir}-cashu-mintUrls`);
         if (mintUrlsJson) {
-            const mintUrls = JSON.parse(mintUrlsJson);
-            if (Array.isArray(mintUrls)) {
-                for (const mintUrl of mintUrls) {
-                    // walletId format: ${lndDir}==${mintUrl}
-                    const walletId = `${lndDir}==${mintUrl}`;
-                    const walletKeys = [
-                        `${walletId}-mintInfo`,
-                        `${walletId}-counter`,
-                        `${walletId}-proofs`,
-                        `${walletId}-balance`,
-                        `${walletId}-pubkey`
-                    ];
-                    for (const walletKey of walletKeys) {
-                        await clearKey(walletKey);
-                    }
-                }
+            const parsed = JSON.parse(mintUrlsJson);
+            if (Array.isArray(parsed)) {
+                legacyMintUrls = parsed;
+            }
+        }
+    } catch (e) {
+        console.warn(
+            `[ClearData] Error reading Cashu mint list for ${lndDir}:`,
+            e
+        );
+    }
+
+    // Clear app-level Cashu storage keys
+    for (const suffix of CASHU_KEY_SUFFIXES) {
+        await clearKey(`${lndDir}-cashu-${suffix}`);
+    }
+
+    // Clear per-mint wallet keys (legacy pre-CDK storage)
+    try {
+        for (const mintUrl of legacyMintUrls) {
+            // walletId format: ${lndDir}==${mintUrl}
+            const walletId = `${lndDir}==${mintUrl}`;
+            const walletKeys = [
+                `${walletId}-mintInfo`,
+                `${walletId}-counter`,
+                `${walletId}-proofs`,
+                `${walletId}-balance`,
+                `${walletId}-pubkey`
+            ];
+            for (const walletKey of walletKeys) {
+                await clearKey(walletKey);
             }
         }
     } catch (e) {

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -367,6 +367,30 @@ async function deleteNodeDataDirectory(node: any): Promise<boolean> {
 }
 
 /**
+ * Stops and deletes a single node's on-disk data directory, retrying on
+ * failure. The likely cause of failure is a file handle still held by a node
+ * that hasn't finished shutting down, which clears on its own after a moment.
+ * Returns whether the directory was removed. Exported so single-wallet
+ * deletion (WalletConfiguration.deleteNodeConfig) shares the wipe path's
+ * retry behavior instead of assuming the first attempt succeeded.
+ */
+export async function deleteNodeDataDirectoryWithRetry(
+    node: any
+): Promise<boolean> {
+    for (let attempt = 1; attempt <= NODE_DIR_DELETE_ATTEMPTS; attempt++) {
+        if (await deleteNodeDataDirectory(node)) return true;
+
+        if (attempt < NODE_DIR_DELETE_ATTEMPTS) {
+            await sleep(NODE_DIR_RETRY_DELAY_MS);
+        }
+    }
+    console.warn(
+        `[ClearData] Gave up deleting node data directory after ${NODE_DIR_DELETE_ATTEMPTS} attempts`
+    );
+    return false;
+}
+
+/**
  * Clears the LNC pairing credentials for a given pairing phrase.
  * Keys are namespaced by sha256(pairingPhrase), so they can only be removed
  * when the phrase is known (it lives in the node config).
@@ -429,17 +453,7 @@ async function clearNodeDataDirectories(settings: any): Promise<void> {
     if (!settings?.nodes || !Array.isArray(settings.nodes)) return;
 
     for (const node of settings.nodes) {
-        for (let attempt = 1; attempt <= NODE_DIR_DELETE_ATTEMPTS; attempt++) {
-            if (await deleteNodeDataDirectory(node)) break;
-
-            if (attempt < NODE_DIR_DELETE_ATTEMPTS) {
-                await sleep(NODE_DIR_RETRY_DELAY_MS);
-            } else {
-                console.warn(
-                    `[ClearData] Gave up deleting node data directory after ${NODE_DIR_DELETE_ATTEMPTS} attempts`
-                );
-            }
-        }
+        await deleteNodeDataDirectoryWithRetry(node);
     }
 }
 

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -54,6 +54,15 @@ import {
     SWAPS_RESCUE_KEY,
     SWAPS_LAST_USED_KEY
 } from '../utils/SwapUtils';
+import {
+    NWC_CONNECTIONS_KEY,
+    NWC_CLIENT_KEYS,
+    NWC_SERVICE_KEYS,
+    NWC_CASHU_ENABLED,
+    NWC_LUD16_ENABLED,
+    NWC_PERSISTENT_SERVICE_ENABLED
+} from '../stores/NostrWalletConnectStore';
+import { PAYMENT_COUNT_KEY, RATING_DISMISSED_KEY } from '../utils/RatingUtils';
 import { deleteLndWallet } from './LndMobileUtils';
 import { deleteLdkNodeWallet, stopLdkNode } from './LdkNodeUtils';
 import { sleep } from './SleepUtils';
@@ -93,6 +102,20 @@ const STORAGE_KEYS = [
     REVERSE_SWAPS_KEY,
     SWAPS_RESCUE_KEY,
     SWAPS_LAST_USED_KEY,
+    // NWC service and client key material (nostr secret keys) plus flags
+    NWC_CONNECTIONS_KEY,
+    NWC_CLIENT_KEYS,
+    NWC_SERVICE_KEYS,
+    NWC_CASHU_ENABLED,
+    NWC_LUD16_ENABLED,
+    NWC_PERSISTENT_SERVICE_ENABLED,
+    // Rating prompt state
+    PAYMENT_COUNT_KEY,
+    RATING_DISMISSED_KEY,
+    // LnurlPayStore writes 'lnurlpay:<paymentHash>' entries with no index to
+    // enumerate them; at least clear the bare key written when a hash is
+    // undefined. Hash-keyed entries are a documented residual.
+    'lnurlpay:',
     // Legacy keys
     LEGACY_CONTACTS_KEY,
     LEGACY_NOTES_KEY,

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -532,6 +532,8 @@ export async function clearNodeKeychainData(
     // identity key). Derivation failure means a non-default aezeed
     // passphrase; those wallets never had the cache written, because the
     // export screen's decryption failed the same way before its write.
+    // Belt and braces: NodeInfoStore also purges the cache at connect
+    // time using the runtime nodeId, which is passphrase-independent.
     if (
         !opts?.skipXprvPurge &&
         node.implementation === 'embedded-lnd' &&

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -497,6 +497,14 @@ async function clearNodeDataDirectories(settings: any): Promise<void> {
 export async function clearAllData(): Promise<void> {
     console.log('[ClearData] Starting to clear all data...');
 
+    // 0. Block all Storage writes for the rest of this JS context. The app
+    // keeps running until the post-wipe restart lands, and an async writer
+    // (biometry check, push token, connection events) calling
+    // updateSettings would re-persist the full in-memory settings blob,
+    // resurrecting every wallet config after the wipe. Observed on-device:
+    // the settings write landed ~20ms after the wipe finished.
+    Storage.blockWrites();
+
     // 1. First, try to get settings to find node-specific data
     let settings: any = null;
     try {

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -57,6 +57,14 @@ import {
 import { deleteLndWallet } from './LndMobileUtils';
 import { deleteLdkNodeWallet, stopLdkNode } from './LdkNodeUtils';
 import { sleep } from './SleepUtils';
+import hashjs from 'hash.js';
+
+// LNC credentials are persisted by backends/LNC/credentialStore.ts under
+// `lnc-rn:<sha256(pairingPhrase)>` and `...:host`. Reconstruct those keys from
+// each node's pairing phrase so a wipe removes them (clearing the literal
+// `lnc-rn` prefix alone never matches the hashed keys).
+const LNC_STORAGE_KEY = 'lnc-rn';
+const lncHash = (value: string) => hashjs.sha256().update(value).digest('hex');
 
 const KEY_PREFIX = 'zeus:';
 
@@ -167,7 +175,7 @@ async function clearKey(key: string) {
  * Deletes the CDK SQLite database file
  * CDK stores all wallet state (mints, proofs, transactions) in this file
  */
-async function clearCDKDatabase(): Promise<void> {
+export async function clearCDKDatabase(): Promise<void> {
     try {
         const dirs = ReactNativeBlobUtil.fs.dirs;
         let dbPath: string;
@@ -277,6 +285,39 @@ async function deleteNodeDataDirectory(node: any): Promise<boolean> {
 }
 
 /**
+ * Clears the LNC pairing credentials for a given pairing phrase.
+ * Keys are namespaced by sha256(pairingPhrase), so they can only be removed
+ * when the phrase is known (it lives in the node config).
+ */
+async function clearLncCredentials(pairingPhrase: string) {
+    const baseKey = `${LNC_STORAGE_KEY}:${lncHash(pairingPhrase)}`;
+    await clearKey(baseKey);
+    await clearKey(`${baseKey}:host`);
+}
+
+/**
+ * Clears all node-namespaced keychain material for a single node config:
+ * - Cashu keys, which are namespaced by getNodeDir() (lndDir for LND-family,
+ *   ldkNodeDir for LDK) - CashuStore.getNodeDir
+ * - LNC pairing credentials, namespaced by sha256(pairingPhrase)
+ *
+ * Exported so both clearAllData() and single-wallet deletion
+ * (WalletConfiguration.deleteNodeConfig) clear the same set of keys.
+ */
+export async function clearNodeKeychainData(node: any): Promise<void> {
+    if (!node) return;
+    if (node.lndDir) {
+        await clearCashuDataForNode(node.lndDir);
+    }
+    if (node.ldkNodeDir) {
+        await clearCashuDataForNode(node.ldkNodeDir);
+    }
+    if (node.pairingPhrase) {
+        await clearLncCredentials(node.pairingPhrase);
+    }
+}
+
+/**
  * Stops and deletes the on-disk node data directories (channel state, wallet
  * db) for every configured node. clearKey/clearCashuDataForNode only touch
  * keychain and Cashu storage; the LND/LDK node directories must be unlinked
@@ -334,21 +375,16 @@ export async function clearAllData(): Promise<void> {
         console.warn('[ClearData] Could not read settings:', e);
     }
 
-    // 2. Clear Cashu data for all known nodes
+    // 2. Clear node-namespaced keychain material (Cashu keys for both LND and
+    // LDK node dirs, plus LNC pairing credentials) for every known node.
     if (settings?.nodes && Array.isArray(settings.nodes)) {
         for (const node of settings.nodes) {
-            if (node.lndDir) {
-                if (__DEV__) {
-                    console.log(
-                        `[ClearData] Clearing Cashu data for node: ${node.lndDir}`
-                    );
-                }
-                await clearCashuDataForNode(node.lndDir);
-            }
+            await clearNodeKeychainData(node);
         }
     }
-    // Also try common lndDir values
+    // Also try common node-dir defaults (getNodeDir falls back to 'lnd' / 'ldk')
     await clearCashuDataForNode('lnd');
+    await clearCashuDataForNode('ldk');
     await clearCashuDataForNode('');
 
     // 2b. Clear CDK SQLite database (contains mints, proofs, transactions)

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -172,35 +172,117 @@ async function clearKey(key: string) {
 }
 
 /**
- * Deletes the CDK SQLite database file
- * CDK stores all wallet state (mints, proofs, transactions) in this file
+ * Directory holding the CDK SQLite database files
+ * iOS: Application Support; Android: files dir
+ */
+function cdkDatabaseDir(): string {
+    const dirs = ReactNativeBlobUtil.fs.dirs;
+    return Platform.OS === 'ios'
+        ? `${dirs.LibraryDir}/Application Support`
+        : `${dirs.DocumentDir}/../files`;
+}
+
+/**
+ * Deletes every CDK SQLite database file (mints, proofs, transactions).
+ *
+ * CDK databases are per-wallet since v13.0.0 (e14d0e9ed):
+ * `cashu_wallet_<sha256(mnemonic)[0..8]>.db`, alongside the pre-v13 shared
+ * `cashu_wallet.db`. CDK opens SQLite with journal_mode=WAL
+ * (cdk-sqlite common.rs), so `-wal`/`-shm` sidecars can hold proof data too.
+ * Sweep everything with the prefix rather than reconstructing filenames,
+ * which is impossible once the seed keys are gone. Full-wipe paths only:
+ * this destroys every wallet's ecash state.
  */
 export async function clearCDKDatabase(): Promise<void> {
     try {
-        const dirs = ReactNativeBlobUtil.fs.dirs;
-        let dbPath: string;
-
-        if (Platform.OS === 'ios') {
-            // iOS: Application Support directory
-            dbPath = `${dirs.LibraryDir}/Application Support/cashu_wallet.db`;
-        } else {
-            // Android: files directory
-            dbPath = `${dirs.DocumentDir}/../files/cashu_wallet.db`;
-        }
-
-        const exists = await ReactNativeBlobUtil.fs.exists(dbPath);
-        if (exists) {
-            await ReactNativeBlobUtil.fs.unlink(dbPath);
-            if (__DEV__) {
-                console.log('[ClearData] CDK database deleted:', dbPath);
-            }
-        } else {
-            if (__DEV__) {
-                console.log('[ClearData] CDK database not found at:', dbPath);
+        const dbDir = cdkDatabaseDir();
+        const entries: string[] = await ReactNativeBlobUtil.fs.ls(dbDir);
+        for (const entry of entries) {
+            if (!entry.startsWith('cashu_wallet')) continue;
+            try {
+                await ReactNativeBlobUtil.fs.unlink(`${dbDir}/${entry}`);
+                if (__DEV__) {
+                    console.log(
+                        '[ClearData] CDK database file deleted:',
+                        entry
+                    );
+                }
+            } catch (e) {
+                console.warn(
+                    `[ClearData] Error deleting CDK database file ${entry}:`,
+                    e
+                );
             }
         }
     } catch (e) {
-        console.warn('[ClearData] Error deleting CDK database:', e);
+        console.warn('[ClearData] Error sweeping CDK database files:', e);
+    }
+}
+
+/**
+ * Deletes a single wallet's per-wallet CDK database (plus WAL/SHM sidecars).
+ *
+ * The filename embeds sha256(cashu mnemonic) (CashuDevKitModule.kt/.swift),
+ * reconstructed here from the node's stored `<nodeDir>-cashu-seed-phrase`,
+ * so this must run BEFORE clearNodeKeychainData wipes that key. Node-dir
+ * rules match clearNodeKeychainData: only embedded-lnd and ldk-node have an
+ * unambiguous namespace; remote nodes share the 'lnd' default, so deleting
+ * "their" database could destroy another wallet's proofs.
+ */
+export async function clearCDKDatabaseForNode(node: any): Promise<void> {
+    if (!node) return;
+
+    let nodeDir: string | null = null;
+    if (node.implementation === 'embedded-lnd') {
+        nodeDir = node.lndDir || 'lnd';
+    } else if (node.implementation === 'ldk-node') {
+        nodeDir = node.ldkNodeDir || 'ldk';
+    }
+    if (!nodeDir) return;
+
+    try {
+        const stored = await Storage.getItem(`${nodeDir}-cashu-seed-phrase`);
+        if (!stored) return;
+
+        // Stored as a JSON word array; the native modules hash the
+        // space-joined mnemonic string
+        let mnemonic: string;
+        try {
+            const parsed = JSON.parse(stored);
+            mnemonic = Array.isArray(parsed)
+                ? parsed.join(' ')
+                : String(parsed);
+        } catch {
+            mnemonic = stored;
+        }
+
+        const hash = hashjs
+            .sha256()
+            .update(mnemonic)
+            .digest('hex')
+            .slice(0, 16);
+        const dbDir = cdkDatabaseDir();
+        for (const suffix of ['', '-wal', '-shm']) {
+            const path = `${dbDir}/cashu_wallet_${hash}.db${suffix}`;
+            try {
+                if (await ReactNativeBlobUtil.fs.exists(path)) {
+                    await ReactNativeBlobUtil.fs.unlink(path);
+                    if (__DEV__) {
+                        console.log(
+                            '[ClearData] CDK wallet database file deleted:',
+                            path
+                        );
+                    }
+                }
+            } catch (e) {
+                console.warn(
+                    `[ClearData] Error deleting CDK wallet database ${path}:`,
+                    e
+                );
+            }
+        }
+    } catch (e) {
+        console.warn('[ClearData] Error clearing CDK database for node:', e);
     }
 }
 

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -63,6 +63,7 @@ import {
     NWC_PERSISTENT_SERVICE_ENABLED
 } from '../stores/NostrWalletConnectStore';
 import { PAYMENT_COUNT_KEY, RATING_DISMISSED_KEY } from '../utils/RatingUtils';
+import { deriveEmbeddedNodeId } from './AezeedUtils';
 import { deleteLndWallet } from './LndMobileUtils';
 import { deleteLdkNodeWallet, stopLdkNode } from './LdkNodeUtils';
 import { sleep } from './SleepUtils';
@@ -493,11 +494,15 @@ async function clearLncCredentials(pairingPhrase: string) {
  * - Cashu keys, which are namespaced by getNodeDir() (lndDir for LND-family,
  *   ldkNodeDir for LDK) - CashuStore.getNodeDir
  * - LNC pairing credentials, namespaced by sha256(pairingPhrase)
+ * - the legacy '<pubkey>-extended-private-keys' xprv cache (KEY-006)
  *
  * Exported so both clearAllData() and single-wallet deletion
  * (WalletConfiguration.deleteNodeConfig) clear the same set of keys.
  */
-export async function clearNodeKeychainData(node: any): Promise<void> {
+export async function clearNodeKeychainData(
+    node: any,
+    opts?: { skipXprvPurge?: boolean }
+): Promise<void> {
     if (!node) return;
     if (node.lndDir) {
         await clearCashuDataForNode(node.lndDir);
@@ -519,6 +524,31 @@ export async function clearNodeKeychainData(node: any): Promise<void> {
     }
     if (node.pairingPhrase) {
         await clearLncCredentials(node.pairingPhrase);
+    }
+    // Builds between Jan 2025 (ba70ce58f) and the removal in this PR
+    // cached ypriv/zpriv under '<pubkey>-extended-private-keys'. The node
+    // pubkey is not stored in the config, so re-derive it from the aezeed
+    // (entropy -> BIP32 master -> m/1017'/coinType'/6'/0/0, lnd's node
+    // identity key). Derivation failure means a non-default aezeed
+    // passphrase; those wallets never had the cache written, because the
+    // export screen's decryption failed the same way before its write.
+    if (
+        !opts?.skipXprvPurge &&
+        node.implementation === 'embedded-lnd' &&
+        Array.isArray(node.seedPhrase) &&
+        node.seedPhrase.length > 0
+    ) {
+        try {
+            const nodeId = await deriveEmbeddedNodeId(
+                node.seedPhrase,
+                node.embeddedLndNetwork?.toLowerCase?.() === 'testnet'
+            );
+            if (nodeId) {
+                await clearKey(`${nodeId}-extended-private-keys`);
+            }
+        } catch (e) {
+            console.warn('[ClearData] Error purging xprv cache for node:', e);
+        }
     }
 }
 
@@ -582,7 +612,14 @@ export async function clearAllData(): Promise<void> {
     // LDK node dirs, plus LNC pairing credentials) for every known node.
     if (settings?.nodes && Array.isArray(settings.nodes)) {
         for (const node of settings.nodes) {
-            await clearNodeKeychainData(node);
+            // Skip the scrypt-heavy xprv re-derivation on Android: the
+            // backing-store deletion in step 8 removes every keychain entry
+            // wholesale, and this path runs on the duress wipe, where added
+            // seconds per embedded wallet matter. iOS has no backing store
+            // to delete, so it must pay for the derivation here.
+            await clearNodeKeychainData(node, {
+                skipXprvPurge: Platform.OS === 'android'
+            });
         }
     }
     // Also try common node-dir defaults (getNodeDir falls back to 'lnd' / 'ldk')

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -539,9 +539,14 @@ export async function clearNodeKeychainData(
         node.seedPhrase.length > 0
     ) {
         try {
+            // Coin type 1 for every non-mainnet network: testnet, signet
+            // (mutinynet), and regtest share HDCoinType 1. Matches the
+            // `(network || 'mainnet').toLowerCase() !== 'mainnet'` rule
+            // WalletConfiguration uses for the same field.
             const nodeId = await deriveEmbeddedNodeId(
                 node.seedPhrase,
-                node.embeddedLndNetwork?.toLowerCase?.() === 'testnet'
+                String(node.embeddedLndNetwork || 'mainnet').toLowerCase() !==
+                    'mainnet'
             );
             if (nodeId) {
                 await clearKey(`${nodeId}-extended-private-keys`);

--- a/utils/RestartUtils.ts
+++ b/utils/RestartUtils.ts
@@ -1,4 +1,5 @@
 import { Alert, NativeModules, Platform } from 'react-native';
+import RNRestart from 'react-native-restart';
 import { localeString } from './LocaleUtils';
 import { settingsStore } from '../stores/Stores';
 import LdkNode from '../ldknode/LdkNodeInjection';
@@ -28,6 +29,25 @@ const stopNode = async () => {
     }
 };
 
+/**
+ * Fully restarts the app. On Android this must go through the native
+ * ProcessPhoenix rebirth (LndMobileTools.restartApp): react-native-restart's
+ * ReactInstanceManager path throws under the New Architecture (see
+ * ReactApplication.getReactNativeHost), so RNRestart.Restart() degrades to
+ * Activity.recreate(), which keeps the JS runtime - and every in-memory
+ * store - alive. After a data wipe that leaves the pre-wipe settings (node
+ * configs, pins) live in memory, and the relaunched UI lands back on the
+ * lockscreen instead of the intro screen. iOS has no process-restart API;
+ * there RNRestart performs a genuine JS reload, which resets module state.
+ */
+const restartApp = () => {
+    if (Platform.OS === 'android') {
+        NativeModules.LndMobileTools.restartApp();
+    } else {
+        RNRestart.Restart();
+    }
+};
+
 const restartNeeded = (force?: boolean) => {
     const title = localeString('restart.title');
     const message = localeString('restart.msg');
@@ -46,7 +66,7 @@ const restartNeeded = (force?: boolean) => {
                 : localeString('general.yes'),
             onPress: async () => {
                 await stopNode();
-                NativeModules.LndMobileTools.restartApp();
+                restartApp();
             }
         });
         Alert.alert(
@@ -59,4 +79,4 @@ const restartNeeded = (force?: boolean) => {
     }
 };
 
-export { restartNeeded };
+export { restartApp, restartNeeded };

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -15,6 +15,7 @@ import RNRestart from 'react-native-restart';
 
 import Button from '../components/Button';
 import Header from '../components/Header';
+import LoadingIndicator from '../components/LoadingIndicator';
 import Pin from '../components/Pin';
 import Screen from '../components/Screen';
 import { ErrorMessage } from '../components/SuccessErrorMessage';
@@ -60,6 +61,7 @@ interface LockscreenState {
     deletePassword: boolean;
     deleteDuressPassword: boolean;
     authenticationAttempts: number;
+    wiping: boolean;
 }
 
 const maxAuthenticationAttempts = 5;
@@ -88,7 +90,8 @@ export default class Lockscreen extends React.Component<
             deleteDuressPin: false,
             deletePassword: false,
             deleteDuressPassword: false,
-            authenticationAttempts: 0
+            authenticationAttempts: 0,
+            wiping: false
         };
     }
 
@@ -283,6 +286,10 @@ export default class Lockscreen extends React.Component<
         } = this.state;
         const { updateSettings, getSettings, setPosStatus } = SettingsStore;
 
+        // a wipe is already running; a second submit must not start another
+        // wipe or mutate settings mid-wipe
+        if (this.state.wiping) return;
+
         this.setState({
             error: false
         });
@@ -347,7 +354,12 @@ export default class Lockscreen extends React.Component<
             ((duressPassphrase && passphraseAttempt === duressPassphrase) ||
                 (duressPin && pinAttempt === duressPin))
         ) {
-            SettingsStore.setLoginStatus(true);
+            // never mark the session logged in here: the wipe takes long
+            // enough that an unlocked app would expose the wallet UI (and
+            // the configs being wiped) before the restart lands. Keeping
+            // loggedIn false holds every auth gate shut for the duration -
+            // back-press still exits and the Wallet view renders nothing.
+            this.setState({ wiping: true });
             await this.deleteNodes();
         } else {
             // need to fetch updated settings to get incremented value of
@@ -362,7 +374,9 @@ export default class Lockscreen extends React.Component<
                 authenticationAttempts
             });
             if (authenticationAttempts >= maxAuthenticationAttempts) {
-                SettingsStore.setLoginStatus(true);
+                // see the duress branch: loggedIn must stay false so the
+                // wallet UI stays gated while the wipe runs
+                this.setState({ wiping: true });
                 // wipe node configs, passwords, and pins
                 await this.authenticationFailure();
             } else {
@@ -516,8 +530,29 @@ export default class Lockscreen extends React.Component<
             deletePin,
             deleteDuressPin,
             deletePassword,
-            deleteDuressPassword
+            deleteDuressPassword,
+            wiping
         } = this.state;
+
+        // neutral cover while the wipe runs, for both the duress and the
+        // failed-attempts paths: an indistinct loading state discloses
+        // nothing about the wipe and leaves nothing interactive until the
+        // restart lands
+        if (wiping) {
+            return (
+                <Screen>
+                    <View
+                        style={{
+                            flex: 1,
+                            justifyContent: 'center',
+                            alignItems: 'center'
+                        }}
+                    >
+                        <LoadingIndicator />
+                    </View>
+                </Screen>
+            );
+        }
 
         return (
             <Screen>

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -11,7 +11,6 @@ import {
 } from 'react-native';
 import { Route } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import RNRestart from 'react-native-restart';
 
 import Button from '../components/Button';
 import Header from '../components/Header';
@@ -25,8 +24,12 @@ import ShowHideToggle from '../components/ShowHideToggle';
 import SettingsStore, { PosEnabled } from '../stores/SettingsStore';
 
 import { verifyBiometry } from '../utils/BiometricUtils';
-import { clearAllData } from '../utils/DataClearUtils';
+import {
+    blockNavigationDuringWipe,
+    clearAllData
+} from '../utils/DataClearUtils';
 import { localeString } from '../utils/LocaleUtils';
+import { restartApp } from '../utils/RestartUtils';
 import { themeColor } from '../utils/ThemeUtils';
 
 interface LockscreenProps {
@@ -73,6 +76,7 @@ export default class Lockscreen extends React.Component<
     LockscreenState
 > {
     private subscription: NativeEventSubscription;
+    private releaseWipeGuard: (() => void) | null = null;
 
     constructor(props: any) {
         super(props);
@@ -257,6 +261,7 @@ export default class Lockscreen extends React.Component<
 
     componentWillUnmount() {
         this.subscription?.remove();
+        this.releaseWipeGuard?.();
     }
 
     handleAppStateChange = (nextAppState: AppStateStatus) => {
@@ -357,8 +362,8 @@ export default class Lockscreen extends React.Component<
             // never mark the session logged in here: the wipe takes long
             // enough that an unlocked app would expose the wallet UI (and
             // the configs being wiped) before the restart lands. Keeping
-            // loggedIn false holds every auth gate shut for the duration -
-            // back-press still exits and the Wallet view renders nothing.
+            // loggedIn false holds every auth gate shut for the duration,
+            // and the wipe guard pins the user to the wiping screen.
             this.setState({ wiping: true });
             await this.deleteNodes();
         } else {
@@ -460,6 +465,9 @@ export default class Lockscreen extends React.Component<
         // pre-wipe in-memory blob and re-persist it (pins, passphrases and
         // all), and a restart is also the only way to drop node credentials
         // still held in memory by the stores.
+        this.releaseWipeGuard = blockNavigationDuringWipe(
+            this.props.navigation
+        );
         try {
             await clearAllData();
         } catch (e) {
@@ -471,7 +479,7 @@ export default class Lockscreen extends React.Component<
             // blob is cleared early, so a restart still lands on a fresh
             // install state rather than stranding the user on a dead
             // lockscreen
-            RNRestart.Restart();
+            restartApp();
         }
     };
 
@@ -480,13 +488,16 @@ export default class Lockscreen extends React.Component<
         // removes the node data dirs, Cashu seeds + CDK db, swap rescue key
         // and the settings blob itself (including pins and passphrases).
         // Restart instead of writing settings back - see deleteNodes above.
+        this.releaseWipeGuard = blockNavigationDuringWipe(
+            this.props.navigation
+        );
         try {
             await clearAllData();
         } catch (e) {
             // see deleteNodes: log only, never surface, always restart
             console.warn('[Lockscreen] wipe failed part-way', e);
         } finally {
-            RNRestart.Restart();
+            restartApp();
         }
     };
 

--- a/views/Settings/SeedQRExport.tsx
+++ b/views/Settings/SeedQRExport.tsx
@@ -112,24 +112,14 @@ export default class SeedQRExport extends React.PureComponent<
             const seedPhrase: string[] =
                 seedFromRoute || SettingsStore.seedPhrase;
 
-            // Cache is keyed by the active node's pubkey — only use it when
-            // exporting the active wallet's seed (no override from route).
+            // Never persist derived extended private keys. Always recompute
+            // them from the seed below, and proactively delete any cache
+            // written by older builds so the wallet's HD master keys do not
+            // linger in the keychain after wallet deletion / data wipe
+            // (KEY-006: '<pubkey>-extended-private-keys' had no deletion path).
             if (!seedFromRoute) {
                 const pubkey = NodeInfoStore!.nodeInfo?.nodeId;
-                const storageKey = `${pubkey}-extended-private-keys`;
-                const extendedKeys = await Storage.getItem(storageKey);
-                if (extendedKeys) {
-                    const extendedKeysJson = JSON.parse(extendedKeys);
-                    const { nodeBase58Segwit, nodeBase58NativeSegwit } =
-                        extendedKeysJson;
-
-                    this.setState({
-                        loading: false,
-                        nodeBase58Segwit,
-                        nodeBase58NativeSegwit
-                    });
-                    return;
-                }
+                await Storage.removeItem(`${pubkey}-extended-private-keys`);
             }
 
             const bits = seedPhrase
@@ -272,17 +262,6 @@ export default class SeedQRExport extends React.PureComponent<
                         : NATIVE_SEGWIT_MAINNET.config
                 )
                 .toBase58();
-
-            // Only cache for the active wallet — never overwrite the active
-            // node's cached keys with an inactive wallet's derived keys.
-            if (!seedFromRoute) {
-                const pubkey = NodeInfoStore!.nodeInfo?.nodeId;
-                const storageKey = `${pubkey}-extended-private-keys`;
-                await Storage.setItem(storageKey, {
-                    nodeBase58Segwit,
-                    nodeBase58NativeSegwit
-                });
-            }
 
             this.setState({
                 loading: false,

--- a/views/Settings/SeedQRExport.tsx
+++ b/views/Settings/SeedQRExport.tsx
@@ -117,9 +117,13 @@ export default class SeedQRExport extends React.PureComponent<
             // written by older builds so the wallet's HD master keys do not
             // linger in the keychain after wallet deletion / data wipe
             // (KEY-006: '<pubkey>-extended-private-keys' had no deletion path).
+            // NodeInfoStore.getNodeInfo also purges on connect; this read-site
+            // purge is belt and braces for when nodeInfo is already loaded.
             if (!seedFromRoute) {
                 const pubkey = NodeInfoStore!.nodeInfo?.nodeId;
-                await Storage.removeItem(`${pubkey}-extended-private-keys`);
+                if (pubkey) {
+                    await Storage.removeItem(`${pubkey}-extended-private-keys`);
+                }
             }
 
             const bits = seedPhrase

--- a/views/Settings/SeedQRExport.tsx
+++ b/views/Settings/SeedQRExport.tsx
@@ -11,10 +11,6 @@ import ecc from '../../zeus_modules/noble_ecc';
 // You must wrap a tiny-secp256k1 compatible implementation
 const bip32 = BIP32Factory(ecc);
 
-const aez = require('aez');
-const crc32 = require('fast-crc32c/impls/js_crc32c');
-const scrypt = require('scrypt-js').scrypt;
-
 import Button from '../../components/Button';
 import CollapsedQR from '../../components/CollapsedQR';
 import Header from '../../components/Header';
@@ -28,7 +24,7 @@ import {
 import NodeInfoStore from '../../stores/NodeInfoStore';
 import SettingsStore from '../../stores/SettingsStore';
 
-import { BIP39_WORD_LIST } from '../../utils/Bip39Utils';
+import { decodeAezeedEntropy } from '../../utils/AezeedUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
 
@@ -55,20 +51,6 @@ interface SeedQRExportState {
     error: string;
 }
 
-const AEZEED_DEFAULT_PASSPHRASE = 'aezeed',
-    AEZEED_VERSION = 0,
-    SCRYPT_N = 32768,
-    SCRYPT_R = 8,
-    SCRYPT_P = 1,
-    SCRYPT_KEY_LENGTH = 32,
-    ENCIPHERED_LENGTH = 33,
-    SALT_LENGTH = 5,
-    AD_LENGTH = SALT_LENGTH + 1,
-    AEZ_TAU = 4,
-    CHECKSUM_LENGTH = 4,
-    CHECKSUM_OFFSET = ENCIPHERED_LENGTH - CHECKSUM_LENGTH,
-    SALT_OFFSET = CHECKSUM_OFFSET - SALT_LENGTH;
-
 @inject('NodeInfoStore', 'SettingsStore')
 @observer
 export default class SeedQRExport extends React.PureComponent<
@@ -82,19 +64,6 @@ export default class SeedQRExport extends React.PureComponent<
         nodeBase58NativeSegwit: '',
         error: ''
     };
-
-    lpad(str: string, padString: string, length: number) {
-        while (str.length < length) {
-            str = padString + str;
-        }
-        return str;
-    }
-
-    getAD(salt: any) {
-        const ad = Buffer.alloc(AD_LENGTH, AEZEED_VERSION);
-        salt.copy(ad, 1);
-        return ad;
-    }
 
     componentDidMount() {
         this.initializeSeed();
@@ -126,66 +95,18 @@ export default class SeedQRExport extends React.PureComponent<
                 }
             }
 
-            const bits = seedPhrase
-                .map((word: string) => {
-                    const index = BIP39_WORD_LIST.indexOf(word);
-                    return this.lpad(index.toString(2), '0', 11);
-                })
-                .join('');
-
-            const seedBytes = (bits.match(/(.{1,8})/g) || []).map(
-                (bin: string) => parseInt(bin, 2)
-            );
-            const seed = Buffer.from(seedBytes);
-
-            if (!seed || seed.length === 0 || seed[0] !== AEZEED_VERSION) {
+            let entropy: string;
+            try {
+                entropy = (await decodeAezeedEntropy(seedPhrase)).toString(
+                    'hex'
+                );
+            } catch (e: any) {
                 this.setState({
                     loading: false,
-                    error: 'Invalid seed or version!'
+                    error: e.message
                 });
                 return;
             }
-
-            const salt = seed.slice(SALT_OFFSET, SALT_OFFSET + SALT_LENGTH);
-            const password = Buffer.from(AEZEED_DEFAULT_PASSPHRASE, 'utf8');
-            const cipherSeed = seed.slice(1, SALT_OFFSET);
-            const checksum = seed.slice(CHECKSUM_OFFSET);
-
-            const newChecksum = crc32.calculate(seed.slice(0, CHECKSUM_OFFSET));
-            if (newChecksum !== checksum.readUInt32BE(0)) {
-                this.setState({
-                    loading: false,
-                    error: 'Invalid seed checksum!'
-                });
-                return;
-            }
-
-            const key = await scrypt(
-                password,
-                salt,
-                SCRYPT_N,
-                SCRYPT_R,
-                SCRYPT_P,
-                SCRYPT_KEY_LENGTH
-            );
-
-            const plainSeedBytes = aez.decrypt(
-                key,
-                null,
-                [this.getAD(salt)],
-                AEZ_TAU,
-                cipherSeed
-            );
-
-            if (plainSeedBytes == null) {
-                this.setState({
-                    loading: false,
-                    error: 'Decryption failed. Invalid passphrase?'
-                });
-                return;
-            }
-
-            const entropy = plainSeedBytes.slice(3).toString('hex');
 
             const SEGWIT_MAINNET = {
                 label: 'BTC (Bitcoin, SegWit, BIP49)',

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -73,18 +73,17 @@ import { getPhoto } from '../../utils/PhotoUtils';
 import {
     clearNodeKeychainData,
     clearCDKDatabase,
-    clearCDKDatabaseForNode
+    clearCDKDatabaseForNode,
+    deleteNodeDataDirectoryWithRetry
 } from '../../utils/DataClearUtils';
 import {
     optimizeNeutrinoPeers,
     createLndWallet,
-    deleteLndWallet,
     stopLnd
 } from '../../utils/LndMobileUtils';
 import {
     createLdkNodeWallet,
     stopLdkNode,
-    deleteLdkNodeWallet,
     getDefaultEsploraServer,
     getDefaultRgsServer,
     DEFAULT_VSS_SERVER,
@@ -812,12 +811,16 @@ export default class WalletConfiguration extends React.Component<
                 justDeletedWallet: active
             });
 
-            // Delete wallet data after settings are updated
-            if (implementation === 'embedded-lnd') {
-                await deleteLndWallet(lndDir || 'lnd');
-            }
-            if (implementation === 'ldk-node' && ldkNodeDir) {
-                await deleteLdkNodeWallet(ldkNodeDir);
+            // Delete wallet data after settings are updated. Retried: the
+            // node may still hold file handles while shutting down, which
+            // clears on its own after a moment.
+            const dirDeleted = await deleteNodeDataDirectoryWithRetry(
+                deletedNode ?? { implementation, lndDir, ldkNodeDir }
+            );
+            if (!dirDeleted) {
+                console.warn(
+                    'Node data directory could not be fully deleted for removed wallet'
+                );
             }
 
             if (newNodes.length === 0) {

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -72,7 +72,8 @@ import AddIcon from '../../assets/images/SVG/Add.svg';
 import { getPhoto } from '../../utils/PhotoUtils';
 import {
     clearNodeKeychainData,
-    clearCDKDatabase
+    clearCDKDatabase,
+    clearCDKDatabaseForNode
 } from '../../utils/DataClearUtils';
 import {
     optimizeNeutrinoPeers,
@@ -784,6 +785,11 @@ export default class WalletConfiguration extends React.Component<
                 await stopLdkNode();
             }
 
+            // Delete this wallet's per-wallet CDK ecash database first: its
+            // filename embeds a hash of the cashu seed, which
+            // clearNodeKeychainData wipes below.
+            await clearCDKDatabaseForNode(deletedNode);
+
             // Clear this node's keychain material (Cashu seeds/keys namespaced
             // by node dir, LNC pairing credentials) so it does not outlive the
             // wallet. This must happen before updateSettings removes the node
@@ -815,9 +821,9 @@ export default class WalletConfiguration extends React.Component<
             }
 
             if (newNodes.length === 0) {
-                // The CDK ecash database is shared across wallets, so only
-                // delete it once the last wallet is gone (otherwise it would
-                // wipe other wallets' proofs).
+                // Last wallet gone: sweep every remaining CDK database file
+                // (legacy shared db, any per-wallet dbs whose seeds are no
+                // longer recoverable, and WAL/SHM sidecars).
                 await clearCDKDatabase();
                 navigation.navigate('IntroSplash');
             } else {

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -765,13 +765,6 @@ export default class WalletConfiguration extends React.Component<
         const deletedNode = index != null ? nodes?.[index] : undefined;
 
         try {
-            const newNodes: any = [];
-            for (let i = 0; nodes && i < nodes.length; i++) {
-                if (index !== i) {
-                    newNodes.push(nodes[i]);
-                }
-            }
-
             // If deleting active embedded LND wallet, stop it first
             if (
                 active &&
@@ -811,17 +804,25 @@ export default class WalletConfiguration extends React.Component<
 
             // Update settings first to clear node references before
             // deleting files — prevents stale references if navigation
-            // triggers a reconnect
-            const newSelectedNodeIndex = this.getNewSelectedNodeIndex(
-                index,
-                settings
+            // triggers a reconnect. The nodes array is computed inside the
+            // serialized update from the freshest persisted settings: the
+            // stops above take seconds, and a functional update is what
+            // keeps a concurrent settings write from either resurrecting
+            // the deleted node or being clobbered by a snapshot taken
+            // before it.
+            const newSettings = await updateSettings(
+                (currentSettings: Settings) => ({
+                    nodes: (currentSettings.nodes || []).filter(
+                        (_: any, i: number) => i !== index
+                    ),
+                    selectedNode: this.getNewSelectedNodeIndex(
+                        index,
+                        currentSettings
+                    ),
+                    justDeletedWallet: active
+                })
             );
-
-            await updateSettings({
-                nodes: newNodes,
-                selectedNode: newSelectedNodeIndex,
-                justDeletedWallet: active
-            });
+            const remainingNodes = newSettings?.nodes || [];
 
             // Delete wallet data after settings are updated. Retried: the
             // node may still hold file handles while shutting down, which
@@ -842,7 +843,7 @@ export default class WalletConfiguration extends React.Component<
                 );
             }
 
-            if (newNodes.length === 0) {
+            if (remainingNodes.length === 0) {
                 // Last wallet gone: sweep every remaining CDK database file
                 // (legacy shared db, any per-wallet dbs whose seeds are no
                 // longer recoverable, and WAL/SHM sidecars).

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -784,6 +784,14 @@ export default class WalletConfiguration extends React.Component<
                 await stopLdkNode();
             }
 
+            // Clear this node's keychain material (Cashu seeds/keys namespaced
+            // by node dir, LNC pairing credentials) so it does not outlive the
+            // wallet. This must happen before updateSettings removes the node
+            // config: the hashed LNC keys can only be reconstructed from the
+            // pairing phrase stored there, so a crash after the config is gone
+            // would orphan them permanently.
+            await clearNodeKeychainData(deletedNode);
+
             // Update settings first to clear node references before
             // deleting files — prevents stale references if navigation
             // triggers a reconnect
@@ -805,11 +813,6 @@ export default class WalletConfiguration extends React.Component<
             if (implementation === 'ldk-node' && ldkNodeDir) {
                 await deleteLdkNodeWallet(ldkNodeDir);
             }
-
-            // Clear this node's keychain material (Cashu seeds/keys namespaced
-            // by node dir, LNC pairing credentials) so it does not outlive the
-            // wallet.
-            await clearNodeKeychainData(deletedNode);
 
             if (newNodes.length === 0) {
                 // The CDK ecash database is shared across wallets, so only

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -170,6 +170,7 @@ interface WalletConfigurationState {
     // NWC
     nostrWalletConnectUrl: string;
     deletingWallet: boolean;
+    saving: boolean;
     // Errors
     lndhubUrlError: boolean;
     usernameError: boolean;
@@ -238,6 +239,7 @@ export default class WalletConfiguration extends React.Component<
         creatingWallet: false,
         errorCreatingWallet: false,
         deletingWallet: false,
+        saving: false,
         // embedded ldk node
         ldkMnemonic: '',
         ldkPassphrase: '',
@@ -575,6 +577,10 @@ export default class WalletConfiguration extends React.Component<
             throw new Error('lndhub settings missing.');
         }
 
+        // Block the action buttons until navigation: a second Save (or a
+        // Delete) firing mid-write would re-persist the stale nodes array.
+        this.setState({ saving: true });
+
         const node = {
             nickname,
             dismissCustodialWarning,
@@ -641,53 +647,58 @@ export default class WalletConfiguration extends React.Component<
             };
         }
 
-        updateSettings(update).then(async () => {
-            if (recoveryCipherSeed) {
-                await updateSettings({
-                    recovery: true
+        updateSettings(update)
+            .then(async () => {
+                if (recoveryCipherSeed) {
+                    await updateSettings({
+                        recovery: true
+                    });
+                }
+
+                this.setState({
+                    saved: true
                 });
-            }
 
-            this.setState({
-                saved: true
-            });
-
-            const activeNodeIndex = settings.selectedNode || 0;
-            if (index === activeNodeIndex) {
-                // updating active node
-                if (originalNode != null) {
-                    const diff = differenceBy(
-                        Object.entries(originalNode),
-                        Object.entries(node),
-                        (entry) => entry[0] + entry[1]
-                    ).filter(
-                        (entry) =>
-                            entry[0] !== 'nickname' && entry[0] !== 'photo'
-                    );
-                    if (diff.length === 0) {
-                        // only nickname or photo was edited - no reconnect necessary
-                        navigation.goBack();
-                        return;
+                const activeNodeIndex = settings.selectedNode || 0;
+                if (index === activeNodeIndex) {
+                    // updating active node
+                    if (originalNode != null) {
+                        const diff = differenceBy(
+                            Object.entries(originalNode),
+                            Object.entries(node),
+                            (entry) => entry[0] + entry[1]
+                        ).filter(
+                            (entry) =>
+                                entry[0] !== 'nickname' && entry[0] !== 'photo'
+                        );
+                        if (diff.length === 0) {
+                            // only nickname or photo was edited - no reconnect necessary
+                            navigation.goBack();
+                            return;
+                        }
                     }
-                }
-                if (implementation === 'lightning-node-connect') {
-                    BackendUtils.disconnect();
-                }
-                setConnectingStatus(true);
-                navigation.popTo('Wallet');
-            } else {
-                if (newEmbeddedLndWallet) {
-                    // New wallet created - trigger fresh connection
-                    // LND was already stopped in createNewWallet(), just navigate
+                    if (implementation === 'lightning-node-connect') {
+                        BackendUtils.disconnect();
+                    }
                     setConnectingStatus(true);
                     navigation.popTo('Wallet');
-                } else if (this.state.newEntry) {
-                    navigation.navigate('Wallets');
                 } else {
-                    navigation.goBack();
+                    if (newEmbeddedLndWallet) {
+                        // New wallet created - trigger fresh connection
+                        // LND was already stopped in createNewWallet(), just navigate
+                        setConnectingStatus(true);
+                        navigation.popTo('Wallet');
+                    } else if (this.state.newEntry) {
+                        navigation.navigate('Wallets');
+                    } else {
+                        navigation.goBack();
+                    }
                 }
-            }
-        });
+            })
+            .catch((error: any) => {
+                console.error('Error saving wallet configuration:', error);
+                this.setState({ saving: false });
+            });
     };
 
     copyNodeConfig = () => {
@@ -744,6 +755,7 @@ export default class WalletConfiguration extends React.Component<
     };
 
     deleteNodeConfig = async () => {
+        if (this.state.deletingWallet) return;
         this.setState({ deletingWallet: true });
         const { SettingsStore, navigation } = this.props;
         const { updateSettings, embeddedLndStarted, settings } = SettingsStore;
@@ -1306,6 +1318,7 @@ export default class WalletConfiguration extends React.Component<
             creatingWallet,
             errorCreatingWallet,
             deletingWallet,
+            saving,
             // LDK Node
             ldkMnemonic,
             ldkNetwork,
@@ -1331,6 +1344,11 @@ export default class WalletConfiguration extends React.Component<
             createAccountSuccess,
             createAccount
         } = SettingsStore;
+
+        // A save or delete in flight: block every action button so a
+        // concurrent updateSettings cannot re-persist stale node configs
+        // (e.g. resurrecting a wallet mid-deletion).
+        const processing = loading || saving || deletingWallet;
 
         const isLocalImpl =
             implementation === 'embedded-lnd' || implementation === 'ldk-node';
@@ -1418,7 +1436,7 @@ export default class WalletConfiguration extends React.Component<
                     }}
                     rightComponent={
                         <Row>
-                            {(loading || deletingWallet) && (
+                            {processing && (
                                 <View style={{ paddingRight: 15 }}>
                                     <LoadingIndicator size={30} />
                                 </View>
@@ -3236,9 +3254,9 @@ export default class WalletConfiguration extends React.Component<
                                                 this.saveWalletConfiguration();
                                             }
                                         }}
-                                        // disable save button if loading, required input missing or input invalid
+                                        // disable save button if processing, required input missing or input invalid
                                         disabled={
-                                            loading ||
+                                            processing ||
                                             hostError ||
                                             (host &&
                                                 !ValidationUtils.isValidServerAddress(
@@ -3326,7 +3344,7 @@ export default class WalletConfiguration extends React.Component<
                                     onPress={() =>
                                         this.setWalletConfigurationAsActive()
                                     }
-                                    disabled={loading}
+                                    disabled={processing}
                                 />
                             </View>
                         )}
@@ -3355,7 +3373,7 @@ export default class WalletConfiguration extends React.Component<
                                             this.copyNodeConfig();
                                         }}
                                         secondary
-                                        disabled={loading}
+                                        disabled={processing}
                                     />
                                 </View>
                             )}
@@ -3368,7 +3386,7 @@ export default class WalletConfiguration extends React.Component<
                                     )}
                                     onPress={this.handleDeletePress}
                                     warning
-                                    disabled={loading}
+                                    disabled={processing}
                                 />
                             </View>
                         )}

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -14,6 +14,7 @@ import {
 import Clipboard from '@react-native-clipboard/clipboard';
 import { inject, observer } from 'mobx-react';
 import differenceBy from 'lodash/differenceBy';
+import isEqual from 'lodash/isEqual';
 import { Route } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { v4 as uuidv4 } from 'uuid';
@@ -811,16 +812,36 @@ export default class WalletConfiguration extends React.Component<
             // the deleted node or being clobbered by a snapshot taken
             // before it.
             const newSettings = await updateSettings(
-                (currentSettings: Settings) => ({
-                    nodes: (currentSettings.nodes || []).filter(
-                        (_: any, i: number) => i !== index
-                    ),
-                    selectedNode: this.getNewSelectedNodeIndex(
-                        index,
-                        currentSettings
-                    ),
-                    justDeletedWallet: active
-                })
+                (currentSettings: Settings) => {
+                    const currentNodes = currentSettings.nodes || [];
+                    // Re-locate the wallet at update time: the captured
+                    // index can go stale during the multi-second stops
+                    // above if a concurrent length-changing nodes write
+                    // (e.g. an overlapping deletion of another wallet)
+                    // shifts the array. Matching the captured config keeps
+                    // the removal pinned to the wallet whose data was just
+                    // wiped, never a neighbor that slid into its slot.
+                    const freshIndex = deletedNode
+                        ? currentNodes.findIndex((node) =>
+                              isEqual(node, deletedNode)
+                          )
+                        : index;
+                    if (freshIndex == null || freshIndex === -1) {
+                        // Config already gone (removed concurrently):
+                        // nothing to filter, just flag the deletion
+                        return { justDeletedWallet: active };
+                    }
+                    return {
+                        nodes: currentNodes.filter(
+                            (_: any, i: number) => i !== freshIndex
+                        ),
+                        selectedNode: this.getNewSelectedNodeIndex(
+                            freshIndex,
+                            currentSettings
+                        ),
+                        justDeletedWallet: active
+                    };
+                }
             );
             const remainingNodes = newSettings?.nodes || [];
 

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -818,8 +818,15 @@ export default class WalletConfiguration extends React.Component<
                 deletedNode ?? { implementation, lndDir, ldkNodeDir }
             );
             if (!dirDeleted) {
-                console.warn(
-                    'Node data directory could not be fully deleted for removed wallet'
+                // Surface the failure instead of navigating away as if the
+                // deletion succeeded: the directory holds wallet and channel
+                // state. The config is already gone, so retrying from the
+                // captured node object is the only remaining path; Skip is
+                // offered so a permanently held file handle cannot strand
+                // the user here. (The duress wipe path never comes through
+                // here and stays silent by design.)
+                await this.promptRetryDataDirDeletion(
+                    deletedNode ?? { implementation, lndDir, ldkNodeDir }
                 );
             }
 
@@ -837,6 +844,42 @@ export default class WalletConfiguration extends React.Component<
             this.setState({ deletingWallet: false });
         }
     };
+
+    // Alert loop for a node data directory that survived deletion retries.
+    // Resolves once a retry succeeds or the user explicitly skips, so the
+    // caller only navigates on an informed decision, never on silent failure.
+    private promptRetryDataDirDeletion = (node: any): Promise<void> =>
+        new Promise((resolve) => {
+            const prompt = () => {
+                Alert.alert(
+                    localeString('general.error'),
+                    localeString(
+                        'views.Settings.WalletConfiguration.deleteWallet.dataDirError'
+                    ),
+                    [
+                        {
+                            text: localeString('general.retry'),
+                            onPress: async () => {
+                                const dirDeleted =
+                                    await deleteNodeDataDirectoryWithRetry(
+                                        node
+                                    );
+                                if (dirDeleted) resolve();
+                                else prompt();
+                            },
+                            isPreferred: true
+                        },
+                        {
+                            text: localeString('general.skip'),
+                            style: 'destructive',
+                            onPress: () => resolve()
+                        }
+                    ],
+                    { cancelable: false }
+                );
+            };
+            prompt();
+        });
 
     private handleDeletePress = () => {
         confirmAction(

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -71,6 +71,10 @@ import AddIcon from '../../assets/images/SVG/Add.svg';
 
 import { getPhoto } from '../../utils/PhotoUtils';
 import {
+    clearNodeKeychainData,
+    clearCDKDatabase
+} from '../../utils/DataClearUtils';
+import {
     optimizeNeutrinoPeers,
     createLndWallet,
     deleteLndWallet,
@@ -746,6 +750,7 @@ export default class WalletConfiguration extends React.Component<
         const { index, implementation, lndDir, ldkNodeDir, active } =
             this.state;
         const { nodes } = settings;
+        const deletedNode = index != null ? nodes?.[index] : undefined;
 
         try {
             const newNodes: any = [];
@@ -801,7 +806,16 @@ export default class WalletConfiguration extends React.Component<
                 await deleteLdkNodeWallet(ldkNodeDir);
             }
 
+            // Clear this node's keychain material (Cashu seeds/keys namespaced
+            // by node dir, LNC pairing credentials) so it does not outlive the
+            // wallet.
+            await clearNodeKeychainData(deletedNode);
+
             if (newNodes.length === 0) {
+                // The CDK ecash database is shared across wallets, so only
+                // delete it once the last wallet is gone (otherwise it would
+                // wipe other wallets' proofs).
+                await clearCDKDatabase();
                 navigation.navigate('IntroSplash');
             } else {
                 navigation.popTo('Wallets');

--- a/views/Tools/index.tsx
+++ b/views/Tools/index.tsx
@@ -55,6 +55,7 @@ interface ToolsProps {
 interface ToolsState {
     isChannelExporting: boolean;
     channelExportMessage: string;
+    isClearingData: boolean;
 }
 
 @inject('SettingsStore', 'NodeInfoStore', 'SyncStore', 'ChannelsStore')
@@ -66,7 +67,8 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
         super(props);
         this.state = {
             isChannelExporting: false,
-            channelExportMessage: ''
+            channelExportMessage: '',
+            isClearingData: false
         };
     }
 
@@ -107,6 +109,7 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
                         // unconditionally (matching Lockscreen's duress paths).
                         // Bailing out on error would leave a session where
                         // every Storage.setItem is a silent no-op.
+                        this.setState({ isClearingData: true });
                         try {
                             await clearAllData();
                         } catch (error) {
@@ -176,8 +179,15 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
                     navigation={navigation}
                 />
                 <ChannelBackupLoadingModal
-                    isOpen={this.state.isChannelExporting}
-                    message={this.state.channelExportMessage}
+                    isOpen={
+                        this.state.isChannelExporting ||
+                        this.state.isClearingData
+                    }
+                    message={
+                        this.state.isClearingData
+                            ? localeString('views.Tools.clearStorage.clearing')
+                            : this.state.channelExportMessage
+                    }
                 />
                 <ScrollView
                     style={{

--- a/views/Tools/index.tsx
+++ b/views/Tools/index.tsx
@@ -102,15 +102,17 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
                     text: localeString('views.Tools.clearStorage.confirm'),
                     style: 'destructive',
                     onPress: async () => {
+                        // clearAllData() latches Storage writes as its first
+                        // step and nothing releases the latch, so restart
+                        // unconditionally (matching Lockscreen's duress paths).
+                        // Bailing out on error would leave a session where
+                        // every Storage.setItem is a silent no-op.
                         try {
                             await clearAllData();
-                            RNRestart.Restart();
                         } catch (error) {
                             console.error('Failed to clear storage:', error);
-                            Alert.alert(
-                                localeString('general.error'),
-                                localeString('views.Tools.clearStorage.error')
-                            );
+                        } finally {
+                            RNRestart.Restart();
                         }
                     }
                 }

--- a/views/Tools/index.tsx
+++ b/views/Tools/index.tsx
@@ -10,7 +10,6 @@ import {
 import { inject, observer } from 'mobx-react';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RouteProp } from '@react-navigation/native';
-import RNRestart from 'react-native-restart';
 
 import AccountIcon from '../../assets/images/SVG/Account.svg';
 import CashuIcon from '../../assets/images/SVG/Ecash.svg';
@@ -31,7 +30,11 @@ import ChannelBackupLoadingModal from '../../components/Modals/ChannelBackupLoad
 
 import BackendUtils from '../../utils/BackendUtils';
 import { localeString } from '../../utils/LocaleUtils';
-import { clearAllData } from '../../utils/DataClearUtils';
+import {
+    blockNavigationDuringWipe,
+    clearAllData
+} from '../../utils/DataClearUtils';
+import { restartApp } from '../../utils/RestartUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import { handleExportChannels } from '../../utils/ChannelMigrationUtils';
 
@@ -62,6 +65,7 @@ interface ToolsState {
 @observer
 export default class Tools extends React.Component<ToolsProps, ToolsState> {
     focusListener: any = null;
+    private releaseWipeGuard: (() => void) | null = null;
 
     constructor(props: ToolsProps) {
         super(props);
@@ -87,6 +91,7 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
         if (this.focusListener) {
             this.focusListener();
         }
+        this.releaseWipeGuard?.();
     }
 
     handleFocus = () => this.props.SettingsStore.getSettings();
@@ -110,12 +115,15 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
                         // Bailing out on error would leave a session where
                         // every Storage.setItem is a silent no-op.
                         this.setState({ isClearingData: true });
+                        this.releaseWipeGuard = blockNavigationDuringWipe(
+                            this.props.navigation
+                        );
                         try {
                             await clearAllData();
                         } catch (error) {
                             console.error('Failed to clear storage:', error);
                         } finally {
-                            RNRestart.Restart();
+                            restartApp();
                         }
                     }
                 }


### PR DESCRIPTION
# Description

Builds on #4327 (KEY-005), now merged. This PR started as KEY-006 from the 2026-08-01 security audit (four classes of secrets surviving deletion and wipes) and grew to eight findings: every fix was verified on-device on both platforms, and the device testing itself surfaced four additional bugs, including one that had silently neutered Android LND directory deletion since 2023.

## Findings

### From the security audit (KEY-006)

1. **Cached account xprvs.** `views/Settings/SeedQRExport.tsx` cached the wallet's BIP49 and BIP84 **master** extended private keys under `<pubkey>-extended-private-keys`. No code path ever deleted this key.
2. **LDK-node Cashu seed.** `clearAllData` only iterated `node.lndDir` for Cashu data, but LDK nodes namespace Cashu keys by `ldkNodeDir` (`CashuStore.getNodeDir`). So `<ldkNodeDir>-cashu-seed-phrase` (identical to the wallet mnemonic on 12-word LDK wallets) survived a full wipe.
3. **LNC pairing keys.** LNC credentials live under `lnc-rn:<sha256(pairingPhrase)>` and `...:host` (`backends/LNC/credentialStore.ts`). `clearAllData` cleared only the literal `lnc-rn` prefix, never the hashed keys.
4. **CDK ecash databases.** `clearCDKDatabase` unlinked only the literal `cashu_wallet.db`, but since v13.0.0 (e14d0e9ed) the native modules create **per-wallet** databases named `cashu_wallet_<sha256(mnemonic)[0..8]>.db`. Every wallet's CDK database (spendable proofs, mint keys, transaction history) survived `clearAllData`, the duress wipe, and wallet deletion. CDK also opens SQLite with `journal_mode=WAL` (cdk-sqlite `common.rs`), so `-wal`/`-shm` sidecars hold recent proof data next to each db, and the db is not encrypted at rest.

### Found during this PR's on-device testing

5. **Android LND directories were never deleted at all.** Two independent bugs in `LndMobileTools.java` each made deletion a no-op: `deleteRecursive`'s only `fileOrDirectory.delete()` call lived inside a `HyperLog.d(...)` statement and was removed along with logging in 54e94665e (2023-09-04), leaving a pure directory walk; and `deleteLndDirectory` built its path as `"--lnddir=" + filesDir + ...`, the LND startup flag pasted into a file path, then resolved success unconditionally. Deleting an embedded wallet left `wallet.db` (encrypted seed), admin macaroons, and `channel.backup` behind, and the merged #4327 duress wipe silently skipped LND directories on Android, its retry loop defeated by the unconditional success. iOS was unaffected.
6. **Cashu clear list had drifted behind CashuStore.** Nine node-dir-namespaced key suffixes written by CashuStore were missing from the clear list, including `offline-pending-tokens` and `offline-spent-tokens` (actual ecash token data); proven on-device by `<nodeDir>-cashu-original-seed-version` surviving a fixed-build deletion. Separately, `clearCashuDataForNode` cleared `-cashu-mintUrls` and then read that same key to enumerate legacy pre-CDK per-mint keys, so that legacy cleanup had always been a no-op.
7. **Async writers resurrected settings after the wipe.** Clear storage wiped everything, then the app restarted into the wallet view with all wallets intact: RNRestart reloads the JS root but the dying context keeps running briefly, `SettingsStore.getSettings` falls back to in-memory settings on a storage miss, and `updateSettings` re-persists the full blob. Device logs showed the resurrecting write landing ~20ms after the wipe finished.
8. **NWC key material was never in the wipe list.** `zeus-nwc-service-keys` (nostr secret keys for the NWC service role) survived a full wipe; client keys and connection configs were equally uncovered.

On iOS, keychain items also survive app uninstall (demonstrated in testing below), compounding all of the above.

## Fixes, by commit

| Commit | Fix |
|---|---|
| 794160723 | **xprv cache:** never persist derived xprvs (recompute per export); delete legacy caches at the read site. **LNC:** reconstruct and clear hashed keys from each node's pairing phrase. **LDK Cashu:** clear both `lndDir` and `ldkNodeDir` namespaces. **`deleteNodeConfig`:** clear the deleted node's keys via shared `clearNodeKeychainData(node)`. |
| 7deb7b6af | Legacy configs without explicit dirs: mirror `getNodeDir()`'s `'lnd'`/`'ldk'` fallbacks, gated by implementation so remote nodes never clear namespaces owned by embedded wallets. |
| ee33ce64a | Clear keychain material before `updateSettings` removes the node config; a crash between the steps would otherwise orphan the hashed LNC keys permanently. |
| 49389b831 | **CDK full wipe:** sweep the CDK directory for the `cashu_wallet` prefix (legacy db, all per-wallet dbs, WAL/SHM sidecars). **Single deletion:** `clearCDKDatabaseForNode` reconstructs the exact filename hash from the stored cashu seed before the keychain clear wipes it; remote nodes excluded so a shared default namespace can never destroy another wallet's proofs. |
| ff1e0f159 | **Android:** restore the `delete()` in `deleteRecursive` (null-guarded, returns success), drop the `--lnddir=` prefix, reject on partial failure. The legacy `"lnd"` branch now deletes only LND artifacts since the files-dir root holds other wallets' data. Single deletion routes through shared `deleteNodeDataDirectoryWithRetry` (3x/500ms) instead of ignoring the result. |
| 3bafdb633 | Exported `CASHU_KEY_SUFFIXES`, complete against CashuStore, with a drift-guard test that greps `stores/CashuStore.ts` for `-cashu-` literals and fails CI when a key is written but not cleared. Legacy per-mint mint list read before clearing so that cleanup actually runs. |
| 31df05f88 | `Storage.blockWrites()` latch: `setItem` becomes a warning no-op for the rest of the JS context once a wipe starts; the post-restart reload starts fresh. Kills the settings-resurrection class for both wipe paths. |
| 36004ff3c | All six `NostrWalletConnectStore` keys, rating counters, and the bare `lnurlpay:` entry added to the wipe list. |
| 55294fc84 | Legacy xprv cache also purged in `NodeInfoStore.getNodeInfo`'s success path, where the pubkey is definitionally known; the read-site purge silently no-oped when the export screen was opened before the node finished connecting (caught by the upgrade-path device test) and could never help users who don't open that screen. |
| ed6a6d104 | **Android orphan kill:** full wipe deletes react-native-keychain's backing stores wholesale (`files/datastore/RN_KEYCHAIN.preferences_pb` plus legacy `shared_prefs/RN_KEYCHAIN.xml`) as its final clearing action, removing the orphaned entries no config-driven clear can reach. Ordered last because react-native-keychain caches the full preference map and a later write would re-persist the orphans; the write latch holds writers until restart. iOS unchanged (system keychain, no file). |

## Known residuals (documented, not fixed here)

- **Pre-v13 shared `cashu_wallet.db`:** one wallet's proofs cannot be selectively removed from the legacy shared file; it dies on last-wallet removal or full wipe. Post-v13 per-wallet databases fully fix this for current wallets.
- **Historical orphans:** devices in the field hold LND directories and keychain entries from wallets deleted by older (broken) builds; their configs are gone, so config-driven cleanup cannot find them. Orphaned *keychain entries* are now killed on Android by the wholesale backing-store deletion (ed6a6d104); orphaned *LND directories* (a files-dir sweep on wipe) and iOS keychain orphans (needs a native delete-all-in-access-group call) remain follow-ups.
- **`lnurlpay:<hash>` metadata:** written with no enumerating index; a write-side index is a follow-up.
- **Cosmetic:** the CDK native module holds its SQLite handle across the wipe and re-creates an empty, schemaless db skeleton (verified: no tables). Avoiding it needs a native close/dispose API on both platforms.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

`utils/DataClearUtils.test.ts` extended to 36 tests: LDK-namespaced Cashu and hashed LNC clearing, legacy default-namespace fallbacks with the remote-node guard, CDK sweep (including partial-failure resilience) and targeted per-wallet deletion (exact native hash derivation, remote/missing-seed refusal), the `CASHU_KEY_SUFFIXES` drift guard against CashuStore's source, the write latch engaging before the first key removal, deletion retry behavior, and NWC key clearing. Verified as real regression guards (assertions fail when the corresponding clearing is removed).

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android (emulator, sdk_gphone64_arm64, Android 15)
- [x] iOS (simulator, iPhone 17 Pro, iOS 18)

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [x] Embedded LND

Remote
- [x] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

> Device testing performed on both platforms, all passes:
> - **Single-wallet deletion** (Android + iOS): deleted wallet's LND dir, CDK db + WAL/SHM sidecars, and cashu keychain keys removed; surviving wallet's ecash balance intact and spent successfully afterward. Restore-from-seed after deletion recovered the deleted wallet's full ecash balance (deterministic db naming confirmed on-device).
> - **Full wipe** (Android + iOS): every `cashu_wallet*` file swept (including orphans from years of accumulated dev state), node dirs deleted, hashed LNC keys cleared, no settings resurrection (iOS keychain went from 96 live entries to 12 orphaned dynamic entries). Post-wipe boot lands on intro and writes only a default settings blob, identical to a fresh install.
> - **Duress wipe** (Android + iOS): same assertions as full wipe, all pass.
> - **iOS uninstall/reinstall** (simulator): all keychain entries survive app deletion, confirming the audit's persistence concern; because the wipe ran first, the survivors contain no key material, and the Keychain Recovery scanner on the fresh install reports "No Lost Data Found".
> - Residual keychain survivors are exclusively pre-existing orphans from old-build deletions and unenumerable hash-keyed dynamic entries, both documented above.
> - **Upgrade path** (Android): pre-PR build wrote the `<pubkey>-extended-private-keys` cache under the real pubkey; PR build purged it on the wallet's next connect, zero occurrences left in the keychain. This test caught and fixed the read-site purge's dependency on nodeInfo being loaded (55294fc84).
> - **LNC credential lifecycle** (Android, regtest litd, public mailbox): pairing writes the hashed `lnc-rn` key pair; single-wallet deletion clears both, verified live. Re-pairing with the consumed phrase fails by design (LNC phrases are one-time; the destroyed static keys were the only resumption path), which is the desired property: after deletion the session is unrecoverable from the device. A brand-new litd session pairs cleanly afterward. A failed pairing attempt does persist credential material, but under a saved wallet config, so deleting that config clears it.
> - **LND REST** (Android, regtest): a connected REST wallet writes no node-namespaced keychain material (credentials live in the settings blob; the Cashu capability gate holds, no `lnd-cashu-*` keys appear). Deletion removes the config cleanly with zero keychain-entry churn and the surviving LNC wallet still connects; the remote-node guards (no default-namespace clearing, no targeted CDK delete) behave as designed.
> - **Android keychain wholesale delete** (emulator): full wipe removed `RN_KEYCHAIN.preferences_pb` entirely, killing three orphaned cashu-seed-phrase families that had survived every prior wipe; a second wipe pass over the already-deleted file ran cleanly (no crash, no file resurrection), demonstrating idempotency. Fresh boot regenerates the store with only the default settings blob; first EncryptedStorage access after the wipe paid a one-time ~28s androidx-crypto keyset regeneration on the emulator.
> - Dev-mode observation: RNRestart occasionally reloads the JS root without relaunching the process, leaving stale in-memory UI over wiped storage until a manual restart; the write latch holds throughout, so nothing re-persists. A hard process restart (e.g. ProcessPhoenix, already a dependency) for the wipe paths is a follow-up candidate.
> - Authoritative uninstall/keychain check on a physical iOS device remains a nice-to-have before release.

### Locales
- [ ] I've added new locale text that requires translations
- [x] N/A

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified





