### PR TITLE
fix(nwc): expire unresolvable pending payments after the HTLC lifetime

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -403,6 +403,31 @@ export default class CLNRest {
             };
         });
 
+    // Definitive point query against the full sendpays index: unlike the
+    // windowed getPayments above, listpays with a payment_hash is not
+    // subject to any row limit, so an empty result proves the node never
+    // attempted the payment. failure_reason is synthesized because the
+    // Payment model derives isFailed from it, not from CLN's status field.
+    lookupPaymentByHash = (data: { paymentHash: string }) =>
+        this.postRequest('/v1/listpays', {
+            payment_hash: data.paymentHash
+        }).then((res: any) => ({
+            payments: (res?.pays || []).map((pay: any) => ({
+                payment_hash: pay.payment_hash,
+                status: pay.status,
+                destination: pay.destination,
+                created_at: pay.created_at,
+                description: pay.description,
+                bolt11: pay.bolt11,
+                bolt12: pay.bolt12,
+                amount_sent_msat: pay.amount_sent_msat,
+                amount_msat: pay.amount_msat,
+                preimage: pay.preimage,
+                failure_reason:
+                    pay.status === 'failed' ? 'FAILURE_REASON_ERROR' : ''
+            }))
+        }));
+
     getNewAddress = (data: any) => {
         let addresstype: string | undefined;
 
@@ -858,4 +883,5 @@ export default class CLNRest {
     supportsCashuWallet = () => false;
     supportsSettingInvoiceExpiration = () => true;
     supportsNostrWalletConnectService = () => true;
+    supportsPaymentLookupByHash = () => true;
 }

--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -125,6 +125,7 @@ export default class EmbeddedLND extends LND {
     getPayments = async (params?: {
         maxPayments?: number;
         reversed?: boolean;
+        creationDateStart?: number;
     }) => await listPayments(params);
     getNewAddress = async (data: any) =>
         await newAddress(

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -378,7 +378,11 @@ export default class LND {
             route_hints: data.route_hints
         });
     getPayments = (
-        params: { maxPayments?: number; reversed?: boolean } = {
+        params: {
+            maxPayments?: number;
+            reversed?: boolean;
+            creationDateStart?: number;
+        } = {
             maxPayments: 500,
             reversed: true
         }
@@ -388,6 +392,10 @@ export default class LND {
                 params?.maxPayments ? `&max_payments=${params.maxPayments}` : ''
             }&reversed=${
                 params?.reversed !== undefined ? params.reversed : true
+            }${
+                params?.creationDateStart
+                    ? `&creation_date_start=${params.creationDateStart}`
+                    : ''
             }`
         );
 
@@ -1057,4 +1065,5 @@ export default class LND {
     supportsAddressMessageSigning = () => true;
     supportsSettingInvoiceExpiration = () => true;
     supportsNostrWalletConnectService = () => true;
+    supportsPaymentsCreationDateFilter = () => this.supports('v0.15.1');
 }

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -1465,6 +1465,27 @@ export default class LdkNode {
     };
 
     /**
+     * Definitive point query: LDK Node's payment store holds the node's
+     * complete, never-auto-pruned payment history, so an empty result
+     * proves the payment was never dispatched.
+     */
+    lookupPaymentByHash = async (data: {
+        paymentHash: string;
+    }): Promise<any> => {
+        const payments = await LdkNodeInjection.payments.listPayments();
+        const matches = payments.filter(
+            (p) =>
+                p.direction === 'outbound' &&
+                p.kind.type !== 'onchain' &&
+                (p.kind.hash === data.paymentHash || p.id === data.paymentHash)
+        );
+
+        return {
+            payments: matches.map((payment) => this.formatPayment(payment))
+        };
+    };
+
+    /**
      * List all payments (raw)
      */
     listPayments = async (): Promise<PaymentDetails[]> => {
@@ -2225,4 +2246,5 @@ export default class LdkNode {
     supportsWatchtowerClient = () => false;
     supportsPeers = () => true;
     supportsNostrWalletConnectService = () => true;
+    supportsPaymentLookupByHash = () => true;
 }

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -206,6 +206,7 @@ export default class LightningNodeConnect {
         params: {
             maxPayments?: number;
             reversed?: boolean;
+            creationDateStart?: number;
         } = {
             maxPayments: 500,
             reversed: true
@@ -218,7 +219,10 @@ export default class LightningNodeConnect {
                     max_payments: params.maxPayments
                 }),
                 reversed:
-                    params?.reversed !== undefined ? params.reversed : true
+                    params?.reversed !== undefined ? params.reversed : true,
+                ...(params?.creationDateStart && {
+                    creation_date_start: params.creationDateStart
+                })
             })
             .then((data: lnrpc.ListPaymentsResponse) => snakeize(data));
     getNewAddress = async (data: any) =>
@@ -919,4 +923,5 @@ export default class LightningNodeConnect {
     supportsCashuWallet = () => false;
     supportsSettingInvoiceExpiration = () => true;
     supportsNostrWalletConnectService = () => true;
+    supportsPaymentsCreationDateFilter = () => this.supports('v0.15.1');
 }

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -248,4 +248,7 @@ export default class LndHub extends LND {
     supportsCashuWallet = () => false;
     supportsSettingInvoiceExpiration = () => false;
     supportsNostrWalletConnectService = () => true;
+    // /gettxs takes no filters and only returns settled payments, so the
+    // inherited LND flag must not leak through.
+    supportsPaymentsCreationDateFilter = () => false;
 }

--- a/lndmobile/index.ts
+++ b/lndmobile/index.ts
@@ -628,6 +628,7 @@ export const listPeers = async (): Promise<lnrpc.ListPeersResponse> => {
 export const listPayments = async (params?: {
     maxPayments?: number;
     reversed?: boolean;
+    creationDateStart?: number;
 }): Promise<lnrpc.ListPaymentsResponse> => {
     const response = await sendCommand<
         lnrpc.IListPaymentsRequest,
@@ -640,7 +641,10 @@ export const listPayments = async (params?: {
         options: {
             include_incomplete: true,
             max_payments: Long.fromValue(params?.maxPayments ?? 1000),
-            ...(params?.reversed && { reversed: params.reversed })
+            ...(params?.reversed && { reversed: params.reversed }),
+            ...(params?.creationDateStart && {
+                creation_date_start: Long.fromValue(params.creationDateStart)
+            })
         }
     });
     return response;

--- a/locales/en.json
+++ b/locales/en.json
@@ -1776,6 +1776,7 @@
     "stores.NostrWalletConnectStore.error.connectionNotFound": "Connection not found",
     "stores.NostrWalletConnectStore.error.paymentQueueWaitExceeded": "Another payment was in progress and this request waited too long; it was not executed. Please try again.",
     "stores.NostrWalletConnectStore.error.makeInvoiceRateLimited": "Too many invoice requests from this connection. Please wait before trying again.",
+    "stores.NostrWalletConnectStore.error.pendingPaymentExpired": "Payment was unresolved for 14 days and could not be found on the node; it was marked failed and its reserved budget was released.",
     "stores.NostrWalletConnectStore.error.failedToConnectRelay": "Failed to Connect {{relayUrl}}",
     "stores.NostrWalletConnectStore.error.failedToLoadConnections": "Failed to load connections",
     "stores.NostrWalletConnectStore.error.failedToSaveConnections": "Failed to save connections",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1761,6 +1761,7 @@
     "stores.NostrWalletConnectStore.error.connectionNameExists": "Connection name already exists",
     "stores.NostrWalletConnectStore.error.connectionNotFound": "Connection not found",
     "stores.NostrWalletConnectStore.error.paymentQueueWaitExceeded": "Another payment was in progress and this request waited too long; it was not executed. Please try again.",
+    "stores.NostrWalletConnectStore.error.pendingPaymentExpired": "Payment was unresolved for 14 days and could not be found on the node; it was marked failed and its reserved budget was released.",
     "stores.NostrWalletConnectStore.error.failedToConnectRelay": "Failed to Connect {{relayUrl}}",
     "stores.NostrWalletConnectStore.error.failedToLoadConnections": "Failed to load connections",
     "stores.NostrWalletConnectStore.error.failedToSaveConnections": "Failed to save connections",

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2050,11 +2050,25 @@ export default class NostrWalletConnectStore {
                 paymentHash
             );
 
-        if (payment) {
+        // Debit the budget on any evidence of settlement, not only when the
+        // payments-list lookup succeeds: with a preimage in hand the payment
+        // definitely settled, and skipping finalizePayment on a list miss
+        // would let the spend escape the budget permanently (it records no
+        // activity, so pendingSpendSats never sees it either).
+        if (payment || preimage) {
             await this.finalizePayment({
                 id: request.invoice,
                 type: 'pay_invoice',
-                decoded: payment,
+                decoded:
+                    payment ||
+                    NostrConnectUtils.buildSettledPaymentFallback({
+                        invoice: request.invoice,
+                        payment_source: 'lightning',
+                        amountSats,
+                        preimage,
+                        feeSats: fees_paid,
+                        paymentHash
+                    }),
                 payment_source: 'lightning',
                 connection,
                 amountSats
@@ -2205,16 +2219,26 @@ export default class NostrWalletConnectStore {
 
         // CashuStore does not surface IN_FLIGHT melts yet; add recordPendingPayment
         // plus getActivities cashu reconciliation when it does.
-        if (payment) {
-            await this.finalizePayment({
-                id: request.invoice,
-                decoded: payment,
-                type: 'pay_invoice',
-                payment_source: 'cashu',
-                amountSats,
-                connection
-            });
-        }
+        //
+        // The melt succeeded (failure returned above), so debit the budget
+        // unconditionally: gating on the payments-list lookup would let the
+        // spend escape the budget when the list misses the fresh melt.
+        await this.finalizePayment({
+            id: request.invoice,
+            decoded:
+                payment ||
+                NostrConnectUtils.buildSettledPaymentFallback({
+                    invoice: request.invoice,
+                    payment_source: 'cashu',
+                    amountSats,
+                    preimage: cashuInvoice.getPreimage,
+                    feeSats: cashuInvoice.fee
+                }),
+            type: 'pay_invoice',
+            payment_source: 'cashu',
+            amountSats,
+            connection
+        });
 
         return {
             result: {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2377,39 +2377,123 @@ export default class NostrWalletConnectStore {
         );
         let changed = false;
         for (const activity of lightningPending) {
-            const payment = payments.find(
-                (p) =>
-                    p.getPaymentRequest === activity.id ||
-                    (!!activity.paymentHash &&
-                        p.paymentHash === activity.paymentHash)
+            const payment = NostrConnectUtils.findPaymentForInvoice(
+                activity.id,
+                payments,
+                activity.paymentHash
             );
             if (!payment) continue;
 
-            let reconciled = false;
-            runInAction(() => {
-                if (activity.status !== 'pending') return;
-                reconciled = true;
-                activity.payment = new Payment(payment);
-                if (!payment.isIncomplete) {
-                    activity.status = 'success';
-                    const amountSats =
-                        Math.floor(Number(activity.satAmount)) ||
-                        Math.floor(Number(payment.getAmount) || 0);
-                    if (amountSats > 0) {
-                        connection.trackSpending(amountSats);
-                    }
-                } else if (payment.isFailed) {
-                    activity.status = 'failed';
-                }
-            });
-            if (reconciled) {
+            if (
+                this.applyPendingPayInvoiceResolution(
+                    connection,
+                    activity,
+                    payment
+                )
+            ) {
                 changed = true;
             }
         }
+
+        // Expiry pass: a pending older than the HTLC-lifetime bound cannot
+        // still be in flight. Confirm with a definitive wide fetch (the
+        // regular refresh may be a throttled cached list); resolve it if the
+        // payment turns up, otherwise mark it failed so its budget
+        // reservation is released. A failed fetch skips the pass entirely —
+        // only a real look at the node may expire a reservation.
+        const expiryCandidates = lightningPending.filter(
+            (activity) =>
+                activity.status === 'pending' &&
+                NostrConnectUtils.isPendingPayInvoiceExpired(activity)
+        );
+        if (expiryCandidates.length > 0) {
+            const definitive = await this.getPaymentsForPendingExpiryCheck();
+            if (definitive) {
+                for (const activity of expiryCandidates) {
+                    const payment = NostrConnectUtils.findPaymentForInvoice(
+                        activity.id,
+                        definitive,
+                        activity.paymentHash
+                    );
+                    if (payment) {
+                        // Note: if the node still reports it in flight
+                        // (zombie payment), the node is the authority — the
+                        // reservation stays.
+                        if (
+                            this.applyPendingPayInvoiceResolution(
+                                connection,
+                                activity,
+                                payment
+                            )
+                        ) {
+                            changed = true;
+                        }
+                        continue;
+                    }
+                    runInAction(() => {
+                        if (activity.status !== 'pending') return;
+                        activity.status = 'failed';
+                        activity.error = localeString(
+                            'stores.NostrWalletConnectStore.error.pendingPaymentExpired'
+                        );
+                        changed = true;
+                    });
+                }
+            }
+        }
+
         if (changed) {
             this.lookupPaymentsCache = null;
         }
         return changed;
+    }
+
+    // Flips a pending pay_invoice activity to its terminal state based on a
+    // payment record from the node, debiting the budget on success.
+    // Returns true when the activity changed. A payment the node still
+    // reports in flight leaves the activity pending.
+    private applyPendingPayInvoiceResolution(
+        connection: NWCConnection,
+        activity: ConnectionActivity,
+        payment: Payment
+    ): boolean {
+        let reconciled = false;
+        runInAction(() => {
+            if (activity.status !== 'pending') return;
+            reconciled = true;
+            activity.payment = new Payment(payment);
+            if (!payment.isIncomplete) {
+                activity.status = 'success';
+                const amountSats =
+                    Math.floor(Number(activity.satAmount)) ||
+                    Math.floor(Number(payment.getAmount) || 0);
+                if (amountSats > 0) {
+                    connection.trackSpending(amountSats);
+                }
+            } else if (payment.isFailed) {
+                activity.status = 'failed';
+            }
+        });
+        return reconciled;
+    }
+
+    // Definitive payments fetch for the pending-expiry pass: wide window,
+    // direct from the backend (paymentsStore.getPayments would overwrite
+    // the wallet activity list and toggle its loading flag). Returns null
+    // on failure so the caller cannot expire anything without a real look.
+    private async getPaymentsForPendingExpiryCheck(): Promise<
+        Payment[] | null
+    > {
+        try {
+            const data = await BackendUtils.getPayments({
+                maxPayments: 2000,
+                reversed: true
+            });
+            if (!data?.payments) return null;
+            return data.payments.map((p: any) => new Payment(p));
+        } catch {
+            return null;
+        }
     }
 
     private async getPaymentsForPendingPayInvoiceRefresh(

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2889,18 +2889,20 @@ export default class NostrWalletConnectStore {
         }
 
         // Expiry pass: a pending older than the HTLC-lifetime bound cannot
-        // still be in flight. Confirm with a definitive wide fetch (the
-        // regular refresh may be a throttled cached list); resolve it if the
-        // payment turns up, otherwise mark it failed so its budget
-        // reservation is released. A failed fetch skips the pass entirely —
-        // only a real look at the node may expire a reservation.
+        // still be in flight. Confirm with a definitive backend-aware fetch
+        // (the regular refresh may be a throttled cached list); resolve it
+        // if the payment turns up, otherwise mark it failed so its budget
+        // reservation is released. An inconclusive fetch skips the pass
+        // entirely: only a real look at the node may expire a reservation.
         const expiryCandidates = pending.filter(
             (activity) =>
                 activity.status === 'pending' &&
                 NostrConnectUtils.isPendingPayInvoiceExpired(activity)
         );
         if (expiryCandidates.length > 0) {
-            const definitive = await this.getPaymentsForPendingExpiryCheck();
+            const definitive = await this.getPaymentsForPendingExpiryCheck(
+                expiryCandidates
+            );
             if (definitive) {
                 for (const activity of expiryCandidates) {
                     const payment = NostrConnectUtils.findPaymentForInvoice(
@@ -3024,20 +3026,66 @@ export default class NostrWalletConnectStore {
         );
     }
 
-    // Definitive payments fetch for the pending-expiry pass: wide window,
-    // direct from the backend (paymentsStore.getPayments would overwrite
-    // the wallet activity list and toggle its loading flag). Returns null
-    // on failure so the caller cannot expire anything without a real look.
-    private async getPaymentsForPendingExpiryCheck(): Promise<
-        Payment[] | null
-    > {
+    // Definitive payments fetch for the pending-expiry pass, direct from
+    // the backend (paymentsStore.getPayments would overwrite the wallet
+    // activity list and toggle its loading flag). Backend-aware, because
+    // not every backend can prove a payment's absence from a plain list
+    // fetch: point lookups by payment hash where supported (CLN listpays,
+    // LDK Node's complete payment store), otherwise a creation-date-bounded
+    // window on LND-family backends, treated as inconclusive when it fills
+    // to the cap. Backends with no reliable strategy (LndHub's success-only
+    // /gettxs) fall through to null, so their pendings are never expired.
+    // Returns null on any failure so the caller cannot expire anything
+    // without a real look.
+    private async getPaymentsForPendingExpiryCheck(
+        expiryCandidates: ConnectionActivity[]
+    ): Promise<Payment[] | null> {
         try {
-            const data = await BackendUtils.getPayments({
-                maxPayments: 2000,
-                reversed: true
-            });
-            if (!data?.payments) return null;
-            return data.payments.map((p: any) => new Payment(p));
+            if (BackendUtils.supportsPaymentLookupByHash()) {
+                const results: Payment[] = [];
+                for (const activity of expiryCandidates) {
+                    const paymentHash =
+                        NostrConnectUtils.normalizePaymentHash(
+                            activity.paymentHash
+                        ) ||
+                        (await NostrConnectUtils.decodeInvoiceTags(activity.id))
+                            .paymentHash;
+                    if (!paymentHash) return null;
+                    const data = await BackendUtils.lookupPaymentByHash({
+                        paymentHash
+                    });
+                    if (!data || !Array.isArray(data.payments)) return null;
+                    for (const p of data.payments) {
+                        results.push(new Payment(p));
+                    }
+                }
+                return results;
+            }
+
+            if (BackendUtils.supportsPaymentsCreationDateFilter()) {
+                const creationDateStart =
+                    NostrConnectUtils.getExpiryCheckCreationDateStart(
+                        expiryCandidates
+                    );
+                if (creationDateStart === null) return null;
+                const data = await BackendUtils.getPayments({
+                    maxPayments: NostrConnectUtils.EXPIRY_CHECK_MAX_PAYMENTS,
+                    reversed: true,
+                    creationDateStart
+                });
+                if (!data?.payments) return null;
+                // A window filled to the cap may have been truncated; only
+                // a complete range proves absence.
+                if (
+                    data.payments.length >=
+                    NostrConnectUtils.EXPIRY_CHECK_MAX_PAYMENTS
+                ) {
+                    return null;
+                }
+                return data.payments.map((p: any) => new Payment(p));
+            }
+
+            return null;
         } catch {
             return null;
         }

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2867,11 +2867,10 @@ export default class NostrWalletConnectStore {
         );
 
         for (const activity of pending) {
-            const payment = payments.find(
-                (p) =>
-                    p.getPaymentRequest === activity.id ||
-                    (!!activity.paymentHash &&
-                        p.paymentHash === activity.paymentHash)
+            const payment = NostrConnectUtils.findPaymentForInvoice(
+                activity.id,
+                payments,
+                activity.paymentHash
             );
             if (!payment) {
                 if (this.abandonStaleUnresolvedPayInvoiceHold(activity)) {
@@ -2887,6 +2886,55 @@ export default class NostrWalletConnectStore {
                     changed = true;
                 }
             });
+        }
+
+        // Expiry pass: a pending older than the HTLC-lifetime bound cannot
+        // still be in flight. Confirm with a definitive wide fetch (the
+        // regular refresh may be a throttled cached list); resolve it if the
+        // payment turns up, otherwise mark it failed so its budget
+        // reservation is released. A failed fetch skips the pass entirely —
+        // only a real look at the node may expire a reservation.
+        const expiryCandidates = pending.filter(
+            (activity) =>
+                activity.status === 'pending' &&
+                NostrConnectUtils.isPendingPayInvoiceExpired(activity)
+        );
+        if (expiryCandidates.length > 0) {
+            const definitive = await this.getPaymentsForPendingExpiryCheck();
+            if (definitive) {
+                for (const activity of expiryCandidates) {
+                    const payment = NostrConnectUtils.findPaymentForInvoice(
+                        activity.id,
+                        definitive,
+                        activity.paymentHash
+                    );
+                    if (payment) {
+                        // Note: if the node still reports it in flight
+                        // (zombie payment), the node is the authority — the
+                        // reservation stays.
+                        runInAction(() => {
+                            if (
+                                this.applyPayInvoiceReconcile(
+                                    activity,
+                                    connection,
+                                    payment
+                                )
+                            ) {
+                                changed = true;
+                            }
+                        });
+                        continue;
+                    }
+                    runInAction(() => {
+                        if (activity.status !== 'pending') return;
+                        activity.status = 'failed';
+                        activity.error = localeString(
+                            'stores.NostrWalletConnectStore.error.pendingPaymentExpired'
+                        );
+                        changed = true;
+                    });
+                }
+            }
         }
 
         if (changed) {
@@ -2974,6 +3022,25 @@ export default class NostrWalletConnectStore {
             before.paymentHash !== listed.paymentHash ||
             before.paymentStatus !== listed.status
         );
+    }
+
+    // Definitive payments fetch for the pending-expiry pass: wide window,
+    // direct from the backend (paymentsStore.getPayments would overwrite
+    // the wallet activity list and toggle its loading flag). Returns null
+    // on failure so the caller cannot expire anything without a real look.
+    private async getPaymentsForPendingExpiryCheck(): Promise<
+        Payment[] | null
+    > {
+        try {
+            const data = await BackendUtils.getPayments({
+                maxPayments: 2000,
+                reversed: true
+            });
+            if (!data?.payments) return null;
+            return data.payments.map((p: any) => new Payment(p));
+        } catch {
+            return null;
+        }
     }
 
     private async getPaymentsForPendingPayInvoiceRefresh(

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -95,6 +95,8 @@ class BackendUtils {
     getInvoices = (...args: any[]) => this.call('getInvoices', args);
     createInvoice = (...args: any[]) => this.call('createInvoice', args);
     getPayments = (...args: any[]) => this.call('getPayments', args);
+    lookupPaymentByHash = (...args: any[]) =>
+        this.call('lookupPaymentByHash', args);
     getNewAddress = (...args: any[]) => this.call('getNewAddress', args);
     getNewChangeAddress = (...args: any[]) =>
         this.call('getNewChangeAddress', args);
@@ -204,6 +206,10 @@ class BackendUtils {
     // services
     supportsNostrWalletConnectService = () =>
         this.call('supportsNostrWalletConnectService');
+    supportsPaymentLookupByHash = () =>
+        this.call('supportsPaymentLookupByHash');
+    supportsPaymentsCreationDateFilter = () =>
+        this.call('supportsPaymentsCreationDateFilter');
     supportsWatchtowerClient = () => this.call('supportsWatchtowerClient');
     supportsPeers = () => this.call('supportsPeers');
     supportsFlowLSP = () => this.call('supportsFlowLSP');

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -1405,4 +1405,49 @@ describe('NostrConnectUtils', () => {
             ).toBe(false);
         });
     });
+
+    describe('getExpiryCheckCreationDateStart', () => {
+        const now = 1_700_000_000_000;
+        const days = (n: number) => n * 24 * 60 * 60 * 1000;
+
+        it('covers the oldest candidate minus the clock-skew margin', () => {
+            const start = NostrConnectUtils.getExpiryCheckCreationDateStart([
+                { createdAt: new Date(now - days(14)) },
+                { createdAt: new Date(now - days(20)) }
+            ]);
+            expect(start).toBe(
+                Math.floor(
+                    (now -
+                        days(20) -
+                        NostrConnectUtils.EXPIRY_CHECK_DATE_MARGIN_MS) /
+                        1000
+                )
+            );
+        });
+
+        it('returns null with no candidates', () => {
+            expect(NostrConnectUtils.getExpiryCheckCreationDateStart([])).toBe(
+                null
+            );
+        });
+
+        it('returns null when any candidate age is unknown', () => {
+            // A window that cannot provably contain every candidate must
+            // not be used as evidence of absence.
+            expect(
+                NostrConnectUtils.getExpiryCheckCreationDateStart([
+                    { createdAt: new Date(now - days(20)) },
+                    {}
+                ])
+            ).toBe(null);
+        });
+
+        it('never returns a negative timestamp', () => {
+            expect(
+                NostrConnectUtils.getExpiryCheckCreationDateStart([
+                    { createdAt: new Date(1000) }
+                ])
+            ).toBe(0);
+        });
+    });
 });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -1221,4 +1221,70 @@ describe('NostrConnectUtils', () => {
             expect(transactions).toEqual([settledPayment, failedPayment]);
         });
     });
+
+    describe('buildSettledPaymentFallback', () => {
+        const invoice = 'lnbc210n1fallbackfixture';
+        const preimage = hex64('a');
+        const paymentHash = hex64('b');
+
+        it('builds a settled lightning Payment from request-side state', () => {
+            const payment = NostrConnectUtils.buildSettledPaymentFallback({
+                invoice,
+                payment_source: 'lightning',
+                amountSats: 21000,
+                preimage,
+                feeSats: '21',
+                paymentHash
+            });
+
+            expect(payment).toBeInstanceOf(Payment);
+            expect(payment).not.toBeInstanceOf(CashuPayment);
+            expect(payment.getPaymentRequest).toBe(invoice);
+            expect(payment.paymentHash).toBe(paymentHash);
+            expect(payment.getPreimage).toBe(preimage);
+            expect(payment.getAmount).toBe(21000);
+            expect(payment.getFee).toBe('21');
+            expect(NostrConnectUtils.isSettledPayment(payment)).toBe(true);
+        });
+
+        it('builds a CashuPayment for the cashu source', () => {
+            const payment = NostrConnectUtils.buildSettledPaymentFallback({
+                invoice,
+                payment_source: 'cashu',
+                amountSats: 500,
+                preimage
+            });
+
+            expect(payment).toBeInstanceOf(CashuPayment);
+            expect(payment.getPaymentRequest).toBe(invoice);
+            expect(payment.getAmount).toBe(500);
+        });
+
+        it('constructs without optional fields instead of throwing', () => {
+            const payment = NostrConnectUtils.buildSettledPaymentFallback({
+                invoice,
+                payment_source: 'lightning',
+                amountSats: 1000
+            });
+
+            expect(payment.getPaymentRequest).toBe(invoice);
+            expect(payment.getAmount).toBe(1000);
+            expect(payment.getPreimage).toBe('');
+            expect(payment.getFee).toBe('0');
+            expect(payment.status).toBe('SUCCEEDED');
+        });
+
+        it('accepts numeric fees and null preimage', () => {
+            const payment = NostrConnectUtils.buildSettledPaymentFallback({
+                invoice,
+                payment_source: 'lightning',
+                amountSats: 1000,
+                preimage: null,
+                feeSats: 3
+            });
+
+            expect(payment.getFee).toBe('3');
+            expect(payment.getPreimage).toBe('');
+        });
+    });
 });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -1287,4 +1287,56 @@ describe('NostrConnectUtils', () => {
             expect(payment.getPreimage).toBe('');
         });
     });
+
+    describe('isPendingPayInvoiceExpired', () => {
+        const now = 1_700_000_000_000;
+        const days = (n: number) => n * 24 * 60 * 60 * 1000;
+
+        it('does not expire fresh or sub-threshold activities', () => {
+            expect(
+                NostrConnectUtils.isPendingPayInvoiceExpired(
+                    { createdAt: new Date(now) },
+                    now
+                )
+            ).toBe(false);
+            expect(
+                NostrConnectUtils.isPendingPayInvoiceExpired(
+                    { createdAt: new Date(now - days(13)) },
+                    now
+                )
+            ).toBe(false);
+        });
+
+        it('expires at and beyond the 14-day bound', () => {
+            expect(
+                NostrConnectUtils.isPendingPayInvoiceExpired(
+                    { createdAt: new Date(now - days(14)) },
+                    now
+                )
+            ).toBe(true);
+            expect(
+                NostrConnectUtils.isPendingPayInvoiceExpired(
+                    { createdAt: new Date(now - days(60)) },
+                    now
+                )
+            ).toBe(true);
+        });
+
+        it('never expires an activity of unknown age', () => {
+            expect(NostrConnectUtils.isPendingPayInvoiceExpired({}, now)).toBe(
+                false
+            );
+        });
+
+        it('expiry message is not an ignorable error (would be pruned)', () => {
+            // The activity-cleanup filter drops failed activities whose
+            // error matches isIgnorableError; the expiry message must
+            // survive it to preserve the audit trail.
+            expect(
+                NostrConnectUtils.isIgnorableError(
+                    'Payment was unresolved for 14 days and could not be found on the node; it was marked failed and its reserved budget was released.'
+                )
+            ).toBe(false);
+        });
+    });
 });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -1353,4 +1353,56 @@ describe('NostrConnectUtils', () => {
             ).toBe(false);
         });
     });
+
+    describe('isPendingPayInvoiceExpired', () => {
+        const now = 1_700_000_000_000;
+        const days = (n: number) => n * 24 * 60 * 60 * 1000;
+
+        it('does not expire fresh or sub-threshold activities', () => {
+            expect(
+                NostrConnectUtils.isPendingPayInvoiceExpired(
+                    { createdAt: new Date(now) },
+                    now
+                )
+            ).toBe(false);
+            expect(
+                NostrConnectUtils.isPendingPayInvoiceExpired(
+                    { createdAt: new Date(now - days(13)) },
+                    now
+                )
+            ).toBe(false);
+        });
+
+        it('expires at and beyond the 14-day bound', () => {
+            expect(
+                NostrConnectUtils.isPendingPayInvoiceExpired(
+                    { createdAt: new Date(now - days(14)) },
+                    now
+                )
+            ).toBe(true);
+            expect(
+                NostrConnectUtils.isPendingPayInvoiceExpired(
+                    { createdAt: new Date(now - days(60)) },
+                    now
+                )
+            ).toBe(true);
+        });
+
+        it('never expires an activity of unknown age', () => {
+            expect(NostrConnectUtils.isPendingPayInvoiceExpired({}, now)).toBe(
+                false
+            );
+        });
+
+        it('expiry message is not an ignorable error (would be pruned)', () => {
+            // The activity-cleanup filter drops failed activities whose
+            // error matches isIgnorableError; the expiry message must
+            // survive it to preserve the audit trail.
+            expect(
+                NostrConnectUtils.isIgnorableError(
+                    'Payment was unresolved for 14 days and could not be found on the node; it was marked failed and its reserved budget was released.'
+                )
+            ).toBe(false);
+        });
+    });
 });

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -1129,6 +1129,28 @@ export default class NostrConnectUtils {
         );
     }
 
+    // A dispatched Lightning payment cannot remain genuinely in flight
+    // past its route's CLTV limit (lnd caps outgoing CLTV at 2016 blocks,
+    // roughly 14 days). A pending pay_invoice activity older than this
+    // whose payment a fresh payments-list fetch still cannot find is
+    // treated as failed, releasing its budget reservation; otherwise a
+    // list miss reserves budget forever (pendingSpendSats derives from
+    // activity status and survives budget renewal).
+    static readonly PENDING_PAY_INVOICE_EXPIRY_MS = 14 * 24 * 60 * 60 * 1000;
+
+    static isPendingPayInvoiceExpired(
+        activity: { createdAt?: Date },
+        nowMs: number = Date.now()
+    ): boolean {
+        // Unknown age never expires: only definitive evidence may release
+        // a budget reservation.
+        if (!activity.createdAt) return false;
+        return (
+            nowMs - activity.createdAt.getTime() >=
+            NostrConnectUtils.PENDING_PAY_INVOICE_EXPIRY_MS
+        );
+    }
+
     // Builds a settled payment record from request-side state, for when a
     // payment verifiably succeeded (preimage in hand) but cannot be found
     // in the node's refreshed payments list (pagination window, indexing

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -1151,6 +1151,35 @@ export default class NostrConnectUtils {
         );
     }
 
+    // Window parameters for the expiry check's date-bounded payments fetch
+    // on backends without a per-hash lookup. A response that fills the whole
+    // window may have been truncated, so the caller must treat it as
+    // inconclusive; the margin absorbs clock skew between the device
+    // timestamps on activities and the node's payment creation dates.
+    static readonly EXPIRY_CHECK_MAX_PAYMENTS = 2000;
+    static readonly EXPIRY_CHECK_DATE_MARGIN_MS = 24 * 60 * 60 * 1000;
+
+    // Unix-seconds creation_date_start covering every candidate, or null
+    // when any candidate's age is unknown (nothing may expire without a
+    // window that provably contains it).
+    static getExpiryCheckCreationDateStart(
+        candidates: { createdAt?: Date }[]
+    ): number | null {
+        if (!candidates.length) return null;
+        const times: number[] = [];
+        for (const candidate of candidates) {
+            if (!candidate.createdAt) return null;
+            times.push(candidate.createdAt.getTime());
+        }
+        const oldest = Math.min(...times);
+        return Math.max(
+            0,
+            Math.floor(
+                (oldest - NostrConnectUtils.EXPIRY_CHECK_DATE_MARGIN_MS) / 1000
+            )
+        );
+    }
+
     // Builds a settled payment record from request-side state, for when a
     // payment verifiably succeeded (preimage in hand) but cannot be found
     // in the node's refreshed payments list (pagination window, indexing

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -1121,6 +1121,28 @@ export default class NostrConnectUtils {
         );
     }
 
+    // A dispatched Lightning payment cannot remain genuinely in flight
+    // past its route's CLTV limit (lnd caps outgoing CLTV at 2016 blocks,
+    // roughly 14 days). A pending pay_invoice activity older than this
+    // whose payment a fresh payments-list fetch still cannot find is
+    // treated as failed, releasing its budget reservation; otherwise a
+    // list miss reserves budget forever (pendingSpendSats derives from
+    // activity status and survives budget renewal).
+    static readonly PENDING_PAY_INVOICE_EXPIRY_MS = 14 * 24 * 60 * 60 * 1000;
+
+    static isPendingPayInvoiceExpired(
+        activity: { createdAt?: Date },
+        nowMs: number = Date.now()
+    ): boolean {
+        // Unknown age never expires: only definitive evidence may release
+        // a budget reservation.
+        if (!activity.createdAt) return false;
+        return (
+            nowMs - activity.createdAt.getTime() >=
+            NostrConnectUtils.PENDING_PAY_INVOICE_EXPIRY_MS
+        );
+    }
+
     // Builds a settled payment record from request-side state, for when a
     // payment verifiably succeeded (preimage in hand) but cannot be found
     // in the node's refreshed payments list (pagination window, indexing

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -1121,6 +1121,41 @@ export default class NostrConnectUtils {
         );
     }
 
+    // Builds a settled payment record from request-side state, for when a
+    // payment verifiably succeeded (preimage in hand) but cannot be found
+    // in the node's refreshed payments list (pagination window, indexing
+    // lag, backends with incomplete listPayments). Budget accounting must
+    // not depend on that lookup: a spend that escapes finalizePayment is
+    // never debited.
+    static buildSettledPaymentFallback({
+        invoice,
+        payment_source,
+        amountSats,
+        preimage,
+        feeSats,
+        paymentHash
+    }: {
+        invoice: string;
+        payment_source: 'lightning' | 'cashu';
+        amountSats: number;
+        preimage?: string | null;
+        feeSats?: string | number | null;
+        paymentHash?: string | null;
+    }): Payment | CashuPayment {
+        const data = {
+            payment_request: invoice,
+            ...(paymentHash ? { payment_hash: paymentHash } : {}),
+            ...(preimage ? { payment_preimage: preimage } : {}),
+            value_sat: amountSats,
+            ...(feeSats ? { fee_sat: feeSats.toString() } : {}),
+            status: 'SUCCEEDED',
+            creation_date: Math.floor(Date.now() / 1000).toString()
+        };
+        return payment_source === 'cashu'
+            ? new CashuPayment(data)
+            : new Payment(data);
+    }
+
     static findInTransitPaymentForInvoice<T extends Payment>(
         invoice: string,
         payments: T[],


### PR DESCRIPTION
# Description

Stacked on #4334 (its commit is included here; only the second commit is new). Together they close out the accounting model behind NWC connection budgets.

## The bug

A pending `pay_invoice` activity whose payment never appears in the node's payments list is stuck forever:

- reconciliation (`reconcilePendingPayInvoiceActivities`) skips activities with no matching list entry
- `pendingSpendSats` derives from activity status, so the stuck pending counts against the budget indefinitely
- budget renewal resets only `totalSpendSats`, so the reservation survives every renewal period
- there is no expiry, no pruning, and no manual release

Net effect: the connection's usable budget is permanently reduced by the stuck amount. This is the fail-closed inverse of the accounting escape fixed in #4334, and was flagged during triage of the same external report (FND-004).

## The fix

A dispatched Lightning payment cannot remain genuinely in flight past its route's CLTV limit (lnd caps outgoing CLTV at 2016 blocks, roughly 14 days). Reconciliation now runs an expiry pass for pendings older than that bound:

- a definitive wide-window fetch (2000 payments, `BackendUtils.getPayments` directly so the wallet activity list and its loading flag are untouched) gets one real look at the node
- a payment that turns up is resolved through the normal reconcile path (success debits the budget; failed releases). If the node still reports it in flight (zombie records exist on lnd), the node is the authority and the reservation holds
- only a payment still missing after that look is marked failed, releasing its reservation, with an explanatory error on the activity
- a failed fetch skips the pass entirely: a reservation can never be released without evidence

On LND-family backends the payments list includes failed and in-flight entries (`include_incomplete=true`), so a wide-window miss at 14 days means the payment never left the node or failed long ago; expiring it is correct in the overwhelming case. The accepted residual: a settled payment the node's list permanently omits is released 14 days late, bounded to one payment.

Implementation notes:

- the per-activity resolution logic is extracted into `applyPendingPayInvoiceResolution` and shared by the regular loop and the expiry pass
- the threshold and age check live in `NostrConnectUtils` (`PENDING_PAY_INVOICE_EXPIRY_MS`, `isPendingPayInvoiceExpired`) with unit tests; activities of unknown age never expire
- the failure message deliberately avoids `isIgnorableError`'s substrings ("has expired" etc.) so the activity-cleanup filter does not prune the audit trail; pinned by a test
- one new `en.json` string

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly (no new errors in changed files)
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

Pending. Planned before ready-for-review (on top of the #4334 matrix):

- Seed a pending activity with a backdated createdAt (>14d), payment absent from the node: reconcile flips it to failed and remainingBudget increases
- Same, payment present and settled on the node: reconcile flips to success and debits (no expiry)
- Same, payment reported in flight by the node: stays pending, reservation holds
- Backend fetch failing (airplane mode): expiry pass is skipped, pending untouched

I have tested this PR with the following types of nodes (please specify node version, and API version where appropriate):

Pending, see above.
