### PR TITLE
fix(nwc): debit budget on settled payments missing from the payments list

### DIFF
--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2050,11 +2050,25 @@ export default class NostrWalletConnectStore {
                 paymentHash
             );
 
-        if (payment) {
+        // Debit the budget on any evidence of settlement, not only when the
+        // payments-list lookup succeeds: with a preimage in hand the payment
+        // definitely settled, and skipping finalizePayment on a list miss
+        // would let the spend escape the budget permanently (it records no
+        // activity, so pendingSpendSats never sees it either).
+        if (payment || preimage) {
             await this.finalizePayment({
                 id: request.invoice,
                 type: 'pay_invoice',
-                decoded: payment,
+                decoded:
+                    payment ||
+                    NostrConnectUtils.buildSettledPaymentFallback({
+                        invoice: request.invoice,
+                        payment_source: 'lightning',
+                        amountSats,
+                        preimage,
+                        feeSats: fees_paid,
+                        paymentHash
+                    }),
                 payment_source: 'lightning',
                 connection,
                 amountSats
@@ -2205,16 +2219,26 @@ export default class NostrWalletConnectStore {
 
         // CashuStore does not surface IN_FLIGHT melts yet; add recordPendingPayment
         // plus getActivities cashu reconciliation when it does.
-        if (payment) {
-            await this.finalizePayment({
-                id: request.invoice,
-                decoded: payment,
-                type: 'pay_invoice',
-                payment_source: 'cashu',
-                amountSats,
-                connection
-            });
-        }
+        //
+        // The melt succeeded (failure returned above), so debit the budget
+        // unconditionally: gating on the payments-list lookup would let the
+        // spend escape the budget when the list misses the fresh melt.
+        await this.finalizePayment({
+            id: request.invoice,
+            decoded:
+                payment ||
+                NostrConnectUtils.buildSettledPaymentFallback({
+                    invoice: request.invoice,
+                    payment_source: 'cashu',
+                    amountSats,
+                    preimage: cashuInvoice.getPreimage,
+                    feeSats: cashuInvoice.fee
+                }),
+            type: 'pay_invoice',
+            payment_source: 'cashu',
+            amountSats,
+            connection
+        });
 
         return {
             result: {

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -1221,4 +1221,70 @@ describe('NostrConnectUtils', () => {
             expect(transactions).toEqual([settledPayment, failedPayment]);
         });
     });
+
+    describe('buildSettledPaymentFallback', () => {
+        const invoice = 'lnbc210n1fallbackfixture';
+        const preimage = hex64('a');
+        const paymentHash = hex64('b');
+
+        it('builds a settled lightning Payment from request-side state', () => {
+            const payment = NostrConnectUtils.buildSettledPaymentFallback({
+                invoice,
+                payment_source: 'lightning',
+                amountSats: 21000,
+                preimage,
+                feeSats: '21',
+                paymentHash
+            });
+
+            expect(payment).toBeInstanceOf(Payment);
+            expect(payment).not.toBeInstanceOf(CashuPayment);
+            expect(payment.getPaymentRequest).toBe(invoice);
+            expect(payment.paymentHash).toBe(paymentHash);
+            expect(payment.getPreimage).toBe(preimage);
+            expect(payment.getAmount).toBe(21000);
+            expect(payment.getFee).toBe('21');
+            expect(NostrConnectUtils.isSettledPayment(payment)).toBe(true);
+        });
+
+        it('builds a CashuPayment for the cashu source', () => {
+            const payment = NostrConnectUtils.buildSettledPaymentFallback({
+                invoice,
+                payment_source: 'cashu',
+                amountSats: 500,
+                preimage
+            });
+
+            expect(payment).toBeInstanceOf(CashuPayment);
+            expect(payment.getPaymentRequest).toBe(invoice);
+            expect(payment.getAmount).toBe(500);
+        });
+
+        it('constructs without optional fields instead of throwing', () => {
+            const payment = NostrConnectUtils.buildSettledPaymentFallback({
+                invoice,
+                payment_source: 'lightning',
+                amountSats: 1000
+            });
+
+            expect(payment.getPaymentRequest).toBe(invoice);
+            expect(payment.getAmount).toBe(1000);
+            expect(payment.getPreimage).toBe('');
+            expect(payment.getFee).toBe('0');
+            expect(payment.status).toBe('SUCCEEDED');
+        });
+
+        it('accepts numeric fees and null preimage', () => {
+            const payment = NostrConnectUtils.buildSettledPaymentFallback({
+                invoice,
+                payment_source: 'lightning',
+                amountSats: 1000,
+                preimage: null,
+                feeSats: 3
+            });
+
+            expect(payment.getFee).toBe('3');
+            expect(payment.getPreimage).toBe('');
+        });
+    });
 });

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -1121,6 +1121,41 @@ export default class NostrConnectUtils {
         );
     }
 
+    // Builds a settled payment record from request-side state, for when a
+    // payment verifiably succeeded (preimage in hand) but cannot be found
+    // in the node's refreshed payments list (pagination window, indexing
+    // lag, backends with incomplete listPayments). Budget accounting must
+    // not depend on that lookup: a spend that escapes finalizePayment is
+    // never debited.
+    static buildSettledPaymentFallback({
+        invoice,
+        payment_source,
+        amountSats,
+        preimage,
+        feeSats,
+        paymentHash
+    }: {
+        invoice: string;
+        payment_source: 'lightning' | 'cashu';
+        amountSats: number;
+        preimage?: string | null;
+        feeSats?: string | number | null;
+        paymentHash?: string | null;
+    }): Payment | CashuPayment {
+        const data = {
+            payment_request: invoice,
+            ...(paymentHash ? { payment_hash: paymentHash } : {}),
+            ...(preimage ? { payment_preimage: preimage } : {}),
+            value_sat: amountSats,
+            ...(feeSats ? { fee_sat: feeSats.toString() } : {}),
+            status: 'SUCCEEDED',
+            creation_date: Math.floor(Date.now() / 1000).toString()
+        };
+        return payment_source === 'cashu'
+            ? new CashuPayment(data)
+            : new Payment(data);
+    }
+
     static findInTransitPaymentForInvoice<T extends Payment>(
         invoice: string,
         payments: T[],


### PR DESCRIPTION
# Description

Fixes the remaining missed-accounting path from external security report FND-004 (NWC budget enforcement).

The report's headline finding, a check-then-act race where N parallel `pay_invoice` requests could each pass the budget check before any debits landed, was already closed by #4303 (per-service payment queue) and #4305 (pending amounts reserved inside `canSpend`). Verification against master also showed its reconcile-miss claim is now fail-closed rather than an escape: an unreconciled pending activity stays counted in `pendingSpendSats` indefinitely.

One claim survived verification as a real residual hole. In `handleLightningPayInvoice`, `finalizePayment`, the only place a settled spend is debited via `trackSpending`, was gated on finding the settled payment in the refreshed payments list:

```ts
if (payment) {
    await this.finalizePayment({ ... });
}
```

If the payment settled (preimage in `TransactionsStore`) but the list lookup missed, the handler returned success with a valid preimage while recording **no activity at all**: neither `totalSpendSats` nor `pendingSpendSats` ever saw the amount, so the spend permanently escaped the connection budget. Miss windows: payments lists windowed at 100 entries on busy nodes, node indexing lag immediately after settlement, backends with incomplete `listPayments` (CLN's missing-entries lists are a known issue), or a failed refresh. The cashu path had the same `if (payment)` gate after the melt had already been confirmed successful.

## What changed

- `stores/NostrWalletConnectStore.ts`: budget accounting no longer depends on the payments-list lookup. The lightning success path finalizes whenever a preimage is in hand (`payment || preimage`); the cashu path finalizes unconditionally once the melt has succeeded. When the list lookup misses, the activity record is synthesized from request-side state (invoice, payment hash, preimage, amount, fee).
- `utils/NostrConnectUtils.ts`: new `buildSettledPaymentFallback()` builds that settled `Payment`/`CashuPayment` record. Passing `decoded: null` into `finalizePayment` was not an option; the `BaseModel` constructor throws on null data.
- `utils/NostrConnectUtils.test.ts`: unit tests for the fallback builder (lightning and cashu shapes, settled-payment semantics, optional-field tolerance).

When the lookup succeeds, behavior is byte-identical to before. The fallback only fires in the window where the spend previously escaped accounting.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly (no new errors in changed files)
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

Pending. Planned before ready-for-review:

- NWC pay_invoice happy path (list lookup succeeds): unchanged behavior, budget debited once
- Forced list miss (busy node or CLN backend): success response still debits budget and records a success activity with correct amount/preimage
- Cashu pay_invoice with and without the melt appearing in cashu payments
- Budget exhaustion after repeated payments confirms no double-counting with reconcile

I have tested this PR with the following types of nodes (please specify node version, and API version where appropriate):

Pending, see above.
