### PR TITLE
fix(lndmobile): correlate payment events by payment hash

### DIFF
--- a/lndmobile/index.ts
+++ b/lndmobile/index.ts
@@ -4,6 +4,10 @@ import { lnrpc, routerrpc, invoicesrpc } from './../proto/lightning';
 import Long from 'long';
 
 import Base64Utils from '../utils/Base64Utils';
+import {
+    getExpectedPaymentHash,
+    matchesExpectedPayment
+} from '../utils/EmbeddedLndPayUtils';
 import { localeString } from '../utils/LocaleUtils';
 import {
     checkLndStreamErrorResponse,
@@ -294,6 +298,11 @@ export const getInfo = async (): Promise<lnrpc.GetInfoResponse> => {
     return response;
 };
 
+const forcedTimeout = async (time_ms: number, response: any) => {
+    await new Promise((res) => setTimeout(res, time_ms));
+    return response;
+};
+
 export const sendPaymentV2Sync = async (
     sendPaymentReq: any
 ): Promise<lnrpc.Payment> => {
@@ -333,18 +342,15 @@ export const sendPaymentV2Sync = async (
         dest
     };
 
-    const forcedTimeout = async (time_ms: number, response: any) => {
-        await new Promise((res) => setTimeout(res, time_ms));
-        return response;
-    };
+    const expectedPaymentHash = getExpectedPaymentHash(options);
 
+    let listener: any;
     const call = () =>
-        new Promise(async (resolve, reject) => {
-            const listener = LndMobileEventEmitter.addListener(
+        new Promise((resolve, reject) => {
+            listener = LndMobileEventEmitter.addListener(
                 'RouterSendPaymentV2',
                 (e) => {
                     try {
-                        listener.remove();
                         const error = checkLndStreamErrorResponse(
                             'RouterSendPaymentV2',
                             e
@@ -356,18 +362,31 @@ export const sendPaymentV2Sync = async (
                             console.log('Got error from RouterSendPaymentV2', [
                                 error
                             ]);
+                            listener.remove();
                             return reject(error);
                         }
 
                         const response = decodeSendPaymentV2Result(e.data);
+                        // a concurrent payment's event: leave it for that
+                        // payment's listener
+                        if (
+                            !matchesExpectedPayment(
+                                expectedPaymentHash,
+                                response
+                            )
+                        ) {
+                            return;
+                        }
+                        listener.remove();
                         resolve(response);
                     } catch (error: any) {
+                        listener.remove();
                         reject(error.message || error.toString());
                     }
                 }
             );
 
-            const response = await sendStreamCommand<
+            sendStreamCommand<
                 routerrpc.ISendPaymentRequest,
                 routerrpc.SendPaymentRequest
             >(
@@ -377,21 +396,28 @@ export const sendPaymentV2Sync = async (
                     options
                 },
                 false
-            );
-
-            return response;
+            ).catch((error) => {
+                listener.remove();
+                reject(error);
+            });
         });
 
-    const result: any = await Promise.race([
-        forcedTimeout((timeout_seconds + 1) * 1000, {
-            payment_error: localeString(
-                'views.SendingLightning.paymentTimedOut'
-            )
-        }),
-        call()
-    ]);
+    try {
+        const result: any = await Promise.race([
+            forcedTimeout((timeout_seconds + 1) * 1000, {
+                payment_error: localeString(
+                    'views.SendingLightning.paymentTimedOut'
+                )
+            }),
+            call()
+        ]);
 
-    return result;
+        return result;
+    } finally {
+        // if the timeout won the race, stop listening so a late event
+        // cannot be mistaken for a different payment's outcome
+        if (listener) listener.remove();
+    }
 };
 
 // TODO error handling
@@ -402,7 +428,9 @@ export const decodeSendPaymentV2Result = (data: string): lnrpc.Payment => {
     });
 };
 
-export const sendKeysendPaymentV2 = (request: any): Promise<lnrpc.Payment> => {
+export const sendKeysendPaymentV2 = async (
+    request: any
+): Promise<lnrpc.Payment> => {
     const {
         dest,
         amt,
@@ -415,6 +443,8 @@ export const sendKeysendPaymentV2 = (request: any): Promise<lnrpc.Payment> => {
         amp
     } = request;
 
+    const timeout_seconds = 60;
+
     const options: routerrpc.ISendPaymentRequest = {
         dest: Base64Utils.hexToBytes(dest),
         amt,
@@ -422,7 +452,7 @@ export const sendKeysendPaymentV2 = (request: any): Promise<lnrpc.Payment> => {
         payment_hash,
         dest_features: [lnrpc.FeatureBit.TLV_ONION_REQ],
         no_inflight_updates: true,
-        timeout_seconds: 60,
+        timeout_seconds,
         max_parts: max_parts || 1,
         fee_limit_sat,
         max_shard_size_msat,
@@ -430,39 +460,81 @@ export const sendKeysendPaymentV2 = (request: any): Promise<lnrpc.Payment> => {
         amp
     };
 
-    return new Promise(async (resolve, reject) => {
-        const listener = LndMobileEventEmitter.addListener(
-            'RouterSendPaymentV2',
-            (e) => {
-                const error = checkLndStreamErrorResponse(
-                    'RouterSendPaymentV2',
-                    e
-                );
-                if (error === 'EOF') {
-                    return;
-                } else if (error) {
-                    console.log('Got error from RouterSendPaymentV2', [error]);
-                    return reject(error);
+    const expectedPaymentHash = getExpectedPaymentHash(options);
+
+    let listener: any;
+    const call = () =>
+        new Promise((resolve, reject) => {
+            listener = LndMobileEventEmitter.addListener(
+                'RouterSendPaymentV2',
+                (e) => {
+                    try {
+                        const error = checkLndStreamErrorResponse(
+                            'RouterSendPaymentV2',
+                            e
+                        );
+                        if (error === 'EOF') {
+                            return;
+                        } else if (error) {
+                            console.log('Got error from RouterSendPaymentV2', [
+                                error
+                            ]);
+                            listener.remove();
+                            return reject(error);
+                        }
+
+                        const response = decodeSendPaymentV2Result(e.data);
+                        // a concurrent payment's event: leave it for that
+                        // payment's listener
+                        if (
+                            !matchesExpectedPayment(
+                                expectedPaymentHash,
+                                response
+                            )
+                        ) {
+                            return;
+                        }
+                        listener.remove();
+                        resolve(response);
+                    } catch (error: any) {
+                        listener.remove();
+                        reject(error.message || error.toString());
+                    }
                 }
+            );
 
-                const response = decodeSendPaymentV2Result(e.data);
-                resolve(response);
+            sendStreamCommand<
+                routerrpc.ISendPaymentRequest,
+                routerrpc.SendPaymentRequest
+            >(
+                {
+                    request: routerrpc.SendPaymentRequest,
+                    method: 'RouterSendPaymentV2',
+                    options
+                },
+                false
+            ).catch((error) => {
                 listener.remove();
-            }
-        );
+                reject(error);
+            });
+        });
 
-        await sendStreamCommand<
-            routerrpc.ISendPaymentRequest,
-            routerrpc.SendPaymentRequest
-        >(
-            {
-                request: routerrpc.SendPaymentRequest,
-                method: 'RouterSendPaymentV2',
-                options
-            },
-            false
-        );
-    });
+    try {
+        const result: any = await Promise.race([
+            forcedTimeout((timeout_seconds + 1) * 1000, {
+                payment_error: localeString(
+                    'views.SendingLightning.paymentTimedOut'
+                )
+            }),
+            call()
+        ]);
+
+        return result;
+    } finally {
+        // if the timeout won the race, stop listening so a late event
+        // cannot be mistaken for a different payment's outcome
+        if (listener) listener.remove();
+    }
 };
 
 /**

--- a/utils/EmbeddedLndPayUtils.test.ts
+++ b/utils/EmbeddedLndPayUtils.test.ts
@@ -1,0 +1,115 @@
+import {
+    getExpectedPaymentHash,
+    matchesExpectedPayment
+} from './EmbeddedLndPayUtils';
+
+// BOLT11 spec reference vector (lnbc2500u, hashed description); its
+// payment_hash is pinned by the spec
+const SPEC_PAYMENT_REQUEST =
+    'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr';
+const SPEC_PAYMENT_HASH =
+    '0001020304050607080900010203040506070809000102030405060708090102';
+
+const KEYSEND_HASH_HEX =
+    '66497159952cabecfee7fd8ac0f3aa1a557a77b21313c5a94559d1e78c90ed8b';
+const KEYSEND_HASH_BASE64 = Buffer.from(KEYSEND_HASH_HEX, 'hex').toString(
+    'base64'
+);
+
+describe('EmbeddedLndPayUtils', () => {
+    describe('getExpectedPaymentHash', () => {
+        it('decodes the payment hash out of a bolt11 payment request', () => {
+            expect(
+                getExpectedPaymentHash({
+                    payment_request: SPEC_PAYMENT_REQUEST
+                })
+            ).toEqual(SPEC_PAYMENT_HASH);
+        });
+
+        it('converts a base64 keysend payment hash to hex', () => {
+            expect(
+                getExpectedPaymentHash({ payment_hash: KEYSEND_HASH_BASE64 })
+            ).toEqual(KEYSEND_HASH_HEX);
+        });
+
+        it('passes a hex payment hash through, lowercased', () => {
+            expect(
+                getExpectedPaymentHash({
+                    payment_hash: KEYSEND_HASH_HEX.toUpperCase()
+                })
+            ).toEqual(KEYSEND_HASH_HEX);
+        });
+
+        it('converts a byte-array payment hash to hex', () => {
+            expect(
+                getExpectedPaymentHash({
+                    payment_hash: Uint8Array.from(
+                        Buffer.from(KEYSEND_HASH_HEX, 'hex')
+                    )
+                })
+            ).toEqual(KEYSEND_HASH_HEX);
+        });
+
+        it('prefers the request payment_hash over the payment_request', () => {
+            expect(
+                getExpectedPaymentHash({
+                    payment_hash: KEYSEND_HASH_HEX,
+                    payment_request: SPEC_PAYMENT_REQUEST
+                })
+            ).toEqual(KEYSEND_HASH_HEX);
+        });
+
+        it('returns null for AMP payments even when a hash is present', () => {
+            expect(
+                getExpectedPaymentHash({
+                    amp: true,
+                    payment_hash: KEYSEND_HASH_HEX,
+                    payment_request: SPEC_PAYMENT_REQUEST
+                })
+            ).toBeNull();
+        });
+
+        it('returns null for an undecodable payment request', () => {
+            expect(
+                getExpectedPaymentHash({ payment_request: 'lnbc1notarealpr' })
+            ).toBeNull();
+        });
+
+        it('returns null when there is nothing to correlate on', () => {
+            expect(getExpectedPaymentHash({})).toBeNull();
+        });
+    });
+
+    describe('matchesExpectedPayment', () => {
+        it('matches when no expected hash is available (legacy first-event behavior)', () => {
+            expect(
+                matchesExpectedPayment(null, {
+                    payment_hash: KEYSEND_HASH_HEX
+                })
+            ).toEqual(true);
+        });
+
+        it('matches its own payment, case-insensitively', () => {
+            expect(
+                matchesExpectedPayment(KEYSEND_HASH_HEX, {
+                    payment_hash: KEYSEND_HASH_HEX.toUpperCase()
+                })
+            ).toEqual(true);
+        });
+
+        it("rejects another payment's event", () => {
+            expect(
+                matchesExpectedPayment(KEYSEND_HASH_HEX, {
+                    payment_hash: SPEC_PAYMENT_HASH
+                })
+            ).toEqual(false);
+        });
+
+        it('matches defensively when the event carries no hash', () => {
+            expect(matchesExpectedPayment(KEYSEND_HASH_HEX, {})).toEqual(true);
+            expect(matchesExpectedPayment(KEYSEND_HASH_HEX, null)).toEqual(
+                true
+            );
+        });
+    });
+});

--- a/utils/EmbeddedLndPayUtils.ts
+++ b/utils/EmbeddedLndPayUtils.ts
@@ -1,0 +1,62 @@
+import Base64Utils from './Base64Utils';
+import Bolt11Utils from './Bolt11Utils';
+
+// The native LND bridges (LndMobile.java, Lndmobile.swift) emit stream events
+// keyed by method name alone, so every in-flight RouterSendPaymentV2 call
+// receives every other call's events. Terminal lnrpc.Payment updates carry
+// payment_hash, which lets each caller filter for its own payment. Stream
+// error events carry only error_code/error_desc and cannot be correlated.
+
+const HEX_64 = /^[0-9a-fA-F]{64}$/;
+
+// The hex payment hash a RouterSendPaymentV2 call should expect its terminal
+// event to carry, or null when correlation isn't possible. AMP payments skip
+// correlation: lnd derives a hash per attempt, so the request-side hash never
+// matches the event's.
+export const getExpectedPaymentHash = (options: {
+    amp?: boolean | null;
+    payment_hash?: string | Uint8Array | number[] | null;
+    payment_request?: string | null;
+}): string | null => {
+    if (options.amp) return null;
+
+    const { payment_hash, payment_request } = options;
+    try {
+        if (payment_hash) {
+            if (typeof payment_hash === 'string') {
+                // keysend callers pass base64; tolerate hex too
+                return HEX_64.test(payment_hash)
+                    ? payment_hash.toLowerCase()
+                    : Base64Utils.base64ToHex(payment_hash).toLowerCase();
+            }
+            return Base64Utils.bytesToHex(
+                Array.from(payment_hash)
+            ).toLowerCase();
+        }
+        if (payment_request) {
+            return (
+                Bolt11Utils.decode(
+                    payment_request
+                ).payment_hash?.toLowerCase() || null
+            );
+        }
+    } catch (e) {
+        // fall through: an undecodable request means no correlation,
+        // not a failed payment
+    }
+    return null;
+};
+
+export const matchesExpectedPayment = (
+    expectedPaymentHash: string | null,
+    payment?: { payment_hash?: string | null } | null
+): boolean => {
+    // no correlation possible: fall back to first-event behavior
+    if (!expectedPaymentHash) return true;
+    // terminal updates always carry a hash; treat a missing one as a match
+    // rather than risk a payment that never resolves
+    if (!payment || !payment.payment_hash) return true;
+    return payment.payment_hash.toLowerCase() === expectedPaymentHash;
+};
+
+export default { getExpectedPaymentHash, matchesExpectedPayment };


### PR DESCRIPTION
# Description

The native LND bridges (`LndMobile.java`, `Lndmobile.swift`) emit gRPC stream events keyed by method name alone, so every in-flight `RouterSendPaymentV2` call receives every other call's events. `sendPaymentV2Sync` and `sendKeysendPaymentV2` registered on that shared event name and resolved on the first event seen, with no payment-hash correlation.

With two payments in flight on embedded LND (e.g. an NWC wallet-service payment overlapping a user-initiated payment, or a rebalance overlapping a send), payment A's terminal event resolved both promises: B reported A's preimage/fee as its own, or A's failure was displayed as B's outcome, and B's real result was never delivered, inviting a re-pay of a payment that succeeded.

### Fix

Terminal `lnrpc.Payment` updates carry `payment_hash`, so each caller now filters events for its own payment. The correlation logic lives in a new pure utility, `utils/EmbeddedLndPayUtils.ts` (+ 12 unit tests):

- keysend: expected hash taken from the request's `payment_hash`
- invoice payments: expected hash decoded from the bolt11 via `Bolt11Utils`
- AMP: correlation skipped (lnd derives per-attempt hashes), preserving first-event behavior
- events that do not match are left for their owner's listener; the listener is only removed on its own terminal event

Stream-level **error** events carry only `error_code`/`error_desc` on both platforms and cannot be attributed to a specific payment; they still reject all pending listeners (rare, gRPC-level failures; fixing that would require native changes on both platforms).

### Adjacent defects fixed in the same path

- **EOF handling**: the invoice path removed its listener before checking for EOF, hanging the promise until the forced timeout; the keysend path kept listening but had no timeout at all, so an EOF-terminated stream hung its promise forever. Keysend now shares the same `forcedTimeout` in-transit shape as invoice payments.
- **Listener cleanup**: listeners are removed when the timeout wins the race, and when `sendStreamCommand` itself rejects (previously the rejection was swallowed by the `async` promise executor and the caller hung).
- **Log hygiene**: dropped `console.log` of raw payment events in the keysend path, which included the payment preimage.

### Testing notes

The correlation helper is fully unit-tested, including against the BOLT11 spec reference vector. The concurrency scenario to exercise on-device: an NWC service `pay_invoice` overlapping a user-initiated payment on embedded LND, plus single-payment regression checks (bolt11 pay, keysend, AMP) to confirm normal flow is unchanged.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
