### PR TITLE
fix: don't contact an untrusted token's mint on view

### DIFF
--- a/views/Cashu/CashuToken.tsx
+++ b/views/Cashu/CashuToken.tsx
@@ -92,7 +92,8 @@ export default class CashuTokenView extends React.Component<
             markTokenSpent,
             clearToken,
             initializeWallet,
-            cashuWallets
+            cashuWallets,
+            mintUrls
         } = CashuStore!!;
 
         clearToken();
@@ -116,7 +117,19 @@ export default class CashuTokenView extends React.Component<
             return;
         }
 
-        if (!spent) {
+        // Only contact the mint for an unspent token when the user already
+        // trusts it (it is in their added mints). A token is a bearer
+        // instrument whose mint field is attacker-chosen, so merely viewing a
+        // scanned/pasted token from an unknown mint must not add that mint,
+        // initialize a wallet for it, or poll it for proof state: doing so
+        // would leak the viewer's IP/timing and the receipt-correlating proof
+        // Y values to an attacker-controlled server without consent. Contact
+        // is deferred to the explicit Add Mint / Receive actions. This mirrors
+        // the cashu.me wallet, which decodes tokens offline and only reaches an
+        // untrusted mint on an explicit user action.
+        const haveMint = mintUrls.includes(mint);
+
+        if (!spent && haveMint) {
             if (__DEV__) {
                 console.log('token not spent last time checked, checking...', {
                     decoded


### PR DESCRIPTION
# Description

Viewing a scanned or pasted Cashu token silently contacted the token's embedded mint before any user action, leaking the viewer's IP and timing plus receipt-correlating data to an attacker-controlled server.

A Cashu token is a bearer instrument whose `mint` field is attacker-chosen. Any `cashuA…`/`cashuB…` string decoded by `handleAnything` and routed into the `CashuToken` view, and for any unspent token `componentDidMount` would:

1. `initializeWallet(mint)` for that mint (writing a `${nodeDir}==${mint}-pubkey` keychain entry), and
2. start a `setInterval` that every 5 seconds called `checkTokenSpent` → `ensureMintAdded` + `CashuDevKit.checkProofsState`, i.e. a `POST /v1/checkstate` to the embedded mint carrying the token's proof `Y` values.

So merely opening a crafted token disclosed the victim's IP/timing (and, over `http://`, to any on-path observer), and the proof `Y` values let the mint confirm exactly which token was being inspected, all without consent and regardless of whether Cashu was even enabled (decode/validate are wallet-independent native calls).

## Fix

Gate the wallet initialization and spent-polling on the token's mint already being in the user's added mints (`mintUrls.includes(mint)`):

- Tokens from mints the user already trusts (their own **sent** tokens, and tokens from added mints) poll for external spend exactly as before.
- Tokens from an **unknown** mint are decoded and displayed fully offline. No wallet init, no keychain write, no `/v1/checkstate`. Contact is deferred to the existing explicit **Add Mint** / **Receive** buttons (Receive is already disabled until the mint is added).

This mirrors the [cashu.me](https://github.com/cashubtc/cashu.me) wallet, which decodes tokens offline and only reaches an untrusted mint on an explicit user action (and never polls proof state on view). The Zeus fix is in fact stricter: cashu.me still fetches benign `/v1/info` display metadata from an unknown mint on view, whereas this change sends nothing at all.

The other two `checkTokenSpent` callers (`CashuStore.checkSentTokensSpentStatus` and the background sweep in `initializeWallets`) only iterate the user's own `sentTokens` from their own trusted mints, so they are unaffected.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass (the only failing suite is the pre-existing, unrelated `PhotoUtils.test.ts`; 48/49 suites and 1043/1044 tests pass, and this change touches only `views/Cashu/CashuToken.tsx`)

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A (no utility file changed; the change is confined to a view component)

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Device testing is still pending. Suggested manual checks:

1. Paste/scan a token from a mint you have **not** added: the token displays, and no network request is made to that mint (verify via logs / proxy). The **Add Mint** and **Receive** buttons still work and only then contact the mint.
2. Your own **sent/gift** token still flips to "spent" when the recipient claims it elsewhere (poll still runs for trusted mints).
3. A token from a mint you **have** added still shows and receives normally.

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
