### PR TITLE
fix: bind ZEUS Pay Cashu redeem to the configured mint

### DIFF
--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -7,7 +7,10 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 import java.net.HttpURLConnection
+import java.net.Inet4Address
+import java.net.InetAddress
 import java.net.URL
+import java.net.URLEncoder
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 
@@ -728,6 +731,59 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
     }
 
     /**
+     * Reject loopback, private (RFC1918), link-local and other internal hosts
+     * for server-supplied mint URLs. Matches on the literal host only (no DNS
+     * resolution) to avoid a rebinding/latency side channel; this is
+     * defense-in-depth on top of the JS-side configured-mint binding.
+     */
+    private fun isDisallowedMintHost(host: String?): Boolean {
+        if (host.isNullOrBlank()) return true
+        val h = host.trim().trimStart('[').trimEnd(']').lowercase()
+        if (h == "localhost" || h.endsWith(".localhost")) return true
+        // A host containing ':' can only be an IPv6 literal (hostnames
+        // cannot contain it), so parse it numerically instead of
+        // prefix-matching one spelling: mapped (::ffff:127.0.0.1),
+        // hex-mapped (::ffff:7f00:1) and zero-expanded (0:0:0:0:0:0:0:1)
+        // forms of the same internal address all normalize to the same
+        // bytes. This still involves no DNS - the brackets force
+        // InetAddress to treat the input as a literal or throw.
+        if (h.contains(':')) return isDisallowedIpv6Literal(h)
+        return isDisallowedIpv4(h)
+    }
+
+    // IPv4 ranges: 127/8, 10/8, 169.254/16, 172.16/12, 192.168/16, 0/8
+    private fun isDisallowedIpv4(h: String): Boolean {
+        return h.startsWith("127.") ||
+            h.startsWith("10.") ||
+            h.startsWith("169.254.") ||
+            h.startsWith("192.168.") ||
+            h.startsWith("0.") ||
+            Regex("^172\\.(1[6-9]|2[0-9]|3[0-1])\\.").containsMatchIn(h)
+    }
+
+    private fun isDisallowedIpv6Literal(literal: String): Boolean {
+        val addr = try {
+            InetAddress.getByName("[$literal]")
+        } catch (e: Exception) {
+            // Not parseable as an IPv6 literal and not a valid hostname
+            // either: fail closed
+            return true
+        }
+        // IPv4-mapped literals parse to an Inet4Address in any spelling;
+        // hold the embedded address to the same rules as a dotted host
+        if (addr is Inet4Address) {
+            return isDisallowedIpv4(addr.hostAddress ?: return true)
+        }
+        if (addr.isLoopbackAddress || addr.isLinkLocalAddress ||
+            addr.isSiteLocalAddress || addr.isAnyLocalAddress
+        ) {
+            return true
+        }
+        // fc00::/7 unique-local: no InetAddress predicate covers it
+        return (addr.address[0].toInt() and 0xfe) == 0xfc
+    }
+
+    /**
      * Check mint quote status directly from the mint's HTTP API.
      * This bypasses the local database check and works for external quotes
      * (e.g., quotes created by ZeusPay server).
@@ -738,7 +794,36 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
             try {
                 // Normalize mint URL and construct the quote endpoint
                 val normalizedUrl = mintUrl.trimEnd('/')
-                val quoteUrl = "$normalizedUrl/v1/mint/quote/bolt11/$quoteId"
+
+                // Security: this issues a raw HTTP GET against a mint URL that
+                // originates from a ZEUS Pay socket event. Refuse cleartext and
+                // internal/loopback/link-local targets so a forged event cannot
+                // downgrade the fetch or drive the device into an SSRF against
+                // the local network. quoteId is percent-encoded so it cannot
+                // alter the request path.
+                val parsed = try {
+                    URL(normalizedUrl)
+                } catch (e: Exception) {
+                    withContext(Dispatchers.Main) {
+                        promise.reject("INVALID_URL", "Invalid mint URL: $mintUrl")
+                    }
+                    return@launch
+                }
+                if (!parsed.protocol.equals("https", ignoreCase = true) ||
+                    isDisallowedMintHost(parsed.host)
+                ) {
+                    Log.e(TAG, "checkExternalMintQuote: refusing unsafe mint URL $mintUrl")
+                    withContext(Dispatchers.Main) {
+                        promise.reject(
+                            "UNSAFE_MINT_URL",
+                            "Refusing to contact non-HTTPS or internal mint host: $mintUrl"
+                        )
+                    }
+                    return@launch
+                }
+
+                val encodedQuoteId = URLEncoder.encode(quoteId, "UTF-8")
+                val quoteUrl = "$normalizedUrl/v1/mint/quote/bolt11/$encodedQuoteId"
 
                 Log.d(TAG, "checkExternalMintQuote: Fetching $quoteUrl")
 
@@ -820,7 +905,16 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     "PAID" -> QuoteState.PAID
                     "PENDING" -> QuoteState.PENDING
                     "ISSUED" -> QuoteState.ISSUED
-                    else -> QuoteState.PAID // Default to PAID for external quotes
+                    // Fail closed: never assume PAID for an unrecognized state.
+                    else -> {
+                        withContext(Dispatchers.Main) {
+                            promise.reject(
+                                "INVALID_QUOTE_STATE",
+                                "Unrecognized mint quote state: $state"
+                            )
+                        }
+                        return@launch
+                    }
                 }
 
                 // Storing a key equal to cdk's seed prefix on the quote

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -712,6 +712,62 @@ class CashuDevKitModule: RCTEventEmitter {
         }
     }
 
+    /// Reject loopback, private (RFC1918), link-local and other internal hosts
+    /// for server-supplied mint URLs. Matches on the literal host only (no DNS
+    /// resolution) to avoid a rebinding/latency side channel; this is
+    /// defense-in-depth on top of the JS-side configured-mint binding.
+    private static func isDisallowedMintHost(_ host: String) -> Bool {
+        let h = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+            .lowercased()
+        if h.isEmpty { return true }
+        if h == "localhost" || h.hasSuffix(".localhost") { return true }
+        // A host containing ":" can only be an IPv6 literal (hostnames
+        // cannot contain it), so parse it numerically instead of
+        // prefix-matching one spelling: mapped (::ffff:127.0.0.1),
+        // hex-mapped (::ffff:7f00:1) and zero-expanded (0:0:0:0:0:0:0:1)
+        // forms of the same internal address all normalize to the same
+        // bytes. inet_pton involves no DNS.
+        if h.contains(":") { return isDisallowedIPv6Literal(h) }
+        return isDisallowedIPv4(h)
+    }
+
+    // IPv4 ranges: 127/8, 10/8, 169.254/16, 172.16/12, 192.168/16, 0/8
+    private static func isDisallowedIPv4(_ h: String) -> Bool {
+        if h.hasPrefix("127.") || h.hasPrefix("10.") ||
+            h.hasPrefix("169.254.") || h.hasPrefix("192.168.") ||
+            h.hasPrefix("0.") {
+            return true
+        }
+        return h.range(of: "^172\\.(1[6-9]|2[0-9]|3[0-1])\\.",
+                       options: .regularExpression) != nil
+    }
+
+    private static func isDisallowedIPv6Literal(_ literal: String) -> Bool {
+        var addr = in6_addr()
+        guard inet_pton(AF_INET6, literal, &addr) == 1 else {
+            // Not parseable as an IPv6 literal and not a valid hostname
+            // either: fail closed
+            return true
+        }
+        let bytes = withUnsafeBytes(of: addr) { Array($0) }
+        // IPv4-mapped (::ffff:a.b.c.d in any spelling): hold the embedded
+        // address to the same rules as a dotted host
+        if bytes[0...9].allSatisfy({ $0 == 0 }) && bytes[10] == 0xff &&
+            bytes[11] == 0xff {
+            let v4 = "\(bytes[12]).\(bytes[13]).\(bytes[14]).\(bytes[15])"
+            return isDisallowedIPv4(v4)
+        }
+        // ::1 loopback and :: unspecified
+        if bytes[0...14].allSatisfy({ $0 == 0 }) &&
+            (bytes[15] == 0 || bytes[15] == 1) {
+            return true
+        }
+        // fe80::/10 link-local, fec0::/10 site-local (deprecated)
+        if bytes[0] == 0xfe && (bytes[1] & 0x80) == 0x80 { return true }
+        // fc00::/7 unique-local
+        return (bytes[0] & 0xfe) == 0xfc
+    }
+
     /// Check mint quote status directly from the mint's HTTP API.
     /// This bypasses the local database check and works for external quotes
     /// (e.g., quotes created by ZeusPay server).
@@ -723,7 +779,36 @@ class CashuDevKitModule: RCTEventEmitter {
             do {
                 // Normalize mint URL and construct the quote endpoint
                 let normalizedUrl = mintUrl.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-                let quoteUrlStr = "\(normalizedUrl)/v1/mint/quote/bolt11/\(quoteId)"
+
+                // Security: this issues a raw HTTP GET against a mint URL that
+                // originates from a ZEUS Pay socket event. Refuse cleartext and
+                // internal/loopback/link-local targets so a forged event cannot
+                // downgrade the fetch or drive the device into an SSRF against
+                // the local network. quoteId is percent-encoded so it cannot
+                // alter the request path.
+                guard let baseUrl = URL(string: normalizedUrl),
+                      baseUrl.scheme?.lowercased() == "https",
+                      let host = baseUrl.host,
+                      !CashuDevKitModule.isDisallowedMintHost(host)
+                else {
+                    reject("UNSAFE_MINT_URL", "Refusing to contact non-HTTPS or internal mint host: \(mintUrl)", nil)
+                    return
+                }
+
+                // Path-segment encoding, not path encoding: .urlPathAllowed
+                // is scoped to a whole path so it permits "/", which would
+                // let a forged quoteId traverse to a different endpoint.
+                // Subtract it to match Android's URLEncoder behavior, and
+                // fail closed instead of falling back to the raw id.
+                let segmentAllowed = CharacterSet.urlPathAllowed
+                    .subtracting(CharacterSet(charactersIn: "/"))
+                guard let encodedQuoteId = quoteId.addingPercentEncoding(
+                    withAllowedCharacters: segmentAllowed
+                ) else {
+                    reject("INVALID_QUOTE_ID", "Quote id cannot be percent-encoded", nil)
+                    return
+                }
+                let quoteUrlStr = "\(normalizedUrl)/v1/mint/quote/bolt11/\(encodedQuoteId)"
 
                 guard let quoteUrl = URL(string: quoteUrlStr) else {
                     reject("INVALID_URL", "Invalid mint URL: \(mintUrl)", nil)
@@ -807,7 +892,9 @@ class CashuDevKitModule: RCTEventEmitter {
                 case "ISSUED":
                     quoteState = .issued
                 default:
-                    quoteState = .paid // Default to PAID for external quotes
+                    // Fail closed: never assume PAID for an unrecognized state.
+                    reject("INVALID_QUOTE_STATE", "Unrecognized mint quote state: \(state)", nil)
+                    return
                 }
 
                 // Storing a key equal to cdk's seed prefix on the quote

--- a/locales/en.json
+++ b/locales/en.json
@@ -1746,6 +1746,7 @@
     "stores.LSPStore.error": "LSP error",
     "stores.LSPStore.connectionError": "Could not connect to LSP. Please check your LSP settings or try again later.",
     "stores.LightningAddressStore.preimageNotFound": "Pre-image not found on your device. Did you recently change devices?",
+    "stores.LightningAddressStore.Cashu.mintMismatch": "Payment references a mint that is not approved on this device",
     "stores.LightningAddressStore.Cashu.quoteNotPaid": "Quote not paid",
     "stores.LightningAddressStore.Cashu.quotePaymentErr": "Error checking for quote payment",
     "stores.NostrWalletConnectStore.initializingService": "Initializing Nostr Wallet Connect service...",

--- a/stores/LightningAddressStore.test.ts
+++ b/stores/LightningAddressStore.test.ts
@@ -1,0 +1,203 @@
+jest.mock('../stores/Stores', () => ({}));
+
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+
+jest.mock('../utils/BackendUtils', () => ({
+    __esModule: true,
+    default: {
+        signMessage: jest.fn()
+    }
+}));
+
+jest.mock('react-native-notifications', () => ({
+    Notifications: {
+        postLocalNotification: jest.fn()
+    }
+}));
+
+jest.mock('react-native-blob-util', () => ({
+    __esModule: true,
+    default: { fetch: jest.fn() }
+}));
+
+jest.mock('socket.io-client', () => ({
+    io: jest.fn(() => ({ connect: jest.fn(), emit: jest.fn(), on: jest.fn() }))
+}));
+
+jest.mock('../storage', () => ({
+    __esModule: true,
+    default: { getItem: jest.fn(), setItem: jest.fn() }
+}));
+
+jest.mock('./CashuStore', () => ({ __esModule: true, default: class {} }));
+jest.mock('./NodeInfoStore', () => ({ __esModule: true, default: class {} }));
+jest.mock('./SettingsStore', () => ({ __esModule: true, default: class {} }));
+
+import LightningAddressStore from './LightningAddressStore';
+
+const CONFIGURED_MINT = 'https://mint.zeusnuts.com';
+const LOCAL_MINT = 'https://mint.minibits.cash/Bitcoin';
+const ATTACKER_MINT = 'http://attacker-mint.example:3338';
+
+const makeStore = (configuredMintUrl?: string, localMintUrls?: string[]) => {
+    const checkInvoicePaid = jest.fn().mockResolvedValue({ isPaid: false });
+    const cashuStore: any = {
+        checkInvoicePaid,
+        deriveCashuSecretKey: jest.fn(),
+        receiveTokenCDK: jest.fn(),
+        mintUrls: localMintUrls
+    };
+    const settingsStore: any = {
+        settings: {
+            lightningAddress: configuredMintUrl
+                ? { mintUrl: configuredMintUrl }
+                : {}
+        }
+    };
+    const nodeInfoStore: any = { nodeInfo: {} };
+    const store = new LightningAddressStore(
+        cashuStore,
+        nodeInfoStore,
+        settingsStore
+    );
+    return { store, checkInvoicePaid };
+};
+
+describe('LightningAddressStore.redeemCashu mint binding', () => {
+    it('refuses to redeem against a mint that is not approved', async () => {
+        const { store, checkInvoicePaid } = makeStore(CONFIGURED_MINT, [
+            LOCAL_MINT
+        ]);
+
+        const result = await store.redeemCashu(
+            'attacker-quote-id',
+            ATTACKER_MINT,
+            21000,
+            false,
+            true
+        );
+
+        expect(result).toBe(false);
+        expect(checkInvoicePaid).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when the event mint matches the configured mint', async () => {
+        const { store, checkInvoicePaid } = makeStore(CONFIGURED_MINT);
+
+        await store.redeemCashu(
+            'quote-id',
+            CONFIGURED_MINT,
+            21000,
+            false,
+            true
+        );
+
+        expect(checkInvoicePaid).toHaveBeenCalledTimes(1);
+        expect(checkInvoicePaid.mock.calls[0][1]).toBe(CONFIGURED_MINT);
+    });
+
+    it('matches on trailing slash or scheme/host case differences and forwards the configured spelling', async () => {
+        const { store, checkInvoicePaid } = makeStore(CONFIGURED_MINT);
+
+        await store.redeemCashu(
+            'quote-id',
+            `${CONFIGURED_MINT.toUpperCase()}/`,
+            21000,
+            false,
+            true
+        );
+
+        expect(checkInvoicePaid).toHaveBeenCalledTimes(1);
+        expect(checkInvoicePaid.mock.calls[0][1]).toBe(CONFIGURED_MINT);
+    });
+
+    it('treats the URL path as case-sensitive', async () => {
+        const { store, checkInvoicePaid } = makeStore(LOCAL_MINT);
+
+        const result = await store.redeemCashu(
+            'quote-id',
+            'https://mint.minibits.cash/bitcoin',
+            21000,
+            false,
+            true
+        );
+
+        expect(result).toBe(false);
+        expect(checkInvoicePaid).not.toHaveBeenCalled();
+    });
+
+    it('accepts a locally added mint that differs from the configured mint and forwards the local spelling', async () => {
+        const { store, checkInvoicePaid } = makeStore(CONFIGURED_MINT, [
+            LOCAL_MINT
+        ]);
+
+        await store.redeemCashu(
+            'quote-id',
+            `${LOCAL_MINT}/`,
+            21000,
+            false,
+            true
+        );
+
+        expect(checkInvoicePaid).toHaveBeenCalledTimes(1);
+        expect(checkInvoicePaid.mock.calls[0][1]).toBe(LOCAL_MINT);
+    });
+
+    it('accepts a locally added mint when no mint is configured', async () => {
+        const { store, checkInvoicePaid } = makeStore(undefined, [LOCAL_MINT]);
+
+        await store.redeemCashu('quote-id', LOCAL_MINT, 21000, false, true);
+
+        expect(checkInvoicePaid).toHaveBeenCalledTimes(1);
+        expect(checkInvoicePaid.mock.calls[0][1]).toBe(LOCAL_MINT);
+    });
+
+    it('refuses to redeem when no mint is configured or locally added', async () => {
+        const { store, checkInvoicePaid } = makeStore(undefined);
+
+        const result = await store.redeemCashu(
+            'quote-id',
+            CONFIGURED_MINT,
+            21000,
+            false,
+            true
+        );
+
+        expect(result).toBe(false);
+        expect(checkInvoicePaid).not.toHaveBeenCalled();
+    });
+
+    it('surfaces an error message on a manual redeem of an unapproved mint', async () => {
+        const { store } = makeStore(CONFIGURED_MINT);
+
+        const result = await store.redeemCashu(
+            'quote-id',
+            ATTACKER_MINT,
+            21000
+        );
+
+        expect(result).toBe(false);
+        expect(store.error).toBe(true);
+        expect(store.error_msg).toBe(
+            'stores.LightningAddressStore.Cashu.mintMismatch'
+        );
+    });
+
+    it('stays silent on an automatic redeem of an unapproved mint', async () => {
+        const { store } = makeStore(CONFIGURED_MINT);
+
+        const result = await store.redeemCashu(
+            'quote-id',
+            ATTACKER_MINT,
+            21000,
+            false,
+            true // localNotification: automatic socket path
+        );
+
+        expect(result).toBe(false);
+        expect(store.error).toBe(false);
+        expect(store.error_msg).toBe('');
+    });
+});

--- a/stores/LightningAddressStore.ts
+++ b/stores/LightningAddressStore.ts
@@ -801,6 +801,23 @@ export default class LightningAddressStore {
         }
     };
 
+    // Normalize a mint URL for equality comparison: strip surrounding
+    // whitespace and any trailing slash, and lower-case the scheme and
+    // host, which are the only case-insensitive parts of a URL (RFC 3986).
+    // The path is kept byte-exact: two mints on one host may differ only
+    // by path case. Matched with a regex rather than the URL polyfill,
+    // which does not case-fold hosts. Kept local so the security check
+    // below does not depend on another store's private helper.
+    private normalizeMintUrl = (url?: string): string => {
+        if (!url) return '';
+        return url
+            .trim()
+            .replace(/\/+$/, '')
+            .replace(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i, (schemeAndHost) =>
+                schemeAndHost.toLowerCase()
+            );
+    };
+
     @action
     public redeemCashu = async (
         quote_id: string,
@@ -812,6 +829,53 @@ export default class LightningAddressStore {
     ) => {
         this.error = false;
         this.error_msg = '';
+
+        // Security: the ZEUS Pay socket is a hint channel, not a command
+        // channel. A `paid` event (and the server-supplied open-payments
+        // list) names the mint URL to redeem from, but the wallet must only
+        // ever mint from a mint the user has approved: the mint this
+        // lightning address was created with (settings.lightningAddress.
+        // mintUrl, set in createCashu) or a mint the user added locally
+        // (cashuStore.mintUrls). The locally added mints keep quotes
+        // redeemable when the configured mint changes or is overwritten by
+        // an unrelated lightningAddress settings write. Binding here, at
+        // the single chokepoint every caller passes through, stops a
+        // malicious or compromised backend from steering the wallet to an
+        // arbitrary mint (fake-deposit injection, unapproved mint trust,
+        // raw-HTTP fetch of an attacker URL). On a match, the locally
+        // stored URL is forwarded downstream instead of the server-supplied
+        // spelling, so the server cannot influence how the mint is keyed in
+        // CDK either.
+        const configuredMintUrl =
+            this.settingsStore?.settings?.lightningAddress?.mintUrl;
+        const trustedMintUrls: string[] = configuredMintUrl
+            ? [configuredMintUrl, ...(this.cashuStore?.mintUrls || [])]
+            : this.cashuStore?.mintUrls || [];
+        const normalizedEventMintUrl = this.normalizeMintUrl(mint_url);
+        const trustedMintUrl = normalizedEventMintUrl
+            ? trustedMintUrls.find(
+                  (url) => this.normalizeMintUrl(url) === normalizedEventMintUrl
+              )
+            : undefined;
+        if (!trustedMintUrl) {
+            console.warn(
+                'LightningAddressStore.redeemCashu: refusing to redeem against a mint that is neither the configured lightning address mint nor a locally added mint'
+            );
+            runInAction(() => {
+                this.redeeming = false;
+                // Automatic paths (socket events, redeem-all on startup)
+                // drop the payment silently, but a user tapping Redeem
+                // needs to see why nothing happened.
+                if (!localNotification) {
+                    this.error = true;
+                    this.error_msg = localeString(
+                        'stores.LightningAddressStore.Cashu.mintMismatch'
+                    );
+                }
+            });
+            return false;
+        }
+
         this.redeeming = true;
 
         const fireLocalNotification = () => {
@@ -848,7 +912,7 @@ export default class LightningAddressStore {
         try {
             const response = await this.cashuStore.checkInvoicePaid(
                 quote_id,
-                mint_url,
+                trustedMintUrl,
                 true, // lockedQuote
                 skipMintCheck
             );


### PR DESCRIPTION
# Description

Security fix. The ZEUS Pay Cashu flow trusted the socket protocol as a command channel rather than a hint. A `paid` event (and the server-supplied open-payments list) carries the `mint_url` to redeem from, and the wallet passed that URL straight through `redeemCashu` -> `checkInvoicePaid` -> `checkAndMintCDK`: it added the named mint, fetched its quote state over a raw HTTP GET, and minted proofs against it, never checking the URL against the mint the lightning address was created with (`settings.lightningAddress.mintUrl`).

A malicious or compromised ZEUS Pay backend (or anyone able to make the server emit a `paid` event for a victim's pubkey) could therefore:

1. Inject a fake deposit: mint unbacked ecash at an attacker mint and fire a local "payment received: N sats" notification.
2. Silently add and trust an unapproved mint for later seed-derived operations (restore uses the seed-derived P2PK key).
3. Drive a raw GET at an attacker-named URL, including `http://` and RFC1918 / loopback / link-local hosts (SSRF-like), with the quote id interpolated unencoded.
4. Fail-open on quote state: the native `addExternalMintQuote` mapped any unrecognized NUT-04 state to `PAID`.

## Fix

Defense in depth, primary fix first:

- `redeemCashu` now refuses any redeem whose `mint_url` does not match a user-approved mint: the configured lightning address mint (`settings.lightningAddress.mintUrl`) or a mint the user has added locally (`cashuStore.mintUrls`). The locally added mints keep open quotes redeemable when the configured mint changes via the picker or is overwritten by an unrelated `lightningAddress` settings write (the settings merge is a shallow top-level spread, and `createZaplocker`/`createNWC` replace the object wholesale). This is the single chokepoint both the socket handler and `redeemAllOpenPaymentsCashu` pass through, so it closes the primary vector regardless of caller. On a match, the locally stored URL is forwarded downstream instead of the server-supplied spelling, so the server cannot influence how the mint is keyed in CDK. Normalization lowercases only the scheme and host; the path stays byte-exact. A rejected manual redeem surfaces a localized error via the existing `ErrorMessage` surface; the automatic socket and startup paths stay silent.
- `checkExternalMintQuote` (Android + iOS) refuses non-HTTPS and internal/loopback/link-local mint hosts, and percent-encodes the quote id.
- `addExternalMintQuote` (Android + iOS) fails closed on an unrecognized state instead of defaulting to `PAID`.

Adds `stores/LightningAddressStore.test.ts` covering the mint-binding guard (reject unapproved mint, accept configured mint incl. slash and scheme/host-case variants while forwarding the configured spelling, path case-sensitivity, accept locally added mints incl. when no mint is configured, reject when nothing is approved, and error surfacing on manual vs automatic rejection).

### Not included (requires server coordination)

Full end-to-end event authentication (ZEUS Pay signing `{quote_id, mint_url, amount_msat, ts}` and the client verifying against the ZEUS Pay pubkey) is a protocol change on the backend and is a recommended follow-up. The mint-binding above provides the concrete protection in the interim: even an unauthenticated forged event can now only ever reference the wallet's own configured mint.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

> Native (Kotlin/Swift) changes are pending on-device verification; the mint-binding guard is covered by unit tests. Device testing of the ZEUS Pay Cashu redeem path (legitimate deposit still redeems; forged/foreign mint is ignored) to follow.

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

