### PR TITLE
fix(nwc): include routing and melt fees in connection budget

### DIFF
--- a/models/NWCConnection.ts
+++ b/models/NWCConnection.ts
@@ -444,6 +444,18 @@ export default class NWCConnection extends BaseModel {
             );
         }
     }
+    /**
+     * Validates spendable budget against the invoice amount only.
+     *
+     * Routing fees are unknown until the payment settles and are intentionally
+     * excluded here. Worst-case overshoot is bounded by PAYMENT_FEE_LIMIT_SATS
+     * (the fee cap passed to the backend). Debit happens on finalize/reconcile
+     * for the settled amount; subsequent pays see the reduced remaining budget.
+     *
+     * Reserving amount + fee_limit up front would reject legitimate payments
+     * when remaining budget is in (amount, amount + fee_limit], which is a
+     * worse failure mode for tight budgets.
+     */
     @action
     public validateBudgetBeforePayment(amountSats: number): {
         success: boolean;

--- a/models/NWCConnection.ts
+++ b/models/NWCConnection.ts
@@ -398,41 +398,81 @@ export default class NWCConnection extends BaseModel {
         this.lastBudgetReset = new Date();
     }
 
+    /**
+     * Align warning flags with current budget state.
+     *
+     * - Always syncs BudgetLimitReached (from effectiveSpendSats).
+     * - Syncs WalletBalanceLowerThanBudget only when availableBalance is passed
+     *   (trackSpending has no wallet balance — leave that to store/init paths).
+     *
+     * @returns true if the warning set changed
+     */
     @action
-    public checkAndResetBudgetIfNeeded(availableBalance?: number): boolean {
+    public syncWarnings(availableBalance?: number): boolean {
         let changed = false;
-        if (availableBalance !== undefined && this.maxAmountSats) {
+
+        if (this.budgetLimitReached) {
+            if (
+                !this._warningTypes.includes(
+                    ConnectionWarningType.BudgetLimitReached
+                )
+            ) {
+                this.addWarning(ConnectionWarningType.BudgetLimitReached);
+                changed = true;
+            }
+        } else if (
+            this._warningTypes.includes(
+                ConnectionWarningType.BudgetLimitReached
+            )
+        ) {
+            this.removeWarning(ConnectionWarningType.BudgetLimitReached);
+            changed = true;
+        }
+
+        if (availableBalance !== undefined && this.hasBudgetLimit) {
             const normalizedAvailable = Math.max(
                 0,
                 Math.floor(Number(availableBalance))
             );
-            if (this.maxAmountSats >= normalizedAvailable) {
-                this.addWarning(
+            const shouldWarn = this.maxAmountSats! >= normalizedAvailable;
+
+            if (shouldWarn) {
+                if (
+                    !this._warningTypes.includes(
+                        ConnectionWarningType.WalletBalanceLowerThanBudget
+                    )
+                ) {
+                    this.addWarning(
+                        ConnectionWarningType.WalletBalanceLowerThanBudget
+                    );
+                    changed = true;
+                }
+            } else if (
+                this._warningTypes.includes(
                     ConnectionWarningType.WalletBalanceLowerThanBudget
-                );
-                changed = true;
-            } else if (this.maxAmountSats <= normalizedAvailable) {
+                )
+            ) {
                 this.removeWarning(
                     ConnectionWarningType.WalletBalanceLowerThanBudget
                 );
                 changed = true;
             }
-            if (this.budgetLimitReached) {
-                this.addWarning(ConnectionWarningType.BudgetLimitReached);
-                changed = true;
-            } else {
-                // Pending payments count toward the limit but can fail and
-                // free budget back up; clear the warning when that happens
-                this.removeWarning(ConnectionWarningType.BudgetLimitReached);
-                changed = true;
-            }
-        }
-        if (!this.needsBudgetReset) {
-            return changed;
         }
 
-        this.resetBudget();
-        return true;
+        return changed;
+    }
+
+    @action
+    public checkAndResetBudgetIfNeeded(availableBalance?: number): boolean {
+        let changed = false;
+        if (this.needsBudgetReset) {
+            this.resetBudget();
+            changed = true;
+        }
+        if (this.syncWarnings(availableBalance)) {
+            changed = true;
+        }
+        return changed;
     }
 
     private validateAmount(amountSats: number): void {
@@ -492,9 +532,10 @@ export default class NWCConnection extends BaseModel {
     }
 
     @action
-    public trackSpending(amountSats: number): void {
+    public trackSpending(amountSats: number, maxBudgetLimit?: number): void {
         this.validateAmount(amountSats);
         this.totalSpendSats += amountSats;
+        this.syncWarnings(maxBudgetLimit);
     }
 
     public hasPermission(permission: Nip47SingleMethod): boolean {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1195,6 +1195,9 @@ export default class NostrWalletConnectStore {
         if (index !== -1) {
             this.connections[index] = connection;
         }
+        runInAction(() => {
+            connection.syncWarnings(this.maxBudgetLimit);
+        });
         if (save) {
             this.scheduleSave();
         }
@@ -2422,7 +2425,10 @@ export default class NostrWalletConnectStore {
                     const spendSats =
                         amountSats + NostrConnectUtils.resolveFeeSats(feeSats);
                     if (spendSats > 0) {
-                        connection.trackSpending(spendSats);
+                        connection.trackSpending(
+                            spendSats,
+                            this.maxBudgetLimit
+                        );
                     }
                 } else if (payment.isFailed) {
                     activity.status = 'failed';
@@ -2718,7 +2724,10 @@ export default class NostrWalletConnectStore {
         // Budget is whole sats; round fractional fees (0.026 → 0, 1.999 → 2).
         const budgetFeeSats = NostrConnectUtils.resolveFeeSats(feeSats);
         runInAction(() => {
-            connection.trackSpending(amountSats + budgetFeeSats);
+            connection.trackSpending(
+                amountSats + budgetFeeSats,
+                this.maxBudgetLimit
+            );
             connection.activity.push({
                 id,
                 type,

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2068,6 +2068,8 @@ export default class NostrWalletConnectStore {
                 paymentHash
             );
 
+        const feeSats = Number(payment?.getFee || fees_paid) || 0;
+
         // Debit the budget on any evidence of settlement, not only when the
         // payments-list lookup succeeds: with a preimage in hand the payment
         // definitely settled, and skipping finalizePayment on a list miss
@@ -2089,16 +2091,15 @@ export default class NostrWalletConnectStore {
                     }),
                 payment_source: 'lightning',
                 connection,
-                amountSats
+                amountSats,
+                feeSats
             });
         }
 
         return {
             result: {
                 preimage: preimage || payment?.getPreimage || '',
-                fees_paid: satsToMillisats(
-                    Number(fees_paid) || Number(payment?.getFee) || 0
-                )
+                fees_paid: satsToMillisats(feeSats)
             },
             error: undefined
         };
@@ -2241,6 +2242,7 @@ export default class NostrWalletConnectStore {
         // The melt succeeded (failure returned above), so debit the budget
         // unconditionally: gating on the payments-list lookup would let the
         // spend escape the budget when the list misses the fresh melt.
+        const feeSats = Number(cashuInvoice.getFee || payment?.getFee || 0);
         await this.finalizePayment({
             id: request.invoice,
             decoded:
@@ -2255,6 +2257,7 @@ export default class NostrWalletConnectStore {
             type: 'pay_invoice',
             payment_source: 'cashu',
             amountSats,
+            feeSats,
             connection
         });
 
@@ -2264,7 +2267,7 @@ export default class NostrWalletConnectStore {
                     cashuInvoice.getPreimage ||
                     cashuInvoice.getPaymentRequest ||
                     '',
-                fees_paid: satsToMillisats(cashuInvoice.fee || 0)
+                fees_paid: satsToMillisats(feeSats)
             },
             error: undefined
         };
@@ -2413,8 +2416,12 @@ export default class NostrWalletConnectStore {
                     const amountSats =
                         Math.floor(Number(activity.satAmount)) ||
                         Math.floor(Number(payment.getAmount) || 0);
-                    if (amountSats > 0) {
-                        connection.trackSpending(amountSats);
+                    const feeSats = Number(payment.getFee) || 0;
+                    activity.fees_paid = feeSats;
+                    const spendSats =
+                        amountSats + NostrConnectUtils.resolveFeeSats(feeSats);
+                    if (spendSats > 0) {
+                        connection.trackSpending(spendSats);
                     }
                 } else if (payment.isFailed) {
                     activity.status = 'failed';
@@ -2696,7 +2703,8 @@ export default class NostrWalletConnectStore {
         payment_source,
         decoded,
         connection,
-        amountSats
+        amountSats,
+        feeSats = 0
     }: {
         id: string;
         type: ConnectionActivityType;
@@ -2704,9 +2712,12 @@ export default class NostrWalletConnectStore {
         decoded: Payment | CashuPayment | null;
         connection: NWCConnection;
         amountSats: number;
+        feeSats?: number;
     }): Promise<void> {
+        // Budget is whole sats; round fractional fees (0.026 → 0, 1.999 → 2).
+        const budgetFeeSats = NostrConnectUtils.resolveFeeSats(feeSats);
         runInAction(() => {
-            connection.trackSpending(amountSats);
+            connection.trackSpending(amountSats + budgetFeeSats);
             connection.activity.push({
                 id,
                 type,
@@ -2715,7 +2726,9 @@ export default class NostrWalletConnectStore {
                         ? new CashuPayment(decoded)
                         : new Payment(decoded),
                 status: 'success',
-                payment_source
+                payment_source,
+                satAmount: amountSats,
+                fees_paid: feeSats
             });
             this.findAndUpdateConnection(connection);
         });

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2068,7 +2068,7 @@ export default class NostrWalletConnectStore {
                 paymentHash
             );
 
-        const feeSats = Number(payment?.getFee || fees_paid) || 0;
+        const feeSats = Number(payment?.getFee) || Number(fees_paid) || 0;
 
         // Debit the budget on any evidence of settlement, not only when the
         // payments-list lookup succeeds: with a preimage in hand the payment
@@ -2242,7 +2242,8 @@ export default class NostrWalletConnectStore {
         // The melt succeeded (failure returned above), so debit the budget
         // unconditionally: gating on the payments-list lookup would let the
         // spend escape the budget when the list misses the fresh melt.
-        const feeSats = Number(cashuInvoice.getFee || payment?.getFee || 0);
+        const feeSats =
+            Number(cashuInvoice.getFee) || Number(payment?.getFee) || 0;
         await this.finalizePayment({
             id: request.invoice,
             decoded:
@@ -2252,7 +2253,7 @@ export default class NostrWalletConnectStore {
                     payment_source: 'cashu',
                     amountSats,
                     preimage: cashuInvoice.getPreimage,
-                    feeSats: cashuInvoice.fee
+                    feeSats
                 }),
             type: 'pay_invoice',
             payment_source: 'cashu',
@@ -2728,6 +2729,8 @@ export default class NostrWalletConnectStore {
                 status: 'success',
                 payment_source,
                 satAmount: amountSats,
+                // Stored internally in sats (may be fractional). NIP-47 `fees_paid` is
+                // msats; convert to msats only when mapping to the NIP-47 response.
                 fees_paid: feeSats
             });
             this.findAndUpdateConnection(connection);

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -443,6 +443,25 @@ describe('NostrConnectUtils', () => {
         });
     });
 
+    describe('resolveFeeSats', () => {
+        it('rounds fractional sats from msat division', () => {
+            expect(NostrConnectUtils.resolveFeeSats(1.2)).toBe(1);
+            expect(NostrConnectUtils.resolveFeeSats(1.999)).toBe(2);
+            expect(NostrConnectUtils.resolveFeeSats('0.5')).toBe(1);
+            expect(NostrConnectUtils.resolveFeeSats(0.026)).toBe(0);
+        });
+
+        it('returns whole sats unchanged and zeros non-positive or invalid values', () => {
+            expect(NostrConnectUtils.resolveFeeSats(3)).toBe(3);
+            expect(NostrConnectUtils.resolveFeeSats(0)).toBe(0);
+            expect(NostrConnectUtils.resolveFeeSats(-1)).toBe(0);
+            expect(NostrConnectUtils.resolveFeeSats(undefined)).toBe(0);
+            expect(NostrConnectUtils.resolveFeeSats(null)).toBe(0);
+            expect(NostrConnectUtils.resolveFeeSats('')).toBe(0);
+            expect(NostrConnectUtils.resolveFeeSats(NaN)).toBe(0);
+        });
+    });
+
     describe('lightning payment in-transit detection', () => {
         describe('isInFlightPaymentStatus', () => {
             it.each([

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -1201,6 +1201,16 @@ export default class NostrConnectUtils {
         );
     }
 
+    /**
+     * Whole-sat budget debit for a fee that may be fractional (msat / 1000).
+     * Round to nearest sat; do not use for NIP-47 fees_paid.
+     */
+    static resolveFeeSats(fee: string | number | null | undefined): number {
+        const raw = Number(fee);
+        if (!Number.isFinite(raw) || raw <= 0) return 0;
+        return Math.round(raw);
+    }
+
     static resolveLightningPaymentInTransit({
         invoice,
         payments,

--- a/views/Settings/NostrWalletConnect/NWCConnectionActivity.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionActivity.tsx
@@ -286,6 +286,11 @@ export default class NWCConnectionActivity extends React.Component<
         return item.satAmount;
     };
 
+    getFee = (item: ConnectionActivity) => {
+        if (item.type !== 'pay_invoice') return 0;
+        return item.payment?.getFee || item.fees_paid || 0;
+    };
+
     getActivityMemo = (item: ConnectionActivity): string | undefined => {
         const payment: any = item.payment;
         const invoice: any = item.invoice;
@@ -411,6 +416,8 @@ export default class NWCConnectionActivity extends React.Component<
     renderActivityListItem = ({ item }: { item: ConnectionActivity }) => {
         const title = this.getActivityTitle(item);
         const subtitleNode = this.getActivitySubtitleNode(item);
+        const amountColor = this.getAmountColor(item);
+        const fee = this.getFee(item);
         const displayTime =
             item.invoice?.getDisplayTime || item.payment?.getDisplayTime;
         const displayTimeShort =
@@ -443,11 +450,41 @@ export default class NWCConnectionActivity extends React.Component<
                         >
                             {title}
                         </ListItem.Title>
-                        <Amount
-                            sats={this.getAmount(item)}
-                            sensitive
-                            color={this.getAmountColor(item)}
-                        />
+                        <View
+                            style={{
+                                ...styles.rightCell,
+                                flexDirection: 'row',
+                                flexWrap: 'wrap',
+                                columnGap: 5,
+                                rowGap: -5,
+                                justifyContent: 'flex-end'
+                            }}
+                        >
+                            <Amount
+                                sats={this.getAmount(item)}
+                                sensitive
+                                color={amountColor}
+                            />
+                            {!!fee && fee != 0 && (
+                                <>
+                                    <Text
+                                        style={{
+                                            color: themeColor('text'),
+                                            fontSize: 16
+                                        }}
+                                    >
+                                        +
+                                    </Text>
+                                    <Amount
+                                        sats={fee}
+                                        sensitive
+                                        color={amountColor}
+                                        fee
+                                        roundAmount
+                                    />
+                                </>
+                            )}
+                        </View>
                     </View>
 
                     {showTimeRow && (
@@ -661,6 +698,11 @@ const styles = StyleSheet.create({
         fontWeight: '600',
         fontFamily: 'PPNeueMontreal-Book',
         flexShrink: 1
+    },
+    rightCell: {
+        fontFamily: 'PPNeueMontreal-Book',
+        textAlign: 'right',
+        flexShrink: 0
     },
     leftCellSecondary: {
         fontFamily: 'PPNeueMontreal-Book',


### PR DESCRIPTION
# Description

NWC connection budgets previously tracked only the invoice amount for `pay_invoice`, so Lightning routing fees and Cashu melt fees never counted against the limit. Clients could overspend the configured budget by the fee on every payment.
This PR includes those fees in budget accounting and shows them on connection activityThis PR includes those fees in budget accounting and surfaces them in connection activity.

### Changes

- **Budget debit** — track `amountSats + feeSats` (via `NostrConnectUtils.resolveFeeSats`) on Lightning settle, Cashu melt success, and pending → success reconcile
- **Fee normalization** — `resolveFeeSats` rounds fractional sats (common after msat ÷ 1000); invalid / non-positive values become `0`
- **Stream fee fallback** — preserve stream fee when payment-list fee is unavailable (avoid `'0'` truthiness dropping the fee)
- **Activity** — store `satAmount` and `fees_paid` on pay activities
- **UI** — show amount + fee on NWC connection activity when a fee is present
- **Warnings** — sync budget limit UI after spend so Limit Exceeded stays accurate
- **Docs** — note that `validateBudgetBeforePayment` checks invoice amount only; a connection can exceed budget by up to the final payment’s fee (bounded by `PAYMENT_FEE_LIMIT_SATS`)

### Test plan

- [ ] Lightning pay with routing fee → budget includes amount + fee; activity shows both
- [ ] Cashu melt with nonzero fee → budget and activity include fee
- [ ] Pending pay that settles later → fee debited once on reconcile
- [ ] Budget near limit → fee can push over; next `pay_invoice` is rejected
- [ ] Limit Exceeded badge updates after spend crosses the budget

<table>
  <tr>
    <th>Lightning Payment Activity</th>
    <th>Cashu Payment Activity</th>
  </tr>
  <tr>
    <td align="center">
      <img
        width="350"
        alt="Lightning Payment Activity"
        src="https://github.com/user-attachments/assets/551ced15-8bb1-4966-ab8f-3d57d5116529"
      />
    </td>
    <td align="center">
      <img
        width="350"
        alt="Cashu Payment Activity"
        src="https://github.com/user-attachments/assets/a2f800a1-b506-4cb3-ab33-c807b7e1750b"
      />
    </td>
  </tr>
</table>

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
