### PR TITLE
Require re-authentication before revealing wallet seed

### DIFF
--- a/utils/NavigationUtils.test.ts
+++ b/utils/NavigationUtils.test.ts
@@ -1,0 +1,111 @@
+jest.mock('../stores/Stores', () => ({
+    settingsStore: {
+        posStatus: 'inactive',
+        settings: {},
+        setPosStatus: jest.fn(),
+        loginMethodConfigured: jest.fn()
+    }
+}));
+
+import { settingsStore } from '../stores/Stores';
+import { protectedNavigation, reAuthNavigation } from './NavigationUtils';
+
+const mockSettingsStore = settingsStore as any;
+
+describe('NavigationUtils', () => {
+    let navigation: any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        navigation = { navigate: jest.fn() };
+        mockSettingsStore.posStatus = 'inactive';
+        mockSettingsStore.settings = {};
+    });
+
+    describe('reAuthNavigation', () => {
+        it('routes via Lockscreen when a login method is configured', () => {
+            mockSettingsStore.loginMethodConfigured.mockReturnValue(true);
+
+            reAuthNavigation(navigation, 'Seed');
+
+            expect(navigation.navigate).toHaveBeenCalledTimes(1);
+            expect(navigation.navigate).toHaveBeenCalledWith('Lockscreen', {
+                pendingNavigation: { screen: 'Seed', params: undefined }
+            });
+        });
+
+        it('passes route params through the Lockscreen pendingNavigation', () => {
+            mockSettingsStore.loginMethodConfigured.mockReturnValue(true);
+            const params = {
+                walletSeedPhrase: ['abandon', 'ability', 'able'],
+                implementation: 'ldk-node',
+                isTestNet: true
+            };
+
+            reAuthNavigation(navigation, 'Seed', params);
+
+            expect(navigation.navigate).toHaveBeenCalledWith('Lockscreen', {
+                pendingNavigation: { screen: 'Seed', params }
+            });
+        });
+
+        it('navigates directly when no login method is configured', () => {
+            mockSettingsStore.loginMethodConfigured.mockReturnValue(false);
+            const params = { skipWarning: true };
+
+            reAuthNavigation(navigation, 'Seed', params);
+
+            expect(navigation.navigate).toHaveBeenCalledTimes(1);
+            expect(navigation.navigate).toHaveBeenCalledWith('Seed', params);
+        });
+
+        it('does not consult POS status', () => {
+            mockSettingsStore.posStatus = 'active';
+            mockSettingsStore.loginMethodConfigured.mockReturnValue(true);
+
+            reAuthNavigation(navigation, 'Seed');
+
+            expect(navigation.navigate).toHaveBeenCalledWith(
+                'Lockscreen',
+                expect.anything()
+            );
+        });
+    });
+
+    describe('protectedNavigation', () => {
+        it('routes via Lockscreen when POS is active and a pin is set', async () => {
+            mockSettingsStore.posStatus = 'active';
+            mockSettingsStore.settings = { pin: '1234' };
+
+            await protectedNavigation(navigation, 'Menu');
+
+            expect(navigation.navigate).toHaveBeenCalledWith('Lockscreen', {
+                pendingNavigation: { screen: 'Menu', params: undefined }
+            });
+        });
+
+        it('navigates directly when POS is inactive', async () => {
+            mockSettingsStore.posStatus = 'inactive';
+            mockSettingsStore.settings = { pin: '1234' };
+
+            await protectedNavigation(navigation, 'Menu');
+
+            expect(navigation.navigate).toHaveBeenCalledWith('Menu', undefined);
+        });
+
+        it('deactivates POS when requested on ungated navigation', async () => {
+            mockSettingsStore.posStatus = 'inactive';
+            mockSettingsStore.settings = {};
+
+            await protectedNavigation(navigation, 'Wallet', true);
+
+            expect(mockSettingsStore.setPosStatus).toHaveBeenCalledWith(
+                'inactive'
+            );
+            expect(navigation.navigate).toHaveBeenCalledWith(
+                'Wallet',
+                undefined
+            );
+        });
+    });
+});

--- a/utils/NavigationUtils.ts
+++ b/utils/NavigationUtils.ts
@@ -22,4 +22,21 @@ const protectedNavigation = async (
     }
 };
 
-export { protectedNavigation };
+// Requires re-authentication (PIN, passphrase, or biometrics) before
+// navigating to a screen that reveals sensitive material (e.g. the seed),
+// regardless of POS status or current session login state
+const reAuthNavigation = (
+    navigation: NativeStackNavigationProp<any, any>,
+    route: string,
+    routeParams?: any
+) => {
+    if (settingsStore.loginMethodConfigured()) {
+        navigation.navigate('Lockscreen', {
+            pendingNavigation: { screen: route, params: routeParams }
+        });
+    } else {
+        navigation.navigate(route, routeParams);
+    }
+};
+
+export { protectedNavigation, reAuthNavigation };

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -310,6 +310,23 @@ export default class Lockscreen extends React.Component<
             } else if (deleteDuressPin) {
                 this.deleteDuressPin();
                 return;
+            } else if (route.params?.pendingNavigation) {
+                // must be handled before selectNodeOnStartup, which would
+                // otherwise drop the re-auth target and land on the wallet
+                // picker
+                if (
+                    (SettingsStore.settings?.pos?.posEnabled ||
+                        PosEnabled.Disabled) !== PosEnabled.Disabled
+                ) {
+                    setPosStatus('inactive');
+                }
+                this.resetAuthenticationAttempts();
+                const { pendingNavigation } = route.params;
+                this.proceed(
+                    pendingNavigation.screen,
+                    pendingNavigation.params
+                );
+                return;
             } else if (SettingsStore.settings.selectNodeOnStartup) {
                 // Only handle wallet selection when NOT modifying security
                 this.resetAuthenticationAttempts();
@@ -334,11 +351,7 @@ export default class Lockscreen extends React.Component<
                     setPosStatus('inactive');
                 }
                 this.resetAuthenticationAttempts();
-                const pendingNavigation = route.params?.pendingNavigation;
-                this.proceed(
-                    pendingNavigation?.screen,
-                    pendingNavigation?.params
-                );
+                this.proceed();
             }
         } else if (
             // duress creds only trigger the wipe on a genuine login attempt -

--- a/views/Menu.tsx
+++ b/views/Menu.tsx
@@ -36,6 +36,7 @@ import Screen from '../components/Screen';
 import BackendUtils from '../utils/BackendUtils';
 import { getPhoto } from '../utils/PhotoUtils';
 import { localeString } from '../utils/LocaleUtils';
+import { reAuthNavigation } from '../utils/NavigationUtils';
 import {
     themeColor,
     getUpgradeBackgroundColor,
@@ -409,7 +410,9 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
                             >
                                 <TouchableOpacity
                                     style={styles.columnField}
-                                    onPress={() => navigation.navigate('Seed')}
+                                    onPress={() =>
+                                        reAuthNavigation(navigation, 'Seed')
+                                    }
                                 >
                                     <View style={styles.icon}>
                                         <KeyIcon

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -27,6 +27,7 @@ import BackendUtils from '../../utils/BackendUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import ValidationUtils from '../../utils/ValidationUtils';
 import { confirmAction } from '../../utils/ActionUtils';
+import { reAuthNavigation } from '../../utils/NavigationUtils';
 
 import Storage from '../../storage';
 
@@ -882,7 +883,9 @@ export default class WalletConfiguration extends React.Component<
                         onPress: () =>
                             // Active embedded-LND only reaches this branch;
                             // SettingsStore already has this wallet's seed.
-                            navigation.navigate('Seed', { skipWarning: true }),
+                            reAuthNavigation(navigation, 'Seed', {
+                                skipWarning: true
+                            }),
                         isPreferred: true
                     },
                     {
@@ -3028,7 +3031,8 @@ export default class WalletConfiguration extends React.Component<
                                         // viewing an inactive wallet so active
                                         // backup/export paths stay unchanged.
                                         if (active) {
-                                            navigation.navigate(
+                                            reAuthNavigation(
+                                                navigation,
                                                 'Seed',
                                                 implementation === 'ldk-node'
                                                     ? {
@@ -3053,7 +3057,7 @@ export default class WalletConfiguration extends React.Component<
                                             (
                                                 walletNetwork || 'mainnet'
                                             ).toLowerCase() !== 'mainnet';
-                                        navigation.navigate('Seed', {
+                                        reAuthNavigation(navigation, 'Seed', {
                                             walletSeedPhrase,
                                             implementation,
                                             isTestNet

--- a/views/Swaps/index.tsx
+++ b/views/Swaps/index.tsx
@@ -34,6 +34,7 @@ import Switch from '../../components/Switch';
 
 import { font } from '../../utils/FontUtils';
 import { localeString } from '../../utils/LocaleUtils';
+import { reAuthNavigation } from '../../utils/NavigationUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import { SATS_PER_BTC } from '../../utils/UnitsUtils';
 import AddressUtils from '../../utils/AddressUtils';
@@ -805,7 +806,7 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
                 <TouchableOpacity style={{ marginTop: -10, marginRight: 6 }}>
                     <KeyIcon
                         onPress={() => {
-                            navigation.navigate('Seed', {
+                            reAuthNavigation(navigation, 'Seed', {
                                 seedPhrase: this.state.seedPhrase
                             });
                         }}

--- a/views/Tools/CashuTools.tsx
+++ b/views/Tools/CashuTools.tsx
@@ -12,6 +12,7 @@ import CashuStore from '../../stores/CashuStore';
 import SettingsStore from '../../stores/SettingsStore';
 
 import { localeString } from '../../utils/LocaleUtils';
+import { reAuthNavigation } from '../../utils/NavigationUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import UrlUtils from '../../utils/UrlUtils';
 
@@ -71,7 +72,10 @@ export default class CashuTools extends React.Component<CashuToolsProps, {}> {
                                         backgroundColor: 'transparent'
                                     }}
                                     onPress={() =>
-                                        navigation.navigate('CashuSeed')
+                                        reAuthNavigation(
+                                            navigation,
+                                            'CashuSeed'
+                                        )
                                     }
                                 >
                                     <ListItem.Content>

--- a/views/Wallet/BalancePane.tsx
+++ b/views/Wallet/BalancePane.tsx
@@ -24,6 +24,7 @@ import RescanStatus from '../../components/RescanStatus';
 
 import { localeString } from '../../utils/LocaleUtils';
 import { IS_BACKED_UP_KEY } from '../../utils/MigrationUtils';
+import { reAuthNavigation } from '../../utils/NavigationUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import UrlUtils from '../../utils/UrlUtils';
 import { CHANNEL_MIGRATION_ACTIVE } from '../../utils/ChannelMigrationUtils';
@@ -418,7 +419,8 @@ export default class BalancePane extends React.PureComponent<
                                             !BalanceStore.loadingLightningBalance && (
                                                 <TouchableOpacity
                                                     onPress={() =>
-                                                        navigation.navigate(
+                                                        reAuthNavigation(
+                                                            navigation,
                                                             'Seed'
                                                         )
                                                     }


### PR DESCRIPTION
# Description

Once the app is unlocked, viewing the wallet mnemonic (`Seed`) and exporting extended private keys (`SeedQRExport`, reachable only from `Seed`) require no further authentication, so a briefly unattended unlocked phone allows silent seed exfiltration. Unlike sending funds, seed theft is invisible to the victim and permanent.

This PR routes every seed-reveal entry point through the existing Lockscreen re-auth mechanism:

- New `reAuthNavigation()` helper in `utils/NavigationUtils.ts`: navigates via `Lockscreen` with `pendingNavigation` whenever a login method (PIN, passphrase, or biometrics) is configured, and directly otherwise. It intentionally uses `loginMethodConfigured()` rather than `loginRequired()`, since the latter is false for the rest of the session once the app is unlocked. `protectedNavigation` (POS-only, existing callers) is untouched; new unit tests lock in its behavior alongside the helper's.
- Gated call sites: menu seed entry, BalancePane backup prompt card, both WalletConfiguration backup paths (active and inactive wallets, including the `walletSeedPhrase` param hop), the delete-wallet channel-export path, re-viewing an existing swap rescue key, and the Cashu BIP-39 seed reveal in Cashu Tools.
- Deliberately ungated: showing a swap rescue key immediately after generating it (the user just triggered creation in-session and the key exists nowhere else yet; a prompt there is friction with no confidentiality gain).
- Standalone Lockscreen bug fix: `onAttemptLogIn` checked `selectNodeOnStartup` before `pendingNavigation`, replacing the stack with the wallet picker and silently dropping the re-auth target on the PIN/passphrase path (the biometric path was already correct). This also benefits the existing POS `pendingNavigation` flow.

Behavior notes, both intended:

- Entering duress credentials at the seed prompt performs the full duress wipe. Coerced seed reveal is the canonical duress scenario, and suppressing duress for `pendingNavigation` would also strip it from the POS auth flow, which shares the param.
- Five failed attempts at the prompt trigger the standard wipe, consistent with every other Lockscreen use.

Known limitation (pre-existing Lockscreen behavior, documented rather than changed here): with biometrics configured but no PIN/passphrase, cancelling the biometric prompt falls through Lockscreen's no-credentials path and proceeds. Same behavior exists at cold start today; fixing it means reworking the pass-through logic and is left for a follow-up.

No new locale strings, no storage changes, no new dependencies.

This pull request is categorized as a:

- [x] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [x] Embedded LND

Remote
- [ ] LND (REST) - N/A, no local seed; gated entry points only render for local wallets
- [ ] LND (Lightning Node Connect) - N/A
- [ ] Core Lightning (CLNRest) - N/A
- [ ] Nostr Wallet Connect - N/A
- [ ] LndHub - N/A

Draft until the device matrix passes. Key manual cases: `selectNodeOnStartup` + PIN lands on Seed and not the wallet picker; inactive-wallet seed params survive the Lockscreen hop; iOS FaceID firing as the delete-wallet alert dismisses; duress and 5-attempt wipes verified on an emulator only.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

