### PR TITLE
fix(nwc): safe pay_invoice activity upsert and reconcile persistence

### DIFF
--- a/models/NWCConnection.test.ts
+++ b/models/NWCConnection.test.ts
@@ -287,19 +287,26 @@ describe('NWCConnection pay_invoice activity lookup', () => {
         ).toBe(0);
     });
 
-    it('findPayInvoiceActivity returns the matching activity', () => {
+    it('findPayInvoiceActivity ignores make_invoice rows with the same id/hash', () => {
         const connection = baseConnection();
+        const paymentHash = 'abc123paymenthash';
         connection.activity.push({
             id: 'lnbc1normalized',
-            type: 'pay_invoice',
+            type: 'make_invoice',
             payment_source: 'lightning',
-            status: 'success',
-            satAmount: 100
+            status: 'pending',
+            satAmount: 100,
+            paymentHash
         });
 
-        expect(connection.findPayInvoiceActivity('lnbc1normalized')).toEqual(
-            connection.activity[0]
-        );
-        expect(connection.findPayInvoiceActivity('missing')).toBeUndefined();
+        expect(
+            connection.findPayInvoiceActivityIndex(
+                'lnbc1normalized',
+                paymentHash
+            )
+        ).toBe(-1);
+        expect(
+            connection.findPayInvoiceActivity('lnbc1normalized', paymentHash)
+        ).toBeUndefined();
     });
 });

--- a/models/NWCConnection.test.ts
+++ b/models/NWCConnection.test.ts
@@ -249,3 +249,57 @@ describe('NWCConnection budget accounting with pending payments', () => {
         ).toBe(false);
     });
 });
+
+describe('NWCConnection pay_invoice activity lookup', () => {
+    it('findPayInvoiceActivityIndex matches by id', () => {
+        const connection = baseConnection();
+        connection.activity.push({
+            id: 'lnbc1normalized',
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'pending',
+            satAmount: 100
+        });
+
+        expect(connection.findPayInvoiceActivityIndex('lnbc1normalized')).toBe(
+            0
+        );
+        expect(connection.findPayInvoiceActivityIndex('missing')).toBe(-1);
+    });
+
+    it('findPayInvoiceActivityIndex matches by paymentHash when ids differ', () => {
+        const connection = baseConnection();
+        const paymentHash = 'abc123paymenthash';
+        connection.activity.push({
+            id: 'lnbc1normalized',
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'pending',
+            satAmount: 100,
+            paymentHash
+        });
+
+        expect(
+            connection.findPayInvoiceActivityIndex(
+                'LNBC1NORMALIZED',
+                paymentHash
+            )
+        ).toBe(0);
+    });
+
+    it('findPayInvoiceActivity returns the matching activity', () => {
+        const connection = baseConnection();
+        connection.activity.push({
+            id: 'lnbc1normalized',
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'success',
+            satAmount: 100
+        });
+
+        expect(connection.findPayInvoiceActivity('lnbc1normalized')).toEqual(
+            connection.activity[0]
+        );
+        expect(connection.findPayInvoiceActivity('missing')).toBeUndefined();
+    });
+});

--- a/models/NWCConnection.ts
+++ b/models/NWCConnection.ts
@@ -248,10 +248,11 @@ export default class NWCConnection extends BaseModel {
     ): number {
         return (this.activity ?? []).findIndex(
             (a) =>
-                a.id === id ||
-                (!!paymentHash &&
-                    !!a.paymentHash &&
-                    a.paymentHash === paymentHash)
+                a.type === 'pay_invoice' &&
+                (a.id === id ||
+                    (!!paymentHash &&
+                        !!a.paymentHash &&
+                        a.paymentHash === paymentHash))
         );
     }
 

--- a/models/NWCConnection.ts
+++ b/models/NWCConnection.ts
@@ -41,6 +41,7 @@ export interface ConnectionActivity {
     isExpired?: boolean;
     expiryLabel?: string;
     fees_paid?: number;
+    is_budget_debited?: boolean;
 }
 
 export enum BudgetRenewalType {

--- a/models/NWCConnection.ts
+++ b/models/NWCConnection.ts
@@ -41,7 +41,7 @@ export interface ConnectionActivity {
     isExpired?: boolean;
     expiryLabel?: string;
     fees_paid?: number;
-    is_budget_debited?: boolean;
+    isBudgetDebited?: boolean;
 }
 
 export enum BudgetRenewalType {

--- a/models/NWCConnection.ts
+++ b/models/NWCConnection.ts
@@ -242,6 +242,27 @@ export default class NWCConnection extends BaseModel {
         return this.totalSpendSats + this.pendingSpendSats;
     }
 
+    public findPayInvoiceActivityIndex(
+        id: string,
+        paymentHash?: string
+    ): number {
+        return (this.activity ?? []).findIndex(
+            (a) =>
+                a.id === id ||
+                (!!paymentHash &&
+                    !!a.paymentHash &&
+                    a.paymentHash === paymentHash)
+        );
+    }
+
+    public findPayInvoiceActivity(
+        id: string,
+        paymentHash?: string
+    ): ConnectionActivity | undefined {
+        const index = this.findPayInvoiceActivityIndex(id, paymentHash);
+        return index !== -1 ? this.activity[index] : undefined;
+    }
+
     @computed public get remainingBudget(): number {
         if (!this.hasBudgetLimit) return Infinity;
         return Math.max(0, this.maxAmountSats! - this.effectiveSpendSats);

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -57,6 +57,7 @@ jest.mock('../storage', () => ({
 
 import Storage from '../storage';
 import NWCConnection, { BudgetRenewalType } from '../models/NWCConnection';
+import NostrConnectUtils from '../utils/NostrConnectUtils';
 import NostrWalletConnectStore, {
     NWC_CLIENT_KEYS
 } from './NostrWalletConnectStore';
@@ -349,5 +350,294 @@ describe('NostrWalletConnectStore relay rotation', () => {
         } finally {
             consoleWarn.mockRestore();
         }
+    });
+});
+
+function buildPayInvoiceTestStore() {
+    const settingsStore: any = {
+        connecting: false,
+        implementation: 'lnd',
+        settings: {
+            locale: 'en',
+            ecash: { enableCashu: false },
+            lightningAddress: { enabled: false }
+        }
+    };
+    const store = new NostrWalletConnectStore(
+        settingsStore,
+        {} as any,
+        {
+            nodeInfo: { nodeId: NODE_PUBKEY },
+            getNodeInfo: jest.fn()
+        } as any,
+        {} as any,
+        { invoices: [] } as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any
+    );
+
+    jest.spyOn(store as any, 'findAndUpdateConnection').mockImplementation(
+        () => undefined
+    );
+    jest.spyOn(store as any, 'scheduleMaxBudgetRefresh').mockImplementation(
+        () => undefined
+    );
+
+    return store;
+}
+
+function seedPayInvoiceConnection(
+    store: NostrWalletConnectStore,
+    overrides: Record<string, unknown> = {}
+) {
+    const connection = new NWCConnection({
+        id: 'conn-pay',
+        name: 'Pay Test App',
+        pubkey: OLD_PUBKEY,
+        relayUrl: OLD_RELAY,
+        permissions: [],
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        totalSpendSats: 0,
+        nodePubkey: NODE_PUBKEY,
+        implementation: 'lnd',
+        activity: [],
+        ...overrides
+    } as any);
+    store.connections = [connection];
+    return connection;
+}
+
+describe('NostrWalletConnectStore pay_invoice activity upsert', () => {
+    const normalizedInvoice = 'lnbc1normalized';
+    const uppercaseInvoice = 'LNBC1NORMALIZED';
+    const paymentHash = 'abc123paymenthash';
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(NostrConnectUtils, 'decodeInvoiceTags').mockResolvedValue({
+            paymentRequest: normalizedInvoice,
+            paymentHash,
+            descriptionHash: '',
+            description: '',
+            amount: 100,
+            expiryTime: 0,
+            createdAt: 0,
+            isExpired: false,
+            network: 'bitcoin'
+        });
+        jest.spyOn(
+            NostrConnectUtils,
+            'notifyOutgoingNwcPaymentFailed'
+        ).mockImplementation(() => undefined);
+        jest.spyOn(
+            NostrConnectUtils,
+            'notifyOutgoingNwcPayment'
+        ).mockImplementation(() => undefined);
+    });
+
+    it('upsertPayInvoiceActivity never demotes success to failed', () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store, {
+            activity: [
+                {
+                    id: normalizedInvoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    satAmount: 100,
+                    isBudgetDebited: true
+                }
+            ]
+        });
+
+        const applied = (store as any).upsertPayInvoiceActivity(connection, {
+            id: normalizedInvoice,
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'failed',
+            satAmount: 100,
+            error: 'payment timed out'
+        });
+
+        expect(applied).toBe(false);
+        expect(connection.activity).toHaveLength(1);
+        expect(connection.activity[0].status).toBe('success');
+    });
+
+    it('upsertPayInvoiceActivity keeps isBudgetDebited sticky across merges', () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store, {
+            activity: [
+                {
+                    id: normalizedInvoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'pending',
+                    satAmount: 100,
+                    isBudgetDebited: true
+                }
+            ]
+        });
+
+        (store as any).upsertPayInvoiceActivity(connection, {
+            id: normalizedInvoice,
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'success',
+            satAmount: 100
+        });
+
+        expect(connection.activity[0].isBudgetDebited).toBe(true);
+    });
+
+    it('upsertPayInvoiceActivity preserves createdAt on merge', () => {
+        const store = buildPayInvoiceTestStore();
+        const createdAt = new Date('2024-06-01T12:00:00Z');
+        const connection = seedPayInvoiceConnection(store, {
+            activity: [
+                {
+                    id: normalizedInvoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'pending',
+                    satAmount: 100,
+                    createdAt
+                }
+            ]
+        });
+
+        (store as any).upsertPayInvoiceActivity(connection, {
+            id: normalizedInvoice,
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'success',
+            satAmount: 100,
+            createdAt: new Date('2024-06-02T00:00:00Z')
+        });
+
+        expect(connection.activity[0].createdAt).toEqual(createdAt);
+    });
+
+    it('upsertPayInvoiceActivity clears error when promoting to success', () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store, {
+            activity: [
+                {
+                    id: normalizedInvoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'failed',
+                    satAmount: 100,
+                    error: 'first attempt failed'
+                }
+            ]
+        });
+
+        (store as any).upsertPayInvoiceActivity(connection, {
+            id: normalizedInvoice,
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'success',
+            satAmount: 100
+        });
+
+        expect(connection.activity[0].status).toBe('success');
+        expect(connection.activity[0].error).toBeUndefined();
+    });
+
+    it('upsertPayInvoiceActivity merges by paymentHash when ids differ', () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store, {
+            activity: [
+                {
+                    id: normalizedInvoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'pending',
+                    satAmount: 100,
+                    paymentHash
+                }
+            ]
+        });
+
+        (store as any).upsertPayInvoiceActivity(connection, {
+            id: uppercaseInvoice,
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'success',
+            satAmount: 100,
+            paymentHash
+        });
+
+        expect(connection.activity).toHaveLength(1);
+        expect(connection.activity[0].status).toBe('success');
+        expect(connection.activity[0].id).toBe(uppercaseInvoice);
+    });
+
+    it('finalizePayment normalizes invoice id and does not double-debit', async () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store, {
+            totalSpendSats: 100,
+            activity: [
+                {
+                    id: normalizedInvoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    satAmount: 100,
+                    isBudgetDebited: true,
+                    paymentHash
+                }
+            ]
+        });
+
+        await (store as any).finalizePayment({
+            rawInvoice: uppercaseInvoice,
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            decoded: null,
+            connection,
+            amountSats: 100,
+            feeSats: 0,
+            paymentHash
+        });
+
+        expect(connection.activity).toHaveLength(1);
+        expect(connection.totalSpendSats).toBe(100);
+        expect(NostrConnectUtils.decodeInvoiceTags).toHaveBeenCalledWith(
+            uppercaseInvoice
+        );
+    });
+
+    it('recordFailedPayment skips notification when success blocks demote', async () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store, {
+            activity: [
+                {
+                    id: normalizedInvoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    satAmount: 100,
+                    isBudgetDebited: true
+                }
+            ]
+        });
+
+        await (store as any).recordFailedPayment({
+            rawInvoice: normalizedInvoice,
+            connection,
+            amountSats: 100,
+            payment_source: 'lightning',
+            errorMessage: 'payment timed out'
+        });
+
+        expect(
+            NostrConnectUtils.notifyOutgoingNwcPaymentFailed
+        ).not.toHaveBeenCalled();
+        expect(connection.activity[0].status).toBe('success');
     });
 });

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2538,7 +2538,10 @@ export default class NostrWalletConnectStore {
             });
         }
 
-        if (changed) this.lookupPaymentsCache = null;
+        if (changed) {
+            this.lookupPaymentsCache = null;
+            this.findAndUpdateConnection(connection);
+        }
         return changed;
     }
 

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1722,7 +1722,7 @@ export default class NostrWalletConnectStore {
         }
     }
 
-    private async pushMakeInvoiceActivityToConnection({
+    private async recordMakeInvoiceActivity({
         connection,
         request,
         status,
@@ -1807,15 +1807,14 @@ export default class NostrWalletConnectStore {
                         );
                     }
 
-                    const result =
-                        await this.pushMakeInvoiceActivityToConnection({
-                            connection,
-                            request,
-                            status: 'pending',
-                            type: 'make_invoice',
-                            paymentRequest: cashuInvoice.paymentRequest,
-                            payment_source: 'cashu'
-                        });
+                    const result = await this.recordMakeInvoiceActivity({
+                        connection,
+                        request,
+                        status: 'pending',
+                        type: 'make_invoice',
+                        paymentRequest: cashuInvoice.paymentRequest,
+                        payment_source: 'cashu'
+                    });
                     return result;
                 } catch (cashuError) {
                     return NostrConnectUtils.createNip47Error(
@@ -1859,7 +1858,7 @@ export default class NostrWalletConnectStore {
 
             await this.invoicesStore.getInvoices();
 
-            const result = await this.pushMakeInvoiceActivityToConnection({
+            const result = await this.recordMakeInvoiceActivity({
                 connection,
                 request,
                 status: 'pending',
@@ -2822,28 +2821,34 @@ export default class NostrWalletConnectStore {
     }): Promise<void> {
         // Budget is whole sats; round fractional fees (0.026 → 0, 1.999 → 2).
         const budgetFeeSats = NostrConnectUtils.resolveFeeSats(feeSats);
+
         runInAction(() => {
-            connection.trackSpending(
-                amountSats + budgetFeeSats,
-                this.maxBudgetLimit
-            );
-            connection.activity.push({
+            const existing = connection.activity.find((a) => a.id === id);
+            const alreadyDebited =
+                !!existing?.is_budget_debited || existing?.status === 'success';
+
+            if (!alreadyDebited) {
+                connection.trackSpending(
+                    amountSats + budgetFeeSats,
+                    this.maxBudgetLimit
+                );
+            }
+
+            this.upsertPayInvoiceActivity(connection, {
                 id,
                 type,
-                payment:
-                    payment_source == 'cashu'
-                        ? new CashuPayment(decoded)
-                        : new Payment(decoded),
+                payment: this.toConnectionActivityPayment(
+                    payment_source,
+                    decoded
+                ),
                 status: 'success',
                 payment_source,
                 satAmount: amountSats,
-                // Stored internally in sats (may be fractional). NIP-47 `fees_paid` is
-                // msats; convert to msats only when mapping to the NIP-47 response.
                 fees_paid: feeSats,
-                is_budget_debited: true // flag to indicate that the budget was debited for this payment
+                is_budget_debited: true
             });
-            this.findAndUpdateConnection(connection);
         });
+
         this.lookupPaymentsCache = null;
         NostrConnectUtils.notifyOutgoingNwcPayment(amountSats, connection.name);
     }
@@ -2866,12 +2871,6 @@ export default class NostrWalletConnectStore {
         const { paymentRequest, paymentHash: decodedPaymentHash } =
             await NostrConnectUtils.decodeInvoiceTags(rawInvoice);
         const id = paymentRequest || rawInvoice;
-        const index = connection.activity.findIndex(
-            (activity) => activity.id === id
-        );
-        const activity = index !== -1 ? connection.activity[index] : undefined;
-        if (activity?.status === 'success') return;
-
         const paymentHash =
             passedPaymentHash ||
             decodedPaymentHash ||
@@ -2879,36 +2878,27 @@ export default class NostrWalletConnectStore {
             undefined;
 
         runInAction(() => {
-            const record: ConnectionActivity = {
+            this.upsertPayInvoiceActivity(connection, {
                 id,
                 type: 'pay_invoice',
                 satAmount: amountSats,
                 status: 'pending',
                 payment_source,
                 createdAt: new Date(),
-                ...(paymentHash ? { paymentHash } : {})
-            };
-
-            if (payment) {
-                record.payment =
-                    payment_source === 'cashu'
-                        ? new CashuPayment(payment)
-                        : new Payment(payment);
-            }
-
-            if (index !== -1) {
-                connection.activity[index] = {
-                    ...connection.activity[index],
-                    ...record
-                };
-            } else {
-                connection.activity.push(record);
-            }
-
-            this.findAndUpdateConnection(connection);
+                ...(paymentHash ? { paymentHash } : {}),
+                ...(payment
+                    ? {
+                          payment: this.toConnectionActivityPayment(
+                              payment_source,
+                              payment
+                          )
+                      }
+                    : {})
+                // is_budget_debited intentionally unset — held via pendingSpendSats
+            });
         });
+
         this.lookupPaymentsCache = null;
-        this.scheduleSave();
     }
 
     private async recordFailedPayment({
@@ -2927,20 +2917,15 @@ export default class NostrWalletConnectStore {
         paymentHash?: string;
     }): Promise<void> {
         if (NostrConnectUtils.isIgnorableError(errorMessage || '')) return;
+
         const { paymentRequest, paymentHash: decodedPaymentHash } =
             await NostrConnectUtils.decodeInvoiceTags(rawInvoice);
         const id = paymentRequest || rawInvoice;
-        const index = connection.activity.findIndex(
-            (activity) => activity.id === id
-        );
-        const activity = index !== -1 ? connection.activity[index] : undefined;
-        if (activity?.status === 'success') return;
-
         const paymentHash =
             passedPaymentHash || decodedPaymentHash || undefined;
 
         runInAction(() => {
-            const record: ConnectionActivity = {
+            this.upsertPayInvoiceActivity(connection, {
                 id,
                 type: 'pay_invoice',
                 satAmount: amountSats,
@@ -2949,25 +2934,63 @@ export default class NostrWalletConnectStore {
                 error: errorMessage,
                 createdAt: new Date(),
                 ...(paymentHash ? { paymentHash } : {})
-            };
-            if (index !== -1) {
-                connection.activity[index] = {
-                    ...connection.activity[index],
-                    ...record
-                };
-            } else {
-                // ➕ add new element
-                connection.activity.push(record);
-            }
-
-            this.findAndUpdateConnection(connection);
+            });
         });
+
         NostrConnectUtils.notifyOutgoingNwcPaymentFailed(
             amountSats,
             connection.name,
             connection.id,
             id
         );
+    }
+    /**
+     * Insert or merge a pay_invoice activity by id.
+     * Never demotes status === 'success'.
+     */
+    @action
+    private upsertPayInvoiceActivity(
+        connection: NWCConnection,
+        record: ConnectionActivity
+    ): void {
+        const index = connection.activity.findIndex((a) => a.id === record.id);
+        const existing = index !== -1 ? connection.activity[index] : undefined;
+
+        if (existing?.status === 'success' && record.status !== 'success') {
+            return;
+        }
+
+        if (index !== -1) {
+            connection.activity[index] = {
+                ...existing,
+                ...record,
+                // Keep original createdAt unless this is a brand-new write
+                createdAt:
+                    existing?.createdAt ?? record.createdAt ?? new Date(),
+                // Don't clear is_budget_debited if already true
+                is_budget_debited:
+                    existing?.is_budget_debited || record.is_budget_debited
+            };
+        } else {
+            connection.activity.push({
+                ...record,
+                createdAt: record.createdAt ?? new Date()
+            });
+        }
+
+        this.findAndUpdateConnection(connection);
+    }
+    private toConnectionActivityPayment(
+        source: ConnectionPaymentSourceType,
+        decoded: Payment | CashuPayment | null | undefined
+    ): Payment | CashuPayment | undefined {
+        if (decoded == null) return undefined;
+        if (source === 'cashu') {
+            return decoded instanceof CashuPayment
+                ? decoded
+                : new CashuPayment(decoded);
+        }
+        return decoded instanceof Payment ? decoded : new Payment(decoded);
     }
 
     // STORAGE OPERATIONS

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -150,6 +150,7 @@ export default class NostrWalletConnectStore {
     @observable private lastConnectionAttempt: number = 0;
     @observable public maxBudgetLimit: number = 0; // Max wallet balance
     private maxBudgetLoadInFlight: Promise<void> | null = null;
+    private maxBudgetRefreshNeeded: boolean = false;
     private scheduledMaxBudgetRefresh: ReturnType<typeof setTimeout> | null =
         null;
     @observable public iosAudioKeepAliveActive: boolean = false;
@@ -398,6 +399,7 @@ export default class NostrWalletConnectStore {
                     await previousReset;
                 }
                 console.log('NWC: resetting service');
+                this.cancelScheduledMaxBudgetRefresh();
                 await this.flushScheduledSave();
                 if (Platform.OS === 'ios') {
                     this.teardownIOSAppStateMonitor();
@@ -2187,7 +2189,7 @@ export default class NostrWalletConnectStore {
         // activity, so pendingSpendSats never sees it either).
         if (payment || preimage) {
             await this.finalizePayment({
-                id: request.invoice,
+                rawInvoice: request.invoice,
                 type: 'pay_invoice',
                 decoded:
                     payment ||
@@ -2202,7 +2204,8 @@ export default class NostrWalletConnectStore {
                 payment_source: 'lightning',
                 connection,
                 amountSats,
-                feeSats
+                feeSats,
+                paymentHash: paymentHash || payment?.paymentHash
             });
         }
 
@@ -2355,7 +2358,7 @@ export default class NostrWalletConnectStore {
         const feeSats =
             Number(cashuInvoice.getFee) || Number(payment?.getFee) || 0;
         await this.finalizePayment({
-            id: request.invoice,
+            rawInvoice: request.invoice,
             decoded:
                 payment ||
                 NostrConnectUtils.buildSettledPaymentFallback({
@@ -2369,7 +2372,8 @@ export default class NostrWalletConnectStore {
             payment_source: 'cashu',
             amountSats,
             feeSats,
-            connection
+            connection,
+            paymentHash: payment?.paymentHash
         });
 
         return {
@@ -2486,6 +2490,12 @@ export default class NostrWalletConnectStore {
         return true;
     }
 
+    /**
+     * Promotes pending pay_invoice activities that have since settled or failed.
+     * Used by the activity screen and by list_transactions — without the latter,
+     * an NWC client sees a settled payment as pending until someone opens the
+     * screen. Node fetches are rate limited by the helper below.
+     */
     private async reconcilePendingPayInvoiceActivities(
         connection: NWCConnection
     ): Promise<boolean> {
@@ -2810,27 +2820,38 @@ export default class NostrWalletConnectStore {
      * Processes payment completion: tracks spending, saves, and shows notification
      */
     private async finalizePayment({
-        id,
+        rawInvoice,
         type,
         payment_source,
         decoded,
         connection,
         amountSats,
-        feeSats = 0
+        feeSats = 0,
+        paymentHash: paymentHashParam
     }: {
-        id: string;
+        rawInvoice: string;
         type: ConnectionActivityType;
         payment_source: ConnectionPaymentSourceType;
         decoded: Payment | CashuPayment | null;
         connection: NWCConnection;
         amountSats: number;
         feeSats?: number;
+        paymentHash?: string;
     }): Promise<void> {
+        const { paymentRequest, paymentHash: decodedPaymentHash } =
+            await NostrConnectUtils.decodeInvoiceTags(rawInvoice);
+        const id = paymentRequest || rawInvoice;
+        const paymentHash =
+            paymentHashParam ||
+            decodedPaymentHash ||
+            decoded?.paymentHash ||
+            undefined;
+
         // Budget is whole sats; round fractional fees (0.026 → 0, 1.999 → 2).
         const budgetFeeSats = NostrConnectUtils.resolveFeeSats(feeSats);
 
         runInAction(() => {
-            const existing = connection.activity.find((a) => a.id === id);
+            const existing = connection.findPayInvoiceActivity(id, paymentHash);
             const alreadyDebited =
                 !!existing?.isBudgetDebited || existing?.status === 'success';
 
@@ -2851,8 +2872,11 @@ export default class NostrWalletConnectStore {
                 status: 'success',
                 payment_source,
                 satAmount: amountSats,
+                // Stored internally in sats (may be fractional). NIP-47 `fees_paid` is
+                // msats; convert to msats only when mapping to the NIP-47 response.
                 fees_paid: feeSats,
-                isBudgetDebited: true
+                isBudgetDebited: true,
+                ...(paymentHash ? { paymentHash } : {})
             });
         });
         this.scheduleMaxBudgetRefresh();
@@ -2901,7 +2925,7 @@ export default class NostrWalletConnectStore {
                           )
                       }
                     : {})
-                // is_budget_debited intentionally unset — held via pendingSpendSats
+                // isBudgetDebited intentionally unset — held via pendingSpendSats
             });
         });
 
@@ -2931,8 +2955,9 @@ export default class NostrWalletConnectStore {
         const paymentHash =
             passedPaymentHash || decodedPaymentHash || undefined;
 
+        let applied = false;
         runInAction(() => {
-            this.upsertPayInvoiceActivity(connection, {
+            applied = this.upsertPayInvoiceActivity(connection, {
                 id,
                 type: 'pay_invoice',
                 satAmount: amountSats,
@@ -2944,27 +2969,32 @@ export default class NostrWalletConnectStore {
             });
         });
 
-        NostrConnectUtils.notifyOutgoingNwcPaymentFailed(
-            amountSats,
-            connection.name,
-            connection.id,
-            id
-        );
+        if (applied) {
+            NostrConnectUtils.notifyOutgoingNwcPaymentFailed(
+                amountSats,
+                connection.name,
+                connection.id,
+                id
+            );
+        }
     }
     /**
-     * Insert or merge a pay_invoice activity by id.
-     * Never demotes status === 'success'.
+     * Insert or merge a pay_invoice activity by id (or paymentHash fallback).
+     * Never demotes status === 'success'. Returns whether the write was applied.
      */
     @action
     private upsertPayInvoiceActivity(
         connection: NWCConnection,
         record: ConnectionActivity
-    ): void {
-        const index = connection.activity.findIndex((a) => a.id === record.id);
+    ): boolean {
+        const index = connection.findPayInvoiceActivityIndex(
+            record.id,
+            record.paymentHash
+        );
         const existing = index !== -1 ? connection.activity[index] : undefined;
 
         if (existing?.status === 'success' && record.status !== 'success') {
-            return;
+            return false;
         }
 
         if (index !== -1) {
@@ -2974,9 +3004,10 @@ export default class NostrWalletConnectStore {
                 // Keep original createdAt unless this is a brand-new write
                 createdAt:
                     existing?.createdAt ?? record.createdAt ?? new Date(),
-                // Don't clear is_budget_debited if already true
+                // Don't clear isBudgetDebited if already true
                 isBudgetDebited:
-                    existing?.isBudgetDebited || record.isBudgetDebited
+                    existing?.isBudgetDebited || record.isBudgetDebited,
+                error: record.status === 'failed' ? record.error : undefined
             };
         } else {
             connection.activity.push({
@@ -2986,6 +3017,7 @@ export default class NostrWalletConnectStore {
         }
 
         this.findAndUpdateConnection(connection);
+        return true;
     }
     private toConnectionActivityPayment(
         source: ConnectionPaymentSourceType,
@@ -3219,6 +3251,7 @@ export default class NostrWalletConnectStore {
 
     public async loadMaxBudget(): Promise<void> {
         if (this.maxBudgetLoadInFlight) {
+            this.maxBudgetRefreshNeeded = true;
             return this.maxBudgetLoadInFlight;
         }
         const load = (async () => {
@@ -3252,6 +3285,16 @@ export default class NostrWalletConnectStore {
             if (this.maxBudgetLoadInFlight === load) {
                 this.maxBudgetLoadInFlight = null;
             }
+            if (this.maxBudgetRefreshNeeded) {
+                this.maxBudgetRefreshNeeded = false;
+                await this.loadMaxBudget();
+            }
+        }
+    }
+    private cancelScheduledMaxBudgetRefresh(): void {
+        if (this.scheduledMaxBudgetRefresh !== null) {
+            clearTimeout(this.scheduledMaxBudgetRefresh);
+            this.scheduledMaxBudgetRefresh = null;
         }
     }
     private scheduleMaxBudgetRefresh(): void {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -400,6 +400,7 @@ export default class NostrWalletConnectStore {
                 }
                 console.log('NWC: resetting service');
                 this.cancelScheduledMaxBudgetRefresh();
+                this.maxBudgetRefreshNeeded = false;
                 await this.flushScheduledSave();
                 if (Platform.OS === 'ios') {
                     this.teardownIOSAppStateMonitor();
@@ -3250,6 +3251,11 @@ export default class NostrWalletConnectStore {
     }
 
     public async loadMaxBudget(): Promise<void> {
+        // A concurrent caller joins the in-flight promise and sets
+        // maxBudgetRefreshNeeded so we re-fetch once it settles. That
+        // second fetch is intentional: the first load may have started
+        // before a payment settled, and joiners need a fresh post-spend
+        // balance rather than the stale in-flight result.
         if (this.maxBudgetLoadInFlight) {
             this.maxBudgetRefreshNeeded = true;
             return this.maxBudgetLoadInFlight;

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2531,9 +2531,9 @@ export default class NostrWalletConnectStore {
 
                 const spendSats =
                     amountSats + NostrConnectUtils.resolveFeeSats(feeSats);
-                if (spendSats > 0 && !activity.is_budget_debited) {
+                if (spendSats > 0 && !activity.isBudgetDebited) {
                     connection.trackSpending(spendSats, this.maxBudgetLimit);
-                    activity.is_budget_debited = true;
+                    activity.isBudgetDebited = true;
                 }
             });
         }
@@ -2828,7 +2828,7 @@ export default class NostrWalletConnectStore {
         runInAction(() => {
             const existing = connection.activity.find((a) => a.id === id);
             const alreadyDebited =
-                !!existing?.is_budget_debited || existing?.status === 'success';
+                !!existing?.isBudgetDebited || existing?.status === 'success';
 
             if (!alreadyDebited) {
                 connection.trackSpending(
@@ -2848,7 +2848,7 @@ export default class NostrWalletConnectStore {
                 payment_source,
                 satAmount: amountSats,
                 fees_paid: feeSats,
-                is_budget_debited: true
+                isBudgetDebited: true
             });
         });
 
@@ -2971,8 +2971,8 @@ export default class NostrWalletConnectStore {
                 createdAt:
                     existing?.createdAt ?? record.createdAt ?? new Date(),
                 // Don't clear is_budget_debited if already true
-                is_budget_debited:
-                    existing?.is_budget_debited || record.is_budget_debited
+                isBudgetDebited:
+                    existing?.isBudgetDebited || record.isBudgetDebited
             };
         } else {
             connection.activity.push({

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2484,29 +2484,25 @@ export default class NostrWalletConnectStore {
         return true;
     }
 
-    /**
-     * Promotes pending pay_invoice activities that have since settled or failed.
-     * Used by the activity screen and by list_transactions — without the latter,
-     * an NWC client sees a settled payment as pending until someone opens the
-     * screen. Node fetches are rate limited by the helper below.
-     */
     private async reconcilePendingPayInvoiceActivities(
         connection: NWCConnection
     ): Promise<boolean> {
-        const lightningPending = connection.activity.filter(
-            (activity) =>
-                activity.type === 'pay_invoice' &&
-                activity.status === 'pending' &&
-                activity.payment_source !== 'cashu'
+        const pending = connection.activity.filter(
+            (a) =>
+                a.type === 'pay_invoice' &&
+                a.status === 'pending' &&
+                a.payment_source !== 'cashu'
         );
-        if (lightningPending.length === 0) return false;
+        if (pending.length === 0) return false;
 
         const payments = await this.getPaymentsForPendingPayInvoiceRefresh(
             connection.id,
-            lightningPending
+            pending
         );
+
         let changed = false;
-        for (const activity of lightningPending) {
+
+        for (const activity of pending) {
             const payment = payments.find(
                 (p) =>
                     p.getPaymentRequest === activity.id ||
@@ -2515,37 +2511,35 @@ export default class NostrWalletConnectStore {
             );
             if (!payment) continue;
 
-            let reconciled = false;
             runInAction(() => {
                 if (activity.status !== 'pending') return;
-                reconciled = true;
+
                 activity.payment = new Payment(payment);
-                if (!payment.isIncomplete) {
-                    activity.status = 'success';
-                    const amountSats =
-                        Math.floor(Number(activity.satAmount)) ||
-                        Math.floor(Number(payment.getAmount) || 0);
-                    const feeSats = Number(payment.getFee) || 0;
-                    activity.fees_paid = feeSats;
-                    const spendSats =
-                        amountSats + NostrConnectUtils.resolveFeeSats(feeSats);
-                    if (spendSats > 0) {
-                        connection.trackSpending(
-                            spendSats,
-                            this.maxBudgetLimit
-                        );
-                    }
-                } else if (payment.isFailed) {
+                changed = true;
+
+                if (payment.isFailed) {
                     activity.status = 'failed';
+                    return;
+                }
+                if (payment.isIncomplete) return;
+
+                activity.status = 'success';
+                const amountSats =
+                    Math.floor(Number(activity.satAmount)) ||
+                    Math.floor(Number(payment.getAmount) || 0);
+                const feeSats = Number(payment.getFee) || 0;
+                activity.fees_paid = feeSats;
+
+                const spendSats =
+                    amountSats + NostrConnectUtils.resolveFeeSats(feeSats);
+                if (spendSats > 0 && !activity.is_budget_debited) {
+                    connection.trackSpending(spendSats, this.maxBudgetLimit);
+                    activity.is_budget_debited = true;
                 }
             });
-            if (reconciled) {
-                changed = true;
-            }
         }
-        if (changed) {
-            this.lookupPaymentsCache = null;
-        }
+
+        if (changed) this.lookupPaymentsCache = null;
         return changed;
     }
 
@@ -2845,7 +2839,8 @@ export default class NostrWalletConnectStore {
                 satAmount: amountSats,
                 // Stored internally in sats (may be fractional). NIP-47 `fees_paid` is
                 // msats; convert to msats only when mapping to the NIP-47 response.
-                fees_paid: feeSats
+                fees_paid: feeSats,
+                is_budget_debited: true // flag to indicate that the budget was debited for this payment
             });
             this.findAndUpdateConnection(connection);
         });

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -149,6 +149,9 @@ export default class NostrWalletConnectStore {
     @observable public persistentNWCServiceEnabled: boolean = false;
     @observable private lastConnectionAttempt: number = 0;
     @observable public maxBudgetLimit: number = 0; // Max wallet balance
+    private maxBudgetLoadInFlight: Promise<void> | null = null;
+    private scheduledMaxBudgetRefresh: ReturnType<typeof setTimeout> | null =
+        null;
     @observable public iosAudioKeepAliveActive: boolean = false;
     @observable public iosAudioKeepAliveUptime: number = 0;
     @observable public iosAudioKeepAliveDisconnects: number = 0;
@@ -2540,6 +2543,7 @@ export default class NostrWalletConnectStore {
 
         if (changed) {
             this.lookupPaymentsCache = null;
+            this.scheduleMaxBudgetRefresh();
             this.findAndUpdateConnection(connection);
         }
         return changed;
@@ -2851,7 +2855,7 @@ export default class NostrWalletConnectStore {
                 isBudgetDebited: true
             });
         });
-
+        this.scheduleMaxBudgetRefresh();
         this.lookupPaymentsCache = null;
         NostrConnectUtils.notifyOutgoingNwcPayment(amountSats, connection.name);
     }
@@ -3213,27 +3217,51 @@ export default class NostrWalletConnectStore {
         return this.cashuEnabled && this.cashuStore.isProperlyConfigured();
     }
 
-    public async loadMaxBudget() {
-        try {
-            if (this.isCashuConfigured) {
-                runInAction(() => {
-                    this.maxBudgetLimit = this.cashuStore.totalBalanceSats || 0;
-                });
-            } else {
-                const balance = await this.balanceStore.getLightningBalance(
-                    true
-                );
-                runInAction(() => {
-                    this.maxBudgetLimit =
-                        Number(balance?.lightningBalance) || 0;
-                });
-            }
-        } catch (error) {
-            runInAction(() => {
-                this.maxBudgetLimit = 0;
-            });
-            console.error('Failed to get max budget:', error);
+    public async loadMaxBudget(): Promise<void> {
+        if (this.maxBudgetLoadInFlight) {
+            return this.maxBudgetLoadInFlight;
         }
+        const load = (async () => {
+            try {
+                if (this.isCashuConfigured) {
+                    runInAction(() => {
+                        this.maxBudgetLimit =
+                            this.cashuStore.totalBalanceSats || 0;
+                    });
+                } else {
+                    const balance = await this.balanceStore.getLightningBalance(
+                        true
+                    );
+                    runInAction(() => {
+                        this.maxBudgetLimit =
+                            Number(balance?.lightningBalance) || 0;
+                    });
+                }
+            } catch (error) {
+                runInAction(() => {
+                    this.maxBudgetLimit = 0;
+                });
+                console.error('Failed to get max budget:', error);
+            }
+        })();
+
+        this.maxBudgetLoadInFlight = load;
+        try {
+            await load;
+        } finally {
+            if (this.maxBudgetLoadInFlight === load) {
+                this.maxBudgetLoadInFlight = null;
+            }
+        }
+    }
+    private scheduleMaxBudgetRefresh(): void {
+        if (this.scheduledMaxBudgetRefresh) return;
+        this.scheduledMaxBudgetRefresh = setTimeout(() => {
+            this.scheduledMaxBudgetRefresh = null;
+            this.loadMaxBudget().catch((err) =>
+                console.error('NWC: scheduled loadMaxBudget failed:', err)
+            );
+        }, 500);
     }
     @computed
     public get activeConnections(): NWCConnection[] {


### PR DESCRIPTION
# Description

Hardens NWC `pay_invoice` activity writes and reconcile persistence so budget and status stay consistent when payments settle in-handler or in the background.

### Problem

- `finalizePayment` always appended a success row, so a prior **pending** row for the same invoice could remain (duplicate activity).
- Reconcile could promote pending → success and debit budget without a durable save, so `is_budget_debited` / status could be lost on process kill.
- Pending, failed, and success paths duplicated find-or-push logic.

### Changes

- Debit budget only once using `is_budget_debited` (skip if already set during reconcile)
- Centralize pending/failed / success writes in `upsertPayInvoiceActivity` (merge by id, never demote success)
- Persist the connection after reconcile mutates activity

### Flow (after)

| Path | Activity | Budget |
|------|----------|--------|
| In-flight | pending | held via `pendingSpendSats` |
| Settled in-handler | upsert → success | debit once |
| Settled later | pending → success | debit once if not already flagged |
| Failed | upsert → failed | no debit |

### Test plan

- [ ] Immediate settle → one success activity, budget debited once
- [ ] In-flight then settle → single row (pending upgraded to success), budget debited once
- [ ] Background settle + app restart → status and budget flag still correct
- [ ] Failed payment → failed activity, budget unchanged


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
