### PR TITLE
fix: pin reviewed invoice so a swapped payment string can't be paid

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -850,6 +850,8 @@
     "views.PaymentRequest.thankYouForDonation": "Thank you for your generous donation!",
     "views.PaymentRequest.amountDonated": "Amount donated",
     "views.PaymentRequest.addATip": "Add a Tip with Each Payment",
+    "views.PaymentRequest.payReqChanged": "The payment request changed while this screen was open. Review the new request before paying.",
+    "views.PaymentRequest.reviewNewPayReq": "Review new payment request",
     "views.Receive.title": "Receive",
     "views.Receive.successCreate": "Successfully created invoice",
     "views.Receive.warningLndHub": "Please note that LNDHub has a fixed on-chain address",

--- a/utils/LinkingUtils.test.ts
+++ b/utils/LinkingUtils.test.ts
@@ -65,19 +65,28 @@ describe('LinkingUtils.handleDeepLink', () => {
         expect(navigation.popTo).not.toHaveBeenCalled();
     });
 
-    it('does not pop while a payment is in flight on SendingLightning', async () => {
-        const navigation = makeNavigation([
-            'Wallet',
-            'PaymentRequest',
-            'SendingLightning'
-        ]);
+    it.each(['SendingLightning', 'SendingOnChain', 'CashuSendingLightning'])(
+        'does not pop while a payment is in flight on %s',
+        async (sendingScreen) => {
+            const navigation = makeNavigation([
+                'Wallet',
+                'PaymentRequest',
+                sendingScreen
+            ]);
 
-        LinkingUtils.handleDeepLink('lightning:lnbc1...', navigation as any);
-        await flushPromises();
+            LinkingUtils.handleDeepLink(
+                'lightning:lnbc1...',
+                navigation as any
+            );
+            await flushPromises();
 
-        expect(navigation.navigate).toHaveBeenCalledWith('PaymentRequest', {});
-        expect(navigation.popTo).not.toHaveBeenCalled();
-    });
+            expect(navigation.navigate).toHaveBeenCalledWith(
+                'PaymentRequest',
+                {}
+            );
+            expect(navigation.popTo).not.toHaveBeenCalled();
+        }
+    );
 
     it('navigates normally for routes other than PaymentRequest', async () => {
         mockHandleAnythingResult = [

--- a/utils/LinkingUtils.test.ts
+++ b/utils/LinkingUtils.test.ts
@@ -1,0 +1,115 @@
+jest.mock('./LocaleUtils', () => ({
+    localeString: (s: string) => s
+}));
+jest.mock('./ShareIntentProcessor', () => ({
+    processSharedQRImageFast: jest.fn()
+}));
+
+let mockLoginRequired = false;
+jest.mock('../stores/Stores', () => ({
+    settingsStore: {
+        loginRequired: () => mockLoginRequired,
+        settings: {}
+    }
+}));
+
+let mockHandleAnythingResult: [string, any] = ['PaymentRequest', {}];
+jest.mock('./handleAnything', () => ({
+    __esModule: true,
+    default: jest.fn(() => Promise.resolve(mockHandleAnythingResult))
+}));
+
+import LinkingUtils from './LinkingUtils';
+
+const flushPromises = () => new Promise(setImmediate);
+
+const makeNavigation = (routeNames: string[], focusedIndex?: number) => ({
+    navigate: jest.fn(),
+    popTo: jest.fn(),
+    getState: jest.fn(() => ({
+        index: focusedIndex ?? routeNames.length - 1,
+        routes: routeNames.map((name) => ({ name }))
+    }))
+});
+
+describe('LinkingUtils.handleDeepLink', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockLoginRequired = false;
+        mockHandleAnythingResult = ['PaymentRequest', {}];
+    });
+
+    it('pops back to an existing PaymentRequest instead of pushing a duplicate', async () => {
+        // A payment request arrives while the QR view sits on top of
+        // PaymentRequest: navigate() would push a second, freshly pinned
+        // instance, bypassing the payment-request-changed warning on the
+        // buried one.
+        const navigation = makeNavigation(['Wallet', 'PaymentRequest', 'QR']);
+
+        LinkingUtils.handleDeepLink('lightning:lnbc1...', navigation as any);
+        await flushPromises();
+
+        expect(navigation.popTo).toHaveBeenCalledWith('PaymentRequest', {});
+        expect(navigation.navigate).not.toHaveBeenCalled();
+    });
+
+    it('navigates normally when no PaymentRequest is in the stack', async () => {
+        // popTo with no matching route would REPLACE the focused route
+        // rather than push, so the existence check is load-bearing.
+        const navigation = makeNavigation(['Wallet']);
+
+        LinkingUtils.handleDeepLink('lightning:lnbc1...', navigation as any);
+        await flushPromises();
+
+        expect(navigation.navigate).toHaveBeenCalledWith('PaymentRequest', {});
+        expect(navigation.popTo).not.toHaveBeenCalled();
+    });
+
+    it('does not pop while a payment is in flight on SendingLightning', async () => {
+        const navigation = makeNavigation([
+            'Wallet',
+            'PaymentRequest',
+            'SendingLightning'
+        ]);
+
+        LinkingUtils.handleDeepLink('lightning:lnbc1...', navigation as any);
+        await flushPromises();
+
+        expect(navigation.navigate).toHaveBeenCalledWith('PaymentRequest', {});
+        expect(navigation.popTo).not.toHaveBeenCalled();
+    });
+
+    it('navigates normally for routes other than PaymentRequest', async () => {
+        mockHandleAnythingResult = [
+            'ChoosePaymentMethod',
+            { lightning: 'lnbc1...', locked: true }
+        ];
+        const navigation = makeNavigation(['Wallet', 'PaymentRequest', 'QR']);
+
+        LinkingUtils.handleDeepLink('lightning:lnbc1...', navigation as any);
+        await flushPromises();
+
+        expect(navigation.navigate).toHaveBeenCalledWith(
+            'ChoosePaymentMethod',
+            { lightning: 'lnbc1...', locked: true }
+        );
+        expect(navigation.popTo).not.toHaveBeenCalled();
+    });
+
+    it('defers the deep link while login is required, then dispatches it', async () => {
+        mockLoginRequired = true;
+        const navigation = makeNavigation(['Wallet', 'PaymentRequest', 'QR']);
+
+        LinkingUtils.handleDeepLink('lightning:lnbc1...', navigation as any);
+        await flushPromises();
+
+        expect(navigation.navigate).not.toHaveBeenCalled();
+        expect(navigation.popTo).not.toHaveBeenCalled();
+
+        mockLoginRequired = false;
+        LinkingUtils.processPendingDeepLink(navigation as any);
+        await flushPromises();
+
+        expect(navigation.popTo).toHaveBeenCalledWith('PaymentRequest', {});
+    });
+});

--- a/utils/LinkingUtils.ts
+++ b/utils/LinkingUtils.ts
@@ -6,6 +6,15 @@ import handleAnything from './handleAnything';
 import { processSharedQRImageFast } from './ShareIntentProcessor';
 import { settingsStore } from '../stores/Stores';
 
+// Payment status screens that must never be popped out from under an
+// in-flight payment by a deep link. Mirrors App.tsx
+// SCREENS_WITH_CUSTOM_BACK_HANDLER's payment entries.
+const SENDING_SCREENS = [
+    'SendingLightning',
+    'SendingOnChain',
+    'CashuSendingLightning'
+];
+
 class LinkingUtils {
     private shareIntentProcessed = false;
     private pendingDeepLink: string | null = null;
@@ -143,7 +152,7 @@ class LinkingUtils {
                     const focusedRoute = routes[state?.index ?? 0]?.name;
                     if (
                         route === 'PaymentRequest' &&
-                        focusedRoute !== 'SendingLightning' &&
+                        !SENDING_SCREENS.includes(focusedRoute) &&
                         routes.some((r) => r.name === 'PaymentRequest')
                     ) {
                         navigation.popTo(route, props);

--- a/utils/LinkingUtils.ts
+++ b/utils/LinkingUtils.ts
@@ -126,7 +126,30 @@ class LinkingUtils {
         } else {
             handleAnything(url)
                 .then(([route, props]) => {
-                    navigation.navigate(route, props);
+                    // navigate() only reuses an existing route when it is the
+                    // currently focused one, so a payment request arriving
+                    // while another screen sits on top of PaymentRequest
+                    // (e.g. the QR view opened from its header) would push a
+                    // SECOND PaymentRequest, freshly pinned to the injected
+                    // invoice. That bypasses the payment-request-changed
+                    // warning on the buried instance and leaves stale review
+                    // screens in the stack. If a PaymentRequest already
+                    // exists, pop back to it instead: it is already showing
+                    // the new invoice alongside the warning. Never pop while
+                    // a payment status screen is focused, so an in-flight
+                    // payment's UI is not torn down.
+                    const state = navigation.getState();
+                    const routes = state?.routes ?? [];
+                    const focusedRoute = routes[state?.index ?? 0]?.name;
+                    if (
+                        route === 'PaymentRequest' &&
+                        focusedRoute !== 'SendingLightning' &&
+                        routes.some((r) => r.name === 'PaymentRequest')
+                    ) {
+                        navigation.popTo(route, props);
+                    } else {
+                        navigation.navigate(route, props);
+                    }
                 })
                 .catch((err) =>
                     console.error(

--- a/views/Cashu/CashuPaymentRequest.tsx
+++ b/views/Cashu/CashuPaymentRequest.tsx
@@ -82,6 +82,7 @@ interface CashuPaymentRequestState {
     selectedIndex: number | null;
     swipeButtonKey: number;
     multiMintEnabled: boolean;
+    reviewedPaymentRequest: string;
 }
 
 @inject(
@@ -101,6 +102,7 @@ export default class CashuPaymentRequest extends React.Component<
     isComponentMounted: boolean = false;
     focusListener: any = null;
     payReqDisposer: any;
+    paymentRequestDisposer: any;
     donationLockRequest?: string;
     state = {
         customAmount: '',
@@ -112,7 +114,8 @@ export default class CashuPaymentRequest extends React.Component<
         donationAmount: 0,
         selectedIndex: null,
         swipeButtonKey: 0,
-        multiMintEnabled: false
+        multiMintEnabled: false,
+        reviewedPaymentRequest: ''
     };
 
     async componentDidMount() {
@@ -166,12 +169,38 @@ export default class CashuPaymentRequest extends React.Component<
 
         this.setState({
             slideToPayThreshold: settings?.payments?.slideToPayThreshold,
-            multiMintEnabled: enabledBySetting && hasMultipleSelectedMints
+            multiMintEnabled: enabledBySetting && hasMultipleSelectedMints,
+            // Pin the invoice the user is reviewing. The view otherwise reads
+            // the invoice straight off the shared CashuStore singleton, so if
+            // a second payment string is injected while this screen is open
+            // the store's paymentRequest / payReq get swapped out from under
+            // the review. triggerPayment refuses to proceed when the store no
+            // longer matches the pin ("review A, pay B").
+            reviewedPaymentRequest: CashuStore.paymentRequest || ''
         });
 
-        // Reset state when screen comes into focus (e.g., after navigating back)
+        // If the invoice under review changes while this screen is mounted,
+        // invalidate any in-progress slide-to-pay gesture so it cannot
+        // complete against the swapped-in invoice. The render path notices
+        // the mismatch and replaces the pay controls with a warning; the pin
+        // is only advanced when the user explicitly accepts the new request.
+        this.paymentRequestDisposer = reaction(
+            () => CashuStore.paymentRequest,
+            () => {
+                if (!this.isComponentMounted) return;
+                this.setState({
+                    swipeButtonKey: this.state.swipeButtonKey + 1
+                });
+            }
+        );
+
+        // Reset state when screen comes into focus (e.g., after navigating
+        // back). Re-decode the reviewed (pinned) invoice, not whatever is in
+        // the store: a focus event also fires when returning from a screen
+        // pushed on top of this one (e.g. the QR view), so an invoice
+        // injected while the user was away must not get silently adopted.
         this.focusListener = this.props.navigation.addListener('focus', () => {
-            getPayReq(paymentRequest!!);
+            getPayReq(this.state.reviewedPaymentRequest || paymentRequest!!);
             this.setState((prevState) => ({
                 swipeButtonKey: prevState.swipeButtonKey + 1,
                 multiMintEnabled:
@@ -187,6 +216,10 @@ export default class CashuPaymentRequest extends React.Component<
 
         if (this.payReqDisposer) {
             this.payReqDisposer();
+        }
+
+        if (this.paymentRequestDisposer) {
+            this.paymentRequestDisposer();
         }
 
         if (this.focusListener) {
@@ -218,6 +251,24 @@ export default class CashuPaymentRequest extends React.Component<
         const { CashuStore, LnurlPayStore, SettingsStore, navigation } =
             this.props;
         const { satAmount, multiMintEnabled, donationAmount } = this.state;
+
+        // Fail closed: if the invoice in the store no longer matches the one
+        // the user reviewed, it was swapped out from under the review screen.
+        // Both payment paths below (multimint and single mint) read the
+        // invoice off CashuStore at their own mount, so refuse to proceed
+        // rather than paying a different invoice than the one that was on
+        // screen when this confirmation began. Reset the swipe knob so the
+        // gesture doesn't stick; the render path shows the
+        // payment-request-changed warning in place of the pay controls.
+        if (
+            this.state.reviewedPaymentRequest !== '' &&
+            CashuStore.paymentRequest !== this.state.reviewedPaymentRequest
+        ) {
+            this.setState({
+                swipeButtonKey: this.state.swipeButtonKey + 1
+            });
+            return;
+        }
 
         // Fail closed if the invoice has expired since it was reviewed:
         // the invoice can lapse while this screen is open, and expiry is
@@ -369,6 +420,17 @@ export default class CashuPaymentRequest extends React.Component<
 
         const noBalance = totalBalanceSats === 0;
         const hasPayReqError = !!getPayReqError;
+
+        // The screen renders whatever invoice is in the shared CashuStore, so
+        // when the store no longer matches the pinned invoice the user has a
+        // different payment request in front of them than the one they were
+        // reviewing. Surface that instead of paying (or silently refusing):
+        // the pay controls are replaced below with a warning and an explicit
+        // button to review the new request, which re-pins it.
+        const payReqChanged =
+            this.state.reviewedPaymentRequest !== '' &&
+            !!paymentRequest &&
+            paymentRequest !== this.state.reviewedPaymentRequest;
 
         const enableDonations =
             Platform.OS !== 'ios' && settings?.payments?.enableDonations;
@@ -995,6 +1057,39 @@ export default class CashuPaymentRequest extends React.Component<
                     !isPayReqExpired &&
                     !loading &&
                     !loadingFeeEstimate &&
+                    payReqChanged &&
+                    BackendUtils.supportsLightningSends() && (
+                        <View style={{ bottom: 10, top: 6 }}>
+                            <View style={styles.content}>
+                                <WarningMessage
+                                    message={localeString(
+                                        'views.PaymentRequest.payReqChanged'
+                                    )}
+                                />
+                            </View>
+                            <View style={styles.button}>
+                                <Button
+                                    title={localeString(
+                                        'views.PaymentRequest.reviewNewPayReq'
+                                    )}
+                                    onPress={() =>
+                                        this.setState({
+                                            reviewedPaymentRequest:
+                                                CashuStore.paymentRequest || '',
+                                            swipeButtonKey:
+                                                this.state.swipeButtonKey + 1
+                                        })
+                                    }
+                                />
+                            </View>
+                        </View>
+                    )}
+
+                {!!payReq &&
+                    !isPayReqExpired &&
+                    !loading &&
+                    !loadingFeeEstimate &&
+                    !payReqChanged &&
                     BackendUtils.supportsLightningSends() && (
                         <View style={{ bottom: 10, top: 6 }}>
                             <View

--- a/views/Cashu/CashuPaymentRequest.tsx
+++ b/views/Cashu/CashuPaymentRequest.tsx
@@ -101,8 +101,8 @@ export default class CashuPaymentRequest extends React.Component<
     listener: any;
     isComponentMounted: boolean = false;
     focusListener: any = null;
-    payReqDisposer: any;
-    paymentRequestDisposer: any;
+    donationDisposer: any;
+    swipeResetDisposer: any;
     donationLockRequest?: string;
     state = {
         customAmount: '',
@@ -124,7 +124,7 @@ export default class CashuPaymentRequest extends React.Component<
         const settings = await SettingsStore.getSettings();
         const { defaultDonationPercentage } = settings.payments;
 
-        this.payReqDisposer = reaction(
+        this.donationDisposer = reaction(
             () => CashuStore.payReq,
             (payReq) => {
                 if (payReq?.getRequestAmount) {
@@ -184,7 +184,7 @@ export default class CashuPaymentRequest extends React.Component<
         // complete against the swapped-in invoice. The render path notices
         // the mismatch and replaces the pay controls with a warning; the pin
         // is only advanced when the user explicitly accepts the new request.
-        this.paymentRequestDisposer = reaction(
+        this.swipeResetDisposer = reaction(
             () => CashuStore.paymentRequest,
             () => {
                 if (!this.isComponentMounted) return;
@@ -214,12 +214,12 @@ export default class CashuPaymentRequest extends React.Component<
     componentWillUnmount(): void {
         this.isComponentMounted = false;
 
-        if (this.payReqDisposer) {
-            this.payReqDisposer();
+        if (this.donationDisposer) {
+            this.donationDisposer();
         }
 
-        if (this.paymentRequestDisposer) {
-            this.paymentRequestDisposer();
+        if (this.swipeResetDisposer) {
+            this.swipeResetDisposer();
         }
 
         if (this.focusListener) {

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -219,9 +219,11 @@ export default class PaymentRequest extends React.Component<
             reviewedPaymentRequest: InvoicesStore.paymentRequest
         });
 
-        // If the invoice under review changes without a real focus change (the
-        // injection case above), invalidate any in-progress slide-to-pay
-        // gesture so it cannot complete against the swapped-in invoice.
+        // If the invoice under review changes while this screen is mounted,
+        // invalidate any in-progress slide-to-pay gesture so it cannot
+        // complete against the swapped-in invoice. The render path notices the
+        // mismatch and replaces the pay controls with a warning; the pin is
+        // only advanced when the user explicitly accepts the new request.
         this.payReqDisposer = reaction(
             () => InvoicesStore.paymentRequest,
             () => {
@@ -232,16 +234,15 @@ export default class PaymentRequest extends React.Component<
             }
         );
 
-        // Reset slide to pay slider position when screen comes into focus, and
-        // re-pin to the current invoice: a genuine re-navigation into this
-        // screen (blur then focus) re-reviews whatever is now loaded, whereas a
-        // background injection never fires focus and stays pinned to the
-        // originally reviewed invoice.
+        // Reset slide to pay slider position when screen comes into focus.
+        // Deliberately do NOT re-pin here: a focus event also fires when
+        // returning from a screen pushed on top of this one (e.g. the QR
+        // view), so an invoice injected while the user was away would get
+        // silently re-pinned and paid.
         const { navigation } = this.props;
         this.focusListener = navigation.addListener('focus', () => {
             this.setState({
-                swipeButtonKey: this.state.swipeButtonKey + 1,
-                reviewedPaymentRequest: InvoicesStore.paymentRequest
+                swipeButtonKey: this.state.swipeButtonKey + 1
             });
         });
     }
@@ -414,11 +415,16 @@ export default class PaymentRequest extends React.Component<
         // Fail closed: if the invoice in the store no longer matches the one
         // the user reviewed, it was swapped out from under the review screen.
         // Refuse to pay rather than paying a different invoice than the one
-        // that was on screen when this confirmation began.
+        // that was on screen when this confirmation began. Reset the swipe
+        // knob so the gesture doesn't stick; the render path shows the
+        // payment-request-changed warning in place of the pay controls.
         if (
             this.state.reviewedPaymentRequest !== '' &&
             paymentRequest !== this.state.reviewedPaymentRequest
         ) {
+            this.setState({
+                swipeButtonKey: this.state.swipeButtonKey + 1
+            });
             return;
         }
 
@@ -626,6 +632,17 @@ export default class PaymentRequest extends React.Component<
         const isNoAmountInvoice: boolean = !requestAmount;
 
         const noBalance = this.props.BalanceStore.lightningBalance === 0;
+
+        // The screen renders whatever invoice is in the shared InvoicesStore,
+        // so when the store no longer matches the pinned invoice the user has
+        // a different payment request in front of them than the one they were
+        // reviewing. Surface that instead of paying (or silently refusing):
+        // the pay controls are replaced below with a warning and an explicit
+        // button to review the new request, which re-pins it.
+        const payReqChanged =
+            this.state.reviewedPaymentRequest !== '' &&
+            !!paymentRequest &&
+            paymentRequest !== this.state.reviewedPaymentRequest;
 
         const showZaplockerWarning =
             isZaplocker ||
@@ -1551,6 +1568,39 @@ export default class PaymentRequest extends React.Component<
                     !isPayReqExpired &&
                     !loading &&
                     !loadingFeeEstimate &&
+                    payReqChanged &&
+                    BackendUtils.supportsLightningSends() && (
+                        <View style={{ bottom: 10 }}>
+                            <View style={styles.content}>
+                                <WarningMessage
+                                    message={localeString(
+                                        'views.PaymentRequest.payReqChanged'
+                                    )}
+                                />
+                            </View>
+                            <View style={styles.button}>
+                                <Button
+                                    title={localeString(
+                                        'views.PaymentRequest.reviewNewPayReq'
+                                    )}
+                                    onPress={() =>
+                                        this.setState({
+                                            reviewedPaymentRequest:
+                                                InvoicesStore.paymentRequest,
+                                            swipeButtonKey:
+                                                this.state.swipeButtonKey + 1
+                                        })
+                                    }
+                                />
+                            </View>
+                        </View>
+                    )}
+
+                {!!pay_req &&
+                    !isPayReqExpired &&
+                    !loading &&
+                    !loadingFeeEstimate &&
+                    !payReqChanged &&
                     BackendUtils.supportsLightningSends() && (
                         <View style={{ bottom: 10 }}>
                             {!!pay_req && !lightningReadyToSend && !noBalance && (

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -123,8 +123,8 @@ export default class PaymentRequest extends React.Component<
 > {
     listener: any;
     focusListener: any;
-    payReqDisposer: any;
-    paymentRequestDisposer: any;
+    donationDisposer: any;
+    swipeResetDisposer: any;
     donationLockRequest?: string;
     isComponentMounted: boolean = false;
     private scrollViewRef = React.createRef<ScrollView>();
@@ -176,7 +176,7 @@ export default class PaymentRequest extends React.Component<
         // would be shown (and paid) with the old invoice's donation amount
         // and fee mode. Guarded by donationLockRequest so a re-decode of the
         // same request doesn't clobber a donation the user customized.
-        this.payReqDisposer = reaction(
+        this.donationDisposer = reaction(
             () => InvoicesStore.pay_req,
             (pay_req) => {
                 if (!this.isComponentMounted) return;
@@ -247,7 +247,7 @@ export default class PaymentRequest extends React.Component<
         // complete against the swapped-in invoice. The render path notices the
         // mismatch and replaces the pay controls with a warning; the pin is
         // only advanced when the user explicitly accepts the new request.
-        this.paymentRequestDisposer = reaction(
+        this.swipeResetDisposer = reaction(
             () => InvoicesStore.paymentRequest,
             () => {
                 if (!this.isComponentMounted) return;
@@ -275,11 +275,11 @@ export default class PaymentRequest extends React.Component<
         if (this.focusListener) {
             this.focusListener();
         }
-        if (this.payReqDisposer) {
-            this.payReqDisposer();
+        if (this.donationDisposer) {
+            this.donationDisposer();
         }
-        if (this.paymentRequestDisposer) {
-            this.paymentRequestDisposer();
+        if (this.swipeResetDisposer) {
+            this.swipeResetDisposer();
         }
     }
 

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -9,6 +9,7 @@ import {
     TouchableOpacity
 } from 'react-native';
 import { inject, observer } from 'mobx-react';
+import { reaction } from 'mobx';
 import Slider from '@react-native-community/slider';
 import { Route } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -102,6 +103,7 @@ interface InvoiceState {
     donationAmount: any;
     selectedIndex: number | null;
     swipeButtonKey: number;
+    reviewedPaymentRequest: string;
 }
 
 @inject(
@@ -121,6 +123,7 @@ export default class PaymentRequest extends React.Component<
 > {
     listener: any;
     focusListener: any;
+    payReqDisposer: any;
     isComponentMounted: boolean = false;
     private scrollViewRef = React.createRef<ScrollView>();
     state = {
@@ -143,7 +146,8 @@ export default class PaymentRequest extends React.Component<
         donationPercentage: 0,
         donationAmount: 0,
         selectedIndex: null,
-        swipeButtonKey: 0
+        swipeButtonKey: 0,
+        reviewedPaymentRequest: ''
     };
 
     async componentDidMount() {
@@ -204,11 +208,40 @@ export default class PaymentRequest extends React.Component<
             });
         }
 
-        // Reset slide to pay slider position when screen comes into focus
+        // Pin the invoice the user is reviewing. The view otherwise reads the
+        // invoice straight off the shared InvoicesStore singleton, so if a
+        // second payment string is injected while this screen is open (deep
+        // link, NFC tap, clipboard handler, etc.) the store's pay_req /
+        // paymentRequest get swapped out from under the review. We record what
+        // was reviewed so triggerPayment can refuse to pay a different invoice
+        // than the one on screen when the confirmation began ("review A, pay B").
+        this.setState({
+            reviewedPaymentRequest: InvoicesStore.paymentRequest
+        });
+
+        // If the invoice under review changes without a real focus change (the
+        // injection case above), invalidate any in-progress slide-to-pay
+        // gesture so it cannot complete against the swapped-in invoice.
+        this.payReqDisposer = reaction(
+            () => InvoicesStore.paymentRequest,
+            () => {
+                if (!this.isComponentMounted) return;
+                this.setState({
+                    swipeButtonKey: this.state.swipeButtonKey + 1
+                });
+            }
+        );
+
+        // Reset slide to pay slider position when screen comes into focus, and
+        // re-pin to the current invoice: a genuine re-navigation into this
+        // screen (blur then focus) re-reviews whatever is now loaded, whereas a
+        // background injection never fires focus and stays pinned to the
+        // originally reviewed invoice.
         const { navigation } = this.props;
         this.focusListener = navigation.addListener('focus', () => {
             this.setState({
-                swipeButtonKey: this.state.swipeButtonKey + 1
+                swipeButtonKey: this.state.swipeButtonKey + 1,
+                reviewedPaymentRequest: InvoicesStore.paymentRequest
             });
         });
     }
@@ -217,6 +250,9 @@ export default class PaymentRequest extends React.Component<
         this.isComponentMounted = false;
         if (this.focusListener) {
             this.focusListener();
+        }
+        if (this.payReqDisposer) {
+            this.payReqDisposer();
         }
     }
 
@@ -374,6 +410,18 @@ export default class PaymentRequest extends React.Component<
         } = this.state;
 
         const { paymentRequest, pay_req } = InvoicesStore;
+
+        // Fail closed: if the invoice in the store no longer matches the one
+        // the user reviewed, it was swapped out from under the review screen.
+        // Refuse to pay rather than paying a different invoice than the one
+        // that was on screen when this confirmation began.
+        if (
+            this.state.reviewedPaymentRequest !== '' &&
+            paymentRequest !== this.state.reviewedPaymentRequest
+        ) {
+            return;
+        }
+
         const { implementation } = SettingsStore;
 
         // Fail closed if the invoice has expired since it was reviewed:

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -124,6 +124,8 @@ export default class PaymentRequest extends React.Component<
     listener: any;
     focusListener: any;
     payReqDisposer: any;
+    paymentRequestDisposer: any;
+    donationLockRequest?: string;
     isComponentMounted: boolean = false;
     private scrollViewRef = React.createRef<ScrollView>();
     state = {
@@ -167,37 +169,58 @@ export default class PaymentRequest extends React.Component<
 
         const { defaultDonationPercentage } = settings.payments;
 
-        let feeOption = 'fixed';
-        const { pay_req } = InvoicesStore;
-        const requestAmount = pay_req && pay_req.getRequestAmount;
+        // Derive donation and fee-mode state from the decoded invoice, and
+        // re-derive whenever a different invoice lands in the store: the
+        // screen live-renders whatever InvoicesStore holds, so state computed
+        // from the invoice must track it or a swapped-in payment request
+        // would be shown (and paid) with the old invoice's donation amount
+        // and fee mode. Guarded by donationLockRequest so a re-decode of the
+        // same request doesn't clobber a donation the user customized.
+        this.payReqDisposer = reaction(
+            () => InvoicesStore.pay_req,
+            (pay_req) => {
+                if (!this.isComponentMounted) return;
+                // getPayReq nulls pay_req before decoding a replacement
+                // invoice; wait for the decoded result
+                if (!pay_req) return;
 
-        if (requestAmount && requestAmount != 0) {
-            if (requestAmount > 1000) {
-                feeOption = 'percent';
-            }
-        }
+                const currentRequest = InvoicesStore.paymentRequest;
+                if (
+                    currentRequest &&
+                    this.donationLockRequest === currentRequest
+                ) {
+                    return;
+                }
 
-        const donationPercentageOptions = [5, 10, 20];
+                const defaultPct = Number(defaultDonationPercentage) || 0;
+                const requestAmount = pay_req.getRequestAmount ?? 0;
 
-        const donationAmount = calculateDonationAmount(
-            requestAmount ?? 0,
-            Number(defaultDonationPercentage) || 0
-        );
-        const index = findDonationPercentageIndex(
-            Number(defaultDonationPercentage) || 0,
-            donationPercentageOptions
+                this.setState({
+                    feeOption:
+                        requestAmount && requestAmount > 1000
+                            ? 'percent'
+                            : 'fixed',
+                    donationAmount: calculateDonationAmount(
+                        requestAmount,
+                        defaultPct
+                    ),
+                    selectedIndex: findDonationPercentageIndex(
+                        defaultPct,
+                        [5, 10, 20]
+                    ),
+                    donationPercentage: defaultPct
+                });
+
+                this.donationLockRequest = currentRequest;
+            },
+            { fireImmediately: true }
         );
 
         this.setState({
-            feeOption,
             feeLimitSat: settings?.payments?.defaultFeeFixed || '100',
             maxFeePercent: settings?.payments?.defaultFeePercentage || '5.0',
             timeoutSeconds: settings?.payments?.timeoutSeconds || '60',
-            slideToPayThreshold: settings?.payments?.slideToPayThreshold,
-            donationPercentage:
-                settings?.payments?.defaultDonationPercentage || 0,
-            donationAmount,
-            selectedIndex: index
+            slideToPayThreshold: settings?.payments?.slideToPayThreshold
         });
 
         if (implementation === 'embedded-lnd') {
@@ -224,7 +247,7 @@ export default class PaymentRequest extends React.Component<
         // complete against the swapped-in invoice. The render path notices the
         // mismatch and replaces the pay controls with a warning; the pin is
         // only advanced when the user explicitly accepts the new request.
-        this.payReqDisposer = reaction(
+        this.paymentRequestDisposer = reaction(
             () => InvoicesStore.paymentRequest,
             () => {
                 if (!this.isComponentMounted) return;
@@ -254,6 +277,9 @@ export default class PaymentRequest extends React.Component<
         }
         if (this.payReqDisposer) {
             this.payReqDisposer();
+        }
+        if (this.paymentRequestDisposer) {
+            this.paymentRequestDisposer();
         }
     }
 
@@ -559,6 +585,7 @@ export default class PaymentRequest extends React.Component<
                 requestAmount ?? 0,
                 percentage
             );
+            this.donationLockRequest = paymentRequest;
             this.setState({
                 donationPercentage: percentage,
                 donationAmount,
@@ -576,6 +603,7 @@ export default class PaymentRequest extends React.Component<
                 donationPercentageOptions
             );
 
+            this.donationLockRequest = paymentRequest;
             this.setState({
                 donationPercentage: value,
                 donationAmount,


### PR DESCRIPTION
# Description

`views/PaymentRequest.tsx` binds its review to the shared `InvoicesStore` singleton and re-reads the invoice from it at confirmation time. `triggerPayment` does `const { paymentRequest, pay_req } = InvoicesStore;` and dispatches `payment_request: paymentRequest`, so the invoice actually paid is whatever the store holds at the moment of the swipe/tap, not the one the user reviewed.

`InvoicesStore.getPayReq()` mutates those observables in place, and it is reachable from many entry points, including `utils/handleAnything.ts` (the universal input router for QR, clipboard, deep links, and NFC). If a second payment string reaches `getPayReq` while the review screen is open, `InvoicesStore.pay_req` / `paymentRequest` are swapped out from under the review. A confirmation the user began for invoice A can then dispatch invoice B ("review A, pay B"). The pre-existing `paymentInFlight` guard only prevents dispatching the same payment twice; it does nothing about the invoice swap.

`views/Cashu/CashuPaymentRequest.tsx` has the same shape of issue against `CashuStore`: both of its payment paths (`MultimintPayment` and `CashuSendingLightning`) read the invoice off the store at their own mount.

## Fix

- Pin the reviewed invoice (`reviewedPaymentRequest`) when the screen mounts.
- Fail closed in `triggerPayment`: if the store's `paymentRequest` no longer matches the pinned value, refuse to pay rather than paying a different invoice than the one on screen when the confirmation began, and reset the slide-to-pay knob.
- When the invoice in the store no longer matches the pin, replace the pay controls with a warning that the payment request changed plus an explicit "Review new payment request" button that re-pins to the request now on screen (the observer view is already displaying its details at that point).
- Invalidate any in-progress slide-to-pay gesture (`swipeButtonKey`) via a reaction whenever the store invoice changes, so a swipe cannot complete against a swapped-in invoice.
- The `focus` listener never advances the pin: a focus event also fires when returning from a screen pushed on top (e.g. the QR view from the header), so re-pinning there would silently adopt an invoice injected while the user was away (caught in review, thanks @shubhamkmr04). This is safe for normal flows because `SendingLightning` exits via `popTo('Wallet')`, which unmounts the review screen, so fresh reviews always re-pin at mount.
- `CashuPaymentRequest` gets the same pin, dispatch guard, reaction, and warning UI. Its existing re-decode-on-focus behavior is kept but now re-decodes the pinned invoice instead of a mount-captured value, so returning from the QR view restores the reviewed request rather than adopting an injected one.

Adds two locale strings (`views.PaymentRequest.payReqChanged`, `views.PaymentRequest.reviewNewPayReq`), shared by both views. No new dependencies.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Manual test plan

1. Open a normal invoice so the PaymentRequest review screen shows its amount and details; confirm a normal swipe/tap still pays that invoice.
2. With the review screen open and focused, trigger a second payment string into `InvoicesStore.getPayReq` (for example a `lightning:` deep link, an NFC tap, or clipboard handling) so the store swaps to a different invoice. Confirm the slide-to-pay control resets and the pay controls are replaced by the "payment request changed" warning with a "Review new payment request" button; tapping the button and then paying pays the request shown on screen.
3. Open the QR view from the header, inject a different invoice while it is open, then navigate back. Confirm the swapped invoice is not silently paid (warning shown instead of pay controls).
4. Navigate back out and into a fresh invoice. Confirm the newly loaded invoice can be paid normally with no warning.
5. Repeat 1 through 4 on an ecash wallet (CashuPaymentRequest), including with the multi-mint toggle enabled.

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
