### PR TITLE
Apply the user's fee rate to LDK on-chain sends

### DIFF
--- a/android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt
+++ b/android/app/src/main/java/app/zeusln/zeus/LdkNodeModule.kt
@@ -1131,12 +1131,12 @@ class LdkNodeModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
     }
 
     @ReactMethod
-    fun sendToOnchainAddress(address: String, amountSats: Double, promise: Promise) {
+    fun sendToOnchainAddress(address: String, amountSats: Double, satPerVbyte: Double, promise: Promise) {
         moduleScope.launch {
             try {
                 val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
                 val onchain = node.onchainPayment()
-                val txid = onchain.sendToAddress(address, amountSats.toLong().toULong(), null)
+                val txid = onchain.sendToAddress(address, amountSats.toLong().toULong(), parseFeeRate(satPerVbyte))
                 val result = Arguments.createMap().apply {
                     putString("txid", txid)
                 }
@@ -1152,12 +1152,12 @@ class LdkNodeModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
     }
 
     @ReactMethod
-    fun sendAllToOnchainAddress(address: String, retainReserve: Boolean, promise: Promise) {
+    fun sendAllToOnchainAddress(address: String, retainReserve: Boolean, satPerVbyte: Double, promise: Promise) {
         moduleScope.launch {
             try {
                 val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
                 val onchain = node.onchainPayment()
-                val txid = onchain.sendAllToAddress(address, retainReserve, null)
+                val txid = onchain.sendAllToAddress(address, retainReserve, parseFeeRate(satPerVbyte))
                 val result = Arguments.createMap().apply {
                     putString("txid", txid)
                 }
@@ -1217,14 +1217,24 @@ class LdkNodeModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
         return outpoints
     }
 
+    /**
+     * Builds the optional FeeRate for an on-chain send. The JS layer passes -1
+     * when the user set no usable rate, in which case we hand ldk-node null so
+     * it applies its own fee estimation.
+     */
+    private fun parseFeeRate(satPerVbyte: Double): FeeRate? {
+        if (satPerVbyte < 1) return null
+        return FeeRate.fromSatPerVbUnchecked(satPerVbyte.toLong().toULong())
+    }
+
     @ReactMethod
-    fun sendToOnchainAddressWithUtxos(address: String, amountSats: Double, utxos: ReadableArray, promise: Promise) {
+    fun sendToOnchainAddressWithUtxos(address: String, amountSats: Double, utxos: ReadableArray, satPerVbyte: Double, promise: Promise) {
         moduleScope.launch {
             try {
                 val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
                 val onchain = node.onchainPayment()
                 val outpoints = parseOutPoints(utxos)
-                val txid = onchain.sendToAddressWithUtxos(address, amountSats.toLong().toULong(), outpoints, null)
+                val txid = onchain.sendToAddressWithUtxos(address, amountSats.toLong().toULong(), outpoints, parseFeeRate(satPerVbyte))
                 val result = Arguments.createMap().apply {
                     putString("txid", txid)
                 }
@@ -1240,13 +1250,13 @@ class LdkNodeModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
     }
 
     @ReactMethod
-    fun sendAllToOnchainAddressWithUtxos(address: String, retainReserve: Boolean, utxos: ReadableArray, promise: Promise) {
+    fun sendAllToOnchainAddressWithUtxos(address: String, retainReserve: Boolean, utxos: ReadableArray, satPerVbyte: Double, promise: Promise) {
         moduleScope.launch {
             try {
                 val node = this@LdkNodeModule.node ?: throw Exception("Node not initialized")
                 val onchain = node.onchainPayment()
                 val outpoints = parseOutPoints(utxos)
-                val txid = onchain.sendAllToAddressWithUtxos(address, retainReserve, outpoints, null)
+                val txid = onchain.sendAllToAddressWithUtxos(address, retainReserve, outpoints, parseFeeRate(satPerVbyte))
                 val result = Arguments.createMap().apply {
                     putString("txid", txid)
                 }

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -11,6 +11,7 @@ import { Hash as sha256Hash } from 'fast-sha256';
 import libraryVersions from '../fetch-libraries-versions.json';
 import LdkNodeInjection from '../ldknode/LdkNodeInjection';
 import Base64Utils from '../utils/Base64Utils';
+import { sanitizeSatPerVbyte } from '../utils/FeeUtils';
 import { localeString } from '../utils/LocaleUtils';
 import type {
     Network,
@@ -1110,6 +1111,11 @@ export default class LdkNode {
     sendCoins = async (data: any): Promise<any> => {
         let txid: string;
 
+        // The fee rate the user set in the UI. Anything unusable becomes the
+        // "no rate" sentinel so ldk-node falls back to its own estimation
+        // rather than being handed a nonsense FeeRate.
+        const satPerVbyte = sanitizeSatPerVbyte(data.sat_per_vbyte);
+
         if (data.utxos?.length > 0) {
             const outpoints = data.utxos.map((s: string) => {
                 const [utxoTxid, vout] = s.split(':');
@@ -1121,7 +1127,8 @@ export default class LdkNode {
                         {
                             address: data.addr,
                             retainReserve: false,
-                            utxos: outpoints
+                            utxos: outpoints,
+                            satPerVbyte
                         }
                     );
             } else {
@@ -1130,18 +1137,22 @@ export default class LdkNode {
                         {
                             address: data.addr,
                             amountSats: Number(data.amount),
-                            utxos: outpoints
+                            utxos: outpoints,
+                            satPerVbyte
                         }
                     );
             }
         } else if (data.send_all) {
             txid = await LdkNodeInjection.onchain.sendAllToOnchainAddress(
-                data.addr
+                data.addr,
+                false,
+                satPerVbyte
             );
         } else {
             txid = await LdkNodeInjection.onchain.sendToOnchainAddress({
                 address: data.addr,
-                amountSats: Number(data.amount)
+                amountSats: Number(data.amount),
+                satPerVbyte
             });
         }
 

--- a/ios/LdkNodeMobile/LdkNodeModule.m
+++ b/ios/LdkNodeMobile/LdkNodeModule.m
@@ -55,11 +55,11 @@ RCT_EXTERN_METHOD(forceCloseChannel:(NSString *)userChannelId counterpartyNodeId
 
 // On-chain Methods
 RCT_EXTERN_METHOD(newOnchainAddress:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
-RCT_EXTERN_METHOD(sendToOnchainAddress:(NSString *)address amountSats:(nonnull NSNumber *)amountSats resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
-RCT_EXTERN_METHOD(sendAllToOnchainAddress:(NSString *)address retainReserve:(BOOL)retainReserve resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(sendToOnchainAddress:(NSString *)address amountSats:(nonnull NSNumber *)amountSats satPerVbyte:(nonnull NSNumber *)satPerVbyte resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(sendAllToOnchainAddress:(NSString *)address retainReserve:(BOOL)retainReserve satPerVbyte:(nonnull NSNumber *)satPerVbyte resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(listUtxos:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
-RCT_EXTERN_METHOD(sendToOnchainAddressWithUtxos:(NSString *)address amountSats:(nonnull NSNumber *)amountSats utxos:(NSArray *)utxos resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
-RCT_EXTERN_METHOD(sendAllToOnchainAddressWithUtxos:(NSString *)address retainReserve:(BOOL)retainReserve utxos:(NSArray *)utxos resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(sendToOnchainAddressWithUtxos:(NSString *)address amountSats:(nonnull NSNumber *)amountSats utxos:(NSArray *)utxos satPerVbyte:(nonnull NSNumber *)satPerVbyte resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(sendAllToOnchainAddressWithUtxos:(NSString *)address retainReserve:(BOOL)retainReserve utxos:(NSArray *)utxos satPerVbyte:(nonnull NSNumber *)satPerVbyte resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
 // BOLT11 Payment Methods
 RCT_EXTERN_METHOD(receiveBolt11:(double)amountMsat invoiceDescription:(NSString *)invoiceDescription expirySecs:(double)expirySecs resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/LdkNodeMobile/LdkNodeModule.swift
+++ b/ios/LdkNodeMobile/LdkNodeModule.swift
@@ -1052,8 +1052,16 @@ class LdkNodeModule: RCTEventEmitter {
         }
     }
 
-    @objc(sendToOnchainAddress:amountSats:resolver:rejecter:)
-    func sendToOnchainAddress(_ address: String, amountSats: NSNumber, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    /// Builds the optional FeeRate for an on-chain send. The JS layer passes -1
+    /// when the user set no usable rate, in which case we hand ldk-node nil so
+    /// it applies its own fee estimation.
+    private func parseFeeRate(_ satPerVbyte: NSNumber) -> FeeRate? {
+        if satPerVbyte.doubleValue < 1 { return nil }
+        return FeeRate.fromSatPerVbUnchecked(satVb: satPerVbyte.uint64Value)
+    }
+
+    @objc(sendToOnchainAddress:amountSats:satPerVbyte:resolver:rejecter:)
+    func sendToOnchainAddress(_ address: String, amountSats: NSNumber, satPerVbyte: NSNumber, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         guard let node = self.getNode() else {
             reject("error", "Node not initialized", nil)
             return
@@ -1061,15 +1069,15 @@ class LdkNodeModule: RCTEventEmitter {
 
         do {
             let onchain = node.onchainPayment()
-            let txid = try onchain.sendToAddress(address: address, amountSats: amountSats.uint64Value, feeRate: nil)
+            let txid = try onchain.sendToAddress(address: address, amountSats: amountSats.uint64Value, feeRate: self.parseFeeRate(satPerVbyte))
             resolve(["txid": txid])
         } catch {
             reject("error", self.errorMessage(error), error)
         }
     }
 
-    @objc(sendAllToOnchainAddress:retainReserve:resolver:rejecter:)
-    func sendAllToOnchainAddress(_ address: String, retainReserve: Bool, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    @objc(sendAllToOnchainAddress:retainReserve:satPerVbyte:resolver:rejecter:)
+    func sendAllToOnchainAddress(_ address: String, retainReserve: Bool, satPerVbyte: NSNumber, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         guard let node = self.getNode() else {
             reject("error", "Node not initialized", nil)
             return
@@ -1077,7 +1085,7 @@ class LdkNodeModule: RCTEventEmitter {
 
         do {
             let onchain = node.onchainPayment()
-            let txid = try onchain.sendAllToAddress(address: address, retainReserve: retainReserve, feeRate: nil)
+            let txid = try onchain.sendAllToAddress(address: address, retainReserve: retainReserve, feeRate: self.parseFeeRate(satPerVbyte))
             resolve(["txid": txid])
         } catch {
             reject("error", self.errorMessage(error), error)
@@ -1109,8 +1117,8 @@ class LdkNodeModule: RCTEventEmitter {
         }
     }
 
-    @objc(sendToOnchainAddressWithUtxos:amountSats:utxos:resolver:rejecter:)
-    func sendToOnchainAddressWithUtxos(_ address: String, amountSats: NSNumber, utxos: NSArray, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    @objc(sendToOnchainAddressWithUtxos:amountSats:utxos:satPerVbyte:resolver:rejecter:)
+    func sendToOnchainAddressWithUtxos(_ address: String, amountSats: NSNumber, utxos: NSArray, satPerVbyte: NSNumber, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         guard let node = self.getNode() else {
             reject("error", "Node not initialized", nil)
             return
@@ -1126,15 +1134,15 @@ class LdkNodeModule: RCTEventEmitter {
                     outpoints.append(OutPoint(txid: txid, vout: vout.uint32Value))
                 }
             }
-            let txid = try onchain.sendToAddressWithUtxos(address: address, amountSats: amountSats.uint64Value, utxos: outpoints, feeRate: nil)
+            let txid = try onchain.sendToAddressWithUtxos(address: address, amountSats: amountSats.uint64Value, utxos: outpoints, feeRate: self.parseFeeRate(satPerVbyte))
             resolve(["txid": txid])
         } catch {
             reject("error", self.errorMessage(error), error)
         }
     }
 
-    @objc(sendAllToOnchainAddressWithUtxos:retainReserve:utxos:resolver:rejecter:)
-    func sendAllToOnchainAddressWithUtxos(_ address: String, retainReserve: Bool, utxos: NSArray, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    @objc(sendAllToOnchainAddressWithUtxos:retainReserve:utxos:satPerVbyte:resolver:rejecter:)
+    func sendAllToOnchainAddressWithUtxos(_ address: String, retainReserve: Bool, utxos: NSArray, satPerVbyte: NSNumber, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         guard let node = self.getNode() else {
             reject("error", "Node not initialized", nil)
             return
@@ -1150,7 +1158,7 @@ class LdkNodeModule: RCTEventEmitter {
                     outpoints.append(OutPoint(txid: txid, vout: vout.uint32Value))
                 }
             }
-            let txid = try onchain.sendAllToAddressWithUtxos(address: address, retainReserves: retainReserve, utxos: outpoints, feeRate: nil)
+            let txid = try onchain.sendAllToAddressWithUtxos(address: address, retainReserves: retainReserve, utxos: outpoints, feeRate: self.parseFeeRate(satPerVbyte))
             resolve(["txid": txid])
         } catch {
             reject("error", self.errorMessage(error), error)

--- a/ldknode/LdkNode.d.ts
+++ b/ldknode/LdkNode.d.ts
@@ -532,21 +532,28 @@ export interface ILdkNodeModule {
 
     // On-chain Methods
     newOnchainAddress(): Promise<string>;
-    sendToOnchainAddress(address: string, amountSats: number): Promise<string>;
+    sendToOnchainAddress(
+        address: string,
+        amountSats: number,
+        satPerVbyte: number
+    ): Promise<string>;
     sendAllToOnchainAddress(
         address: string,
-        retainReserve: boolean
+        retainReserve: boolean,
+        satPerVbyte: number
     ): Promise<string>;
     listUtxos(): Promise<{ utxos: any[] }>;
     sendToOnchainAddressWithUtxos(
         address: string,
         amountSats: number,
-        utxos: Array<{ txid: string; vout: number }>
+        utxos: Array<{ txid: string; vout: number }>,
+        satPerVbyte: number
     ): Promise<{ txid: string }>;
     sendAllToOnchainAddressWithUtxos(
         address: string,
         retainReserve: boolean,
-        utxos: Array<{ txid: string; vout: number }>
+        utxos: Array<{ txid: string; vout: number }>,
+        satPerVbyte: number
     ): Promise<{ txid: string }>;
 
     // BOLT11 Payment Methods

--- a/ldknode/LdkNodeInjection.ts
+++ b/ldknode/LdkNodeInjection.ts
@@ -335,25 +335,30 @@ const newOnchainAddress = async (): Promise<string> => {
 
 const sendToOnchainAddress = async ({
     address,
-    amountSats
+    amountSats,
+    satPerVbyte
 }: {
     address: string;
     amountSats: number;
+    satPerVbyte?: number;
 }): Promise<string> => {
     const result: any = await LdkNodeModule.sendToOnchainAddress(
         address,
-        amountSats
+        amountSats,
+        satPerVbyte ?? -1
     );
     return result.txid;
 };
 
 const sendAllToOnchainAddress = async (
     address: string,
-    retainReserve: boolean = false
+    retainReserve: boolean = false,
+    satPerVbyte?: number
 ): Promise<string> => {
     const result: any = await LdkNodeModule.sendAllToOnchainAddress(
         address,
-        retainReserve
+        retainReserve,
+        satPerVbyte ?? -1
     );
     return result.txid;
 };
@@ -374,16 +379,19 @@ const listUtxos = async (): Promise<WalletUtxo[]> => {
 const sendToOnchainAddressWithUtxos = async ({
     address,
     amountSats,
-    utxos
+    utxos,
+    satPerVbyte
 }: {
     address: string;
     amountSats: number;
     utxos: Array<{ txid: string; vout: number }>;
+    satPerVbyte?: number;
 }): Promise<string> => {
     const result: any = await LdkNodeModule.sendToOnchainAddressWithUtxos(
         address,
         amountSats,
-        utxos
+        utxos,
+        satPerVbyte ?? -1
     );
     return result.txid;
 };
@@ -391,16 +399,19 @@ const sendToOnchainAddressWithUtxos = async ({
 const sendAllToOnchainAddressWithUtxos = async ({
     address,
     retainReserve = false,
-    utxos
+    utxos,
+    satPerVbyte
 }: {
     address: string;
     retainReserve?: boolean;
     utxos: Array<{ txid: string; vout: number }>;
+    satPerVbyte?: number;
 }): Promise<string> => {
     const result: any = await LdkNodeModule.sendAllToOnchainAddressWithUtxos(
         address,
         retainReserve,
-        utxos
+        utxos,
+        satPerVbyte ?? -1
     );
     return result.txid;
 };
@@ -1116,21 +1127,25 @@ export interface ILdkNodeInjections {
         sendToOnchainAddress: (params: {
             address: string;
             amountSats: number;
+            satPerVbyte?: number;
         }) => Promise<string>;
         sendAllToOnchainAddress: (
             address: string,
-            retainReserve?: boolean
+            retainReserve?: boolean,
+            satPerVbyte?: number
         ) => Promise<string>;
         listUtxos: () => Promise<WalletUtxo[]>;
         sendToOnchainAddressWithUtxos: (params: {
             address: string;
             amountSats: number;
             utxos: Array<{ txid: string; vout: number }>;
+            satPerVbyte?: number;
         }) => Promise<string>;
         sendAllToOnchainAddressWithUtxos: (params: {
             address: string;
             retainReserve?: boolean;
             utxos: Array<{ txid: string; vout: number }>;
+            satPerVbyte?: number;
         }) => Promise<string>;
     };
     bolt11: {

--- a/utils/FeeUtils.test.ts
+++ b/utils/FeeUtils.test.ts
@@ -1,4 +1,4 @@
-import FeeUtils from './FeeUtils';
+import FeeUtils, { sanitizeSatPerVbyte, NO_SAT_PER_VBYTE } from './FeeUtils';
 
 const satoshisPerBTC = 100_000_000;
 
@@ -68,6 +68,42 @@ describe('FeeUtils', () => {
             expect(FeeUtils.toFixed(-500000 / satoshisPerBTC, true)).toEqual(
                 '-0.00500000'
             );
+        });
+    });
+
+    describe('sanitizeSatPerVbyte', () => {
+        it('passes through a usable rate', () => {
+            expect(sanitizeSatPerVbyte('5')).toEqual(5);
+            expect(sanitizeSatPerVbyte(5)).toEqual(5);
+            expect(sanitizeSatPerVbyte('1')).toEqual(1);
+        });
+
+        it('returns the sentinel when no rate is supplied', () => {
+            expect(sanitizeSatPerVbyte(undefined)).toEqual(NO_SAT_PER_VBYTE);
+            expect(sanitizeSatPerVbyte(null)).toEqual(NO_SAT_PER_VBYTE);
+            expect(sanitizeSatPerVbyte('')).toEqual(NO_SAT_PER_VBYTE);
+        });
+
+        it('rejects rates below one sat/vB', () => {
+            expect(sanitizeSatPerVbyte(0)).toEqual(NO_SAT_PER_VBYTE);
+            expect(sanitizeSatPerVbyte('0')).toEqual(NO_SAT_PER_VBYTE);
+            expect(sanitizeSatPerVbyte(-1)).toEqual(NO_SAT_PER_VBYTE);
+            expect(sanitizeSatPerVbyte('0.5')).toEqual(NO_SAT_PER_VBYTE);
+        });
+
+        it('rejects values that are not finite numbers', () => {
+            expect(sanitizeSatPerVbyte('abc')).toEqual(NO_SAT_PER_VBYTE);
+            expect(sanitizeSatPerVbyte(NaN)).toEqual(NO_SAT_PER_VBYTE);
+            expect(sanitizeSatPerVbyte(Infinity)).toEqual(NO_SAT_PER_VBYTE);
+        });
+
+        it('floors fractional rates to whole sat/vB', () => {
+            expect(sanitizeSatPerVbyte('2.9')).toEqual(2);
+            expect(sanitizeSatPerVbyte(10.01)).toEqual(10);
+        });
+
+        it('does not impose an upper bound on an explicit rate', () => {
+            expect(sanitizeSatPerVbyte('5000')).toEqual(5000);
         });
     });
 });

--- a/utils/FeeUtils.ts
+++ b/utils/FeeUtils.ts
@@ -26,3 +26,35 @@ class FeeUtils {
 
 const feeUtils = new FeeUtils();
 export default feeUtils;
+
+/**
+ * Sentinel meaning "no fee rate supplied - let the node pick its own".
+ * Matches the -1 convention used for optional numerics in LdkNodeInjection.
+ */
+export const NO_SAT_PER_VBYTE = -1;
+
+/**
+ * Normalizes a user-supplied on-chain fee rate (sat/vB) for the ldk-node
+ * bridge.
+ *
+ * ldk-node builds its FeeRate with fromSatPerVbUnchecked, which performs no
+ * validation, so a missing, zero, negative, fractional-to-zero, or NaN rate
+ * must never reach it. Any of those yield NO_SAT_PER_VBYTE so the node falls
+ * back to its own fee estimation instead of building a transaction around a
+ * nonsense rate.
+ *
+ * Note this deliberately does NOT impose an upper bound: silently lowering a
+ * rate the user explicitly typed would misreport what was broadcast. Bounding
+ * absurd fee rates is a separate concern that needs its own confirmation UX.
+ *
+ * @param satPerVbyte - Fee rate as collected by the UI
+ * @returns A whole sat/vB rate, or NO_SAT_PER_VBYTE if none applies
+ */
+export function sanitizeSatPerVbyte(
+    satPerVbyte?: string | number | null
+): number {
+    if (satPerVbyte == null || satPerVbyte === '') return NO_SAT_PER_VBYTE;
+    const rate = Math.floor(Number(satPerVbyte));
+    if (!Number.isFinite(rate) || rate < 1) return NO_SAT_PER_VBYTE;
+    return rate;
+}


### PR DESCRIPTION
# Description

`LdkNode.sendCoins` never forwarded `sat_per_vbyte`. All four of its branches (send-all and fixed-amount, with and without UTXO selection) called into the bridge, which in turn passed a hardcoded `null`/`nil` for ldk-node's optional `FeeRate`. The rate the user picked in the send flow was collected, displayed, and then discarded — every LDK on-chain transaction went out at whatever ldk-node's own fee estimator chose.

Unlike the routing fee limit, this parameter did not exist anywhere in the bridge, so it is threaded through all four layers:

- `backends/LdkNode.ts` — passes the sanitized rate into all four branches
- `ldknode/LdkNodeInjection.ts` + `ldknode/LdkNode.d.ts` — optional `satPerVbyte`, forwarded as `?? -1`
- `android/.../LdkNodeModule.kt` and `ios/LdkNodeMobile/LdkNodeModule.swift` / `.m` — new `parseFeeRate` helper mapping the `-1` sentinel to `null`, so ldk-node keeps its existing behavior when no rate applies

`-1` matches the sentinel convention already used for optional numerics in `LdkNodeInjection`.

The underlying ldk-node API supported this all along — that trailing `null`/`nil` *is* the optional `FeeRate` argument, and the vendored bindings expose the constructor (`ldk_node.kt:6651`, `LDKNode.swift:2099`).

### Fee-rate validation

`FeeRate` is built with `fromSatPerVbUnchecked`, which validates nothing, so `sanitizeSatPerVbyte` guards the TS boundary: missing, empty, zero, negative, sub-1, `NaN`, and infinite values all collapse to the sentinel rather than reaching the FFI.

It deliberately imposes **no upper bound** — quietly lowering a rate the user explicitly typed would misreport what was actually broadcast, and bounding absurd fee rates needs its own confirmation UX rather than a silent clamp here.

### Notes for review

- **Requires a native rebuild on both platforms.**
- `sendAllToAddress` with a high rate can now fail for insufficient funds where it previously succeeded at the estimator's rate; the node's error surfaces to the user.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

6 unit tests for `sanitizeSatPerVbyte` in `utils/FeeUtils.test.ts`.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

**Draft: device testing still outstanding, and this is the one change here that cannot be validated by unit tests alone.** The Kotlin and Swift have not been through a compiler yet — API signatures and argument arity were verified by hand against the vendored bindings. Needs a native build on both platforms and a real send through each of the four branches (send-all / fixed-amount × with / without UTXO selection), confirming the broadcast transaction's actual feerate matches what was entered.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
