### PR TITLE
views: Lightning Address: push device token when notifications enabled

### DIFF
--- a/views/Cashu/LightningAddress/LightningAddressSettings.tsx
+++ b/views/Cashu/LightningAddress/LightningAddressSettings.tsx
@@ -337,6 +337,15 @@ export default class CashuLightningAddressSettings extends React.Component<
                                                 notifications: value
                                             }
                                         });
+                                        if (value === 1) {
+                                            LightningAddressStore.updatePushCredentials().catch(
+                                                (e) =>
+                                                    console.log(
+                                                        'Failed to update push credentials',
+                                                        e
+                                                    )
+                                            );
+                                        }
                                     } catch (e) {
                                         this.setState({ notifications: prev });
                                     }

--- a/views/LightningAddress/LightningAddressSettings.tsx
+++ b/views/LightningAddress/LightningAddressSettings.tsx
@@ -414,6 +414,15 @@ export default class LightningAddressSettings extends React.Component<
                                                 notifications: value
                                             }
                                         });
+                                        if (value === 1) {
+                                            LightningAddressStore.updatePushCredentials().catch(
+                                                (e) =>
+                                                    console.log(
+                                                        'Failed to update push credentials',
+                                                        e
+                                                    )
+                                            );
+                                        }
                                     } catch (e) {
                                         this.setState({ notifications: prev });
                                     }

--- a/views/LightningAddress/NWCAddressSettings.tsx
+++ b/views/LightningAddress/NWCAddressSettings.tsx
@@ -251,6 +251,15 @@ export default class NWCAddressSettings extends React.Component<
                                                 notifications: value
                                             }
                                         });
+                                        if (value === 1) {
+                                            LightningAddressStore.updatePushCredentials().catch(
+                                                (e) =>
+                                                    console.log(
+                                                        'Failed to update push credentials',
+                                                        e
+                                                    )
+                                            );
+                                        }
                                     } catch (e) {
                                         this.setState({ notifications: prev });
                                     }


### PR DESCRIPTION
# Description

When a user switches the ZEUS Pay notifications preference to Push in any of the lightning address settings views, only the `notifications` value was sent to the zeuspay.com server. The device token itself was not written until the next wallet connect passed the gate in `Wallet.tsx` (lightning address enabled, not testnet, backend supports lightning address, notifications === 1). So a user who enabled notifications after address creation would not receive push notifications until they restarted or reconnected the wallet, which makes troubleshooting "why am I not getting notifications" confusing.

This PR makes all three lightning address settings views (Zaplocker, Cashu, NWC) call `LightningAddressStore.updatePushCredentials()` immediately after the preference update succeeds, when the selected value is Push.

`updatePushCredentials()` already handles the edge cases:
- if the OS hasn't delivered a device token yet, it sets `pendingPushUpdate` and flushes when the token arrives via `setDeviceToken`
- if the server already has the current token (`serviceDeviceToken` from the status call), it skips the network write entirely

The call has its own `.catch` (matching the existing pattern in `setDeviceToken`), so a failed token push logs rather than reverting the notifications preference, which did update successfully. Disabling notifications behaves exactly as before.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

(Device testing pending; will update before marking ready for review.)

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
