### PR TITLE
fix(nwc): enforce connection expiry on all subscribed methods

### DIFF
--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -704,6 +704,36 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
         return connection;
     }
 
+    it('rejects and unsubscribes when the connection record is missing', async () => {
+        const store = buildStore();
+        store.connections = [];
+
+        const connectionId = 'conn-missing';
+        const unsub = jest.fn();
+        (store as any).activeSubscriptions.set(connectionId, unsub);
+
+        const response = await (store as any).withGlobalHandler(
+            connectionId,
+            async () => ({
+                result: { should: 'not-run' },
+                error: undefined
+            })
+        );
+
+        expect(response).toEqual({
+            result: undefined,
+            error: {
+                code: 'UNAUTHORIZED',
+                message:
+                    'stores.NostrWalletConnectStore.error.connectionNotFound'
+            }
+        });
+        expect(unsub).toHaveBeenCalled();
+        expect((store as any).activeSubscriptions.has(connectionId)).toBe(
+            false
+        );
+    });
+
     it('rejects every NWC method once the connection has expired', async () => {
         const store = buildStore();
         const connection = seedConnection(store, {

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -641,3 +641,120 @@ describe('NostrWalletConnectStore pay_invoice activity upsert', () => {
         expect(connection.activity[0].status).toBe('success');
     });
 });
+
+describe('NostrWalletConnectStore connection expiry enforcement', () => {
+    function buildStore() {
+        const settingsStore: any = {
+            connecting: false,
+            implementation: 'lnd',
+            settings: {
+                locale: 'en',
+                ecash: { enableCashu: false },
+                lightningAddress: { enabled: false }
+            }
+        };
+        const store = new NostrWalletConnectStore(
+            settingsStore,
+            {} as any,
+            {
+                nodeInfo: { nodeId: NODE_PUBKEY },
+                getNodeInfo: jest.fn()
+            } as any,
+            {} as any,
+            { invoices: [] } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any
+        );
+
+        (store as any).walletServiceKeys = {
+            privateKey: SERVICE_PRIV,
+            publicKey: SERVICE_PUB
+        };
+        jest.spyOn(store as any, 'scheduleSave').mockImplementation(
+            () => undefined
+        );
+        jest.spyOn(store as any, 'saveConnections').mockResolvedValue(
+            undefined
+        );
+
+        return store;
+    }
+
+    function seedConnection(
+        store: NostrWalletConnectStore,
+        overrides: Record<string, unknown> = {}
+    ) {
+        const connection = new NWCConnection({
+            id: 'conn-expiry',
+            name: 'Expired App',
+            pubkey: OLD_PUBKEY,
+            relayUrl: OLD_RELAY,
+            permissions: ['get_info', 'get_balance', 'make_invoice'],
+            createdAt: new Date('2024-01-01T00:00:00Z'),
+            totalSpendSats: 0,
+            nodePubkey: NODE_PUBKEY,
+            implementation: 'lnd',
+            activity: [],
+            ...overrides
+        } as any);
+        store.connections = [connection];
+        return connection;
+    }
+
+    it('rejects every NWC method once the connection has expired', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date('2020-01-01T00:00:00Z')
+        });
+        expect(connection.isExpired).toBe(true);
+
+        const unsub = jest.fn();
+        (store as any).activeSubscriptions.set(connection.id, unsub);
+
+        const response = await (store as any).withGlobalHandler(
+            connection.id,
+            async () => ({
+                result: { should: 'not-run' },
+                error: undefined
+            })
+        );
+
+        expect(response).toEqual({
+            result: undefined,
+            error: {
+                code: 'RESTRICTED',
+                message:
+                    'views.Settings.NostrWalletConnect.error.connectionExpired'
+            }
+        });
+        expect(unsub).toHaveBeenCalled();
+        expect((store as any).activeSubscriptions.has(connection.id)).toBe(
+            false
+        );
+        expect(connection.lastUsed).toBeUndefined();
+    });
+
+    it('allows non-expired connections through withGlobalHandler', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+
+        const response = await (store as any).withGlobalHandler(
+            connection.id,
+            async () => ({
+                result: { ok: true },
+                error: undefined
+            })
+        );
+
+        expect(response).toEqual({
+            result: { ok: true },
+            error: undefined
+        });
+        expect(connection.lastUsed).toBeInstanceOf(Date);
+    });
+});

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -704,6 +704,36 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
         return connection;
     }
 
+    it('returns INTERNAL_ERROR without unsubscribing when wallet identity is unknown', async () => {
+        const store = buildStore();
+        (store as any).nodeInfoStore.nodeInfo = {};
+        const connection = seedConnection(store);
+
+        const unsub = jest.fn();
+        (store as any).activeSubscriptions.set(connection.id, unsub);
+
+        const response = await (store as any).withGlobalHandler(
+            connection.id,
+            async () => ({
+                result: { should: 'not-run' },
+                error: undefined
+            })
+        );
+
+        expect(response).toEqual({
+            result: undefined,
+            error: {
+                code: 'INTERNAL_ERROR',
+                message:
+                    'stores.NostrWalletConnectStore.error.walletIdentityUnavailable'
+            }
+        });
+        expect(unsub).not.toHaveBeenCalled();
+        expect((store as any).activeSubscriptions.has(connection.id)).toBe(
+            true
+        );
+    });
+
     it('rejects and unsubscribes when the connection record is missing', async () => {
         const store = buildStore();
         store.connections = [];

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1615,10 +1615,32 @@ export default class NostrWalletConnectStore {
         return successfulPublishes;
     }
 
+    /**
+     * Runs every subscribed NWC request through one gate: reject (and drop
+     * the subscription) when the connection has expired.
+     */
     private async withGlobalHandler<T>(
         connectionId: string,
         handler: () => Promise<T>
     ): Promise<T> {
+        const { connection } = this.getConnection({ connectionId });
+        if (!connection) {
+            return NostrConnectUtils.createNip47Error(
+                localeString(
+                    'stores.NostrWalletConnectStore.error.connectionNotFound'
+                ),
+                Nip47ErrorCode.NOT_FOUND
+            ) as T;
+        }
+        if (connection.isExpired) {
+            this.unsubscribeFromConnection(connectionId);
+            return NostrConnectUtils.createNip47Error(
+                localeString(
+                    'views.Settings.NostrWalletConnect.error.connectionExpired'
+                ),
+                Nip47ErrorCode.RESTRICTED
+            ) as T;
+        }
         await this.markConnectionUsed(connectionId);
         return await handler();
     }

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1617,7 +1617,7 @@ export default class NostrWalletConnectStore {
 
     /**
      * Runs every subscribed NWC request through one gate: reject (and drop
-     * the subscription) when the connection has expired.
+     * the subscription) when the connection is missing or has expired.
      */
     private async withGlobalHandler<T>(
         connectionId: string,
@@ -1625,11 +1625,12 @@ export default class NostrWalletConnectStore {
     ): Promise<T> {
         const { connection } = this.getConnection({ connectionId });
         if (!connection) {
+            this.unsubscribeFromConnection(connectionId);
             return NostrConnectUtils.createNip47Error(
                 localeString(
                     'stores.NostrWalletConnectStore.error.connectionNotFound'
                 ),
-                Nip47ErrorCode.NOT_FOUND
+                Nip47ErrorCode.UNAUTHORIZED
             ) as T;
         }
         if (connection.isExpired) {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1618,6 +1618,8 @@ export default class NostrWalletConnectStore {
     /**
      * Runs every subscribed NWC request through one gate: reject (and drop
      * the subscription) when the connection is missing or has expired.
+     * When wallet identity is transiently unknown (e.g. during reconnect),
+     * returns INTERNAL_ERROR without dropping the subscription.
      */
     private async withGlobalHandler<T>(
         connectionId: string,
@@ -1625,6 +1627,14 @@ export default class NostrWalletConnectStore {
     ): Promise<T> {
         const { connection } = this.getConnection({ connectionId });
         if (!connection) {
+            if (!this.hasWalletContext()) {
+                return NostrConnectUtils.createNip47Error(
+                    localeString(
+                        'stores.NostrWalletConnectStore.error.walletIdentityUnavailable'
+                    ),
+                    Nip47ErrorCode.INTERNAL_ERROR
+                ) as T;
+            }
             this.unsubscribeFromConnection(connectionId);
             return NostrConnectUtils.createNip47Error(
                 localeString(

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -124,7 +124,9 @@ export enum Nip47ErrorCode {
     FAILED_TO_CREATE_INVOICE = 'FAILED_TO_CREATE_INVOICE',
     NOT_FOUND = 'NOT_FOUND',
     INSUFFICIENT_BALANCE = 'INSUFFICIENT_BALANCE',
-    INVOICE_EXPIRED = 'INVOICE_EXPIRED'
+    INVOICE_EXPIRED = 'INVOICE_EXPIRED',
+    /** NIP-47: pubkey not allowed for this operation (e.g. connection expired). */
+    RESTRICTED = 'RESTRICTED'
 }
 
 export default class NostrConnectUtils {

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -123,6 +123,8 @@ export enum Nip47ErrorCode {
     FAILED_TO_PAY_INVOICE = 'FAILED_TO_PAY_INVOICE',
     FAILED_TO_CREATE_INVOICE = 'FAILED_TO_CREATE_INVOICE',
     NOT_FOUND = 'NOT_FOUND',
+    /** NIP-47: pubkey has no wallet connected (e.g. unknown connection). */
+    UNAUTHORIZED = 'UNAUTHORIZED',
     INSUFFICIENT_BALANCE = 'INSUFFICIENT_BALANCE',
     INVOICE_EXPIRED = 'INVOICE_EXPIRED',
     /** NIP-47: pubkey not allowed for this operation (e.g. connection expired). */


### PR DESCRIPTION
# Description

Expired NWC connections were only blocked on pay_invoice (via validateBudgetBeforePayment). A connection that was already subscribed could still call get_info, get_balance, make_invoice, lookup_invoice, list_transactions, and sign_message until the next resubscribe cycle.

This PR enforces expiry at the shared request gate (withGlobalHandler), so every subscribed NWC method is rejected once connection.isExpired is true. Expired requests return NIP-47 RESTRICTED with the existing “connection expired” message, and the subscription is dropped so further events are not handled.

## Changes

- Gate all NWC handler requests in withGlobalHandler before markConnectionUsed
- Return RESTRICTED for expired connections (NIP-47-appropriate error code)
- Unsubscribe expired connections on first rejected request
- Add Nip47ErrorCode.RESTRICTED to NostrConnectUtils
- Add unit tests for expiry rejection, unsubscribe behavior, and non-expired passthrough

Test plan

- [x] Run `yarn test`
- [ ] Manual: create an NWC connection with a short expiry, wait until expired, confirm get_info / make_invoice / sign_message return RESTRICTED
- [ ] Manual: confirm non-expired connections still work normally
- [ ] Manual: confirm pay_invoice on expired connection still returns RESTRICTED (not INSUFFICIENT_BALANCE)



This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
