### PR TITLE
Cashu: restore freshest Nostr mint backup, gate on stored timestamp floor

### DIFF
--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -5619,6 +5619,10 @@ export default class CashuStore {
 
     @action
     public deleteCashuData = async () => {
+        // Deletion can block on the empty-backup publish below (up to 10s
+        // against unreachable relays), so guard against concurrent runs from
+        // repeated taps
+        if (this.loading) return;
         this.loading = true;
         const lndDir = this.getNodeDir();
 

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -2702,7 +2702,9 @@ export default class CashuStore {
             }
 
             // Backup mint list to Nostr (fire and forget)
-            this.nostrBackupMints();
+            this.nostrBackupMints().catch((e) =>
+                console.warn('Nostr mint backup failed (background):', e)
+            );
 
             runInAction(() => {
                 this.loading = false;
@@ -2802,7 +2804,9 @@ export default class CashuStore {
         await this.calculateTotalBalance();
 
         // Backup updated mint list to Nostr (fire and forget)
-        this.nostrBackupMints();
+        this.nostrBackupMints().catch((e) =>
+            console.warn('Nostr mint backup failed (background):', e)
+        );
 
         runInAction(() => {
             this.loading = false;
@@ -2837,7 +2841,7 @@ export default class CashuStore {
     @action
     public nostrBackupMints = async () => {
         const seed = this.getNostrBackupSeed();
-        if (!seed || this.mintUrls.length === 0) return;
+        if (!seed) return;
 
         try {
             const { privateKeyHex, publicKeyHex } =
@@ -2876,12 +2880,23 @@ export default class CashuStore {
             const result = await restoreMintsFromNostr(
                 privateKeyHex,
                 publicKeyHex,
-                DEFAULT_NOSTR_RELAYS
+                DEFAULT_NOSTR_RELAYS,
+                this.nostrMintBackupTimestamp ?? 0
             );
-            if (result && result.mints.length > 0) {
-                return result.mints;
-            }
-            return null;
+            if (!result) return null;
+
+            // Ratchet the freshness floor to the accepted backup so
+            // older replays can never be restored later, even if the
+            // backup turns out to be empty
+            runInAction(() => {
+                this.nostrMintBackupTimestamp = result.timestamp;
+            });
+            await Storage.setItem(
+                `${this.getNodeDir()}-cashu-nostrMintBackupTimestamp`,
+                String(result.timestamp)
+            );
+
+            return result.mints.length > 0 ? result.mints : null;
         } catch (e) {
             console.warn('Nostr mint restore failed:', e);
             return null;
@@ -3330,8 +3345,8 @@ export default class CashuStore {
                 // or recovery), try to restore the mint list from Nostr
                 // backup. A stored empty list means the user removed every
                 // mint; treating it as fresh would resurrect the removed
-                // mints from the stale relay backup, since empty lists are
-                // deliberately never published
+                // mints from a relay that never received the empty backup
+                // that removeMint publishes
                 if (!storedMintUrls) {
                     try {
                         const nostrMints = await this.nostrRestoreMints();
@@ -5643,10 +5658,10 @@ export default class CashuStore {
             // Persist an empty mint list instead of removing the key.
             // Boot treats a missing key as a fresh install or recovery and
             // restores the mint list from the Nostr backup (and re-adds the
-            // onboarding mints); since nostrBackupMints never publishes an
-            // empty list, the stale backup would resurrect every deleted
-            // mint on the next launch. An empty list records that the user
-            // deliberately deleted their mints, matching removeMint
+            // onboarding mints); deleting Cashu data does not publish a
+            // backup, so the stale non-empty one would resurrect every
+            // deleted mint on the next launch. An empty list records that
+            // the user deliberately deleted their mints, matching removeMint
             await Storage.setItem(
                 `${lndDir}-cashu-mintUrls`,
                 JSON.stringify([])

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -5655,13 +5655,43 @@ export default class CashuStore {
                 console.warn('CDK: Failed to delete wallet database:', e);
             }
 
+            // Overwrite the relay backup with an empty one before the seed
+            // (which derives the backup keypair) is removed below. Without
+            // this, reinstalling and restoring from the same seed would pull
+            // the stale non-empty backup and resurrect every mint deleted
+            // here. Calls backupMintsToNostr directly rather than
+            // nostrBackupMints so nothing is persisted mid-delete: a publish
+            // outlasting the race below would otherwise re-create the
+            // timestamp key after it is removed. Best-effort: bounded so
+            // unreachable relays cannot stall deletion, and failure
+            // (e.g. offline) must not abort cleanup
+            const backupSeed = this.getNostrBackupSeed();
+            if (backupSeed) {
+                const { privateKeyHex, publicKeyHex } =
+                    deriveMintBackupKeypair(backupSeed);
+                await Promise.race([
+                    backupMintsToNostr(
+                        privateKeyHex,
+                        publicKeyHex,
+                        [],
+                        DEFAULT_NOSTR_RELAYS
+                    ).catch((e) =>
+                        console.warn(
+                            'Nostr empty mint backup failed during delete:',
+                            e
+                        )
+                    ),
+                    new Promise((resolve) => setTimeout(resolve, 10000))
+                ]);
+            }
+
             // Persist an empty mint list instead of removing the key.
             // Boot treats a missing key as a fresh install or recovery and
             // restores the mint list from the Nostr backup (and re-adds the
-            // onboarding mints); deleting Cashu data does not publish a
-            // backup, so the stale non-empty one would resurrect every
-            // deleted mint on the next launch. An empty list records that
-            // the user deliberately deleted their mints, matching removeMint
+            // onboarding mints); the empty-backup publish above is
+            // best-effort, so the stale non-empty backup can still be the
+            // freshest on relays. An empty list records that the user
+            // deliberately deleted their mints, matching removeMint
             await Storage.setItem(
                 `${lndDir}-cashu-mintUrls`,
                 JSON.stringify([])

--- a/utils/NostrMintBackup.test.ts
+++ b/utils/NostrMintBackup.test.ts
@@ -1,10 +1,120 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { bytesToHex } from '@noble/hashes/utils';
-import { getPublicKey, nip19 } from 'nostr-tools';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { getEventHash, getPublicKey, nip19, nip44 } from 'nostr-tools';
 import * as bip39 from '@scure/bip39';
 
-import { deriveMintBackupKeypair } from './NostrMintBackup';
+import {
+    backupMintsToNostr,
+    deriveMintBackupKeypair,
+    restoreMintsFromNostr
+} from './NostrMintBackup';
 import Base64Utils from './Base64Utils';
+
+let mockRelayFactory: ((url: string) => any) | null = null;
+
+jest.mock('nostr-tools', () => {
+    const actual = jest.requireActual('nostr-tools');
+    class MockRelay {
+        constructor(url: string) {
+            return mockRelayFactory
+                ? mockRelayFactory(url)
+                : new actual.Relay(url);
+        }
+        static async connect(url: string) {
+            const relay = mockRelayFactory
+                ? mockRelayFactory(url)
+                : new actual.Relay(url);
+            await relay.connect();
+            return relay;
+        }
+    }
+    return { ...actual, Relay: MockRelay };
+});
+
+interface RelayScript {
+    events?: any[];
+    neverRespond?: boolean;
+    failConnect?: boolean;
+}
+
+function installFakeRelays(scripts: Record<string, RelayScript>) {
+    const relays: Record<string, any> = {};
+    mockRelayFactory = (url: string) => {
+        const script = scripts[url] ?? {};
+        const relay = {
+            url,
+            connect: () =>
+                script.failConnect
+                    ? Promise.reject(new Error('connect failed'))
+                    : Promise.resolve(),
+            subscribe: (_filters: any, params: any) => {
+                const sub = { close: jest.fn() };
+                if (!script.neverRespond) {
+                    // Fires after the caller has taken the subscription
+                    // handle, under both real and fake timers
+                    queueMicrotask(() => {
+                        for (const ev of script.events ?? []) {
+                            params.onevent(ev);
+                        }
+                        params.oneose();
+                    });
+                }
+                return sub;
+            },
+            publish: jest.fn(() => Promise.resolve()),
+            close: jest.fn()
+        };
+        relays[url] = relay;
+        return relay;
+    };
+    return relays;
+}
+
+function makeBackupEvent(
+    signerPrivHex: string,
+    conversationKey: Uint8Array,
+    mints: string[],
+    timestamp: number,
+    opts: {
+        tamperSig?: boolean;
+        rawPayload?: string;
+        plainContent?: string;
+    } = {}
+) {
+    const plaintext =
+        opts.rawPayload !== undefined
+            ? opts.rawPayload
+            : JSON.stringify({ mints, timestamp });
+    const content =
+        opts.plainContent !== undefined
+            ? opts.plainContent
+            : nip44.encrypt(plaintext, conversationKey);
+    const signerPriv = hexToBytes(signerPrivHex);
+    const unsigned = {
+        kind: 30078,
+        content,
+        tags: [
+            ['d', 'mint-list'],
+            ['client', 'zeus']
+        ],
+        created_at: timestamp,
+        pubkey: getPublicKey(signerPriv)
+    };
+    // Signed by hand rather than with finalizeEvent: finalizeEvent marks
+    // the event as already verified, and verifyEvent trusts that marker,
+    // which would make the signature assertions below vacuous
+    const id = getEventHash(unsigned as any);
+    const event: any = {
+        ...unsigned,
+        id,
+        sig: bytesToHex(schnorr.sign(hexToBytes(id), signerPriv))
+    };
+    if (opts.tamperSig) {
+        event.sig = (event.sig[0] === '0' ? '1' : '0') + event.sig.slice(1);
+    }
+    return event;
+}
 
 describe('NostrMintBackup', () => {
     // A fixed test mnemonic (DO NOT use in production)
@@ -101,6 +211,324 @@ describe('NostrMintBackup', () => {
             expect(publicKeyHex).toBe(
                 'e1c971f6a291628471291a266ab85c6ffd7116c7aab6299a6801ae502f56d69b'
             );
+        });
+    });
+
+    describe('restoreMintsFromNostr', () => {
+        const { privateKey, privateKeyHex, publicKeyHex } =
+            deriveMintBackupKeypair(testSeed);
+        const conversationKey = nip44.getConversationKey(
+            privateKey,
+            publicKeyHex
+        );
+
+        afterEach(() => {
+            mockRelayFactory = null;
+            jest.useRealTimers();
+        });
+
+        it('returns the freshest backup across relays, not the first to answer', async () => {
+            installFakeRelays({
+                'wss://relay-a': {
+                    events: [
+                        makeBackupEvent(
+                            privateKeyHex,
+                            conversationKey,
+                            ['https://old-mint'],
+                            1000
+                        )
+                    ]
+                },
+                'wss://relay-b': {
+                    events: [
+                        makeBackupEvent(
+                            privateKeyHex,
+                            conversationKey,
+                            ['https://new-mint'],
+                            2000
+                        )
+                    ]
+                }
+            });
+
+            const result = await restoreMintsFromNostr(
+                privateKeyHex,
+                publicKeyHex,
+                ['wss://relay-a', 'wss://relay-b']
+            );
+
+            expect(result).toEqual({
+                mints: ['https://new-mint'],
+                timestamp: 2000
+            });
+        });
+
+        it('lets a newer empty backup beat an older non-empty one', async () => {
+            installFakeRelays({
+                'wss://relay-a': {
+                    events: [
+                        makeBackupEvent(
+                            privateKeyHex,
+                            conversationKey,
+                            ['https://old-mint'],
+                            1000
+                        )
+                    ]
+                },
+                'wss://relay-b': {
+                    events: [
+                        makeBackupEvent(
+                            privateKeyHex,
+                            conversationKey,
+                            [],
+                            2000
+                        )
+                    ]
+                }
+            });
+
+            const result = await restoreMintsFromNostr(
+                privateKeyHex,
+                publicKeyHex,
+                ['wss://relay-a', 'wss://relay-b']
+            );
+
+            expect(result).toEqual({ mints: [], timestamp: 2000 });
+        });
+
+        it('drops backups older than minTimestamp', async () => {
+            installFakeRelays({
+                'wss://relay-a': {
+                    events: [
+                        makeBackupEvent(
+                            privateKeyHex,
+                            conversationKey,
+                            ['https://old-mint'],
+                            1000
+                        )
+                    ]
+                }
+            });
+
+            const result = await restoreMintsFromNostr(
+                privateKeyHex,
+                publicKeyHex,
+                ['wss://relay-a'],
+                1500
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('accepts a backup whose timestamp equals minTimestamp', async () => {
+            installFakeRelays({
+                'wss://relay-a': {
+                    events: [
+                        makeBackupEvent(
+                            privateKeyHex,
+                            conversationKey,
+                            ['https://mint'],
+                            1000
+                        )
+                    ]
+                }
+            });
+
+            const result = await restoreMintsFromNostr(
+                privateKeyHex,
+                publicKeyHex,
+                ['wss://relay-a'],
+                1000
+            );
+
+            expect(result).toEqual({
+                mints: ['https://mint'],
+                timestamp: 1000
+            });
+        });
+
+        it('rejects events signed by a different pubkey', async () => {
+            // Valid signature from another key, but content encrypted
+            // with our conversation key — the pubkey check must fire
+            // independently of decryptability
+            const attackerPrivHex = bytesToHex(
+                sha256(Base64Utils.utf8ToBytes('attacker'))
+            );
+            installFakeRelays({
+                'wss://relay-a': {
+                    events: [
+                        makeBackupEvent(
+                            attackerPrivHex,
+                            conversationKey,
+                            ['https://evil-mint'],
+                            9999
+                        )
+                    ]
+                }
+            });
+
+            const result = await restoreMintsFromNostr(
+                privateKeyHex,
+                publicKeyHex,
+                ['wss://relay-a']
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('rejects events with a tampered signature', async () => {
+            installFakeRelays({
+                'wss://relay-a': {
+                    events: [
+                        makeBackupEvent(
+                            privateKeyHex,
+                            conversationKey,
+                            ['https://mint'],
+                            1000,
+                            { tamperSig: true }
+                        )
+                    ]
+                }
+            });
+
+            const result = await restoreMintsFromNostr(
+                privateKeyHex,
+                publicKeyHex,
+                ['wss://relay-a']
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('rejects malformed backup payloads', async () => {
+            installFakeRelays({
+                'wss://relay-a': {
+                    events: [
+                        makeBackupEvent(privateKeyHex, conversationKey, [], 0, {
+                            rawPayload: JSON.stringify({
+                                mints: [1, 2],
+                                timestamp: 1000
+                            })
+                        })
+                    ]
+                },
+                'wss://relay-b': {
+                    events: [
+                        makeBackupEvent(privateKeyHex, conversationKey, [], 0, {
+                            rawPayload: JSON.stringify({
+                                mints: 'not-an-array',
+                                timestamp: 1000
+                            })
+                        })
+                    ]
+                },
+                'wss://relay-c': {
+                    events: [
+                        makeBackupEvent(privateKeyHex, conversationKey, [], 0, {
+                            plainContent: 'not-nip44-ciphertext'
+                        })
+                    ]
+                }
+            });
+
+            const result = await restoreMintsFromNostr(
+                privateKeyHex,
+                publicKeyHex,
+                ['wss://relay-a', 'wss://relay-b', 'wss://relay-c']
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('times out a hung relay without losing other relays', async () => {
+            jest.useFakeTimers();
+            const relays = installFakeRelays({
+                'wss://relay-a': { neverRespond: true },
+                'wss://relay-b': {
+                    events: [
+                        makeBackupEvent(
+                            privateKeyHex,
+                            conversationKey,
+                            ['https://mint'],
+                            2000
+                        )
+                    ]
+                }
+            });
+
+            const promise = restoreMintsFromNostr(privateKeyHex, publicKeyHex, [
+                'wss://relay-a',
+                'wss://relay-b'
+            ]);
+            await jest.advanceTimersByTimeAsync(10000);
+            const result = await promise;
+
+            expect(result).toEqual({
+                mints: ['https://mint'],
+                timestamp: 2000
+            });
+            expect(relays['wss://relay-a'].close).toHaveBeenCalled();
+        });
+
+        it('returns null when all relays fail or have no backup', async () => {
+            installFakeRelays({
+                'wss://relay-a': { failConnect: true },
+                'wss://relay-b': { events: [] }
+            });
+
+            const result = await restoreMintsFromNostr(
+                privateKeyHex,
+                publicKeyHex,
+                ['wss://relay-a', 'wss://relay-b']
+            );
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('backupMintsToNostr', () => {
+        const { privateKey, privateKeyHex, publicKeyHex } =
+            deriveMintBackupKeypair(testSeed);
+        const conversationKey = nip44.getConversationKey(
+            privateKey,
+            publicKeyHex
+        );
+
+        afterEach(() => {
+            mockRelayFactory = null;
+        });
+
+        it('publishes a valid signed event for an empty mint list', async () => {
+            // Removing the last mint must propagate an empty backup,
+            // otherwise the stale non-empty list stays latest forever
+            const relays = installFakeRelays({ 'wss://relay-a': {} });
+
+            const timestamp = await backupMintsToNostr(
+                privateKeyHex,
+                publicKeyHex,
+                [],
+                ['wss://relay-a']
+            );
+
+            const publishMock = relays['wss://relay-a'].publish;
+            expect(publishMock).toHaveBeenCalledTimes(1);
+            const event = publishMock.mock.calls[0][0];
+            expect(event.pubkey).toBe(publicKeyHex);
+            // Re-derive the id and check the schnorr signature directly:
+            // verifyEvent would short-circuit on the marker finalizeEvent
+            // leaves behind and assert nothing
+            expect(getEventHash(event)).toBe(event.id);
+            expect(
+                schnorr.verify(
+                    hexToBytes(event.sig),
+                    hexToBytes(event.id),
+                    hexToBytes(event.pubkey)
+                )
+            ).toBe(true);
+            const decrypted = JSON.parse(
+                nip44.decrypt(event.content, conversationKey)
+            );
+            expect(decrypted).toEqual({ mints: [], timestamp });
         });
     });
 });

--- a/utils/NostrMintBackup.test.ts
+++ b/utils/NostrMintBackup.test.ts
@@ -80,6 +80,7 @@ function makeBackupEvent(
         tamperSig?: boolean;
         rawPayload?: string;
         plainContent?: string;
+        createdAt?: number;
     } = {}
 ) {
     const plaintext =
@@ -98,7 +99,7 @@ function makeBackupEvent(
             ['d', 'mint-list'],
             ['client', 'zeus']
         ],
-        created_at: timestamp,
+        created_at: opts.createdAt ?? timestamp,
         pubkey: getPublicKey(signerPriv)
     };
     // Signed by hand rather than with finalizeEvent: finalizeEvent marks
@@ -294,6 +295,90 @@ describe('NostrMintBackup', () => {
             );
 
             expect(result).toEqual({ mints: [], timestamp: 2000 });
+        });
+
+        it('ranks freshness by the payload timestamp, not created_at', async () => {
+            // The documented contract is that the NIP-44 payload timestamp
+            // is canonical and the outer created_at is ignored (matching
+            // cashu.me). Lock that in with events where the two disagree
+            // and created_at points the other way
+            installFakeRelays({
+                'wss://relay-a': {
+                    events: [
+                        makeBackupEvent(
+                            privateKeyHex,
+                            conversationKey,
+                            ['https://new-mint'],
+                            2000,
+                            { createdAt: 500 }
+                        )
+                    ]
+                },
+                'wss://relay-b': {
+                    events: [
+                        makeBackupEvent(
+                            privateKeyHex,
+                            conversationKey,
+                            ['https://old-mint'],
+                            1000,
+                            { createdAt: 9000 }
+                        )
+                    ]
+                }
+            });
+
+            const result = await restoreMintsFromNostr(
+                privateKeyHex,
+                publicKeyHex,
+                ['wss://relay-a', 'wss://relay-b']
+            );
+
+            expect(result).toEqual({
+                mints: ['https://new-mint'],
+                timestamp: 2000
+            });
+        });
+
+        it('applies minTimestamp to the payload timestamp, not created_at', async () => {
+            // A stale payload cannot pass the floor on the strength of a
+            // newer created_at, and a fresh payload is not dropped for
+            // carrying an older one
+            installFakeRelays({
+                'wss://relay-a': {
+                    events: [
+                        makeBackupEvent(
+                            privateKeyHex,
+                            conversationKey,
+                            ['https://stale-mint'],
+                            1000,
+                            { createdAt: 9999 }
+                        )
+                    ]
+                },
+                'wss://relay-b': {
+                    events: [
+                        makeBackupEvent(
+                            privateKeyHex,
+                            conversationKey,
+                            ['https://fresh-mint'],
+                            2000,
+                            { createdAt: 500 }
+                        )
+                    ]
+                }
+            });
+
+            const result = await restoreMintsFromNostr(
+                privateKeyHex,
+                publicKeyHex,
+                ['wss://relay-a', 'wss://relay-b'],
+                1500
+            );
+
+            expect(result).toEqual({
+                mints: ['https://fresh-mint'],
+                timestamp: 2000
+            });
         });
 
         it('drops backups older than minTimestamp', async () => {

--- a/utils/NostrMintBackup.ts
+++ b/utils/NostrMintBackup.ts
@@ -1,6 +1,12 @@
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
-import { getPublicKey, finalizeEvent, Relay, nip44 } from 'nostr-tools';
+import {
+    getPublicKey,
+    finalizeEvent,
+    verifyEvent,
+    Relay,
+    nip44
+} from 'nostr-tools';
 
 import Base64Utils from './Base64Utils';
 
@@ -9,6 +15,22 @@ const DOMAIN_SEPARATOR = 'cashu-mint-backup';
 interface MintBackupData {
     mints: string[];
     timestamp: number;
+}
+
+export interface MintBackupResult {
+    mints: string[];
+    timestamp: number;
+}
+
+function isValidMintBackupData(data: any): data is MintBackupData {
+    return (
+        !!data &&
+        typeof data === 'object' &&
+        Array.isArray(data.mints) &&
+        data.mints.every((m: any) => typeof m === 'string') &&
+        typeof data.timestamp === 'number' &&
+        Number.isFinite(data.timestamp)
+    );
 }
 
 /**
@@ -103,51 +125,65 @@ export async function backupMintsToNostr(
 /**
  * Restores mint URLs from Nostr relays by fetching the kind 30078
  * event and decrypting with NIP-44.
+ *
+ * Queries every relay and returns the freshest backup by the
+ * encrypted payload's timestamp (relays can withhold or replay old
+ * events, but cannot forge the AEAD-protected payload; the outer
+ * created_at is not authenticated by decryption, so it is ignored).
+ * Backups older than minTimestamp are dropped, so a restore can
+ * never roll back behind a backup this device has already seen.
+ * The freshest result is returned even if its mint list is empty:
+ * a newer empty backup must beat an older non-empty one.
  */
 export async function restoreMintsFromNostr(
     privateKeyHex: string,
     publicKeyHex: string,
-    relays: string[]
-): Promise<{ mints: string[]; timestamp: number } | null> {
+    relays: string[],
+    minTimestamp: number = 0
+): Promise<MintBackupResult | null> {
     const conversationKey = nip44.getConversationKey(
         hexToBytes(privateKeyHex),
         publicKeyHex
     );
 
-    // Try each relay until we get a result
-    for (const relayUrl of relays) {
-        try {
-            const result = await fetchFromRelay(
-                relayUrl,
-                publicKeyHex,
-                conversationKey
-            );
-            if (result) return result;
-        } catch (e) {
-            console.warn(
-                `Nostr mint restore: failed to fetch from ${relayUrl}:`,
-                e
-            );
-        }
+    const results = await Promise.all(
+        relays.map((relayUrl) =>
+            fetchFromRelay(relayUrl, publicKeyHex, conversationKey).catch(
+                (e) => {
+                    console.warn(
+                        `Nostr mint restore: failed to fetch from ${relayUrl}:`,
+                        e
+                    );
+                    return null;
+                }
+            )
+        )
+    );
+
+    let best: MintBackupResult | null = null;
+    for (const result of results) {
+        if (!result) continue;
+        if (result.timestamp < minTimestamp) continue;
+        if (!best || result.timestamp > best.timestamp) best = result;
     }
 
-    return null;
+    return best;
 }
 
 function fetchFromRelay(
     relayUrl: string,
     publicKeyHex: string,
     conversationKey: Uint8Array
-): Promise<{ mints: string[]; timestamp: number } | null> {
+): Promise<MintBackupResult | null> {
     return new Promise((resolve) => {
+        const relay = new Relay(relayUrl);
+
         const timeout = setTimeout(() => {
             try {
                 relay.close();
             } catch {}
             resolve(null);
         }, 10000);
-
-        const relay = new Relay(relayUrl);
 
         relay
             .connect()
@@ -164,12 +200,29 @@ function fetchFromRelay(
                     {
                         onevent(event: any) {
                             try {
+                                if (event.pubkey !== publicKeyHex) {
+                                    console.warn(
+                                        `Nostr mint restore: event from unexpected pubkey on ${relayUrl}`
+                                    );
+                                    return;
+                                }
+                                if (!verifyEvent(event)) {
+                                    console.warn(
+                                        `Nostr mint restore: invalid event signature on ${relayUrl}`
+                                    );
+                                    return;
+                                }
                                 const decrypted = nip44.decrypt(
                                     event.content,
                                     conversationKey
                                 );
-                                const data: MintBackupData =
-                                    JSON.parse(decrypted);
+                                const data = JSON.parse(decrypted);
+                                if (!isValidMintBackupData(data)) {
+                                    console.warn(
+                                        `Nostr mint restore: malformed backup payload on ${relayUrl}`
+                                    );
+                                    return;
+                                }
                                 clearTimeout(timeout);
                                 sub.close();
                                 relay.close();

--- a/views/Tools/CashuTools.tsx
+++ b/views/Tools/CashuTools.tsx
@@ -48,7 +48,7 @@ export default class CashuTools extends React.Component<CashuToolsProps, {}> {
 
     render() {
         const { navigation, CashuStore, SettingsStore } = this.props;
-        const { seedVersion } = CashuStore;
+        const { seedVersion, loading } = CashuStore;
         const isLdk = SettingsStore.implementation === 'ldk-node';
         return (
             <Screen>
@@ -210,6 +210,7 @@ export default class CashuTools extends React.Component<CashuToolsProps, {}> {
                                         'views.Tools.cashu.deleteData'
                                     )}
                                     onPress={this.handleDeleteData}
+                                    disabled={loading}
                                     warning
                                 />
                             </View>


### PR DESCRIPTION
# Description

## Problem

The Cashu mint list is backed up to Nostr relays as a NIP-44 encrypted kind 30078 replaceable event and restored on fresh installs when the local mint list is empty. The restore path had no freshness validation:

- `restoreMintsFromNostr` iterated the 8 default relays serially and returned the first decryptable result. A relay serving a stale event (an honest relay that missed the latest publish, or a malicious relay replaying an old but validly signed backup) could roll the mint list back. On a fresh install the wallet silently adopts the restored list, adds each mint to CDK, and runs proof restore against it, so a mint the user deliberately removed gets re-added and contacted.
- The persisted `nostrMintBackupTimestamp` was loaded and displayed but never consulted during restore.
- Removing the last mint never updated the backup at all (`nostrBackupMints` early-returned on an empty list), so the stale non-empty list stayed latest on every relay forever. In that case the rollback needed no misbehaving relay at all.
- The fetched event's signature and author were never checked, and the decrypted payload shape was not validated before flowing into `CashuDevKit.addMint`.

## Fix

- `restoreMintsFromNostr` now queries all relays in parallel and keeps the backup with the highest encrypted payload `timestamp`. The inner timestamp is authenticated by the NIP-44 AEAD; the outer `created_at` is not, so it is ignored. Payload format is unchanged (`{mints, timestamp}`), so cashu.me cross-compatibility is preserved.
- Restores are gated on the persisted `nostrMintBackupTimestamp` as a floor (equal passes, older is dropped) and the floor ratchets forward on every accepted restore. A replayed older backup can never be restored once a newer one has been seen.
- Removing the last mint now publishes an empty backup so the removal propagates to relays. A newer empty backup beats an older non-empty one; it advances the floor and restores nothing.
- `fetchFromRelay` verifies `event.pubkey` and the event signature and validates the decrypted payload shape (mints is a string array, timestamp is a finite number) before accepting.
- The fire-and-forget backup calls in `addMint`/`removeMint` now catch failures instead of leaving unhandled rejections. The manual Mint sync view still awaits and surfaces errors as before.
- Parallel querying also cuts the worst-case fresh-install restore from 80s (8 relays x 10s serial) to 10s.

## Behavior notes

- A device whose relays only retain events older than its stored floor now gets "No mint backup found" instead of silently restoring stale data. This is intended.
- The "Last backup" timestamp in Tools > Nostr keys > Mint sync now also updates when a restore accepts a backup, even if the user cancels adding the mints: it reflects the latest authenticated backup observed.
- Out of scope, possible follow-up: capping accepted timestamps at now plus slack, so a peer device with a fast clock cannot ratchet the floor into the future.

## Tests

`utils/NostrMintBackup.test.ts` gains a scriptable fake relay harness (partial mock of `relayInit`, real key derivation, NIP-44 encryption, and event signing) and 10 new cases: freshest-across-relays regression (fails on master, returns the stale relay's list), newer-empty-beats-older-non-empty, minTimestamp floor and equal-timestamp acceptance, wrong-pubkey rejection, tampered-signature rejection, malformed payload rejection, hung-relay timeout without losing other relays, all-relays-fail, and an empty-list backup round-trip.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
