### PR TITLE
Cashu: probe multi-mint melt quotes only until capacity covers the payment

### DIFF
--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -1229,7 +1229,21 @@ export default class CashuStore {
         const skipped: { mintUrl: string; reason: MultimintSkipReason }[] = [];
         const candidates: Candidate[] = [];
 
-        for (const mintUrl of supportedMints) {
+        // Probe in descending balance order and stop once probed usable
+        // capacity covers the payment. A melt quote request contains the
+        // full invoice (payee, amount, payment hash), so every probe
+        // discloses the payment's destination to that mint. Don't send
+        // it to mints that can't end up participating. If coverage is
+        // never reached, every mint still gets probed, so skip
+        // diagnostics on failure are unchanged.
+        const probeOrder = [...supportedMints].sort(
+            (a, b) =>
+                (normalizedBalances[b] || 0) - (normalizedBalances[a] || 0)
+        );
+        let probedUsable = 0;
+
+        for (const mintUrl of probeOrder) {
+            if (probedUsable >= amountToPay) break;
             const balance = normalizedBalances[mintUrl] || 0;
             if (balance <= 0) {
                 skipped.push({ mintUrl, reason: 'noBalance' });
@@ -1259,6 +1273,7 @@ export default class CashuStore {
                 skipped.push({ mintUrl, reason: 'feeOverBalance' });
                 continue;
             }
+            probedUsable += usable;
             candidates.push({
                 mintUrl,
                 normalizedMintUrl,


### PR DESCRIPTION
# Description

When paying an invoice with Multi-mint (MPP) enabled, the melt planner (`prepareMultiMintMeltQuotesCDK`) requests a melt quote from **every** MPP-capable selected mint with a positive balance before deciding how to split the payment. A melt quote request contains the full BOLT11 invoice, so every probed mint learns the payment's destination pubkey, amount, and payment hash, including mints that end up contributing nothing (e.g. when the largest mint covers the whole amount and the allocator short-circuits, or when the planner falls back to a single-mint regular melt).

Under NUT-05 the quote request *is* the invoice, so disclosure to mints that actually participate is inherent and unavoidable. The fixable part is over-probing: contacting mints that were never going to be needed.

## Fix

Probe mints in descending balance order and stop as soon as the probed usable capacity (balance net of quoted fee reserve) covers the payment amount. Mints beyond that point never receive the invoice.

Properties preserved:

- The allocator's inputs are unchanged in shape: candidates are still sorted by usable capacity, the proportional split and re-quote/shrink logic are untouched.
- Failure diagnostics are unchanged: if probed capacity never reaches the payment amount, the loop runs through every mint exactly as before, so `multiMintPlannerSkips` (which feeds the error message naming the mint that couldn't participate) is populated identically on failure paths.
- The single-funded-mint and `totalAllocated < amountToPay` fallback paths are untouched.

In the common case (one high-balance mint can cover the payment alone), this reduces invoice disclosure from all selected mints to exactly one.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
