### PR TITLE
Block payment of expired lightning invoices

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -810,6 +810,7 @@
     "views.Payment.writeNote": "Write your note here",
     "views.PaymentRequest.title": "Lightning Invoice",
     "views.PaymentRequest.error": "Error loading invoice",
+    "views.PaymentRequest.invoiceExpired": "This invoice has expired and can no longer be paid",
     "views.PaymentRequest.customAmt": "Custom Amount",
     "views.PaymentRequest.payDefault": "Pay default amount",
     "views.PaymentRequest.payCustom": "Pay custom amount",

--- a/models/Invoice.test.ts
+++ b/models/Invoice.test.ts
@@ -1,5 +1,7 @@
 jest.mock('../stores/Stores', () => ({}));
 
+import { autorun } from 'mobx';
+
 import Invoice from './Invoice';
 
 // decodes with timestamp 1700074718 and expiry 3600 (see Bolt11Utils.test.ts)
@@ -35,6 +37,85 @@ describe('Invoice.originalTimeUntilExpiryInSeconds', () => {
             destination: '02758997f184be06f4350b136db0bed6f8'
         });
         expect(invoice.originalTimeUntilExpiryInSeconds).toBeUndefined();
+    });
+});
+
+describe('Invoice.isExpired / isExpiredNow', () => {
+    const timestamp = 1700074718;
+    const expiry = 3600;
+    const expiryMs = (timestamp + expiry) * 1000;
+
+    // lnd-style decodepayreq response: expiry fields present,
+    // but no bolt11 string to re-decode
+    const lndDecodeResponse = {
+        destination: '02758997f184be06f4350b136db0bed6f8',
+        timestamp: timestamp.toString(),
+        expiry: expiry.toString(),
+        cltv_expiry: '80'
+    };
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('is true for an invoice whose bolt11 expiry has passed', () => {
+        const invoice = new Invoice({ payment_request: paymentRequest });
+
+        expect(invoice.isExpired).toBe(true);
+        expect(invoice.isExpiredNow()).toBe(true);
+    });
+
+    it('is true for a decode response without a bolt11 string when the original payment request is threaded through', () => {
+        const invoice = new Invoice({
+            ...lndDecodeResponse,
+            paymentRequest
+        });
+
+        expect(invoice.isExpired).toBe(true);
+        expect(invoice.isExpiredNow()).toBe(true);
+    });
+
+    it('fails open (false) for a decode response without any bolt11 string, which is why InvoicesStore.getPayReq must thread it through', () => {
+        const invoice = new Invoice(lndDecodeResponse);
+
+        expect(invoice.isExpired).toBe(false);
+        expect(invoice.isExpiredNow()).toBe(false);
+    });
+
+    it('is false before the expiry timestamp and true after it', () => {
+        const invoice = new Invoice({ payment_request: paymentRequest });
+
+        jest.useFakeTimers();
+
+        jest.setSystemTime(expiryMs - 1000);
+        expect(invoice.isExpiredNow()).toBe(false);
+
+        jest.setSystemTime(expiryMs + 1000);
+        expect(invoice.isExpiredNow()).toBe(true);
+    });
+
+    it('isExpiredNow stays fresh while the isExpired computed is observed', () => {
+        const invoice = new Invoice({ payment_request: paymentRequest });
+
+        jest.useFakeTimers();
+        jest.setSystemTime(expiryMs - 1000);
+
+        // keep the computed observed so MobX caches it, as an
+        // @observer screen rendering the invoice would
+        let observed: boolean | undefined;
+        const dispose = autorun(() => {
+            observed = invoice.isExpired;
+        });
+
+        expect(observed).toBe(false);
+
+        jest.setSystemTime(expiryMs + 1000);
+
+        // Date.now() is not observable, so the cached computed may
+        // still report false; the plain method must not
+        expect(invoice.isExpiredNow()).toBe(true);
+
+        dispose();
     });
 });
 

--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -377,6 +377,13 @@ export default class Invoice extends BaseModel {
     }
 
     @computed public get isExpired(): boolean {
+        return this.isExpiredNow();
+    }
+
+    // plain method, not @computed: Date.now() is not observable, so a
+    // cached computed can report a stale "not expired" when re-checked
+    // later (e.g. at payment dispatch time)
+    public isExpiredNow(): boolean {
         const getExpiryTimestamp = this.getExpiryUnixTimestamp();
 
         if (getExpiryTimestamp == null) {

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -4079,6 +4079,16 @@ export default class CashuStore {
             // Set payReq early so the view can render invoice details
             // even if melt quote preparation fails
             this.payReq = payReq;
+
+            // don't request melt quotes for an expired invoice: it can't
+            // be paid, and the quote requests would needlessly disclose
+            // the invoice to the mint(s)
+            if (payReq.isExpiredNow()) {
+                this.meltQuotes = [];
+                this.meltQuote = undefined;
+                return;
+            }
+
             const rawPaymentAmt = payReq.getRequestAmount
                 ? payReq.getRequestAmount
                 : 0;

--- a/stores/InvoicesStore.test.ts
+++ b/stores/InvoicesStore.test.ts
@@ -1,0 +1,63 @@
+jest.mock('../stores/Stores', () => ({}));
+jest.mock('react-native-blob-util', () => ({}));
+jest.mock('../ldknode/LdkNodeInjection', () => ({}));
+jest.mock('../utils/BackendUtils', () => ({
+    __esModule: true,
+    default: {
+        decodePaymentRequest: jest.fn(),
+        isLNDBased: jest.fn(() => false)
+    }
+}));
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (s: string) => s
+}));
+jest.mock('../utils/ErrorUtils', () => ({
+    errorToUserFriendly: (error: Error) => error.message
+}));
+
+import InvoicesStore from './InvoicesStore';
+import BackendUtils from '../utils/BackendUtils';
+
+// decodes with timestamp 1700074718 and expiry 3600 (see Bolt11Utils.test.ts)
+const paymentRequest =
+    'lnbcrt1230n1pj429x7pp57t97q4awqj3f529snr0pa6senk83sq5pp760qf5a4jzvd7xgwcksdqqcqzzsxqrrsssp57eqtv7vxr46arupna3w4ct0lkf2mqmz9wt044cwkks0rwlnhfr5s9qyyssqragwpwav7nfwv2xyuuamxxj4pnnpzv2hlw7j473repd3sq7st698ta9kmzmygt0w7tmncl56a6mnma0w7e5dlpqd0wy6x3v35rssldspjhh8p0';
+
+// lnd-style decodepayreq response: expiry fields present,
+// but no bolt11 string to re-decode
+const lndDecodeResponse = {
+    destination: '02758997f184be06f4350b136db0bed6f8',
+    timestamp: '1700074718',
+    expiry: '3600',
+    num_satoshis: '123'
+};
+
+const newStore = () =>
+    new InvoicesStore({} as any, {} as any, {} as any, {} as any);
+
+describe('InvoicesStore.getPayReq', () => {
+    it('threads the original payment request through so expiry is computable when the decode response omits the bolt11 string', async () => {
+        (BackendUtils.decodePaymentRequest as jest.Mock).mockResolvedValue(
+            lndDecodeResponse
+        );
+
+        const store = newStore();
+        await store.getPayReq(paymentRequest);
+
+        expect(store.getPayReqError).toBeNull();
+        expect(store.pay_req).not.toBeNull();
+        expect(store.pay_req!.getPaymentRequest).toBe(paymentRequest);
+        expect(store.pay_req!.isExpiredNow()).toBe(true);
+    });
+
+    it('surfaces decode errors and clears pay_req', async () => {
+        (BackendUtils.decodePaymentRequest as jest.Mock).mockRejectedValue(
+            new Error('decode failed')
+        );
+
+        const store = newStore();
+        await store.getPayReq(paymentRequest);
+
+        expect(store.pay_req).toBeNull();
+        expect(store.getPayReqError).toBe('decode failed');
+    });
+});

--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -703,7 +703,10 @@ export default class InvoicesStore {
         return BackendUtils.decodePaymentRequest([paymentRequest])
             .then((data: any) => {
                 runInAction(() => {
-                    this.pay_req = new Invoice(data);
+                    // thread the original bolt11 string through: several
+                    // backends' decode responses omit it, leaving the
+                    // Invoice unable to compute its expiry
+                    this.pay_req = new Invoice({ ...data, paymentRequest });
                     this.getPayReqError = null;
                     this.loading = false;
                 });

--- a/views/Cashu/CashuPaymentRequest.tsx
+++ b/views/Cashu/CashuPaymentRequest.tsx
@@ -24,7 +24,10 @@ import KeyValue from '../../components/KeyValue';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import Screen from '../../components/Screen';
 import Switch from '../../components/Switch';
-import { WarningMessage } from '../../components/SuccessErrorMessage';
+import {
+    ErrorMessage,
+    WarningMessage
+} from '../../components/SuccessErrorMessage';
 
 import BalanceStore from '../../stores/BalanceStore';
 import CashuStore from '../../stores/CashuStore';
@@ -215,6 +218,17 @@ export default class CashuPaymentRequest extends React.Component<
         const { CashuStore, LnurlPayStore, SettingsStore, navigation } =
             this.props;
         const { satAmount, multiMintEnabled, donationAmount } = this.state;
+
+        // Fail closed if the invoice has expired since it was reviewed:
+        // the invoice can lapse while this screen is open, and expiry is
+        // otherwise only enforced by the mint and recipient
+        if (CashuStore.payReq?.isExpiredNow()) {
+            // re-render so the expired notice appears and the pay
+            // controls are removed
+            this.forceUpdate();
+            return;
+        }
+
         const requestAmount = CashuStore.payReq?.getRequestAmount;
         const paymentAmount = satAmount
             ? satAmount.toString()
@@ -332,6 +346,8 @@ export default class CashuPaymentRequest extends React.Component<
         } = LnurlPayStore;
 
         const isZaplockerValid = isPmtHashSigValid && isRelaysSigValid;
+
+        const isPayReqExpired = !!payReq && payReq.isExpiredNow();
 
         const requestAmount =
             payReq && payReq.getRequestAmount
@@ -479,6 +495,20 @@ export default class CashuPaymentRequest extends React.Component<
                         {!loading && !loadingFeeEstimate && !!payReq && (
                             <View style={styles.content}>
                                 <>
+                                    {isPayReqExpired && (
+                                        <View
+                                            style={{
+                                                paddingTop: 10,
+                                                paddingBottom: 10
+                                            }}
+                                        >
+                                            <ErrorMessage
+                                                message={localeString(
+                                                    'views.PaymentRequest.invoiceExpired'
+                                                )}
+                                            />
+                                        </View>
+                                    )}
                                     {showZaplockerWarning &&
                                         implementation === 'embedded-lnd' && (
                                             <View
@@ -962,6 +992,7 @@ export default class CashuPaymentRequest extends React.Component<
                 </View>
 
                 {!!payReq &&
+                    !isPayReqExpired &&
                     !loading &&
                     !loadingFeeEstimate &&
                     BackendUtils.supportsLightningSends() && (

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -704,7 +704,7 @@ export default class PaymentRequest extends React.Component<
                     }}
                     rightComponent={
                         <Row>
-                            <SwapButton />
+                            {!isPayReqExpired && <SwapButton />}
                             <QRButton />
                         </Row>
                     }

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -30,7 +30,10 @@ import Switch from '../components/Switch';
 import Text from '../components/Text';
 import TextInput from '../components/TextInput';
 import { Row } from '../components/layout/Row';
-import { WarningMessage } from '../components/SuccessErrorMessage';
+import {
+    ErrorMessage,
+    WarningMessage
+} from '../components/SuccessErrorMessage';
 
 import BalanceStore from '../stores/BalanceStore';
 import ChannelsStore from '../stores/ChannelsStore';
@@ -433,6 +436,16 @@ export default class PaymentRequest extends React.Component<
         const { paymentRequest, pay_req } = InvoicesStore;
         const { implementation } = SettingsStore;
 
+        // Fail closed if the invoice has expired since it was reviewed:
+        // the invoice can lapse while this screen is open, and expiry is
+        // otherwise only enforced by the recipient
+        if (pay_req?.isExpiredNow()) {
+            // re-render so the expired notice appears and the pay
+            // controls are removed
+            this.forceUpdate();
+            return;
+        }
+
         const isCLightning: boolean = implementation === 'cln-rest';
 
         // Zaplocker
@@ -520,6 +533,8 @@ export default class PaymentRequest extends React.Component<
 
         const locale = SettingsStore.settings.locale;
         if (pay_req) pay_req.determineFormattedOriginalTimeUntilExpiry(locale);
+
+        const isPayReqExpired = !!pay_req && pay_req.isExpiredNow();
 
         // variables cannot be destructured traditionally here
         // due to how we clear the pay_req from the store upon
@@ -725,6 +740,20 @@ export default class PaymentRequest extends React.Component<
                         {!loading && !loadingFeeEstimate && !!pay_req && (
                             <View style={styles.content}>
                                 <>
+                                    {isPayReqExpired && (
+                                        <View
+                                            style={{
+                                                paddingTop: 10,
+                                                paddingBottom: 10
+                                            }}
+                                        >
+                                            <ErrorMessage
+                                                message={localeString(
+                                                    'views.PaymentRequest.invoiceExpired'
+                                                )}
+                                            />
+                                        </View>
+                                    )}
                                     {showZaplockerWarning &&
                                         implementation === 'embedded-lnd' && (
                                             <View
@@ -1559,6 +1588,7 @@ export default class PaymentRequest extends React.Component<
                 </View>
 
                 {!!pay_req &&
+                    !isPayReqExpired &&
                     !loading &&
                     !loadingFeeEstimate &&
                     BackendUtils.supportsLightningSends() && (


### PR DESCRIPTION
# Description

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 21 47 12" src="https://github.com/user-attachments/assets/6dd4b594-d096-42dd-a2ce-03d9950c0ab7" />

`Invoice.isExpired` is computed by the model but was never consulted anywhere on the user-initiated send path. An expired BOLT11 invoice loaded into `pay_req` with no error, rendered on the Payment Request screen with no warning (the screen even displays the original expiry duration), and dispatched on swipe or button press. BOLT 11 places expiry enforcement on the payer ("a reader... SHOULD NOT... pay an expired invoice"), so the outcome was delegated entirely to backend and recipient behavior: lnd and CLN payer-side checks turn this into a late, ugly failure after authorization, while backends that delegate the decision outward (LndHub, NWC client) can result in an expired invoice actually being paid if the recipient still settles it (stale invoice replay). The NWC service role already performs this exact check before paying (`NostrWalletConnectStore`), so this brings the main send path in line with it.

Changes:

- `views/PaymentRequest.tsx`: shows an expired error notice, hides the pay/swipe controls when the invoice is expired, and fail-closes in `triggerPayment` so an invoice that lapses while the user sits on the review screen is also caught at dispatch time
- `stores/InvoicesStore.ts`: `getPayReq` now threads the original bolt11 string into the `Invoice` model. This is load-bearing: the decode responses of LND (REST), embedded LND, Lightning Node Connect, and CLNRest omit the bolt11 string, which made `isExpired` silently return `false` on those backends. Without this, the view gate would be a no-op on exactly the most common backends
- `models/Invoice.ts`: adds a plain `isExpiredNow()` method that the `isExpired` computed delegates to. `Date.now()` is not observable, so a MobX computed caches its value while observed and could report a stale "not expired" when re-checked at dispatch time; the plain method always evaluates fresh
- Regression tests for the model (including the decode-response-without-bolt11 case on both sides of the threading fix, and freshness under observation with fake timers) and for `getPayReq` threading

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
