### PR TITLE
fix(lnc): pin Metro to app react-native over nested zeus_modules copy

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -23,8 +23,8 @@ const config = {
         // PlatformConstants / TurboModuleRegistry.
         blockList: [
             defaultConfig.resolver.blockList,
-            /zeus_modules[/\\].+[/\\]node_modules[/\\]react-native[/\\].*/,
-            /zeus_modules[/\\].+[/\\]node_modules[/\\]@react-native[/\\].*/
+            /zeus_modules[/\\].+[/\\]node_modules[/\\]react-native[/\\]/,
+            /zeus_modules[/\\].+[/\\]node_modules[/\\]@react-native[/\\]/
         ],
         extraNodeModules: {
             'react-native': path.resolve(__dirname, 'node_modules/react-native')

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
@@ -16,7 +17,18 @@ const config = {
         assetExts: defaultConfig.resolver.assetExts.filter(
             (ext) => ext !== 'svg'
         ),
-        sourceExts: [...defaultConfig.resolver.sourceExts, 'svg']
+        sourceExts: [...defaultConfig.resolver.sourceExts, 'svg'],
+        // Nested react-native under zeus_modules (e.g. lnc-rn after a local
+        // yarn) would otherwise shadow the app copy and crash on
+        // PlatformConstants / TurboModuleRegistry.
+        blockList: [
+            defaultConfig.resolver.blockList,
+            /zeus_modules[/\\].+[/\\]node_modules[/\\]react-native[/\\].*/,
+            /zeus_modules[/\\].+[/\\]node_modules[/\\]@react-native[/\\].*/
+        ],
+        extraNodeModules: {
+            'react-native': path.resolve(__dirname, 'node_modules/react-native')
+        }
     }
 };
 


### PR DESCRIPTION
# Description

## Problem

When `yarn` is run inside the vendored `zeus_modules/@lightninglabs/lnc-rn`, a nested `react-native` can appear under that package's `node_modules`. Metro's hierarchical resolve then prefers that copy over the app's React Native.

That loads a second `TurboModuleRegistry` and crashes LNC init:

```
Invariant Violation: TurboModuleRegistry.getEnforcing(...): 'PlatformConstants' could not be found
  at new NativeEventEmitter (lnc-rn/lib/lnc.ts)

```

## Changes

This PR updates `metro.config.js` to:

- `blockList` nested `react-native` / `@react-native` under `zeus_modules`
- `extraNodeModules` pin `react-native` to the app `node_modules` copy

## How to Verify

- Ensure nested RN exists (or recreate with `yarn` inside `zeus_modules/@lightninglabs/lnc-rn`)
- `yarn start --reset-cache`
- Connect an LNC node and confirm init no longer hits `PlatformConstants`

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
