### PR TITLE
fix: enforce DNSSEC validation on BIP 353 BOLT 12 address resolution

### DIFF
--- a/utils/handleAnything.test.ts
+++ b/utils/handleAnything.test.ts
@@ -904,6 +904,156 @@ describe('handleAnything', () => {
         });
     });
 
+    describe('BIP 353 BOLT 12 address resolution', () => {
+        // The worked example from BIP 353 (matt@mattcorallo.com): a decoy
+        // TXT record that must be ignored, plus the real record split
+        // across two character-strings that must be concatenated in RDATA
+        // order.
+        const DECOY_TXT =
+            '"as long as it doesn\'t start with bitcoin:, other records should be ignored"';
+        const B12_PART1 =
+            'bitcoin:bc1qztwy6xen3zdtt7z0vrgapmjtfz8acjkfp5fp7l?lno=lno1zr5qyugqgskrk70kqmuq7v3dnr2fnmhukps9n8hut48vkqpqnskt2svsqwjakp7k6pyhtkuxw7y2kqmsxlwruhzqv0zsnhh9q3t9xhx39suc6qsr07ekm5esdyum0w66mnx8vdquwvp7dp5jp7j3v5cp6aj0w329fnkqqv60q96sz5nkrc5r95qffx002q53tqdk';
+        const B12_PART2 =
+            '8x9m2tmt85jtpmcycvfnrpx3lr45h2g7na3sec7xguctfzzcm8jjqtj5ya27te60j03vpt0vq9tm2n9yxl2hngfnmygesa25s4u4zlxewqpvp94xt7rur4rhxunwkthk9vly3lm5hh0pqv4aymcqejlgssnlpzwlggykkajp7yjs5jvr2agkyypcdlj280cy46jpynsezrcj2kwa2lyr8xvd6lfkph4xrxtk2xc3lpq';
+        const REAL_TXT = `"${B12_PART1}" "${B12_PART2}"`;
+        const RECONSTRUCTED_URI = B12_PART1 + B12_PART2;
+        const ADDRESS = 'matt@mattcorallo.com';
+
+        const txt = (data: string) => ({
+            name: 'matt.user._bitcoin-payment.mattcorallo.com',
+            type: 16,
+            TTL: 3600,
+            data
+        });
+
+        const originalFetch = global.fetch;
+        let mockDnsFetch: jest.Mock;
+
+        const mockDoHResponse = (json: any) => {
+            mockDnsFetch = jest.fn().mockResolvedValue({
+                json: async () => json
+            });
+            global.fetch = mockDnsFetch as any;
+        };
+
+        const bitcoinUriCalls = () =>
+            mockProcessBIP21Uri.mock.calls.filter((call: any[]) =>
+                String(call[0]).toLowerCase().startsWith('bitcoin:')
+            );
+
+        beforeEach(() => {
+            mockIsValidLightningAddress = true;
+            mockProcessBIP21Uri.mockImplementation((input: string) => {
+                if (input === RECONSTRUCTED_URI) {
+                    return {
+                        value: 'bc1qztwy6xen3zdtt7z0vrgapmjtfz8acjkfp5fp7l',
+                        offer: 'lno1zr5qyugqgskrk70kqmuq'
+                    };
+                }
+                return { value: input };
+            });
+            // LNURL fallback succeeds so non-BOLT 12 outcomes are observable
+            mockBlobUtilFetch.mockResolvedValue({
+                info: () => ({ status: 200 }),
+                json: () => ({ callback: 'https://example.com/callback' })
+            });
+        });
+
+        afterEach(() => {
+            global.fetch = originalFetch;
+        });
+
+        it('accepts a DNSSEC-validated answer, ignoring the non-bitcoin: decoy record', async () => {
+            mockDoHResponse({
+                Status: 0,
+                AD: true,
+                Answer: [txt(DECOY_TXT), txt(REAL_TXT)]
+            });
+            // no LNURL endpoint on the domain
+            mockBlobUtilFetch.mockRejectedValue(new Error('404'));
+
+            const result = await handleAnything(ADDRESS);
+
+            expect(mockProcessBIP21Uri).toHaveBeenCalledWith(RECONSTRUCTED_URI);
+            expect(result[0]).toBe('ChoosePaymentMethod');
+            expect(result[1].offer).toBe('lno1zr5qyugqgskrk70kqmuq');
+        });
+
+        it('rejects an answer without the AD (DNSSEC-validated) bit', async () => {
+            mockDoHResponse({
+                Status: 0,
+                AD: false,
+                Answer: [txt(REAL_TXT)]
+            });
+
+            const result = await handleAnything(ADDRESS);
+
+            expect(bitcoinUriCalls()).toHaveLength(0);
+            expect(result[0]).toBe('LnurlPay');
+        });
+
+        it('rejects a non-NOERROR response status', async () => {
+            mockDoHResponse({
+                Status: 2,
+                AD: true,
+                Answer: [txt(REAL_TXT)]
+            });
+
+            const result = await handleAnything(ADDRESS);
+
+            expect(bitcoinUriCalls()).toHaveLength(0);
+            expect(result[0]).toBe('LnurlPay');
+        });
+
+        it('rejects multiple bitcoin: TXT records', async () => {
+            mockDoHResponse({
+                Status: 0,
+                AD: true,
+                Answer: [txt(REAL_TXT), txt(REAL_TXT)]
+            });
+
+            const result = await handleAnything(ADDRESS);
+
+            expect(bitcoinUriCalls()).toHaveLength(0);
+            expect(result[0]).toBe('LnurlPay');
+        });
+
+        it('rejects when only non-bitcoin: TXT records exist', async () => {
+            mockDoHResponse({
+                Status: 0,
+                AD: true,
+                Answer: [txt(DECOY_TXT)]
+            });
+
+            const result = await handleAnything(ADDRESS);
+
+            expect(bitcoinUriCalls()).toHaveLength(0);
+            expect(result[0]).toBe('LnurlPay');
+        });
+
+        it('ignores non-TXT records even if their data looks like a bitcoin: URI', async () => {
+            mockDoHResponse({
+                Status: 0,
+                AD: true,
+                Answer: [{ ...txt(REAL_TXT), type: 5 }]
+            });
+
+            const result = await handleAnything(ADDRESS);
+
+            expect(bitcoinUriCalls()).toHaveLength(0);
+            expect(result[0]).toBe('LnurlPay');
+        });
+
+        it('rejects an empty or missing Answer section', async () => {
+            mockDoHResponse({ Status: 0, AD: true });
+
+            const result = await handleAnything(ADDRESS);
+
+            expect(bitcoinUriCalls()).toHaveLength(0);
+            expect(result[0]).toBe('LnurlPay');
+        });
+    });
+
     describe('node configuration handling', () => {
         it('should handle lndhub:// URLs', async () => {
             const lndhubUrl =

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -545,8 +545,23 @@ const handleAnything = async (
                 }
             });
             const json = await res.json();
-            if (json.Answer && json.Answer[0]) {
-                bolt12 = json.Answer[0].data;
+
+            // BIP 353 requires the payment instructions to be secured by
+            // DNSSEC. Cloudflare performs the validation and reports the
+            // outcome via the AD (Authenticated Data) bit; Status 0 is
+            // NOERROR. If the answer is not proven-signed we MUST ignore it,
+            // otherwise a forged, poisoned, or hijacked DNS response could
+            // silently redirect the payment to an attacker's offer.
+            const dnssecValidated = json?.Status === 0 && json?.AD === true;
+
+            // BIP 353 mandates exactly one TXT (type 16) record. Reject
+            // zero, multiples, or non-TXT answers (e.g. a spoofed CNAME).
+            const txtAnswers = Array.isArray(json?.Answer)
+                ? json.Answer.filter((a: any) => a?.type === 16)
+                : [];
+
+            if (dnssecValidated && txtAnswers.length === 1) {
+                bolt12 = txtAnswers[0].data;
                 bolt12 = bolt12!.replace(/("|\\|\s+)/g, '');
                 bolt12 = bolt12!.replace(/bitcoin:b12=/, '');
 

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -549,21 +549,31 @@ const handleAnything = async (
             // BIP 353 requires the payment instructions to be secured by
             // DNSSEC. Cloudflare performs the validation and reports the
             // outcome via the AD (Authenticated Data) bit; Status 0 is
-            // NOERROR. If the answer is not proven-signed we MUST ignore it,
+            // NOERROR. If the answer is not proven-signed we ignore it,
             // otherwise a forged, poisoned, or hijacked DNS response could
             // silently redirect the payment to an attacker's offer.
+            // TODO: BIP 353 also states clients MUST NOT trust a remote
+            // resolver to validate DNSSEC on their behalf. Full conformance
+            // requires validating the DNSSEC proof chain client-side.
             const dnssecValidated = json?.Status === 0 && json?.AD === true;
 
-            // BIP 353 mandates exactly one TXT (type 16) record. Reject
-            // zero, multiples, or non-TXT answers (e.g. a spoofed CNAME).
-            const txtAnswers = Array.isArray(json?.Answer)
-                ? json.Answer.filter((a: any) => a?.type === 16)
-                : [];
+            // Concatenate each TXT record's character-strings in RDATA order,
+            // never across records. BIP 353 requires TXT records at the label
+            // which don't begin with 'bitcoin:' to be ignored, and treats
+            // multiple 'bitcoin:' records as invalid.
+            const bitcoinTxts: string[] = (
+                Array.isArray(json?.Answer) ? json.Answer : []
+            )
+                .filter(
+                    (a: any) => a?.type === 16 && typeof a?.data === 'string'
+                )
+                .map((a: any) => a.data.replace(/("|\\|\s+)/g, ''))
+                .filter((data: string) =>
+                    data.toLowerCase().startsWith('bitcoin:')
+                );
 
-            if (dnssecValidated && txtAnswers.length === 1) {
-                bolt12 = txtAnswers[0].data;
-                bolt12 = bolt12!.replace(/("|\\|\s+)/g, '');
-                bolt12 = bolt12!.replace(/bitcoin:b12=/, '');
+            if (dnssecValidated && bitcoinTxts.length === 1) {
+                bolt12 = bitcoinTxts[0].replace(/^bitcoin:b12=/i, '');
 
                 const {
                     value: _v,


### PR DESCRIPTION
# Description

The BIP 353 BOLT 12 lookup in `utils/handleAnything.ts` (the "try BOLT 12 address first" path for `user@domain` addresses) queried Cloudflare DoH for the `_bitcoin-payment` TXT record and consumed the first answer unconditionally:

```ts
if (json.Answer && json.Answer[0]) {
    bolt12 = json.Answer[0].data;
    ...
}
```

Two problems:

1. **No DNSSEC validation.** The response was used without checking that the record was DNSSEC-signed. BIP 353 requires payment instructions to be secured by DNSSEC and states that unsigned records MUST be ignored. Cloudflare validates DNSSEC and reports the outcome in the `AD` (Authenticated Data) bit, which we were not reading.
2. **Blind answer selection.** `Answer[0]` was taken with no record-type filter and no application of BIP 353's resolution rules, so a spoofed CNAME, a decoy TXT record, or extra answers in the section could feed garbage into `processBIP21Uri`. This also broke the spec's own worked example (`matt@mattcorallo.com`), which pairs the real record with a decoy: `Answer[0]` is the decoy, which happens to contain `bitcoin:` mid-sentence, so it slipped past `processBIP21Uri`'s `.includes('bitcoin:')` and parsed no `lno`.

Because the whole block is wrapped in an empty `catch` and flows straight into the LNURL path, a failed or absent signature was silently indistinguishable from "this domain has no BIP 353 record." A forged, cache-poisoned, or DNS-hijacked TXT answer for a recipient whose zone is unsigned could substitute an attacker's BOLT 12 offer and redirect the payment.

## Fix

- Gate acceptance on `json.Status === 0 && json.AD === true` (NOERROR + DNSSEC-authenticated). Anything not proven-signed is ignored, matching BIP 353.
- Select the payment instruction per BIP 353's resolution rules: filter `Answer` to TXT records (`type === 16`), concatenate each record's character-strings in RDATA order, ignore records that don't begin (case-insensitively) with `bitcoin:`, and require exactly one `bitcoin:` record, treating multiples as invalid. This accepts the spec's worked example (real record + decoy) while rejecting spoofed non-TXT answers and injected extra `bitcoin:` records.

Transport to Cloudflare is already HTTPS, so this closes the unsigned-zone / DNS-hijack redirection vector that DNSSEC is meant to defend against. Note that the `AD` bit still trusts Cloudflare's validation; BIP 353 ultimately wants clients to validate the DNSSEC proof chain themselves, which is a larger follow-up and is marked as a `TODO` in the code.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

`utils/handleAnything.test.ts` now mocks the DoH response and covers: the AD/Status gate (unsigned or non-NOERROR replies fall through to LNURL), the BIP 353 worked example (non-`bitcoin:` decoy ignored, character-strings concatenated in RDATA order), multiple `bitcoin:` records rejected, non-TXT answers ignored even when their data looks like a `bitcoin:` URI, and empty/missing Answer sections.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
