### PR TITLE
config: new default LSP hosts: zeuslsp.com

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1295,12 +1295,12 @@ export const LNDHUB_AUTH_MODES = [
     { key: 'Alby', value: 'Alby' }
 ];
 
-export const DEFAULT_LSP_MAINNET = 'https://0conf.lnolymp.us';
-export const DEFAULT_LSP_TESTNET = 'https://testnet-0conf.lnolymp.us';
+export const DEFAULT_LSP_MAINNET = 'https://flow.zeuslsp.com';
+export const DEFAULT_LSP_TESTNET = 'https://flow.testnet.zeuslsp.com';
 
 // LSPS1 REST
-export const DEFAULT_LSPS1_REST_MAINNET = 'https://lsps1.lnolymp.us';
-export const DEFAULT_LSPS1_REST_TESTNET = 'https://testnet-lsps1.lnolymp.us';
+export const DEFAULT_LSPS1_REST_MAINNET = 'https://lsps1.zeuslsp.com';
+export const DEFAULT_LSPS1_REST_TESTNET = 'https://lsps1.testnet.zeuslsp.com';
 
 export const DEFAULT_LSPS1_PUBKEY_MAINNET =
     '031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581';
@@ -1309,9 +1309,9 @@ export const DEFAULT_LSPS1_PUBKEY_TESTNET =
 export const DEFAULT_LSPS1_HOST_MAINNET = '45.79.192.236:9735';
 export const DEFAULT_LSPS1_HOST_TESTNET = '139.144.22.237:9735';
 
-export const DEFAULT_LSP_MUTINYNET = 'https://mutinynet-flow.lnolymp.us';
+export const DEFAULT_LSP_MUTINYNET = 'https://flow.mutinynet.zeuslsp.com';
 export const DEFAULT_LSPS1_REST_MUTINYNET =
-    'https://mutinynet-lsps1.lnolymp.us';
+    'https://lsps1.mutinynet.zeuslsp.com';
 export const DEFAULT_LSPS1_PUBKEY_MUTINYNET =
     '032ae843e4d7d177f151d021ac8044b0636ec72b1ce3ffcde5c04748db2517ab03';
 export const DEFAULT_LSPS1_HOST_MUTINYNET = '45.79.201.241:9735';
@@ -1928,6 +1928,9 @@ export default class SettingsStore {
                 this.settings = parsedSettings;
                 await MigrationsUtils.migrateRgsDefaultToZeus(parsedSettings);
                 await MigrationsUtils.migrateInvoiceExpiryDisplay(
+                    parsedSettings
+                );
+                await MigrationsUtils.migrateOlympusHostsToZeusLsp(
                     parsedSettings
                 );
                 this.settings = parsedSettings;

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -21,8 +21,9 @@ jest.mock('../utils/BackendUtils', () => ({}));
 jest.mock('../stores/SettingsStore', () => ({
     DEFAULT_FIAT_RATES_SOURCE: 'Zeus',
     DEFAULT_FIAT: 'USD',
-    DEFAULT_LSP_MAINNET: 'https://0conf.lnolymp.us',
-    DEFAULT_LSP_TESTNET: 'https://testnet-0conf.lnolymp.us',
+    DEFAULT_LSP_MAINNET: 'https://flow.zeuslsp.com',
+    DEFAULT_LSP_TESTNET: 'https://flow.testnet.zeuslsp.com',
+    DEFAULT_LSP_MUTINYNET: 'https://flow.mutinynet.zeuslsp.com',
     DEFAULT_NOSTR_RELAYS: [
         'wss://relay.damus.io',
         'wss://nostr.land',
@@ -48,8 +49,9 @@ jest.mock('../stores/SettingsStore', () => ({
         '031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581',
     DEFAULT_LSPS1_PUBKEY_TESTNET:
         '03e84a109cd70e57864274932fc87c5e6434c59ebb8e6e7d28532219ba38f7f6df',
-    DEFAULT_LSPS1_REST_MAINNET: 'https://lsps1.lnolymp.us',
-    DEFAULT_LSPS1_REST_TESTNET: 'https://testnet-lsps1.lnolymp.us',
+    DEFAULT_LSPS1_REST_MAINNET: 'https://lsps1.zeuslsp.com',
+    DEFAULT_LSPS1_REST_TESTNET: 'https://lsps1.testnet.zeuslsp.com',
+    DEFAULT_LSPS1_REST_MUTINYNET: 'https://lsps1.mutinynet.zeuslsp.com',
     DEFAULT_SPEEDLOADER: 'https://egs.lnze.us/',
     DEFAULT_NOSTR_RELAYS_2023: [
         'wss://nostr.mutinywallet.com',
@@ -110,16 +112,16 @@ describe('MigrationUtils', () => {
             routeHints: false,
             zapReceiptsEnabled: true
         },
-        lspMainnet: 'https://0conf.lnolymp.us',
-        lspTestnet: 'https://testnet-0conf.lnolymp.us',
+        lspMainnet: 'https://flow.zeuslsp.com',
+        lspTestnet: 'https://flow.testnet.zeuslsp.com',
         lsps1HostMainnet: '45.79.192.236:9735',
         lsps1HostTestnet: '139.144.22.237:9735',
         lsps1PubkeyMainnet:
             '031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581',
         lsps1PubkeyTestnet:
             '03e84a109cd70e57864274932fc87c5e6434c59ebb8e6e7d28532219ba38f7f6df',
-        lsps1RestMainnet: 'https://lsps1.lnolymp.us',
-        lsps1RestTestnet: 'https://testnet-lsps1.lnolymp.us',
+        lsps1RestMainnet: 'https://lsps1.zeuslsp.com',
+        lsps1RestTestnet: 'https://lsps1.testnet.zeuslsp.com',
         lsps1Token: '',
         neutrinoPeersMainnet: [
             'btcd1.lnolymp.us',
@@ -171,6 +173,38 @@ describe('MigrationUtils', () => {
                 )
             ).resolves.toEqual({
                 ...defaultSettings
+            });
+        });
+        it('migrates old default Olympus LSP hosts to zeuslsp.com hosts', async () => {
+            await expect(
+                MigrationUtils.legacySettingsMigrations(
+                    JSON.stringify({
+                        lspMainnet: 'https://0conf.lnolymp.us',
+                        lspTestnet: 'https://testnet-0conf.lnolymp.us',
+                        lspMutinynet: 'https://mutinynet-flow.lnolymp.us',
+                        lsps1RestMainnet: 'https://lsps1.lnolymp.us',
+                        lsps1RestTestnet: 'https://testnet-lsps1.lnolymp.us',
+                        lsps1RestMutinynet: 'https://mutinynet-lsps1.lnolymp.us'
+                    })
+                )
+            ).resolves.toEqual({
+                ...defaultSettings,
+                lspMutinynet: 'https://flow.mutinynet.zeuslsp.com',
+                lsps1RestMutinynet: 'https://lsps1.mutinynet.zeuslsp.com'
+            });
+        });
+        it('leaves custom LSP hosts untouched', async () => {
+            await expect(
+                MigrationUtils.legacySettingsMigrations(
+                    JSON.stringify({
+                        lspMainnet: 'https://my-custom-lsp.com',
+                        lsps1RestMainnet: 'https://my-custom-lsps1.com'
+                    })
+                )
+            ).resolves.toEqual({
+                ...defaultSettings,
+                lspMainnet: 'https://my-custom-lsp.com',
+                lsps1RestMainnet: 'https://my-custom-lsps1.com'
             });
         });
         it('handles mod3', async () => {
@@ -467,6 +501,119 @@ describe('MigrationUtils', () => {
                 timePeriod: 'Hours',
                 expirySeconds: '3600'
             });
+        });
+    });
+
+    describe('migrateOlympusHostsToZeusLsp', () => {
+        const EncryptedStorage = require('react-native-encrypted-storage');
+        const { settingsStore } = require('../stores/Stores');
+
+        beforeEach(() => {
+            EncryptedStorage.getItem.mockReset();
+            EncryptedStorage.setItem.mockReset();
+            settingsStore.setSettings.mockReset();
+        });
+
+        it('rewrites all six old default hosts on v2 settings', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                lspMainnet: 'https://0conf.lnolymp.us',
+                lspTestnet: 'https://testnet-0conf.lnolymp.us',
+                lspMutinynet: 'https://mutinynet-flow.lnolymp.us',
+                lsps1RestMainnet: 'https://lsps1.lnolymp.us',
+                lsps1RestTestnet: 'https://testnet-lsps1.lnolymp.us',
+                lsps1RestMutinynet: 'https://mutinynet-lsps1.lnolymp.us'
+            };
+
+            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
+
+            expect(settings).toEqual({
+                lspMainnet: 'https://flow.zeuslsp.com',
+                lspTestnet: 'https://flow.testnet.zeuslsp.com',
+                lspMutinynet: 'https://flow.mutinynet.zeuslsp.com',
+                lsps1RestMainnet: 'https://lsps1.zeuslsp.com',
+                lsps1RestTestnet: 'https://lsps1.testnet.zeuslsp.com',
+                lsps1RestMutinynet: 'https://lsps1.mutinynet.zeuslsp.com'
+            });
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'zeuslsp-hosts-2026',
+                'true'
+            );
+        });
+
+        it('persists the settings object rather than a JSON string', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                lspMainnet: 'https://0conf.lnolymp.us'
+            };
+
+            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
+
+            const persistedSettings =
+                settingsStore.setSettings.mock.calls[0][0];
+            expect(typeof persistedSettings).not.toBe('string');
+            expect(persistedSettings).toBe(settings);
+        });
+
+        it('leaves custom hosts untouched and does not rewrite storage', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                lspMainnet: 'https://my-custom-lsp.com',
+                lsps1RestMainnet: 'https://my-custom-lsps1.com'
+            };
+
+            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
+
+            expect(settings).toEqual({
+                lspMainnet: 'https://my-custom-lsp.com',
+                lsps1RestMainnet: 'https://my-custom-lsps1.com'
+            });
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'zeuslsp-hosts-2026',
+                'true'
+            );
+        });
+
+        it('leaves unset hosts unset so runtime falls back to new defaults', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {};
+
+            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
+
+            expect(settings).toEqual({});
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'zeuslsp-hosts-2026',
+                'true'
+            );
+        });
+
+        it('is a no-op when the migration flag is already set', async () => {
+            EncryptedStorage.getItem.mockResolvedValue('true');
+            const settings: any = {
+                lspMainnet: 'https://0conf.lnolymp.us'
+            };
+
+            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
+
+            expect(settings.lspMainnet).toBe('https://0conf.lnolymp.us');
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
+        });
+
+        it('is idempotent when run twice without the flag', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                lspMainnet: 'https://0conf.lnolymp.us'
+            };
+
+            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
+            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
+
+            expect(settings.lspMainnet).toBe('https://flow.zeuslsp.com');
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -19,6 +19,8 @@ import {
     DEFAULT_LSPS1_PUBKEY_TESTNET,
     DEFAULT_LSPS1_REST_MAINNET,
     DEFAULT_LSPS1_REST_TESTNET,
+    DEFAULT_LSP_MUTINYNET,
+    DEFAULT_LSPS1_REST_MUTINYNET,
     DEFAULT_SPEEDLOADER,
     DEFAULT_NOSTR_RELAYS_2023,
     PosEnabled,
@@ -457,6 +459,9 @@ class MigrationsUtils {
         // migrate old default RGS server to new ZEUS RGS server
         await this.migrateRgsDefaultToZeus(newSettings);
 
+        // migrate old default Olympus LSP hosts to new zeuslsp.com hosts
+        await this.migrateOlympusHostsToZeusLsp(newSettings);
+
         return newSettings;
     }
 
@@ -483,6 +488,68 @@ class MigrationsUtils {
         }
         await settingsStore.setSettings(settings);
         await EncryptedStorage.setItem(MOD_KEY_RGS, 'true');
+        return settings;
+    }
+
+    // Rewrite persisted old-default Olympus LSP hosts (lnolymp.us) to the
+    // new zeuslsp.com hosts. Only values still equal to an old default are
+    // touched; custom hosts are left alone. Unset values need no migration —
+    // runtime falls back to the (updated) DEFAULT_* constants. Must run on
+    // both the legacy and modern (zeus-settings-v2) paths.
+    public async migrateOlympusHostsToZeusLsp(settings: any) {
+        const MOD_KEY_ZEUSLSP = 'zeuslsp-hosts-2026';
+        const mod = await EncryptedStorage.getItem(MOD_KEY_ZEUSLSP);
+        if (mod) return settings;
+
+        const hostMigrations: Array<{
+            settingsKey: string;
+            oldHost: string;
+            newHost: string;
+        }> = [
+            {
+                settingsKey: 'lspMainnet',
+                oldHost: 'https://0conf.lnolymp.us',
+                newHost: DEFAULT_LSP_MAINNET
+            },
+            {
+                settingsKey: 'lspTestnet',
+                oldHost: 'https://testnet-0conf.lnolymp.us',
+                newHost: DEFAULT_LSP_TESTNET
+            },
+            {
+                settingsKey: 'lspMutinynet',
+                oldHost: 'https://mutinynet-flow.lnolymp.us',
+                newHost: DEFAULT_LSP_MUTINYNET
+            },
+            {
+                settingsKey: 'lsps1RestMainnet',
+                oldHost: 'https://lsps1.lnolymp.us',
+                newHost: DEFAULT_LSPS1_REST_MAINNET
+            },
+            {
+                settingsKey: 'lsps1RestTestnet',
+                oldHost: 'https://testnet-lsps1.lnolymp.us',
+                newHost: DEFAULT_LSPS1_REST_TESTNET
+            },
+            {
+                settingsKey: 'lsps1RestMutinynet',
+                oldHost: 'https://mutinynet-lsps1.lnolymp.us',
+                newHost: DEFAULT_LSPS1_REST_MUTINYNET
+            }
+        ];
+
+        let changed = false;
+        for (const { settingsKey, oldHost, newHost } of hostMigrations) {
+            if (settings?.[settingsKey] === oldHost) {
+                settings[settingsKey] = newHost;
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            await settingsStore.setSettings(settings);
+        }
+        await EncryptedStorage.setItem(MOD_KEY_ZEUSLSP, 'true');
         return settings;
     }
 


### PR DESCRIPTION
## Description

We're moving the default LSP hosts in our infra from lnolymp.us to zeuslsp.com. This PR updates the six default Flow 2.0 and LSPS1 REST hosts and ships a migration for users who have the old defaults persisted in their settings.

| Setting | Old default | New default |
|---|---|---|
| `lspMainnet` | `https://0conf.lnolymp.us` | `https://flow.zeuslsp.com` |
| `lspTestnet` | `https://testnet-0conf.lnolymp.us` | `https://flow.testnet.zeuslsp.com` |
| `lspMutinynet` | `https://mutinynet-flow.lnolymp.us` | `https://flow.mutinynet.zeuslsp.com` |
| `lsps1RestMainnet` | `https://lsps1.lnolymp.us` | `https://lsps1.zeuslsp.com` |
| `lsps1RestTestnet` | `https://testnet-lsps1.lnolymp.us` | `https://lsps1.testnet.zeuslsp.com` |
| `lsps1RestMutinynet` | `https://mutinynet-lsps1.lnolymp.us` | `https://lsps1.mutinynet.zeuslsp.com` |

Out of scope, unchanged: `backups.lnolymp.us` (SCB backups), neutrino peers (`btcd*.lnolymp.us`), and the LSPS1 P2P `DEFAULT_LSPS1_HOST_*` entries (mainnet P2P host is moving separately in #4344 under its own flag).

## Implementation

- The six `DEFAULT_LSP_*` / `DEFAULT_LSPS1_REST_*` constants in `stores/SettingsStore.ts` now point at the new hosts. All readers (`getLspConfigForNetwork` fallbacks, the reset buttons in LSP and LSPS1 settings views, the legacy default backfills) go through these constants, so fresh installs and resets pick up the new hosts automatically.
- New `migrateOlympusHostsToZeusLsp` in `utils/MigrationUtils.ts`, gated by the `zeuslsp-hosts-2026` flag in EncryptedStorage, modeled on `migrateRgsDefaultToZeus`.

## Migration plan

- **Cohorts:** fresh installs get new defaults from the constants (migration only sets the flag). Users on `zeus-settings-v2` and legacy blob users with an old default persisted get that value rewritten to the new host. Users with custom hosts are untouched (exact string match against the old defaults only). Unset keys stay unset; runtime falls back to the new constants.
- **Both load paths:** runs at the end of `legacySettingsMigrations` and on the modern `zeus-settings-v2` branch of `getSettings`, after `migrateInvoiceExpiryDisplay`.
- **Idempotent:** rewriting is a pure old-value to new-value map; running twice is a no-op. `setSettings` is awaited and receives the settings object (not a JSON string); the flag is only written after persistence succeeds, so a crash mid-migration retries on next boot.
- **Revert story:** the migration only rewrites old default strings to new default strings, so reverting this PR before release is safe. If it ships and needs rollback, a counter-migration under a fresh flag can map the values back the same way.

## Testing

- 8 new Jest tests in `utils/MigrationUtils.test.ts` (legacy path rewrite, custom hosts untouched, and a v2 path block covering rewrite of all six hosts, object-not-string persistence, flag no-op, unset-keys no-op, double-run idempotency); 30/30 passing
- tsc, eslint, prettier clean
- Device testing pending: fresh install, upgrade from v2 with old defaults persisted, upgrade with one custom host, on iOS and Android

This PR is consistent with the [contribution guidelines](https://github.com/ZeusLN/zeus/blob/master/CONTRIBUTING.md).
