### PR TITLE
fix(lnc): route payment results through handlePayment on every path

### DIFF
--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -401,7 +401,7 @@ export default class LightningNodeConnect {
                     } else if (decision.kind === 'error') {
                         settle(() => reject(decision.error));
                     }
-                    // 'ignore': EOF, IN_FLIGHT, or another payment's event
+                    // 'ignore': EOF, a non-terminal status, or another payment's event
                 }
             );
         });

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -1,4 +1,8 @@
-import { NativeModules, NativeEventEmitter } from 'react-native';
+import {
+    NativeModules,
+    NativeEventEmitter,
+    EmitterSubscription
+} from 'react-native';
 
 import LNC from '../zeus_modules/@lightninglabs/lnc-rn';
 import { lnrpc, walletrpc } from '../zeus_modules/@lightninglabs/lnc-core';
@@ -10,6 +14,11 @@ import OpenChannelRequest from '../models/OpenChannelRequest';
 
 import Base64Utils from '../utils/Base64Utils';
 import { snakeize } from '../utils/DataFormatUtils';
+import {
+    decideLncPayEvent,
+    deriveExpectedPaymentHash
+} from '../utils/LncPayUtils';
+import { localeString } from '../utils/LocaleUtils';
 import { toLnrpcAddressType } from '../utils/LndUtils';
 import VersionUtils from '../utils/VersionUtils';
 
@@ -333,10 +342,68 @@ export default class LightningNodeConnect {
             .decodePayReq({ pay_req: urlParams && urlParams[0] })
             .then((data: lnrpc.PayReq) => snakeize(data));
     payLightningInvoice = (data: any) => {
+        // sendPaymentV2 is a streaming RPC: the call returns the event name
+        // ('routerrpc.Router.SendPaymentV2') and results arrive on a channel
+        // shared by every concurrent payment, with no request correlation.
+        // Resolve with this payment's terminal result so callers get the
+        // same promise contract as every other backend. The expected hash
+        // must be derived before pubkey is stripped.
+        const expectedHash = deriveExpectedPaymentHash(data);
         if (data.pubkey) delete data.pubkey;
-        return this.lnc.lnd.router.sendPaymentV2({
+
+        const streamingCall = this.lnc.lnd.router.sendPaymentV2({
             ...data,
             allow_self_payment: true
+        });
+
+        const { LncModule } = NativeModules;
+        const eventEmitter = new NativeEventEmitter(LncModule);
+        return new Promise((resolve, reject) => {
+            let settled = false;
+            let subscription: EmitterSubscription;
+
+            const settle = (fn: () => void) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timer);
+                subscription.remove();
+                fn();
+            };
+
+            // If the stream dies without a terminal event, resolve with the
+            // designed in-transit shape rather than rejecting: the payment
+            // may still settle node-side, and a hard failure here invites a
+            // retry (a double-send on keysend, where every attempt carries
+            // a fresh preimage).
+            const timeoutMs =
+                ((Number(data.timeout_seconds) || 60) + 60) * 1000;
+            const timer = setTimeout(
+                () =>
+                    settle(() =>
+                        resolve({
+                            payment_error: localeString(
+                                'views.SendingLightning.paymentTimedOut'
+                            )
+                        })
+                    ),
+                timeoutMs
+            );
+
+            subscription = eventEmitter.addListener(
+                streamingCall,
+                (event: any) => {
+                    const decision = decideLncPayEvent(
+                        event?.result,
+                        expectedHash
+                    );
+                    if (decision.kind === 'terminal') {
+                        settle(() => resolve(decision.result));
+                    } else if (decision.kind === 'error') {
+                        settle(() => reject(decision.error));
+                    }
+                    // 'ignore': EOF, IN_FLIGHT, or another payment's event
+                }
+            );
         });
     };
     closeChannel = async (urlParams?: Array<string>) => {

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -709,23 +709,19 @@ export default class TransactionsStore {
                 ? BackendUtils.sendKeysend
                 : BackendUtils.payLightningInvoice;
 
-        if (this.settingsStore.implementation === 'lightning-node-connect') {
-            return payFunc(data);
-        } else {
-            payFunc(data)
-                .then((response: any) => {
-                    const result = response.result || response;
-                    this.handlePayment(result, seq);
-                })
-                .catch((err: Error) => {
-                    this.handlePaymentError(err, seq);
-                });
-        }
+        payFunc(data)
+            .then((response: any) => {
+                const result = response.result || response;
+                this.handlePayment(result, seq);
+            })
+            .catch((err: Error) => {
+                this.handlePaymentError(err, seq);
+            });
     };
 
     // Clears the in-flight guard on behalf of payment `seq`. Callers that
-    // can't identify their payment (LNC view subscriptions) omit `seq` and
-    // clear unconditionally, matching the pre-ownership behavior.
+    // can't identify their payment omit `seq` and clear unconditionally,
+    // matching the pre-ownership behavior.
     @action
     private clearPaymentInFlight = (seq?: number) => {
         if (seq !== undefined && this.inFlightOwnerSeq !== seq) return;
@@ -770,19 +766,15 @@ export default class TransactionsStore {
 
         const payFunc = BackendUtils.payLightningInvoice;
 
-        if (this.settingsStore.implementation === 'lightning-node-connect') {
-            return payFunc(data);
-        } else {
-            return payFunc(data)
-                .then((response: any) => {
-                    const result = response.result || response;
-                    return result;
-                })
-                .catch((err: any) => {
-                    console.error('Payment error:', err);
-                    throw err;
-                });
-        }
+        return payFunc(data)
+            .then((response: any) => {
+                const result = response.result || response;
+                return result;
+            })
+            .catch((err: any) => {
+                console.error('Payment error:', err);
+                throw err;
+            });
     };
 
     @action

--- a/utils/LncPayUtils.test.ts
+++ b/utils/LncPayUtils.test.ts
@@ -90,6 +90,23 @@ describe('decideLncPayEvent', () => {
         expect(decideLncPayEvent(event).kind).toBe('ignore');
     });
 
+    it('ignores INITIATED updates, even with a matching hash', () => {
+        // Streamed as the first event when no_inflight_updates is false;
+        // treating it as terminal would report failure for a payment that
+        // goes on to settle.
+        const event = JSON.stringify({
+            status: 'INITIATED',
+            payment_hash: SPEC_HASH_HEX
+        });
+        expect(decideLncPayEvent(event, SPEC_HASH_HEX).kind).toBe('ignore');
+        expect(decideLncPayEvent(event).kind).toBe('ignore');
+    });
+
+    it('ignores deprecated UNKNOWN status updates', () => {
+        const event = JSON.stringify({ status: 'UNKNOWN' });
+        expect(decideLncPayEvent(event, SPEC_HASH_HEX).kind).toBe('ignore');
+    });
+
     it('accepts a terminal event when no hash is expected', () => {
         const decision = decideLncPayEvent(terminalEvent);
         expect(decision.kind).toBe('terminal');

--- a/utils/LncPayUtils.test.ts
+++ b/utils/LncPayUtils.test.ts
@@ -1,0 +1,156 @@
+import {
+    decideLncPayEvent,
+    deriveExpectedPaymentHash,
+    normalizePaymentHash
+} from './LncPayUtils';
+
+// BOLT11 spec reference vector (lnbc2500u with hashed description)
+// https://github.com/lightning/bolts/blob/master/11-payment-encoding.md#examples
+const BOLT11_SPEC_FIXTURE =
+    'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr';
+const SPEC_HASH_HEX =
+    '0001020304050607080900010203040506070809000102030405060708090102';
+const SPEC_HASH_BASE64 = Buffer.from(SPEC_HASH_HEX, 'hex').toString('base64');
+
+const OTHER_HASH_HEX =
+    'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+describe('normalizePaymentHash', () => {
+    it('passes through hex, lowercased', () => {
+        expect(normalizePaymentHash(SPEC_HASH_HEX)).toBe(SPEC_HASH_HEX);
+        expect(normalizePaymentHash(SPEC_HASH_HEX.toUpperCase())).toBe(
+            SPEC_HASH_HEX
+        );
+    });
+
+    it('converts base64-encoded 32 bytes to hex', () => {
+        expect(normalizePaymentHash(SPEC_HASH_BASE64)).toBe(SPEC_HASH_HEX);
+    });
+
+    it('returns undefined for garbage', () => {
+        expect(normalizePaymentHash(undefined)).toBeUndefined();
+        expect(normalizePaymentHash('')).toBeUndefined();
+        expect(normalizePaymentHash('not a hash')).toBeUndefined();
+        expect(normalizePaymentHash('abcd')).toBeUndefined();
+        expect(normalizePaymentHash(42)).toBeUndefined();
+    });
+});
+
+describe('deriveExpectedPaymentHash', () => {
+    it('uses the keysend payment_hash (base64) when present', () => {
+        expect(
+            deriveExpectedPaymentHash({ payment_hash: SPEC_HASH_BASE64 })
+        ).toBe(SPEC_HASH_HEX);
+    });
+
+    it('decodes the bolt11 invoice hash', () => {
+        expect(
+            deriveExpectedPaymentHash({ payment_request: BOLT11_SPEC_FIXTURE })
+        ).toBe(SPEC_HASH_HEX);
+    });
+
+    it('skips correlation for AMP payments', () => {
+        expect(
+            deriveExpectedPaymentHash({
+                amp: true,
+                payment_hash: SPEC_HASH_BASE64,
+                payment_request: BOLT11_SPEC_FIXTURE
+            })
+        ).toBeUndefined();
+    });
+
+    it('returns undefined when nothing is derivable', () => {
+        expect(deriveExpectedPaymentHash({})).toBeUndefined();
+        expect(
+            deriveExpectedPaymentHash({ payment_request: 'lnbc1garbage' })
+        ).toBeUndefined();
+    });
+});
+
+describe('decideLncPayEvent', () => {
+    const terminalEvent = JSON.stringify({
+        status: 'SUCCEEDED',
+        payment_hash: SPEC_HASH_HEX,
+        payment_preimage: 'aa'.repeat(32)
+    });
+
+    it('ignores EOF and empty events', () => {
+        expect(decideLncPayEvent('EOF').kind).toBe('ignore');
+        expect(decideLncPayEvent('').kind).toBe('ignore');
+        expect(decideLncPayEvent(undefined).kind).toBe('ignore');
+        expect(decideLncPayEvent(null).kind).toBe('ignore');
+    });
+
+    it('ignores IN_FLIGHT updates, even with a matching hash', () => {
+        const event = JSON.stringify({
+            status: 'IN_FLIGHT',
+            payment_hash: SPEC_HASH_HEX
+        });
+        expect(decideLncPayEvent(event, SPEC_HASH_HEX).kind).toBe('ignore');
+        expect(decideLncPayEvent(event).kind).toBe('ignore');
+    });
+
+    it('accepts a terminal event when no hash is expected', () => {
+        const decision = decideLncPayEvent(terminalEvent);
+        expect(decision.kind).toBe('terminal');
+        if (decision.kind === 'terminal') {
+            expect(decision.result.status).toBe('SUCCEEDED');
+        }
+    });
+
+    it('accepts a terminal event with a matching hex hash', () => {
+        expect(decideLncPayEvent(terminalEvent, SPEC_HASH_HEX).kind).toBe(
+            'terminal'
+        );
+    });
+
+    it('matches when the event hash is base64 of the same bytes', () => {
+        const event = JSON.stringify({
+            status: 'SUCCEEDED',
+            payment_hash: SPEC_HASH_BASE64
+        });
+        expect(decideLncPayEvent(event, SPEC_HASH_HEX).kind).toBe('terminal');
+    });
+
+    it("ignores another payment's terminal event", () => {
+        expect(decideLncPayEvent(terminalEvent, OTHER_HASH_HEX).kind).toBe(
+            'ignore'
+        );
+    });
+
+    it('tolerates a terminal event without a payment_hash', () => {
+        const event = JSON.stringify({ status: 'SUCCEEDED' });
+        expect(decideLncPayEvent(event, SPEC_HASH_HEX).kind).toBe('terminal');
+    });
+
+    it('passes FAILED events through as terminal', () => {
+        const event = JSON.stringify({
+            status: 'FAILED',
+            failure_reason: 'FAILURE_REASON_NO_ROUTE',
+            payment_hash: SPEC_HASH_HEX
+        });
+        const decision = decideLncPayEvent(event, SPEC_HASH_HEX);
+        expect(decision.kind).toBe('terminal');
+        if (decision.kind === 'terminal') {
+            expect(decision.result.failure_reason).toBe(
+                'FAILURE_REASON_NO_ROUTE'
+            );
+        }
+    });
+
+    it('turns a non-JSON native error string into a real Error', () => {
+        const raw = 'rpc error: code = Unavailable desc = connection closed';
+        const decision = decideLncPayEvent(raw, SPEC_HASH_HEX);
+        expect(decision.kind).toBe('error');
+        if (decision.kind === 'error') {
+            expect(decision.error).toBeInstanceOf(Error);
+            expect(decision.error.message).toBe(raw);
+        }
+    });
+
+    it('treats JSON that is not an object as an error', () => {
+        expect(decideLncPayEvent('"unavailable"').kind).toBe('error');
+        expect(decideLncPayEvent('123').kind).toBe('error');
+        expect(decideLncPayEvent('null').kind).toBe('error');
+    });
+});

--- a/utils/LncPayUtils.ts
+++ b/utils/LncPayUtils.ts
@@ -1,6 +1,15 @@
 import Base64Utils from './Base64Utils';
 import Bolt11Utils from './Bolt11Utils';
 
+// lnrpc.Payment.PaymentStatus values that mean the payment is still in
+// progress. INITIATED ("created and has not attempted any HTLCs") streams
+// as the first event whenever no_inflight_updates is false, which is the
+// default on LNC (the store only sets it for Tor and AMP). UNKNOWN is
+// deprecated and documented as never returned, but is non-terminal if it
+// ever were. Anything else is treated as terminal so new lnd statuses
+// fail loudly rather than strand the payment.
+const NON_TERMINAL_STATUSES = new Set(['UNKNOWN', 'IN_FLIGHT', 'INITIATED']);
+
 export type LncPayEventDecision =
     | { kind: 'ignore' }
     | { kind: 'terminal'; result: any }
@@ -79,7 +88,7 @@ export const decideLncPayEvent = (
         return { kind: 'error', error: new Error(eventResult) };
     }
 
-    if (result.status === 'IN_FLIGHT') return { kind: 'ignore' };
+    if (NON_TERMINAL_STATUSES.has(result.status)) return { kind: 'ignore' };
 
     if (expectedHashHex) {
         const eventHash = normalizePaymentHash(result.payment_hash);

--- a/utils/LncPayUtils.ts
+++ b/utils/LncPayUtils.ts
@@ -1,0 +1,92 @@
+import Base64Utils from './Base64Utils';
+import Bolt11Utils from './Bolt11Utils';
+
+export type LncPayEventDecision =
+    | { kind: 'ignore' }
+    | { kind: 'terminal'; result: any }
+    | { kind: 'error'; error: Error };
+
+const HEX_32_BYTES = /^[0-9a-fA-F]{64}$/;
+
+// Normalizes a payment hash to lowercase hex. Accepts 64-char hex or
+// base64-encoded 32 bytes: requests carry base64 (LND REST convention)
+// while LNC stream events carry hex, and callers shouldn't care which.
+export const normalizePaymentHash = (hash: unknown): string | undefined => {
+    if (typeof hash !== 'string' || !hash) return undefined;
+    if (HEX_32_BYTES.test(hash)) return hash.toLowerCase();
+    try {
+        const hex = Base64Utils.base64ToHex(hash);
+        if (HEX_32_BYTES.test(hex)) return hex.toLowerCase();
+    } catch {}
+    return undefined;
+};
+
+// Derives the payment hash (lowercase hex) an outgoing SendPaymentV2
+// request expects its result events to carry. Returns undefined when no
+// hash can be pinned down, in which case the caller must fall back to
+// accepting the first terminal event on the stream:
+// - AMP payments: lnd derives per-attempt hashes, so the request-side
+//   hash never matches the events; correlating would filter out the
+//   payment's own result.
+// - keysend: the store builds payment_hash (base64) from its preimage.
+// - bolt11: the hash is inside the invoice.
+export const deriveExpectedPaymentHash = (data: {
+    payment_hash?: string;
+    payment_request?: string;
+    amp?: boolean;
+}): string | undefined => {
+    if (data.amp) return undefined;
+    if (data.payment_hash) return normalizePaymentHash(data.payment_hash);
+    if (data.payment_request) {
+        try {
+            return normalizePaymentHash(
+                Bolt11Utils.decode(data.payment_request).payment_hash
+            );
+        } catch {
+            return undefined;
+        }
+    }
+    return undefined;
+};
+
+// Classifies one raw `event.result` string from the shared
+// 'routerrpc.Router.SendPaymentV2' LNC event channel. Everything on that
+// channel shares one shape: JSON text of an lnrpc.Payment, the 'EOF'
+// stream-close sentinel, or a raw Go error string (the native module has
+// no separate error channel). Events with a parseable payment_hash that
+// differs from expectedHashHex belong to a concurrent payment on the
+// same channel; events without one are tolerated as matches so a payment
+// is never stranded by a sparse event.
+export const decideLncPayEvent = (
+    eventResult: unknown,
+    expectedHashHex?: string
+): LncPayEventDecision => {
+    if (
+        !eventResult ||
+        typeof eventResult !== 'string' ||
+        eventResult === 'EOF'
+    ) {
+        return { kind: 'ignore' };
+    }
+
+    let result: any;
+    try {
+        result = JSON.parse(eventResult);
+    } catch {
+        return { kind: 'error', error: new Error(eventResult) };
+    }
+    if (typeof result !== 'object' || result === null) {
+        return { kind: 'error', error: new Error(eventResult) };
+    }
+
+    if (result.status === 'IN_FLIGHT') return { kind: 'ignore' };
+
+    if (expectedHashHex) {
+        const eventHash = normalizePaymentHash(result.payment_hash);
+        if (eventHash && eventHash !== expectedHashHex) {
+            return { kind: 'ignore' };
+        }
+    }
+
+    return { kind: 'terminal', result };
+};

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -389,7 +389,7 @@ export default class PaymentRequest extends React.Component<
             );
         }
 
-        const streamingCall = TransactionsStore.sendPayment({
+        TransactionsStore.sendPayment({
             payment_request,
             amount,
             max_parts,
@@ -401,10 +401,6 @@ export default class PaymentRequest extends React.Component<
             amp,
             timeout_seconds
         });
-
-        if (SettingsStore.implementation === 'lightning-node-connect') {
-            this.subscribePayment(streamingCall);
-        }
 
         navigation.navigate('SendingLightning', {
             enableDonations,

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import {
-    NativeModules,
-    NativeEventEmitter,
     Platform,
     ScrollView,
     StyleSheet,
@@ -122,7 +120,6 @@ export default class PaymentRequest extends React.Component<
     InvoiceProps,
     InvoiceState
 > {
-    listener: any;
     focusListener: any;
     isComponentMounted: boolean = false;
     private scrollViewRef = React.createRef<ScrollView>();
@@ -305,30 +302,6 @@ export default class PaymentRequest extends React.Component<
             }
             await sleep(3000);
         }
-    };
-
-    subscribePayment = (streamingCall: string) => {
-        const { handlePayment, handlePaymentError } =
-            this.props.TransactionsStore;
-        const { LncModule } = NativeModules;
-        const eventEmitter = new NativeEventEmitter(LncModule);
-        this.listener = eventEmitter.addListener(
-            streamingCall,
-            (event: any) => {
-                if (event.result && event.result !== 'EOF') {
-                    try {
-                        const result = JSON.parse(event.result);
-                        if (result && result.status !== 'IN_FLIGHT') {
-                            handlePayment(result);
-                            this.listener = null;
-                        }
-                    } catch (error: any) {
-                        handlePaymentError(event.result);
-                        this.listener = null;
-                    }
-                }
-            }
-        );
     };
 
     displayFeeRecommendation = () => {

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -546,8 +546,7 @@ export default class Send extends React.Component<SendProps, SendState> {
     };
 
     sendKeySendPayment = (satAmount: string | number) => {
-        const { TransactionsStore, SettingsStore, navigation } = this.props;
-        const { implementation } = SettingsStore;
+        const { TransactionsStore, navigation } = this.props;
         const {
             destination,
             maxParts,
@@ -562,9 +561,8 @@ export default class Send extends React.Component<SendProps, SendState> {
         // flight so a rapid double-tap can't dispatch a second keysend.
         if (TransactionsStore.paymentInFlight) return;
 
-        let streamingCall;
         if (enableAtomicMultiPathPayment) {
-            streamingCall = TransactionsStore.sendPayment({
+            TransactionsStore.sendPayment({
                 amount: satAmount.toString(),
                 pubkey: destination,
                 message,
@@ -574,17 +572,13 @@ export default class Send extends React.Component<SendProps, SendState> {
                 amp: true
             });
         } else {
-            streamingCall = TransactionsStore.sendPayment({
+            TransactionsStore.sendPayment({
                 amount: satAmount.toString(),
                 pubkey: destination,
                 fee_limit_sat: feeLimitSat,
                 max_fee_percent: maxFeePercent,
                 message
             });
-        }
-
-        if (implementation === 'lightning-node-connect') {
-            this.subscribePayment(streamingCall);
         }
 
         navigation.navigate('SendingLightning');

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -3,8 +3,6 @@ import {
     AppState,
     FlatList,
     Image,
-    NativeModules,
-    NativeEventEmitter,
     StyleSheet,
     Text,
     View,
@@ -134,7 +132,6 @@ interface SendState {
 )
 @observer
 export default class Send extends React.Component<SendProps, SendState> {
-    listener: any;
     private backPressSubscription: NativeEventSubscription;
     private appStateSubscription: NativeEventSubscription | null = null;
     private previousAmount: string = '';
@@ -348,7 +345,6 @@ export default class Send extends React.Component<SendProps, SendState> {
     componentWillUnmount(): void {
         this.backPressSubscription?.remove();
         this.appStateSubscription?.remove();
-        if (this.listener && this.listener.stop) this.listener.stop();
     }
 
     readClipboard = async () => {
@@ -364,30 +360,6 @@ export default class Send extends React.Component<SendProps, SendState> {
         }
 
         this.setState({ clipboard });
-    };
-
-    subscribePayment = (streamingCall: string) => {
-        const { handlePayment, handlePaymentError } =
-            this.props.TransactionsStore;
-        const { LncModule } = NativeModules;
-        const eventEmitter = new NativeEventEmitter(LncModule);
-        this.listener = eventEmitter.addListener(
-            streamingCall,
-            (event: any) => {
-                if (event.result && event.result !== 'EOF') {
-                    try {
-                        const result = JSON.parse(event.result);
-                        if (result && result.status !== 'IN_FLIGHT') {
-                            handlePayment(result);
-                            this.listener = null;
-                        }
-                    } catch (error: any) {
-                        handlePaymentError(event.result);
-                        this.listener = null;
-                    }
-                }
-            }
-        );
     };
 
     scanNfc = async () => {

--- a/views/Tools/Sweep.tsx
+++ b/views/Tools/Sweep.tsx
@@ -1,12 +1,5 @@
 import * as React from 'react';
-import {
-    NativeModules,
-    NativeEventEmitter,
-    StyleSheet,
-    Text,
-    View,
-    ScrollView
-} from 'react-native';
+import { StyleSheet, Text, View, ScrollView } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { Route } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -60,7 +53,6 @@ interface SweepState {
 )
 @observer
 export default class Sweep extends React.Component<SweepProps, SweepState> {
-    listener: any;
     constructor(props: SweepProps) {
         super(props);
         const { route } = props;
@@ -73,12 +65,6 @@ export default class Sweep extends React.Component<SweepProps, SweepState> {
         };
     }
 
-    componentWillUnmount() {
-        if (this.listener && this.listener.stop) {
-            this.listener.stop();
-        }
-    }
-
     componentDidUpdate(prevProps: SweepProps) {
         if (
             this.props.route.params?.destination !==
@@ -89,30 +75,6 @@ export default class Sweep extends React.Component<SweepProps, SweepState> {
             });
         }
     }
-
-    subscribePayment = (streamingCall: string) => {
-        const { handlePayment, handlePaymentError } =
-            this.props.TransactionsStore;
-        const { LncModule } = NativeModules;
-        const eventEmitter = new NativeEventEmitter(LncModule);
-        this.listener = eventEmitter.addListener(
-            streamingCall,
-            (event: any) => {
-                if (event.result && event.result !== 'EOF') {
-                    try {
-                        const result = JSON.parse(event.result);
-                        if (result && result.status !== 'IN_FLIGHT') {
-                            handlePayment(result);
-                            this.listener = null;
-                        }
-                    } catch (error: any) {
-                        handlePaymentError(event.result);
-                        this.listener = null;
-                    }
-                }
-            }
-        );
-    };
 
     sendCoins = () => {
         const { SettingsStore, TransactionsStore, navigation } = this.props;


### PR DESCRIPTION
# Description

Fixes an internal security review finding (M17): on lightning-node-connect, the NWC wallet service never observes payment results, and the donation flow misreads them.

## The bug

On LNC, `sendPaymentV2` is a streaming RPC. `LightningNodeConnect.payLightningInvoice` returned the raw event name (`'routerrpc.Router.SendPaymentV2'`), and `TransactionsStore.sendPaymentInternal` passed it through untouched, leaving result handling to whichever caller remembered to attach a `NativeEventEmitter` listener. Only the Send and PaymentRequest views did, via byte-identical `subscribePayment` copies.

Consequences on an LNC backend:

- **NWC wallet service** (`supportsNostrWalletConnectService` is true for LNC): `NostrWalletConnectStore` discards `sendPayment`'s return value, so no listener is ever attached. Every NWC payment, including instantly settled ones, ran out the full 120s window and answered in-transit with an empty preimage; `TransactionsStore.loading` stayed stuck true until the next reset. Every payment's amount also escaped the pending-budget check window until reconcile, so this fix shrinks the residual LNC exposure of the pending-budget work (#4305) to genuinely slow payments only.
- **Donation flow**: `sendPaymentSilently` had the same pass-through branch. `SendingLightning` awaited it, received the event-name string, misread it as success, and computed `result.amount_msat / 1000` = NaN.
- The view listeners themselves leaked (never called `.remove()`), passed no payment sequence (so they could clear another payment's in-flight guard from #4301), and called `handlePaymentError` with a raw string instead of an `Error`.

## What changed

- `backends/LightningNodeConnect.ts`: `payLightningInvoice` now resolves with the payment's terminal result, the same promise contract as every other backend. All concurrent `SendPaymentV2` calls share one event channel with no request correlation, so events are matched to their payment by `payment_hash`: read from the keysend request, or decoded from the bolt11 invoice. AMP payments skip correlation (lnd derives per-attempt hashes) and fall back to first-terminal-event, the previous behavior. If no terminal event arrives within `timeout_seconds` plus grace, the promise resolves with the designed in-transit `payment_error` shape rather than rejecting, since a hard failure invites a retry that double-sends on keysend. The subscription is always removed once settled.
- `utils/LncPayUtils.ts` (new): pure per-event classification (EOF/IN_FLIGHT/hash-mismatch skip, terminal, error) and expected-hash derivation, with unit tests.
- `stores/TransactionsStore.ts`: both LNC special-case branches deleted; LNC now flows through the generic `handlePayment(result, seq)` / `handlePaymentError(err, seq)` path.
- `views/Send.tsx`, `views/PaymentRequest.tsx`: dead `subscribePayment` copies, listener fields, and the bogus `.stop()` cleanup removed. `views/Tools/Sweep.tsx` carried a third, never-invoked copy, also removed.
- `views/Tools/Rebalance.tsx`: intentionally untouched. It calls the backend directly but only used its own subscriber when the result was a string, which no longer happens; the resolved object flows into its existing `handleLncPaymentResult`. The guard branch is retained as defensive code.

Known caveat (status quo, not a regression): two concurrent payments that both lack a derivable hash (e.g. two AMP payments) both accept the first terminal event. Uncorrelated native error strings on the shared channel are attributed to all listening payments.

Keysend on LNC flows through the same `payLightningInvoice` path, so one fix covers both.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly (no new errors in changed files)
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

Pending. Planned matrix before ready-for-review:

- LNC user payment: bolt11 success/failure/timeout, keysend, AMP keysend (exercises the no-correlation fallback)
- NWC-over-LNC: instant-settle payment returns a real preimage instead of in-transit after 120s; budget settles
- Rebalance on LNC (direct backend caller)
- Donation flow on LNC (amount no longer NaN)
- Regression pass on LND (REST)

I have tested this PR with the following types of nodes (please specify node version, and API version where appropriate):

Pending, see above.
