### PR TITLE
fix: stop logging sensitive payment and credential material

### DIFF
--- a/PushNotificationManager.tsx
+++ b/PushNotificationManager.tsx
@@ -22,7 +22,7 @@ export default class PushNotificationManager extends React.Component<any, any> {
         Notifications.events().registerRemoteNotificationsRegistered(
             (event) => {
                 const deviceToken = event.deviceToken;
-                console.log('Device Token Received', deviceToken);
+                if (__DEV__) console.log('Device Token Received', deviceToken);
                 lightningAddressStore.setDeviceToken(deviceToken);
             }
         );
@@ -52,7 +52,11 @@ export default class PushNotificationManager extends React.Component<any, any> {
     registerNotificationEvents = () => {
         Notifications.events().registerNotificationReceivedForeground(
             (notification, completion) => {
-                console.log('Notification Received - Foreground', notification);
+                if (__DEV__)
+                    console.log(
+                        'Notification Received - Foreground',
+                        notification
+                    );
                 // Don't display redeem notification if auto-redeem is on
                 if (
                     settingsStore.settings?.lightningAddress
@@ -83,7 +87,11 @@ export default class PushNotificationManager extends React.Component<any, any> {
 
         Notifications.events().registerNotificationOpened(
             (notification, completion) => {
-                console.log('Notification opened by device user', notification);
+                if (__DEV__)
+                    console.log(
+                        'Notification opened by device user',
+                        notification
+                    );
                 console.log(
                     `Notification opened with an action identifier: ${notification.identifier}`
                 );
@@ -94,7 +102,11 @@ export default class PushNotificationManager extends React.Component<any, any> {
 
         Notifications.events().registerNotificationReceivedBackground(
             (notification, completion: any) => {
-                console.log('Notification Received - Background', notification);
+                if (__DEV__)
+                    console.log(
+                        'Notification Received - Background',
+                        notification
+                    );
                 // Calling completion on iOS with `alert: true` will present the native iOS inApp notification.
                 completion({ alert: true, sound: true, badge: false });
             }
@@ -102,7 +114,11 @@ export default class PushNotificationManager extends React.Component<any, any> {
 
         Notifications.getInitialNotification()
             .then((notification) => {
-                console.log('Initial notification was:', notification || 'N/A');
+                if (__DEV__)
+                    console.log(
+                        'Initial notification was:',
+                        notification || 'N/A'
+                    );
                 this.goToNwcActivityFromNotif(notification?.payload);
             })
             .catch((err) =>

--- a/android/app/src/main/java/com/zeus/lnc-rn/LncModule.kt
+++ b/android/app/src/main/java/com/zeus/lnc-rn/LncModule.kt
@@ -118,9 +118,6 @@ class LncModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
 
   @ReactMethod
   fun connectServer(namespace: String, mailboxServerAddr: String, isDevServer: Boolean = false, connectPhrase: String, localStatic: String, remoteStatic: String, promise: Promise) {
-     Log.d("connectMailbox", "called with connectPhrase: " + connectPhrase
-     + " and mailboxServerAddr: " + mailboxServerAddr);
-
      try {
          Lndmobile.connectServer(namespace, mailboxServerAddr, isDevServer, connectPhrase, localStatic ?: "", remoteStatic ?: "")
          promise.resolve(null)
@@ -137,9 +134,6 @@ class LncModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaMod
 
   @ReactMethod
   fun invokeRPC(namespace: String, route: String, requestData: String, rnCallback: Callback) {
-     Log.d("request", "called with route: " + route
-     + " and requestData: " + requestData);
-
      val gocb = AndroidCallback()
      gocb.setCallback(rnCallback)
      Lndmobile.invokeRPC(namespace, route, requestData, gocb)

--- a/lndmobile/index.ts
+++ b/lndmobile/index.ts
@@ -434,7 +434,6 @@ export const sendKeysendPaymentV2 = (request: any): Promise<lnrpc.Payment> => {
         const listener = LndMobileEventEmitter.addListener(
             'RouterSendPaymentV2',
             (e) => {
-                console.log(e);
                 const error = checkLndStreamErrorResponse(
                     'RouterSendPaymentV2',
                     e
@@ -447,14 +446,12 @@ export const sendKeysendPaymentV2 = (request: any): Promise<lnrpc.Payment> => {
                 }
 
                 const response = decodeSendPaymentV2Result(e.data);
-                console.log(response);
-
                 resolve(response);
                 listener.remove();
             }
         );
 
-        const response = await sendStreamCommand<
+        await sendStreamCommand<
             routerrpc.ISendPaymentRequest,
             routerrpc.SendPaymentRequest
         >(
@@ -465,7 +462,6 @@ export const sendKeysendPaymentV2 = (request: any): Promise<lnrpc.Payment> => {
             },
             false
         );
-        console.log(response);
     });
 };
 

--- a/stores/LightningAddressStore.ts
+++ b/stores/LightningAddressStore.ts
@@ -863,8 +863,8 @@ export default class LightningAddressStore {
                     // If server returns a token, receive it
                     if (redeemData.token) {
                         console.log(
-                            'Receiving token from server:',
-                            redeemData.token
+                            'Receiving token from server for quote:',
+                            quote_id
                         );
                         // Provide our Cashu secret key; CDK will only use it if the token is P2PK-locked.
                         const signingKey =

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -711,7 +711,9 @@ export default class SwapStore {
             // Save the updated swaps back to encrypted storage
             await Storage.setItem(SWAPS_KEY, JSON.stringify(swaps));
 
-            console.log('Swap updated in storage:', swaps[swapIndex]);
+            console.log(
+                `Swap ${swapId} updated in storage: status=${swaps[swapIndex].status}`
+            );
         } catch (error) {
             console.error('Error updating swap in storage:', error);
             throw error;

--- a/views/Swaps/SwapDetails.tsx
+++ b/views/Swaps/SwapDetails.tsx
@@ -330,7 +330,7 @@ export default class SwapDetails extends React.Component<
                             createdResponse.id,
                             endpoint
                         );
-                        console.log('Fetched claim details:', claimTxDetails);
+                        console.log('Fetched claim details');
 
                         const isValid = this.validatePreimage(
                             claimTxDetails?.preimage,


### PR DESCRIPTION
# Description

Removes log statements that exposed secrets in release builds.

**Fixes**
- `stores/SwapStore.ts`: logged the whole persisted swap object, including `refundPrivateKey`, the ECPair private key, and the reverse-swap preimage (fund-loss grade). Now logs swap id + status only.
- `stores/LightningAddressStore.ts`: logged the raw Cashu bearer token from the ZEUS Pay redeem endpoint (spendable ecash). Now logs the quote id only.
- `views/Swaps/SwapDetails.tsx`: logged Boltz claim details including the payment preimage.
- `lndmobile/index.ts`: the keysend `sendPaymentV2` path logged the raw stream event and the decoded `lnrpc.Payment` (`payment_preimage`, full route hops) on every payment. Aligned with the non-keysend path, which never logged these.
- `android LncModule.kt`: logged the LNC pairing phrase (a bearer credential for the node) on connect, and every LNC RPC request body via `invokeRPC` (invoices, destinations, amounts, PSBTs) to logcat. Both removed. The iOS module never logged them.
- `PushNotificationManager.tsx`: device token and full notification payload logs are now gated behind `__DEV__` (payload content is server-controlled).

**Not in this PR (intentionally)**
- Build-level backstops (babel `transform-remove-console` for release bundles, ProGuard `Log.v/d/i` strip + R8 optimization switch): split out per review feedback, tracked in #4345. The ProGuard piece needs keep rules for `zeus-cashu-restore.aar` and `react-native-nitro-tor` plus a reproducible-build re-verification before it can ship.
- `CashuDevKitModule` logcat dumps (mint quote response etc.): deferred to land on top of #4211, converting them to its redacted `logToFile` channel instead of deleting the signal.
- Medium-tier object dumps (LSPStore, ContactStore, ChannelsStore, route hints, Boltz WS frames): explicit gating can follow separately; the release strip in #4345 will cover them in release builds.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

> **Draft note:** device testing pending. Required before merge: (1) LNC connect + RPC on Android to confirm the removed logs broke nothing; (2) a keysend payment on embedded LND; (3) a swap refund path hit to exercise the SwapStore change; (4) `adb logcat` spot check that the LNC pairing phrase and request bodies no longer appear.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
