### PR TITLE
Pass the configured payment timeout to keysend

### DIFF
--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -453,7 +453,8 @@ export default class Send extends React.Component<SendProps, SendState> {
             enableAtomicMultiPathPayment,
             feeLimitSat,
             maxFeePercent,
-            feeOption
+            feeOption,
+            timeoutSeconds
         } = this.state;
 
         // Guard against double-submission: bail if a payment is already in
@@ -468,6 +469,7 @@ export default class Send extends React.Component<SendProps, SendState> {
                 max_parts: maxParts,
                 max_shard_amt: maxShardAmt,
                 fee_limit_sat: feeLimitSat,
+                timeout_seconds: timeoutSeconds,
                 amp: true
             });
         } else {
@@ -479,6 +481,7 @@ export default class Send extends React.Component<SendProps, SendState> {
                 // cap, so only send the percent when that mode is selected
                 max_fee_percent:
                     feeOption === 'percent' ? maxFeePercent : undefined,
+                timeout_seconds: timeoutSeconds,
                 message
             });
         }


### PR DESCRIPTION
# Description

`sendKeySendPayment` built both the AMP and non-AMP `sendPayment` requests without `timeout_seconds`. `TransactionsStore` falls back to `Number(timeout_seconds) || 60` for LND-based, cln-rest and ldk-node backends, so the omission was silent: a user who configured a 120s payment timeout still got 60s on every keysend, with no indication the setting had been ignored.

The value was already read into component state from `settings.payments.timeoutSeconds` (`Send.tsx:312`), and the invoice path already forwards it (`PaymentRequest.tsx:481`). Keysend was the only send path that dropped it.

This is a pass-through only. The on-screen timeout input remains BOLT 12 only; `settings.payments.timeoutSeconds` stays the source of truth for keysend. Adding a per-payment input to the keysend branch would be a UX addition beyond the bug and belongs in its own PR.

### Note for review

One downstream effect worth stating explicitly: the in-flight guard's backstop is computed as `(timeout_seconds + 60)` seconds. Keysend previously resolved to the 60s default, giving a 120s backstop; a user-configured 300s timeout now yields a 360s backstop. That is the backstop behaving as designed, but it does lengthen the worst-case lockout if a completion callback is lost.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

No utility file was modified — the change is four lines in a view. A unit test would require extracting the request builder out of the component, which is more churn than the fix.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

**Draft: device testing still outstanding.** Needs `settings.payments.timeoutSeconds` set to a distinctive value (e.g. 90), a keysend to an unreachable pubkey, and confirmation the failure arrives at ~90s rather than ~60s — repeated with AMP enabled to cover both call sites. Plus a regression check that a normal keysend to a reachable peer still settles promptly.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
