### PR TITLE
ui: Themes: distinguish placeholders from input text

### DIFF
--- a/components/Channels/ChannelsFilter.tsx
+++ b/components/Channels/ChannelsFilter.tsx
@@ -8,7 +8,7 @@ import { FilterOptions } from '../../components/Channels/FilterOptions';
 import SortButton from '../../components/Channels/SortButton';
 
 import { localeString } from '../../utils/LocaleUtils';
-import { themeColor } from '../../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../../utils/ThemeUtils';
 
 import ChannelsStore, {
     ChannelsType,
@@ -165,7 +165,7 @@ class ChannelsFilter extends React.PureComponent<ChannelsFilterProps> {
                             color: themeColor('text'),
                             fontFamily: 'PPNeueMontreal-Book'
                         }}
-                        placeholderTextColor={themeColor('secondaryText')}
+                        placeholderTextColor={placeholderColor()}
                         containerStyle={{
                             backgroundColor: 'transparent',
                             borderTopWidth: 0,

--- a/components/CurrencyList.tsx
+++ b/components/CurrencyList.tsx
@@ -12,7 +12,7 @@ import UnitsStore from '../stores/UnitsStore';
 import FiatStore from '../stores/FiatStore';
 
 import { localeString } from '../utils/LocaleUtils';
-import { themeColor } from '../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../utils/ThemeUtils';
 import { numberWithCommas, numberWithDecimals } from '../utils/UnitsUtils';
 
 import BitcoinIcon from '../assets/images/SVG/bitcoin-icon.svg';
@@ -294,7 +294,7 @@ export default class CurrencyList extends React.Component<
                         color: themeColor('text'),
                         fontFamily: 'PPNeueMontreal-Book'
                     }}
-                    placeholderTextColor={themeColor('secondaryText')}
+                    placeholderTextColor={placeholderColor()}
                     containerStyle={{
                         backgroundColor: 'transparent',
                         borderTopWidth: 0,

--- a/components/TextInput.tsx
+++ b/components/TextInput.tsx
@@ -10,7 +10,7 @@ import {
     View,
     ViewStyle
 } from 'react-native';
-import { themeColor } from './../utils/ThemeUtils';
+import { placeholderColor, themeColor } from './../utils/ThemeUtils';
 
 interface TextInputProps {
     placeholder?: string;
@@ -175,7 +175,7 @@ const TextInput = React.forwardRef<TextInputRN, TextInputProps>(
                                 : themeColor('text'))
                     }}
                     placeholderTextColor={
-                        placeholderTextColor || themeColor('secondaryText')
+                        placeholderTextColor || placeholderColor()
                     }
                     editable={!locked}
                     keyboardType={keyboardType}

--- a/utils/ThemeUtils.ts
+++ b/utils/ThemeUtils.ts
@@ -95,6 +95,7 @@ const Junkie: { [key: string]: any } = {
     modalBackground: 'rgb(51, 51, 51)',
     text: 'white',
     secondaryText: 'lightgray',
+    placeholderText: '#A7A9AC',
     highlight: 'rgb(249, 212, 0)',
     error: '#992600',
     separator: 'darkgray',
@@ -173,6 +174,7 @@ const Purple: { [key: string]: any } = {
     modalBackground: '#dbd0e1',
     text: '#776d86',
     secondaryText: '#6f7286',
+    placeholderText: '#948BA3',
     highlight: '#ffd24b',
     error: '#C9592D',
     separator: '##9fa3bf',
@@ -208,6 +210,7 @@ const Deadpool: { [key: string]: any } = {
     modalBackground: '#000',
     text: '#F4F9FF',
     secondaryText: '#F4F9FF',
+    placeholderText: '#E8A0A6',
     highlight: '#ffd24b',
     error: '#D12531',
     separator: '#D12531',
@@ -283,7 +286,8 @@ const Popsicle: { [key: string]: any } = {
     separator: '#141414',
     bolt: '#fff',
     chain: '#fff',
-    secondaryText: 'lightgray'
+    secondaryText: 'lightgray',
+    placeholderText: '#A7A9AC'
 };
 
 const Nostrich: { [key: string]: any } = {
@@ -310,7 +314,8 @@ const Desert: { [key: string]: any } = {
     modalBackground: '#141414',
     separator: '#141414',
     text: '#FFFFFF',
-    secondaryText: '#E8E8E8'
+    secondaryText: '#E8E8E8',
+    placeholderText: '#A7A9AC'
 };
 
 const OrangeCreamSoda: { [key: string]: any } = {
@@ -320,7 +325,8 @@ const OrangeCreamSoda: { [key: string]: any } = {
     secondary: '#141414',
     modalBackground: '#141414',
     separator: '#141414',
-    secondaryText: '#E6E6E6'
+    secondaryText: '#E6E6E6',
+    placeholderText: '#A7A9AC'
 };
 
 const Mint: { [key: string]: any } = {
@@ -336,6 +342,7 @@ const Mint: { [key: string]: any } = {
     background: '#46B48A',
     modalBackground: '#46B48A',
     secondaryText: '#FFFDF2',
+    placeholderText: '#A7A9AC',
     separator: '#141414',
     highlight: '#ffd24b',
     bolt: '#fff',
@@ -360,7 +367,8 @@ const Watermelon: { [key: string]: any } = {
     highlight: '#ffd24b',
     bolt: '#fff',
     chain: '#fff',
-    secondaryText: 'lightgray'
+    secondaryText: 'lightgray',
+    placeholderText: '#A7A9AC'
 };
 
 const Radioactive: { [key: string]: any } = {
@@ -445,6 +453,13 @@ export function themeColor(themeString: string): any {
         default:
             return Dark[themeString];
     }
+}
+
+// Color for placeholder text in inputs and search bars. Some themes use a
+// secondaryText that is nearly identical to text, so they define a dedicated
+// placeholderText color to keep placeholders distinguishable from user input.
+export function placeholderColor(): string {
+    return themeColor('placeholderText') || themeColor('secondaryText');
 }
 
 // based on https://stackoverflow.com/a/41491220/1836528

--- a/views/Cashu/RecoverMintQuote.tsx
+++ b/views/Cashu/RecoverMintQuote.tsx
@@ -13,7 +13,7 @@ import { ErrorMessage } from '../../components/SuccessErrorMessage';
 import CashuStore from '../../stores/CashuStore';
 
 import { localeString } from '../../utils/LocaleUtils';
-import { themeColor } from '../../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../../utils/ThemeUtils';
 
 interface RecoverMintQuoteProps {
     navigation: NativeStackNavigationProp<any, any>;
@@ -207,7 +207,7 @@ export default class RecoverMintQuote extends React.Component<
                         placeholder={localeString(
                             'views.Cashu.RecoverMintQuote.quoteIdPlaceholder'
                         )}
-                        placeholderTextColor={themeColor('secondaryText')}
+                        placeholderTextColor={placeholderColor()}
                         style={{
                             color: themeColor('text'),
                             fontFamily: 'PPNeueMontreal-Book',

--- a/views/OnChainAddresses.tsx
+++ b/views/OnChainAddresses.tsx
@@ -24,7 +24,7 @@ import { ErrorMessage } from '../components/SuccessErrorMessage';
 
 import AddressUtils from '../utils/AddressUtils';
 import { localeString } from '../utils/LocaleUtils';
-import { themeColor } from '../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../utils/ThemeUtils';
 
 import UTXOsStore from '../stores/UTXOsStore';
 
@@ -569,7 +569,7 @@ export default class OnChainAddresses extends React.Component<
                         inputStyle={{
                             color: themeColor('text')
                         }}
-                        placeholderTextColor={themeColor('secondaryText')}
+                        placeholderTextColor={placeholderColor()}
                         containerStyle={{
                             backgroundColor: 'transparent',
                             borderTopWidth: 0,

--- a/views/POS/Categories.tsx
+++ b/views/POS/Categories.tsx
@@ -11,7 +11,7 @@ import Screen from '../../components/Screen';
 import InventoryStore from '../../stores/InventoryStore';
 
 import { localeString } from '../../utils/LocaleUtils';
-import { themeColor } from '../../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../../utils/ThemeUtils';
 
 import ProductCategory from '../../models/ProductCategory';
 
@@ -133,7 +133,7 @@ export default class ProductCategories extends React.Component<
                         inputStyle={{
                             color: themeColor('text')
                         }}
-                        placeholderTextColor={themeColor('secondaryText')}
+                        placeholderTextColor={placeholderColor()}
                         containerStyle={{
                             backgroundColor: 'transparent',
                             borderTopWidth: 0,

--- a/views/POS/ProductCategoryDetails.tsx
+++ b/views/POS/ProductCategoryDetails.tsx
@@ -271,9 +271,6 @@ export default class ProductCategoryDetails extends React.Component<
                                         placeholder={localeString(
                                             'views.Settings.POS.Category.name'
                                         )}
-                                        placeholderTextColor={themeColor(
-                                            'secondaryText'
-                                        )}
                                         style={styles.textInput}
                                     />
                                 </View>

--- a/views/POS/ProductDetails.tsx
+++ b/views/POS/ProductDetails.tsx
@@ -324,9 +324,6 @@ export default class ProductDetails extends React.Component<
                                                 placeholder={localeString(
                                                     'views.Settings.POS.Product.name'
                                                 )}
-                                                placeholderTextColor={themeColor(
-                                                    'secondaryText'
-                                                )}
                                                 style={styles.textInput}
                                             />
                                             <TextInput
@@ -338,9 +335,6 @@ export default class ProductDetails extends React.Component<
                                                 value={product?.sku}
                                                 placeholder={localeString(
                                                     'views.Settings.POS.Product.sku'
-                                                )}
-                                                placeholderTextColor={themeColor(
-                                                    'secondaryText'
                                                 )}
                                                 style={styles.textInput}
                                                 autoCapitalize="none"

--- a/views/POS/Products.tsx
+++ b/views/POS/Products.tsx
@@ -12,7 +12,7 @@ import Screen from '../../components/Screen';
 import InventoryStore from '../../stores/InventoryStore';
 
 import { localeString } from '../../utils/LocaleUtils';
-import { themeColor } from '../../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../../utils/ThemeUtils';
 import Product from '../../models/Product';
 
 interface ProductsProps {
@@ -131,7 +131,7 @@ export default class Products extends React.Component<
                         inputStyle={{
                             color: themeColor('text')
                         }}
-                        placeholderTextColor={themeColor('secondaryText')}
+                        placeholderTextColor={placeholderColor()}
                         containerStyle={{
                             backgroundColor: 'transparent',
                             borderTopWidth: 0,

--- a/views/Settings/AddContact.tsx
+++ b/views/Settings/AddContact.tsx
@@ -27,7 +27,7 @@ import { Row } from '../../components/layout/Row';
 import AddressUtils from '../../utils/AddressUtils';
 import { confirmAction } from '../../utils/ActionUtils';
 import { getPhoto } from '../../utils/PhotoUtils';
-import { themeColor } from '../../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../../utils/ThemeUtils';
 
 import ContactStore from '../../stores/ContactStore';
 import LightningBolt from '../../assets/images/SVG/Lightning Bolt.svg';
@@ -133,7 +133,7 @@ const ContactInputField = ({
                 }}
                 value={value}
                 placeholder={placeholder}
-                placeholderTextColor={themeColor('secondaryText')}
+                placeholderTextColor={placeholderColor()}
                 style={[
                     styles.fieldInput,
                     {
@@ -924,9 +924,7 @@ export default class AddContact extends React.Component<
                                 placeholder={localeString(
                                     'views.Settings.AddContact.name'
                                 )}
-                                placeholderTextColor={themeColor(
-                                    'secondaryText'
-                                )}
+                                placeholderTextColor={placeholderColor()}
                                 style={dynamicStyles.textInput}
                                 autoCapitalize="none"
                             />
@@ -949,9 +947,7 @@ export default class AddContact extends React.Component<
                                 placeholder={localeString(
                                     'views.Settings.AddContact.description'
                                 )}
-                                placeholderTextColor={themeColor(
-                                    'secondaryText'
-                                )}
+                                placeholderTextColor={placeholderColor()}
                                 style={[dynamicStyles.textInput]}
                                 autoCapitalize="none"
                             />

--- a/views/Settings/Contacts.tsx
+++ b/views/Settings/Contacts.tsx
@@ -20,7 +20,7 @@ import { ContactAvatar } from '../../components/ContactAvatar';
 
 import { confirmAction } from '../../utils/ActionUtils';
 import { localeString } from '../../utils/LocaleUtils';
-import { themeColor } from '../../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../../utils/ThemeUtils';
 
 import Storage from '../../storage';
 
@@ -381,9 +381,7 @@ export default class Contacts extends React.Component<
                                             inputStyle={{
                                                 color: themeColor('text')
                                             }}
-                                            placeholderTextColor={themeColor(
-                                                'secondaryText'
-                                            )}
+                                            placeholderTextColor={placeholderColor()}
                                             containerStyle={{
                                                 backgroundColor: 'none',
                                                 borderTopWidth: 0,
@@ -436,9 +434,7 @@ export default class Contacts extends React.Component<
                                         inputStyle={{
                                             color: themeColor('text')
                                         }}
-                                        placeholderTextColor={themeColor(
-                                            'secondaryText'
-                                        )}
+                                        placeholderTextColor={placeholderColor()}
                                         containerStyle={{
                                             backgroundColor: 'transparent',
                                             borderTopWidth: 0,

--- a/views/Settings/Language.tsx
+++ b/views/Settings/Language.tsx
@@ -10,7 +10,7 @@ import Screen from '../../components/Screen';
 import SettingsStore, { LOCALE_KEYS } from '../../stores/SettingsStore';
 
 import { localeString, bridgeJavaStrings } from '../../utils/LocaleUtils';
-import { themeColor } from '../../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../../utils/ThemeUtils';
 
 interface LanguageProps {
     navigation: NativeStackNavigationProp<any, any>;
@@ -93,7 +93,7 @@ export default class Language extends React.Component<
                         inputStyle={{
                             color: themeColor('text')
                         }}
-                        placeholderTextColor={themeColor('secondaryText')}
+                        placeholderTextColor={placeholderColor()}
                         containerStyle={{
                             backgroundColor: 'transparent',
                             borderTopWidth: 0,

--- a/views/Settings/NostrWalletConnect/NWCConnectionsList.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionsList.tsx
@@ -22,7 +22,7 @@ import { Tag } from '../../../components/Channels/Tag';
 import SettingsStore from '../../../stores/SettingsStore';
 import NostrWalletConnectStore from '../../../stores/NostrWalletConnectStore';
 
-import { themeColor } from '../../../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../../../utils/ThemeUtils';
 import { localeString } from '../../../utils/LocaleUtils';
 import DateTimeUtils from '../../../utils/DateTimeUtils';
 import UrlUtils from '../../../utils/UrlUtils';
@@ -527,9 +527,7 @@ export default class NWCConnectionsList extends React.Component<
                                             styles.searchInput,
                                             { color: themeColor('text') }
                                         ]}
-                                        placeholderTextColor={themeColor(
-                                            'secondaryText'
-                                        )}
+                                        placeholderTextColor={placeholderColor()}
                                         containerStyle={{
                                             backgroundColor: 'transparent',
                                             borderTopWidth: 0,

--- a/views/Settings/SelectCurrency.tsx
+++ b/views/Settings/SelectCurrency.tsx
@@ -19,7 +19,7 @@ import UnitsStore from '../../stores/UnitsStore';
 import Storage from '../../storage';
 
 import { localeString } from '../../utils/LocaleUtils';
-import { themeColor } from '../../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../../utils/ThemeUtils';
 
 import Star from '../../assets/images/SVG/Star.svg';
 
@@ -257,7 +257,7 @@ export default class SelectCurrency extends React.Component<
                             color: themeColor('text'),
                             fontFamily: 'PPNeueMontreal-Book'
                         }}
-                        placeholderTextColor={themeColor('secondaryText')}
+                        placeholderTextColor={placeholderColor()}
                         containerStyle={{
                             backgroundColor: 'transparent',
                             borderTopWidth: 0,

--- a/views/Tools/Watchtowers/AddWatchtower.tsx
+++ b/views/Tools/Watchtowers/AddWatchtower.tsx
@@ -198,7 +198,6 @@ export default class AddWatchtower extends React.Component<
                                     : themeColor('error')
                             }
                             placeholder={'02abc...'}
-                            placeholderTextColor={themeColor('secondaryText')}
                             autoCapitalize="none"
                             autoCorrect={false}
                         />
@@ -236,7 +235,6 @@ export default class AddWatchtower extends React.Component<
                             placeholder={localeString(
                                 'views.OpenChannel.hostPort'
                             )}
-                            placeholderTextColor={themeColor('secondaryText')}
                             autoCapitalize="none"
                             autoCorrect={false}
                         />

--- a/views/Tools/Watchtowers/WatchtowerList.tsx
+++ b/views/Tools/Watchtowers/WatchtowerList.tsx
@@ -18,7 +18,7 @@ import Screen from '../../../components/Screen';
 import BackendUtils from '../../../utils/BackendUtils';
 
 import { localeString } from '../../../utils/LocaleUtils';
-import { themeColor } from '../../../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../../../utils/ThemeUtils';
 import Base64Utils from '../../../utils/Base64Utils';
 
 import Add from '../../../assets/images/SVG/Add.svg';
@@ -298,9 +298,7 @@ export default class Watchtowers extends React.Component<
                                     color: themeColor('text'),
                                     fontFamily: 'PPNeueMontreal-Book'
                                 }}
-                                placeholderTextColor={themeColor(
-                                    'secondaryText'
-                                )}
+                                placeholderTextColor={placeholderColor()}
                                 containerStyle={{
                                     backgroundColor: 'transparent',
                                     borderTopWidth: 0,

--- a/views/Wallet/SquarePosPane.tsx
+++ b/views/Wallet/SquarePosPane.tsx
@@ -18,7 +18,7 @@ import UnitsStore from '../../stores/UnitsStore';
 import SettingsStore from '../../stores/SettingsStore';
 
 import { localeString } from '../../utils/LocaleUtils';
-import { themeColor } from '../../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../../utils/ThemeUtils';
 interface SquarePosPaneProps {
     navigation: NativeStackNavigationProp<any, any>;
     ActivityStore?: ActivityStore;
@@ -150,7 +150,7 @@ export default class SquarePosPane extends React.PureComponent<
                         }}
                         value={search}
                         inputStyle={{ color: themeColor('text') }}
-                        placeholderTextColor={themeColor('secondaryText')}
+                        placeholderTextColor={placeholderColor()}
                         containerStyle={{
                             backgroundColor: 'transparent',
                             borderTopWidth: 0,

--- a/views/Wallet/StandalonePosPane.tsx
+++ b/views/Wallet/StandalonePosPane.tsx
@@ -29,7 +29,7 @@ import SettingsStore from '../../stores/SettingsStore';
 import InventoryStore from '../../stores/InventoryStore';
 
 import { localeString } from '../../utils/LocaleUtils';
-import { themeColor } from '../../utils/ThemeUtils';
+import { placeholderColor, themeColor } from '../../utils/ThemeUtils';
 import { SATS_PER_BTC } from '../../utils/UnitsUtils';
 import { getFormattedAmount, getAmountFromSats } from '../../utils/AmountUtils';
 
@@ -466,7 +466,7 @@ export default class StandalonePosPane extends React.PureComponent<
                         inputStyle={{
                             color: themeColor('text')
                         }}
-                        placeholderTextColor={themeColor('secondaryText')}
+                        placeholderTextColor={placeholderColor()}
                         containerStyle={{
                             backgroundColor: 'transparent',
                             borderTopWidth: 0,


### PR DESCRIPTION
# Description

In several themes the placeholder text color in inputs and search bars is identical or nearly identical to the entered text color, so users cannot tell whether a field is empty or already filled in.

Every placeholder in the app resolves to `themeColor('secondaryText')`, while entered text uses `themeColor('text')` (themes that omit `text` fall back to the Dark theme's `white`). Comparing the resolved pair per theme:

| Theme | text (resolved) | secondaryText | contrast between them |
|---|---|---|---|
| Deadpool | `#F4F9FF` | `#F4F9FF` | identical |
| Mint | `white` (fallback) | `#FFFDF2` | ~1.0:1 |
| Purple | `#776d86` | `#6f7286` | ~1.0:1 |
| Desert | `#FFFFFF` | `#E8E8E8` | ~1.2:1 |
| Orange Cream Soda | `white` (fallback) | `#E6E6E6` | ~1.25:1 |
| Junkie / Popsicle / Watermelon | `white` | `lightgray` | ~1.5:1 |

Healthy themes (Dark, Light, etc.) sit around 2.4:1.

`secondaryText` cannot simply be darkened in these themes because it also serves as the label/subtitle color on bright gradient backgrounds (e.g. Orange Cream Soda's orange, Mint's green). Inputs and search bars, however, always render on `themeColor('secondary')`, which is dark or theme-tinted in all affected themes.

## Approach

* Add an optional `placeholderText` theme color, tuned against each affected theme's `secondary` background:
  * `#A7A9AC` (the Dark theme gray) for Mint, Desert, Orange Cream Soda, Junkie, Popsicle and Watermelon
  * `#E8A0A6` (muted pink) for Deadpool, readable on its red inputs
  * `#948BA3` for Purple, sitting between its text and its lavender input background
* Add a `placeholderColor()` helper in `ThemeUtils` that returns `placeholderText` with a `secondaryText` fallback, so all other themes behave exactly as before
* Use the helper in the `TextInput` component default and in the 17 views/components that passed `themeColor('secondaryText')` to SearchBars and inputs directly

Sites with intentionally hardcoded placeholder colors (Lockscreen, SetPassword, SetDuressPassword, stealth NotepadApp) are unchanged.

|Before|After|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-05 at 02 10 59" src="https://github.com/user-attachments/assets/01a3409d-cbc6-4c71-8804-2464633cc379" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-05 at 02 10 23" src="https://github.com/user-attachments/assets/9928c4f1-a639-4aff-8296-3c856024be54" />|

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A (theme color tables have no existing coverage; `placeholderColor()` is a two-line lookup on `settingsStore`)

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Backend-independent styling change; platform testing pending (draft), planned across the affected themes on both platforms.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
