### PR TITLE
fix: never touch the network during a clipboard probe

### DIFF
--- a/utils/handleAnything.test.ts
+++ b/utils/handleAnything.test.ts
@@ -22,10 +22,13 @@ let mockIsValidLightningAddress = false;
 let mockIsValidLightningOffer = false;
 let mockIsValidNoffer = false;
 let mockIsValidLNDHubAddress = false;
+let mockIsValidNpub = false;
 let mockProcessLNDHubAddress = jest.fn();
 let mockSupportsOnchainSends = true;
 let mockGetLnurlParams = {};
 let mockBlobUtilFetch = jest.fn();
+const mockRelayInit = jest.fn();
+const mockNip19Decode = jest.fn();
 
 const ZEUS_ECASH_GIFT_URL = 'https://zeusln.com/e/';
 jest.mock('./AddressUtils', () => ({
@@ -38,7 +41,7 @@ jest.mock('./AddressUtils', () => ({
     isValidNoffer: () => mockIsValidNoffer,
     isValidLNDHubAddress: () => mockIsValidLNDHubAddress,
     processLNDHubAddress: (...args: any[]) => mockProcessLNDHubAddress(...args),
-    isValidNpub: () => false,
+    isValidNpub: () => mockIsValidNpub,
     isPsbt: () => false,
     isValidTxHex: () => false,
     ZEUS_ECASH_GIFT_URL
@@ -107,6 +110,14 @@ jest.mock('js-lnurl', () => ({
     findlnurl: (...args: any[]) => mockFindLnurl(...args),
     decodelnurl: () => null
 }));
+jest.mock('nostr-tools', () => ({
+    relayInit: (...args: any[]) => mockRelayInit(...args),
+    nip05: { queryProfile: jest.fn() },
+    nip19: { decode: (...args: any[]) => mockNip19Decode(...args) }
+}));
+jest.mock('../stores/SettingsStore', () => ({
+    DEFAULT_NOSTR_RELAYS: ['wss://relay.example.com']
+}));
 
 describe('handleAnything', () => {
     beforeEach(() => {
@@ -119,6 +130,9 @@ describe('handleAnything', () => {
         mockProcessNodeUri.mockReset();
         mockGetLnurlParamsFn.mockReset();
         mockFindLnurl.mockReset();
+        mockRelayInit.mockReset();
+        mockNip19Decode.mockReset();
+        mockIsValidNpub = false;
         mockIsValidBitcoinAddress = false;
         mockIsValidLightningPubKey = false;
         mockIsValidLightningPaymentRequest = false;
@@ -467,6 +481,63 @@ describe('handleAnything', () => {
             const result = await handleAnything(data, undefined, true);
 
             expect(result).toEqual(true);
+        });
+    });
+
+    // Regression tests for the clipboard-probe network-egress bug: a clipboard
+    // probe (isClipboardValue === true) must classify the value LOCALLY and must
+    // NOT perform any network egress. Previously, LNURL-shaped and npub inputs
+    // fell through to getlnurlParams (a live HTTP GET of an attacker-controllable
+    // target, including RFC1918/link-local literals) and nostrProfileLookup
+    // (outbound Nostr relay connections) on every app foreground.
+    describe('clipboard probe must not touch the network', () => {
+        it('does not fetch lnurl params for a bech32 LNURL clipboard value', async () => {
+            const data =
+                'LNURL1DP68GURN8GHJ7ARN9EJX2UN8D9NKJTNRDAKJ7SJ5GVH42J2VFE24YNP0WPSHJTMF9ATKWD622CE953JGWV6XXUMRDPXNVCJ8X4G9GF2CHDF';
+            mockProcessBIP21Uri.mockReturnValue({ value: data });
+            // findlnurl matches the bech32 payload and decodes to an internal URL
+            mockFindLnurl.mockReturnValue('http://192.168.0.1/probe');
+
+            const result = await handleAnything(data, undefined, true);
+
+            expect(result).toBe(true);
+            expect(mockGetLnurlParamsFn).not.toHaveBeenCalled();
+        });
+
+        it('does not fetch lnurl params for a URL-shaped LNURL clipboard value', async () => {
+            const data = 'http://attacker.example/lnurlp/beacon';
+            mockProcessBIP21Uri.mockReturnValue({ value: data });
+
+            const result = await handleAnything(data, undefined, true);
+
+            expect(result).toBe(true);
+            expect(mockGetLnurlParamsFn).not.toHaveBeenCalled();
+        });
+
+        it('still fetches lnurl params when NOT a clipboard probe (control)', async () => {
+            const data = 'http://attacker.example/lnurlp/beacon';
+            mockProcessBIP21Uri.mockReturnValue({ value: data });
+            mockGetLnurlParamsFn.mockResolvedValue({
+                tag: 'payRequest',
+                domain: 'attacker.example'
+            });
+
+            await handleAnything(data);
+
+            expect(mockGetLnurlParamsFn).toHaveBeenCalledWith(data);
+        });
+
+        it('does not open Nostr relay connections for an npub clipboard value', async () => {
+            const data =
+                'npub1sg6plzptd64u62a878hep2kev88swjh3tw00gjsfl8f237lmu63q0uf63m';
+            mockProcessBIP21Uri.mockReturnValue({ value: data });
+            mockIsValidNpub = true;
+
+            const result = await handleAnything(data, undefined, true);
+
+            expect(result).toBe(true);
+            expect(mockNip19Decode).not.toHaveBeenCalled();
+            expect(mockRelayInit).not.toHaveBeenCalled();
         });
     });
 

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -787,6 +787,12 @@ const handleAnything = async (
         !!lnurl ||
         (value && /\/lnurl|lnurlp|lnurlw|lnurlc|lnurlauth/i.test(value))
     ) {
+        // The input is already recognized as LNURL-shaped locally (bech32
+        // decode, findlnurl, or an lnurl* URL path). That is enough to show
+        // the paste badge, so never fetch during a clipboard probe: defer
+        // getlnurlParams (a live HTTP GET of an attacker-controllable target)
+        // to when the user actually acts on the value.
+        if (isClipboardValue) return true;
         const raw: string = findlnurl(value) || lnurl || value || '';
         return getlnurlParams(raw)
             .then((params: any) => {
@@ -886,6 +892,10 @@ const handleAnything = async (
                 );
             });
     } else if (AddressUtils.isValidNpub(data)) {
+        // A valid npub is fully classified locally; do not open Nostr relay
+        // connections (nostrProfileLookup) during a clipboard probe. Defer the
+        // lookup to when the user acts on the value.
+        if (isClipboardValue) return true;
         try {
             const decoded = nip19.decode(data);
             const pubkey = decoded.data.toString();

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -806,7 +806,6 @@ const handleAnything = async (
 
                 switch (params.tag) {
                     case 'withdrawRequest':
-                        if (isClipboardValue) return true;
                         if (ecash) {
                             return [
                                 'ChoosePaymentMethod',
@@ -823,7 +822,6 @@ const handleAnything = async (
                             }
                         ];
                     case 'payRequest':
-                        if (isClipboardValue) return true;
                         params.lnurlText = raw;
                         return [
                             'LnurlPay',
@@ -834,7 +832,6 @@ const handleAnything = async (
                             }
                         ];
                     case 'channelRequest':
-                        if (isClipboardValue) return true;
                         return [
                             'LnurlChannel',
                             {
@@ -843,7 +840,6 @@ const handleAnything = async (
                         ];
                     case 'login':
                         if (BackendUtils.supportsLnurlAuth()) {
-                            if (isClipboardValue) return true;
                             return [
                                 'LnurlAuth',
                                 {
@@ -851,7 +847,6 @@ const handleAnything = async (
                                 }
                             ];
                         } else {
-                            if (isClipboardValue) return false;
                             Alert.alert(
                                 localeString('general.error'),
                                 localeString(
@@ -868,7 +863,6 @@ const handleAnything = async (
                         }
                         break;
                     default:
-                        if (isClipboardValue) return false;
                         Alert.alert(
                             localeString('general.error'),
                             params.status === 'ERROR'


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

The clipboard probe (`isClipboardValue`) runs the full `handleAnything` router on every `WalletHeader` mount, every wallet-screen `focus`, and every `AppState -> active` transition (`components/WalletHeader.tsx`, `views/Send.tsx`) to decide whether to show a paste badge. It is meant to classify the clipboard string **locally**, but two input classes fell through to a network sink before the clipboard early-returns were consulted:

1. **LNURL (bech32 or `lnurl*` URL):** the branch calls `getlnurlParams(raw)`, which performs a live HTTP GET of the decoded URL, and the `isClipboardValue` guards only ran *inside* the resulting `.then()` callback, so the fetch always fired first. `js-lnurl` imposes no scheme/egress policy on bech32-decoded payloads, so a crafted `lnurl1...` can name any `http://` target, including RFC1918 (`192.168.x.x`) and link-local (`169.254.169.254`) literals.
2. **Nostr `npub`:** the branch ran `nostrProfileLookup`, opening connections to every default relay, with no clipboard guard at all.

### Impact

Any app that can write the clipboard, or a page that gets the user to copy a string, could:

- covertly beacon wallet foreground events, source IP, and timing on every app foreground while the poisoned string sits on the clipboard (Tor is bypassed on these paths);
- perform blind GETs into the local network (SSRF) from the wallet process.

No user interaction beyond opening/foregrounding the wallet is required, and `privacy.clipboard` defaults to on.

### Fix

Both branches already recognize the value locally before hitting the sink, so return early in probe mode:

- LNURL branch: `if (isClipboardValue) return true;` before `getlnurlParams`.
- npub branch: `if (isClipboardValue) return true;` before `nip19.decode` / `nostrProfileLookup`.

The actual fetch/relay lookup is deferred to when the user taps the badge or otherwise acts on the value (non-probe call), where behavior is unchanged. All other input classes (bitcoin address, BOLT11, lightning address, BTCPay, etc.) already early-returned before their network sinks and are unaffected.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

Adds a `clipboard probe must not touch the network` regression suite to `utils/handleAnything.test.ts`:

- bech32 LNURL clipboard value -> `true`, `getParams` not called
- `lnurl*` URL clipboard value -> `true`, `getParams` not called
- control: non-probe call still fetches
- npub clipboard value -> `true`, no `nip19.decode` / relay init

Verified the suite fails without the source guards (3 failing) and passes with them. Full `handleAnything.test.ts` (117 tests) green; prettier, eslint, and tsc clean on the changed files.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Device testing pending: foreground with a poisoned LNURL/npub on the clipboard; confirm no outbound request until the badge is tapped.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
