### PR TITLE
ui: LnurlPay: start amount empty instead of min sendable

### DIFF
--- a/views/LnurlPay/LnurlPay.tsx
+++ b/views/LnurlPay/LnurlPay.tsx
@@ -162,17 +162,21 @@ export default class LnurlPay extends React.Component<
             // If only amount is provided, use it and derive satAmount
             finalAmount = amount;
             finalSatAmount = getSatAmount(amount);
-        } else {
-            // Fall back to min sat amount
+        } else if (lnurl.minSendable === lnurl.maxSendable) {
+            // Fixed amount: prefill the locked input with the required amount
             const { amount: unformattedAmount } = getUnformattedAmount({
                 sats: minSendableSats
             });
-            const unspecifiedDefault =
+            finalAmount =
                 units === 'sats'
                     ? minSendableSats.toString()
                     : unformattedAmount;
-            finalAmount = amount && amount != 0 ? amount : unspecifiedDefault;
             finalSatAmount = minSendableSats;
+        } else {
+            // Variable amount: start empty so the user doesn't have to
+            // delete a prefilled value
+            finalAmount = '';
+            finalSatAmount = '';
         }
 
         // Find matching contact by Lightning Address
@@ -600,7 +604,9 @@ export default class LnurlPay extends React.Component<
                                 buttonStyle={{
                                     backgroundColor: themeColor('secondary')
                                 }}
-                                disabled={loading}
+                                disabled={
+                                    loading || !satAmount || satAmount == 0
+                                }
                             />
                         </View>
                     </View>


### PR DESCRIPTION
# Description

When paying an LNURL-pay or lightning address with a variable amount, the amount input was prefilled with the minimum sendable amount (usually 1 sat), forcing the user to delete it before typing the amount they actually want to send.

This PR makes the input start empty when the amount is variable and no amount was passed in via route params. The fixed-amount case (`minSendable === maxSendable`) still prefills the locked input with the required amount, and amounts passed in via route params still prefill as before.

Since the field can now start empty, the confirm button is also disabled while no amount is entered; previously an empty amount would have been submitted as NaN millisats in the LNURL callback URL.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding