### PR TITLE
fix(nwc): rotate and persist client secret on relay change

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2013,7 +2013,7 @@
     "views.Settings.NostrWalletConnect.regenerateConnection": "Regenerate Connection",
     "views.Settings.NostrWalletConnect.regeneratingConnection": "Regenerating connection…",
     "views.Settings.NostrWalletConnect.regenerateConnection.confirm": "This removes the current connection and creates a new one with a new connection secret. Any app that was linked with the old secret will stop working until you connect it again using the new QR code or pairing link. Are you sure you want to regenerate the connection?",
-    "views.Settings.NostrWalletConnect.relayChangeWarning": "⚠️ Changing the relay URL requires regenerating the connection and will need to use new connection secret.",
+    "views.Settings.NostrWalletConnect.relayChangeWarning": "⚠️ Changing the relay URL rotates the connection secret. Linked apps must reconnect with the new QR code or pairing link.",
     "views.Settings.NostrWalletConnect.createFirstConnection": "Tap the + button to create your first connection",
     "views.Settings.NostrWalletConnect.chooseWalletPermissions": "Choose wallet permissions",
     "views.Settings.NostrWalletConnect.fullAccess": "Full Access",

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1,0 +1,353 @@
+jest.mock('../stores/Stores', () => ({}));
+
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+
+jest.mock('../utils/BackendUtils', () => ({
+    __esModule: true,
+    default: {
+        supportsNodeInfo: () => false,
+        supportsCashuWallet: () => false
+    }
+}));
+
+jest.mock('../utils/IOSAudioKeepAliveUtils', () => ({
+    __esModule: true,
+    default: {
+        isAvailable: () => false,
+        start: jest.fn(),
+        stop: jest.fn(),
+        disarm: jest.fn(),
+        onInterrupted: jest.fn(),
+        onInterruptionEnded: jest.fn(),
+        onRouteChanged: jest.fn(),
+        onStatusUpdate: jest.fn(),
+        onSuspended: jest.fn()
+    }
+}));
+
+jest.mock('react-native-notifications', () => ({
+    Notifications: {
+        postLocalNotification: jest.fn()
+    }
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+    require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+jest.mock('@getalby/sdk', () => ({
+    NWCWalletService: jest.fn().mockImplementation(() => ({
+        connected: true,
+        close: jest.fn(),
+        publishWalletServiceInfoEvent: jest.fn().mockResolvedValue(undefined)
+    })),
+    NWCWalletServiceKeyPair: jest.fn()
+}));
+
+jest.mock('../storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn()
+    }
+}));
+
+import Storage from '../storage';
+import NWCConnection, { BudgetRenewalType } from '../models/NWCConnection';
+import NostrWalletConnectStore, {
+    NWC_CLIENT_KEYS
+} from './NostrWalletConnectStore';
+
+const hex64 = (c: string) => c.repeat(64);
+const OLD_PUBKEY = hex64('a');
+const OLD_PRIVKEY = hex64('b');
+const OTHER_PUBKEY = hex64('c');
+const SERVICE_PRIV = hex64('1');
+const SERVICE_PUB = hex64('2');
+const NODE_PUBKEY = 'test-node-pubkey';
+const OLD_RELAY = 'wss://relay.old.example';
+const NEW_RELAY = 'wss://relay.new.example';
+
+describe('NostrWalletConnectStore relay rotation', () => {
+    let clientKeys: Record<string, string>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        clientKeys = { [OLD_PUBKEY]: OLD_PRIVKEY };
+
+        (Storage.getItem as jest.Mock).mockImplementation(
+            async (key: string) => {
+                if (key === NWC_CLIENT_KEYS) {
+                    return JSON.stringify(clientKeys);
+                }
+                return false;
+            }
+        );
+        (Storage.setItem as jest.Mock).mockImplementation(
+            async (key: string, value: string) => {
+                if (key === NWC_CLIENT_KEYS) {
+                    clientKeys = JSON.parse(value);
+                }
+            }
+        );
+    });
+
+    function buildStore(options?: { publishNewRelay?: boolean }) {
+        const publishNewRelay = options?.publishNewRelay !== false;
+        const settingsStore: any = {
+            connecting: false,
+            implementation: 'lnd',
+            settings: {
+                locale: 'en',
+                ecash: { enableCashu: false },
+                lightningAddress: { enabled: false }
+            }
+        };
+        const store = new NostrWalletConnectStore(
+            settingsStore,
+            {} as any,
+            {
+                nodeInfo: { nodeId: NODE_PUBKEY },
+                getNodeInfo: jest.fn()
+            } as any,
+            {} as any,
+            { invoices: [] } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any
+        );
+
+        (store as any).walletServiceKeys = {
+            privateKey: SERVICE_PRIV,
+            publicKey: SERVICE_PUB
+        };
+        (store as any).lud16Enabled = false;
+        (store as any).nwcWalletServices.set(OLD_RELAY, {
+            connected: true,
+            close: jest.fn()
+        });
+        (store as any).nwcWalletServices.set(NEW_RELAY, {
+            connected: true,
+            close: jest.fn()
+        });
+        (store as any).publishedRelays.add(OLD_RELAY);
+        if (publishNewRelay) {
+            (store as any).publishedRelays.add(NEW_RELAY);
+        }
+
+        jest.spyOn(
+            store as any,
+            'unsubscribeFromConnection'
+        ).mockImplementation(() => undefined);
+        jest.spyOn(store as any, 'subscribeToConnection').mockResolvedValue(
+            undefined
+        );
+        jest.spyOn(store as any, 'saveConnections').mockResolvedValue(
+            undefined
+        );
+        jest.spyOn(store as any, 'scheduleSave').mockImplementation(
+            () => undefined
+        );
+
+        return store;
+    }
+
+    function seedConnection(
+        store: NostrWalletConnectStore,
+        overrides: Record<string, unknown> = {}
+    ) {
+        const connection = new NWCConnection({
+            id: 'conn-1',
+            name: 'Test App',
+            pubkey: OLD_PUBKEY,
+            relayUrl: OLD_RELAY,
+            permissions: [],
+            createdAt: new Date('2024-01-01T00:00:00Z'),
+            totalSpendSats: 42,
+            nodePubkey: NODE_PUBKEY,
+            implementation: 'lnd',
+            activity: [],
+            ...overrides
+        } as any);
+        store.connections = [connection, ...store.connections];
+        return connection;
+    }
+
+    it('rotates keys, preserves identity, and drops the unused old relay', async () => {
+        const store = buildStore();
+        const createdAt = new Date('2024-01-01T00:00:00Z');
+        const expiresAt = new Date('2025-06-15T12:00:00Z');
+        const connection = seedConnection(store, {
+            createdAt,
+            expiresAt,
+            maxAmountSats: 5000,
+            budgetRenewal: BudgetRenewalType.Never,
+            lastBudgetReset: new Date('2024-03-01T00:00:00Z'),
+            activity: [
+                {
+                    id: 'lnbc1activity',
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    satAmount: 21
+                }
+            ]
+        });
+        const oldService = (store as any).nwcWalletServices.get(OLD_RELAY);
+
+        const result = await store.updateConnection(connection.id, {
+            relayUrl: NEW_RELAY,
+            expiresAt,
+            maxAmountSats: 5000,
+            budgetRenewal: BudgetRenewalType.Never
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.nostrUrl).toEqual(expect.stringContaining(NEW_RELAY));
+        expect(connection.id).toBe('conn-1');
+        expect(connection.relayUrl).toBe(NEW_RELAY);
+        expect(connection.pubkey).not.toBe(OLD_PUBKEY);
+        expect(connection.createdAt).toEqual(createdAt);
+        expect(connection.expiresAt).toEqual(expiresAt);
+        expect(connection.totalSpendSats).toBe(42);
+        expect(connection.maxAmountSats).toBe(5000);
+        expect(connection.activity).toHaveLength(1);
+        expect(clientKeys[OLD_PUBKEY]).toBeUndefined();
+        expect(clientKeys[connection.pubkey]).toEqual(expect.any(String));
+        expect(oldService.close).toHaveBeenCalled();
+        expect((store as any).nwcWalletServices.has(OLD_RELAY)).toBe(false);
+        expect((store as any).publishedRelays.has(OLD_RELAY)).toBe(false);
+    });
+
+    it('leaves relayUrl unchanged when storing the new key fails so retry can rotate', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store);
+        const consoleError = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+
+        try {
+            (Storage.setItem as jest.Mock).mockImplementation(async () => {
+                throw new Error('storage write failed');
+            });
+
+            const result = await store.updateConnection(connection.id, {
+                relayUrl: NEW_RELAY
+            });
+
+            expect(result.success).toBe(false);
+            expect(result.nostrUrl).toBeUndefined();
+            expect(connection.relayUrl).toBe(OLD_RELAY);
+            expect(connection.pubkey).toBe(OLD_PUBKEY);
+        } finally {
+            consoleError.mockRestore();
+        }
+    });
+
+    it('still returns the pairing URL if subscribe/save fails after durable rotation', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store);
+        const consoleWarn = jest
+            .spyOn(console, 'warn')
+            .mockImplementation(() => {});
+
+        try {
+            (store as any).subscribeToConnection.mockRejectedValue(
+                new Error('subscribe failed')
+            );
+
+            const result = await store.updateConnection(connection.id, {
+                relayUrl: NEW_RELAY
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.nostrUrl).toEqual(expect.stringContaining(NEW_RELAY));
+            expect(connection.pubkey).not.toBe(OLD_PUBKEY);
+            expect(clientKeys[OLD_PUBKEY]).toBeUndefined();
+            expect(clientKeys[connection.pubkey]).toEqual(expect.any(String));
+        } finally {
+            consoleWarn.mockRestore();
+        }
+    });
+
+    it('does not rotate keys on non-relay edits', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store);
+        const pubkeyBefore = connection.pubkey;
+
+        const result = await store.updateConnection(connection.id, {
+            name: 'Renamed App',
+            maxAmountSats: 2500
+        });
+
+        expect(result).toEqual({ success: true });
+        expect(connection.name).toBe('Renamed App');
+        expect(connection.maxAmountSats).toBe(2500);
+        expect(connection.pubkey).toBe(pubkeyBefore);
+        expect(connection.relayUrl).toBe(OLD_RELAY);
+        expect(clientKeys).toEqual({ [OLD_PUBKEY]: OLD_PRIVKEY });
+    });
+
+    it('keeps the old relay service when another connection still uses it', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store);
+        seedConnection(store, {
+            id: 'conn-2',
+            name: 'Other App',
+            pubkey: OTHER_PUBKEY,
+            relayUrl: OLD_RELAY
+        });
+        const oldService = (store as any).nwcWalletServices.get(OLD_RELAY);
+
+        await store.updateConnection(connection.id, { relayUrl: NEW_RELAY });
+
+        expect(oldService.close).not.toHaveBeenCalled();
+        expect((store as any).nwcWalletServices.has(OLD_RELAY)).toBe(true);
+        expect((store as any).publishedRelays.has(OLD_RELAY)).toBe(true);
+    });
+
+    it('releases an unused relay service when deleting the last connection on it', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store);
+        const oldService = (store as any).nwcWalletServices.get(OLD_RELAY);
+
+        await store.deleteConnection(connection.id);
+
+        expect(oldService.close).toHaveBeenCalled();
+        expect((store as any).nwcWalletServices.has(OLD_RELAY)).toBe(false);
+        expect((store as any).publishedRelays.has(OLD_RELAY)).toBe(false);
+        expect(store.connections).toHaveLength(0);
+        expect(clientKeys[OLD_PUBKEY]).toBeUndefined();
+    });
+
+    it('succeeds when publishing wallet service info to the new relay fails', async () => {
+        const store = buildStore({ publishNewRelay: false });
+        const connection = seedConnection(store);
+        const consoleWarn = jest
+            .spyOn(console, 'warn')
+            .mockImplementation(() => {});
+
+        try {
+            jest.spyOn(
+                store as any,
+                'publishWalletServiceInfoWithRetry'
+            ).mockRejectedValue(new Error('publish failed'));
+
+            const result = await store.updateConnection(connection.id, {
+                relayUrl: NEW_RELAY
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.nostrUrl).toEqual(expect.stringContaining(NEW_RELAY));
+            expect(connection.relayUrl).toBe(NEW_RELAY);
+            expect(connection.pubkey).not.toBe(OLD_PUBKEY);
+        } finally {
+            consoleWarn.mockRestore();
+        }
+    });
+});

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -701,13 +701,34 @@ export default class NostrWalletConnectStore {
                 updates.name = newName;
             }
             const oldRelayUrl = connection.relayUrl;
+            const oldPubkey = connection.pubkey;
             const newRelayUrl = updates.relayUrl;
-            const relayUrlChanged = newRelayUrl && newRelayUrl !== oldRelayUrl;
+            const relayUrlChanged = !!(
+                newRelayUrl && newRelayUrl !== oldRelayUrl
+            );
 
             if (relayUrlChanged) {
                 this.unsubscribeFromConnection(connectionId);
                 if (!this.nwcWalletServices.has(newRelayUrl)) {
-                    await this.initializeNWCWalletServices();
+                    this.nwcWalletServices.set(
+                        newRelayUrl,
+                        new NWCWalletService({
+                            relayUrls: [newRelayUrl]
+                        })
+                    );
+                }
+                if (!this.publishedRelays.has(newRelayUrl)) {
+                    const nwcWalletService =
+                        this.nwcWalletServices.get(newRelayUrl);
+                    if (
+                        nwcWalletService &&
+                        this.walletServiceKeys?.privateKey
+                    ) {
+                        await this.publishWalletServiceInfoWithRetry(
+                            nwcWalletService,
+                            newRelayUrl
+                        );
+                    }
                 }
             }
 
@@ -735,15 +756,32 @@ export default class NostrWalletConnectStore {
                 }
                 this.findAndUpdateConnection(connection);
             });
-            await this.subscribeToConnection(connection);
+
             if (relayUrlChanged) {
-                return {
-                    nostrUrl:
-                        this.generateConnectionSecret(newRelayUrl)
-                            .connectionUrl,
-                    success: true
-                };
+                const {
+                    connectionUrl,
+                    connectionPrivateKey,
+                    connectionPublicKey
+                } = this.generateConnectionSecret(newRelayUrl);
+
+                await this.storeClientKeys(
+                    connectionPublicKey,
+                    connectionPrivateKey
+                );
+                await this.deleteClientKeys(oldPubkey);
+
+                runInAction(() => {
+                    connection.pubkey = connectionPublicKey;
+                    this.findAndUpdateConnection(connection);
+                });
+
+                await this.subscribeToConnection(connection);
+                await this.saveConnections();
+
+                return { nostrUrl: connectionUrl, success: true };
             }
+
+            await this.subscribeToConnection(connection);
             return { success: true };
         } catch (error: any) {
             console.error('Failed to update NWC connection:', error);

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -632,6 +632,7 @@ export default class NostrWalletConnectStore {
                     )
                 );
             }
+            const relayUrl = connection.relayUrl;
             await this.deleteClientKeys(connection.pubkey);
             this.unsubscribeFromConnection(connectionId);
             this.lastPendingPaymentStatusFetchByConnection.delete(connectionId);
@@ -639,6 +640,7 @@ export default class NostrWalletConnectStore {
             runInAction(() => {
                 this.connections.splice(index, 1);
             });
+            this.releaseUnusedRelayService(relayUrl);
             await this.saveConnections();
         } catch (error: any) {
             runInAction(() => {
@@ -701,9 +703,10 @@ export default class NostrWalletConnectStore {
                 updates.name = newName;
             }
             const oldPubkey = connection.pubkey;
+            const oldRelayUrl = connection.relayUrl;
             const newRelayUrl = updates.relayUrl;
             const relayUrlChanged = !!(
-                newRelayUrl && newRelayUrl !== connection.relayUrl
+                newRelayUrl && newRelayUrl !== oldRelayUrl
             );
 
             // Fallible rotation work must finish before any connection mutation
@@ -790,6 +793,10 @@ export default class NostrWalletConnectStore {
                 }
                 this.findAndUpdateConnection(connection);
             });
+
+            if (relayUrlChanged) {
+                this.releaseUnusedRelayService(oldRelayUrl);
+            }
 
             if (relayUrlChanged && rotatedSecret) {
                 await this.subscribeToConnection(connection);
@@ -1493,6 +1500,35 @@ export default class NostrWalletConnectStore {
                 error
             );
         }
+    }
+
+    /**
+     * Close and drop a relay's NWCWalletService when no remaining connection
+     * references it, so unused websockets and publishedRelays entries do not
+     * linger after delete or relay change.
+     */
+    private releaseUnusedRelayService(relayUrl: string): void {
+        if (!relayUrl) return;
+        if (this.connections.some((c) => c.relayUrl === relayUrl)) {
+            return;
+        }
+
+        const service = this.nwcWalletServices.get(relayUrl);
+        if (service) {
+            try {
+                service.close();
+            } catch (error) {
+                console.warn(
+                    `NWC: Failed to close unused relay service ${relayUrl}:`,
+                    error
+                );
+            }
+        }
+
+        runInAction(() => {
+            this.nwcWalletServices.delete(relayUrl);
+            this.publishedRelays.delete(relayUrl);
+        });
     }
 
     private async unsubscribeFromAllConnections(): Promise<void> {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -799,8 +799,18 @@ export default class NostrWalletConnectStore {
             }
 
             if (relayUrlChanged && rotatedSecret) {
-                await this.subscribeToConnection(connection);
-                await this.saveConnections();
+                // Rotation (new key stored + pubkey rebound) is already durable.
+                // If subscribe/save fails here, still return the pairing URL so
+                // the UI can show the QR; subscription recovers on restart.
+                try {
+                    await this.subscribeToConnection(connection);
+                    await this.saveConnections();
+                } catch (error) {
+                    console.warn(
+                        'NWC: Relay change rotation persisted but subscribe/save failed; returning pairing URL anyway:',
+                        error
+                    );
+                }
                 await this.deleteClientKeys(oldPubkey);
 
                 return {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -700,34 +700,65 @@ export default class NostrWalletConnectStore {
                 }
                 updates.name = newName;
             }
-            const oldRelayUrl = connection.relayUrl;
             const oldPubkey = connection.pubkey;
             const newRelayUrl = updates.relayUrl;
             const relayUrlChanged = !!(
-                newRelayUrl && newRelayUrl !== oldRelayUrl
+                newRelayUrl && newRelayUrl !== connection.relayUrl
             );
 
+            // Fallible rotation work must finish before any connection mutation
+            // so a failed attempt leaves relayUrl unchanged and retries still
+            // detect the change and return a new pairing URL.
+            let rotatedSecret:
+                | {
+                      connectionUrl: string;
+                      connectionPrivateKey: string;
+                      connectionPublicKey: string;
+                  }
+                | undefined;
+
             if (relayUrlChanged) {
+                if (!this.walletServiceKeys?.privateKey) {
+                    await this.loadWalletServiceKeys();
+                }
+
+                rotatedSecret = this.generateConnectionSecret(newRelayUrl!);
+                await this.storeClientKeys(
+                    rotatedSecret.connectionPublicKey,
+                    rotatedSecret.connectionPrivateKey
+                );
+
                 this.unsubscribeFromConnection(connectionId);
-                if (!this.nwcWalletServices.has(newRelayUrl)) {
+                if (!this.nwcWalletServices.has(newRelayUrl!)) {
                     this.nwcWalletServices.set(
-                        newRelayUrl,
+                        newRelayUrl!,
                         new NWCWalletService({
-                            relayUrls: [newRelayUrl]
+                            relayUrls: [newRelayUrl!]
                         })
                     );
                 }
-                if (!this.publishedRelays.has(newRelayUrl)) {
-                    const nwcWalletService =
-                        this.nwcWalletServices.get(newRelayUrl);
+                if (!this.publishedRelays.has(newRelayUrl!)) {
+                    const nwcWalletService = this.nwcWalletServices.get(
+                        newRelayUrl!
+                    );
                     if (
                         nwcWalletService &&
                         this.walletServiceKeys?.privateKey
                     ) {
-                        await this.publishWalletServiceInfoWithRetry(
-                            nwcWalletService,
-                            newRelayUrl
-                        );
+                        try {
+                            await this.publishWalletServiceInfoWithRetry(
+                                nwcWalletService,
+                                newRelayUrl!
+                            );
+                            await new Promise((resolve) =>
+                                setTimeout(resolve, 500)
+                            );
+                        } catch (error) {
+                            console.warn(
+                                `NWC: Failed to publish wallet service info to relay ${newRelayUrl} before connection update:`,
+                                error
+                            );
+                        }
                     }
                 }
             }
@@ -738,6 +769,9 @@ export default class NostrWalletConnectStore {
                 const newMaxAmountSats = updates.maxAmountSats;
 
                 Object.assign(connection, updates);
+                if (rotatedSecret) {
+                    connection.pubkey = rotatedSecret.connectionPublicKey;
+                }
 
                 const hadBudget = connection.hasBudgetLimit;
                 const hasBudget =
@@ -757,28 +791,15 @@ export default class NostrWalletConnectStore {
                 this.findAndUpdateConnection(connection);
             });
 
-            if (relayUrlChanged) {
-                const {
-                    connectionUrl,
-                    connectionPrivateKey,
-                    connectionPublicKey
-                } = this.generateConnectionSecret(newRelayUrl);
-
-                await this.storeClientKeys(
-                    connectionPublicKey,
-                    connectionPrivateKey
-                );
-                await this.deleteClientKeys(oldPubkey);
-
-                runInAction(() => {
-                    connection.pubkey = connectionPublicKey;
-                    this.findAndUpdateConnection(connection);
-                });
-
+            if (relayUrlChanged && rotatedSecret) {
                 await this.subscribeToConnection(connection);
                 await this.saveConnections();
+                await this.deleteClientKeys(oldPubkey);
 
-                return { nostrUrl: connectionUrl, success: true };
+                return {
+                    nostrUrl: rotatedSecret.connectionUrl,
+                    success: true
+                };
             }
 
             await this.subscribeToConnection(connection);

--- a/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
+++ b/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
@@ -544,61 +544,6 @@ export default class AddOrEditNWCConnection extends React.Component<
         return params;
     };
 
-    regenerateConnection = async () => {
-        const { NostrWalletConnectStore, route, navigation } = this.props;
-        const { connectionId } = route.params ?? {};
-
-        if (!connectionId) {
-            this.setState({
-                error: localeString(
-                    'stores.NostrWalletConnectStore.error.connectionNotFound'
-                )
-            });
-            return;
-        }
-        this.setState({ loading: true, error: '' });
-        try {
-            await NostrWalletConnectStore.loadConnections();
-            const { connection } = NostrWalletConnectStore.getConnection({
-                connectionId
-            });
-            if (!connection) {
-                throw new Error(
-                    localeString(
-                        'stores.NostrWalletConnectStore.error.connectionNotFound'
-                    )
-                );
-            }
-            const totalSpendSats = connection.totalSpendSats;
-            const lastBudgetReset = connection.lastBudgetReset;
-            const createdAt = connection.createdAt;
-            const params = await this.buildConnectionParams(
-                false,
-                connectionId
-            );
-            if (!params) return;
-            params.totalSpendSats = totalSpendSats;
-            params.lastBudgetReset = lastBudgetReset;
-            params.createdAt = createdAt;
-            await NostrWalletConnectStore.deleteConnection(connectionId);
-            const nostrUrl = await NostrWalletConnectStore.createConnection(
-                params
-            );
-            if (nostrUrl) {
-                const createdConnection =
-                    NostrWalletConnectStore.connections[0];
-                navigation.navigate('NWCConnectionQR', {
-                    connectionId: createdConnection.id,
-                    nostrUrl
-                });
-            }
-        } catch (error) {
-            this.setState({ error: (error as Error).message, loading: false });
-        } finally {
-            this.setState({ loading: false });
-        }
-    };
-
     createOrUpdateConnection = async () => {
         const { NostrWalletConnectStore, route, navigation } = this.props;
         const { connectionId, isEdit } = route.params ?? {};
@@ -817,19 +762,15 @@ export default class AddOrEditNWCConnection extends React.Component<
 
     getButtonTitle = (): string => {
         const { route } = this.props;
-        if (!route.params?.isEdit) {
+        if (route.params?.isEdit) {
             return localeString(
-                'views.Settings.NostrWalletConnect.createConnection'
+                'views.Settings.NostrWalletConnect.updateConnection'
             );
         }
 
-        return this.isRelayChanged()
-            ? localeString(
-                  'views.Settings.NostrWalletConnect.regenerateConnection'
-              )
-            : localeString(
-                  'views.Settings.NostrWalletConnect.updateConnection'
-              );
+        return localeString(
+            'views.Settings.NostrWalletConnect.createConnection'
+        );
     };
 
     isButtonDisabled = (): boolean => {
@@ -1422,11 +1363,7 @@ export default class AddOrEditNWCConnection extends React.Component<
                     <View style={styles.bottomButtonContainer}>
                         <Button
                             title={this.getButtonTitle()}
-                            onPress={
-                                route.params?.isEdit && this.isRelayChanged()
-                                    ? this.regenerateConnection
-                                    : this.createOrUpdateConnection
-                            }
+                            onPress={this.createOrUpdateConnection}
                             secondary={this.isButtonDisabled()}
                             disabled={this.isButtonDisabled()}
                             noUppercase

--- a/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
+++ b/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
@@ -563,7 +563,7 @@ export default class AddOrEditNWCConnection extends React.Component<
                     params
                 );
                 if (updated.success) {
-                    // Relay change rotates the client secret — show the new
+                    // Relay change rotates the client secret; show the new
                     // pairing URL so the app can re-connect.
                     if (updated.nostrUrl) {
                         navigation.navigate('NWCConnectionQR', {

--- a/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
+++ b/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
@@ -618,7 +618,16 @@ export default class AddOrEditNWCConnection extends React.Component<
                     params
                 );
                 if (updated.success) {
-                    setTimeout(() => navigation.goBack(), 100);
+                    // Relay change rotates the client secret — show the new
+                    // pairing URL so the app can re-connect.
+                    if (updated.nostrUrl) {
+                        navigation.navigate('NWCConnectionQR', {
+                            connectionId,
+                            nostrUrl: updated.nostrUrl
+                        });
+                    } else {
+                        setTimeout(() => navigation.goBack(), 100);
+                    }
                 } else {
                     this.setState({
                         error:


### PR DESCRIPTION
## Description

Fixes NWC relay-change secret rotation so the new pairing URL works, and routes edit-screen relay changes through `updateConnection` instead of delete + create.

### Problem

On relay change, `updateConnection` generated a fresh keypair but:

- Never persisted the new client key
- Never updated `connection.pubkey`
- Never revoked the old secret

The returned pairing URL was inert while the old credential kept working. The edit screen also used regenerate (delete + create), which wiped activity.

### Changes

- Persist the new client key, rebind `connection.pubkey`, delete the old key, then subscribe
- Run rotation **before** mutating the connection so failed attempts stay retryable
- If subscribe/save fails after durable rotation, still return the pairing URL (subscription recovers on restart)
- Ensure a wallet service exists for the new relay and publish service info if needed
- Drop unused relay services on delete and relay change
- Edit screen always uses `updateConnection`; show the new QR when a secret is rotated
- Preserve connection identity, budget, and activity across relay changes
- Details-screen **Regenerate Connection** stays a full re-pair (unchanged)
- Store tests for key store / delete / pubkey rebind on relay change

### Behavior note (expiry)

The old edit path went through `createConnection` with `params.id` / `params.createdAt`, which triggered `refreshExpiryForRegenerate`. Relay change now keeps the form’s expiry as-is. Intentional: relay change preserves connection identity rather than acting as a full regenerate.

### Test plan

- [ ] Relay change on a linked client → old secret dead, new QR pairs
- [ ] Name/budget-only edit → no rotation, no QR screen
- [ ] Create connection + details-screen regenerate still work
- [ ] Unit tests: relay change stores new key, deletes old, rebinds pubkey

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [x] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
