### PR TITLE
fix: warn before sending node credentials over cleartext HTTP

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -364,6 +364,7 @@
     "views.Settings.WalletConfiguration.seedPhraseLength": "Seed phrase length",
     "views.Settings.WalletConfiguration.seedPhraseLength.12": "12 words",
     "views.Settings.WalletConfiguration.seedPhraseLength.24": "24 words",
+    "views.Settings.WalletConfiguration.cleartextHttpWarning": "This connection uses unencrypted HTTP. Your node credentials will be sent in cleartext and can be read or stolen by anyone on the network path. Only proceed if you trust the entire connection, such as a local or VPN-only link.",
     "views.Settings.WalletConfiguration.saveWallet": "Save Wallet Config",
     "views.Settings.WalletConfiguration.setWalletActive": "Set Wallet Config as Active",
     "views.Settings.WalletConfiguration.walletActive": "Wallet Active",

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -26,6 +26,7 @@ import ConnectionFormatUtils from '../../utils/ConnectionFormatUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import BackendUtils from '../../utils/BackendUtils';
 import { themeColor } from '../../utils/ThemeUtils';
+import UrlUtils from '../../utils/UrlUtils';
 import ValidationUtils from '../../utils/ValidationUtils';
 import { confirmAction } from '../../utils/ActionUtils';
 
@@ -528,7 +529,61 @@ export default class WalletConfiguration extends React.Component<
         }
     }
 
+    // Returns true when the active implementation would carry node
+    // credentials (macaroon/rune/token) over an explicit http:// scheme to
+    // a host that is neither loopback nor a Tor onion service. A bare host
+    // or an https:// scheme resolves to HTTPS in the backend getURL(), so
+    // only an explicit http:// is treated as insecure. Gated per
+    // implementation because state retains fields the active backend never
+    // transmits credentials over (e.g. a stale host on an lndhub config).
+    private hasInsecureCleartextTransport = (): boolean => {
+        const { implementation, host, lndhubUrl } = this.state;
+        switch (implementation) {
+            case 'lnd':
+            case 'cln-rest':
+                return UrlUtils.isCleartextHttpTransport(host);
+            case 'lndhub':
+                return UrlUtils.isCleartextHttpTransport(lndhubUrl);
+            default:
+                return false;
+        }
+    };
+
     saveWalletConfiguration = (
+        recoveryCipherSeed?: string,
+        newEmbeddedLndWallet?: boolean
+    ) => {
+        if (this.hasInsecureCleartextTransport()) {
+            confirmAction(
+                localeString('general.warning'),
+                localeString(
+                    'views.Settings.WalletConfiguration.cleartextHttpWarning'
+                ),
+                {
+                    text: localeString('general.proceed'),
+                    style: 'destructive',
+                    onPress: () =>
+                        this.performSaveWalletConfiguration(
+                            recoveryCipherSeed,
+                            newEmbeddedLndWallet
+                        )
+                },
+                {
+                    text: localeString('general.cancel'),
+                    onPress: () => void 0,
+                    isPreferred: true
+                }
+            );
+            return;
+        }
+
+        this.performSaveWalletConfiguration(
+            recoveryCipherSeed,
+            newEmbeddedLndWallet
+        );
+    };
+
+    private performSaveWalletConfiguration = (
         recoveryCipherSeed?: string,
         newEmbeddedLndWallet?: boolean
     ) => {
@@ -3267,7 +3322,12 @@ export default class WalletConfiguration extends React.Component<
                                                 implementation !==
                                                     'lightning-node-connect' &&
                                                 implementation !==
-                                                    'nostr-wallet-connect'
+                                                    'nostr-wallet-connect' &&
+                                                // The cert modal is about TLS
+                                                // trust; a cleartext http host
+                                                // has no cert, so skip straight
+                                                // to the cleartext warning.
+                                                !this.hasInsecureCleartextTransport()
                                             ) {
                                                 this.setState({
                                                     showCertModal: true


### PR DESCRIPTION
# Description

When a wallet is configured with a host that uses an explicit `http://` scheme, the REST backends transmit the node's bearer credential over an unencrypted connection with no warning:

- `getURL()` in `backends/LND.ts` and `backends/CLNRest.ts` honors the scheme verbatim (`host.includes('://') ? host : 'https://'+host`), so `http://host` stays cleartext. `LndHub` inherits this via `extends LND`.
- The credential rides in the request headers regardless of scheme: LND/LndHub send the macaroon in `Grpc-Metadata-macaroon`, CLNRest sends the rune, LndHub sends its token.
- The CLNRest import parser will even force cleartext for a shared connection string via `clnrest+http://...` or the legacy `clnrest://http://...` (`utils/ConnectionFormatUtils.ts`).

A macaroon/rune is a bearer credential granting node control, so anyone on the network path (LAN, Wi-Fi, ISP) can capture it and drain funds. Nothing in the connect flow warned the user.

## Fix

`saveWalletConfiguration` now checks whether the credential-bearing host is a cleartext `http://` endpoint that is **not** loopback and **not** a `.onion` service. If so, it requires an explicit confirmation (destructive-styled) before saving.

- Exemptions: loopback (`localhost`, `127.0.0.0/8`, `::1`) never leaves the device, and `.onion` is authenticated at the Tor layer, so neither exposes the credential.
- The existing TLS certificate-verification modal is skipped for cleartext hosts, since there is no certificate to trust; the user sees the single relevant cleartext warning instead of a confusing "install your certificate" prompt.
- Applies to the credential-bearing REST backends only (`lnd`, `cln-rest` via `host`; `lndhub` via `lndhubUrl`).

This is a warn-and-confirm, not a hard block, so legitimate LAN/VPN tunneling users can still proceed deliberately.

Note: this does not change the `certVerification` default (TLS verification off), which is a separate, deliberate design decision for self-signed LND certs. Happy to discuss that separately if desired.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Manual test plan (device tests pending)

Configuring an `lnd`/`cln-rest`/`lndhub` wallet with an `http://` clearnet host now prompts before save; bare-host (defaults https), `https://`, `.onion`, and `localhost`/`127.x`/`[::1]` hosts save without the prompt.

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
