### PR TITLE
fix: LSPS1: update Olympus mainnet host

### DIFF
--- a/.claude/skills/zeus-config-and-flags/SKILL.md
+++ b/.claude/skills/zeus-config-and-flags/SKILL.md
@@ -208,7 +208,7 @@ Per-network TRIPLETS (mainnet/testnet/mutinynet). The canonical resolver is `get
 | `requestSimpleTaproot` | `true` |
 | `lsps1RestMainnet` / `...Testnet` / `...Mutinynet` | `https://lsps1.lnolymp.us` / `https://testnet-lsps1.lnolymp.us` / `https://mutinynet-lsps1.lnolymp.us` |
 | `lsps1PubkeyMainnet` / `...Testnet` / `...Mutinynet` | Olympus node pubkeys (see `DEFAULT_LSPS1_PUBKEY_*` consts) |
-| `lsps1HostMainnet` / `...Testnet` / `...Mutinynet` | `45.79.192.236:9735` / `139.144.22.237:9735` / `45.79.201.241:9735` |
+| `lsps1HostMainnet` / `...Testnet` / `...Mutinynet` | `45.79.207.158:9735` / `139.144.22.237:9735` / `45.79.201.241:9735` |
 | `lsps1Token` | `''` |
 | `lsps1ShowPurchaseButton` | unset — DEPRECATED |
 

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1306,7 +1306,7 @@ export const DEFAULT_LSPS1_PUBKEY_MAINNET =
     '031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581';
 export const DEFAULT_LSPS1_PUBKEY_TESTNET =
     '03e84a109cd70e57864274932fc87c5e6434c59ebb8e6e7d28532219ba38f7f6df';
-export const DEFAULT_LSPS1_HOST_MAINNET = '45.79.192.236:9735';
+export const DEFAULT_LSPS1_HOST_MAINNET = '45.79.207.158:9735';
 export const DEFAULT_LSPS1_HOST_TESTNET = '139.144.22.237:9735';
 
 export const DEFAULT_LSP_MUTINYNET = 'https://mutinynet-flow.lnolymp.us';
@@ -1930,6 +1930,7 @@ export default class SettingsStore {
                 await MigrationsUtils.migrateInvoiceExpiryDisplay(
                     parsedSettings
                 );
+                await MigrationsUtils.migrateLsps1MainnetHost(parsedSettings);
                 this.settings = parsedSettings;
             } else {
                 console.log('attempting to load legacy settings');

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -42,7 +42,7 @@ jest.mock('../stores/SettingsStore', () => ({
         'btcd-testnet.lightning.computer',
         'testnet.blixtwallet.com'
     ],
-    DEFAULT_LSPS1_HOST_MAINNET: '45.79.192.236:9735',
+    DEFAULT_LSPS1_HOST_MAINNET: '45.79.207.158:9735',
     DEFAULT_LSPS1_HOST_TESTNET: '139.144.22.237:9735',
     DEFAULT_LSPS1_PUBKEY_MAINNET:
         '031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581',
@@ -112,7 +112,7 @@ describe('MigrationUtils', () => {
         },
         lspMainnet: 'https://0conf.lnolymp.us',
         lspTestnet: 'https://testnet-0conf.lnolymp.us',
-        lsps1HostMainnet: '45.79.192.236:9735',
+        lsps1HostMainnet: '45.79.207.158:9735',
         lsps1HostTestnet: '139.144.22.237:9735',
         lsps1PubkeyMainnet:
             '031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581',
@@ -227,6 +227,29 @@ describe('MigrationUtils', () => {
                 )
             ).resolves.toEqual({
                 ...defaultSettings
+            });
+        });
+        it('migrates old Olympus LSPS1 mainnet host on the legacy path', async () => {
+            await expect(
+                MigrationUtils.legacySettingsMigrations(
+                    JSON.stringify({
+                        lsps1HostMainnet: '45.79.192.236:9735'
+                    })
+                )
+            ).resolves.toEqual({
+                ...defaultSettings
+            });
+        });
+        it('keeps a custom LSPS1 mainnet host on the legacy path', async () => {
+            await expect(
+                MigrationUtils.legacySettingsMigrations(
+                    JSON.stringify({
+                        lsps1HostMainnet: 'mynode.example.com:9735'
+                    })
+                )
+            ).resolves.toEqual({
+                ...defaultSettings,
+                lsps1HostMainnet: 'mynode.example.com:9735'
             });
         });
         it('migrates old POS squareEnabled setting to posEnabled', async () => {
@@ -467,6 +490,80 @@ describe('MigrationUtils', () => {
                 timePeriod: 'Hours',
                 expirySeconds: '3600'
             });
+        });
+    });
+
+    describe('migrateLsps1MainnetHost', () => {
+        const EncryptedStorage = require('react-native-encrypted-storage');
+        const { settingsStore } = require('../stores/Stores');
+
+        beforeEach(() => {
+            EncryptedStorage.getItem.mockReset();
+            EncryptedStorage.setItem.mockReset();
+            settingsStore.setSettings.mockReset();
+        });
+
+        it('rewrites the old default host on v2 settings and persists', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                lsps1HostMainnet: '45.79.192.236:9735'
+            };
+
+            await MigrationUtils.migrateLsps1MainnetHost(settings);
+
+            expect(settings.lsps1HostMainnet).toBe('45.79.207.158:9735');
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+            const persistedSettings =
+                settingsStore.setSettings.mock.calls[0][0];
+            expect(typeof persistedSettings).not.toBe('string');
+            expect(persistedSettings).toBe(settings);
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'olympus-host-2026',
+                'true'
+            );
+        });
+
+        it('leaves a custom host untouched and does not rewrite storage', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                lsps1HostMainnet: 'mynode.example.com:9735'
+            };
+
+            await MigrationUtils.migrateLsps1MainnetHost(settings);
+
+            expect(settings.lsps1HostMainnet).toBe('mynode.example.com:9735');
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'olympus-host-2026',
+                'true'
+            );
+        });
+
+        it('only sets the flag when no host is persisted', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {};
+
+            await MigrationUtils.migrateLsps1MainnetHost(settings);
+
+            expect(settings).toEqual({});
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'olympus-host-2026',
+                'true'
+            );
+        });
+
+        it('is a no-op when the migration flag is already set', async () => {
+            EncryptedStorage.getItem.mockResolvedValue('true');
+            const settings: any = {
+                lsps1HostMainnet: '45.79.192.236:9735'
+            };
+
+            await MigrationUtils.migrateLsps1MainnetHost(settings);
+
+            expect(settings.lsps1HostMainnet).toBe('45.79.192.236:9735');
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
         });
     });
 

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -457,7 +457,32 @@ class MigrationsUtils {
         // migrate old default RGS server to new ZEUS RGS server
         await this.migrateRgsDefaultToZeus(newSettings);
 
+        // migrate old Olympus LSPS1 mainnet host to new host
+        await this.migrateLsps1MainnetHost(newSettings);
+
         return newSettings;
+    }
+
+    // The Olympus mainnet node moved hosts. The 'lsps1-hosts1' migration
+    // persisted the old default into every existing user's settings, so
+    // changing DEFAULT_LSPS1_HOST_MAINNET alone only fixes fresh installs.
+    // Rewrite the host for users still on the old default; users who set
+    // a custom host keep it. Must run on both the legacy and modern
+    // (zeus-settings-v2) paths.
+    public async migrateLsps1MainnetHost(settings: any) {
+        const MOD_KEY_OLYMPUS_HOST = 'olympus-host-2026';
+        const modOlympusHost = await EncryptedStorage.getItem(
+            MOD_KEY_OLYMPUS_HOST
+        );
+        if (modOlympusHost) return settings;
+
+        const OLD_LSPS1_HOST_MAINNET = '45.79.192.236:9735';
+        if (settings?.lsps1HostMainnet === OLD_LSPS1_HOST_MAINNET) {
+            settings.lsps1HostMainnet = DEFAULT_LSPS1_HOST_MAINNET;
+            await settingsStore.setSettings(settings);
+        }
+        await EncryptedStorage.setItem(MOD_KEY_OLYMPUS_HOST, 'true');
+        return settings;
     }
 
     public async migrateRgsDefaultToZeus(settings: any) {


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

The Olympus mainnet node has moved to a new host. The node URI is now:

`031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581@45.79.207.158:9735`

The pubkey is unchanged; only the host changed (`45.79.192.236:9735` to `45.79.207.158:9735`).

Changing `DEFAULT_LSPS1_HOST_MAINNET` alone would only fix fresh installs: the `lsps1-hosts1` migration persisted the old default into every existing user's settings blob, and `getLspConfigForNetwork` prefers the persisted value. This PR therefore also ships a one-shot migration.

## Migration plan

New `MigrationUtils.migrateLsps1MainnetHost` (flag `olympus-host-2026`, EncryptedStorage):

- If `settings.lsps1HostMainnet` equals the old default `45.79.192.236:9735`, rewrite it to `45.79.207.158:9735` and persist via `settingsStore.setSettings` (awaited, object payload). Users with a custom host are left untouched.
- The flag is set only after the write succeeds, so a crash mid-migration retries on next boot.
- Runs on **both** load paths: called from `legacySettingsMigrations` (after the `lsps1-hosts1` block, which backfills missing hosts with the new default) and from the modern `zeus-settings-v2` branch of `SettingsStore.getSettings`.
- Cohorts: fresh installs get the new default directly; legacy-blob upgraders and current v2 users on the old default get rewritten once; users with custom hosts keep them.
- Idempotent: the rewrite only fires while the value equals the old default; running twice is a no-op.
- Revert story: revert-safe in code (the migration only adds a repair). If the node ever moves back to the old IP, a counter-migration with a new flag key would be needed, since migrated users have the new host persisted.

No new storage keys are introduced (only an EncryptedStorage migration flag, which is the convention for MOD_KEY flags), so no DataClearUtils / KeychainRecoveryUtils / cloud-sync registration applies.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Configuration change
- [ ] Code refactor
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

Added 6 Jest tests in `utils/MigrationUtils.test.ts`: legacy-path rewrite, legacy-path custom-host preservation, v2 rewrite + object-payload persistence, custom-host no-op, missing-key flag-only, and already-flagged no-op (28/28 passing).

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Draft pending manual testing: upgrade-from-current-release on both platforms (verify the persisted `lsps1HostMainnet` flips to the new host exactly once and custom hosts survive), fresh install, and an LSPS1 channel purchase against the new host.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
