### PR TITLE
Route ancillary HTTP calls over Tor and warn on Tor-bypassing WebSocket RPCs

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -381,6 +381,7 @@
     "views.Settings.WalletConfiguration.duplicateWallet": "Duplicate Wallet Config",
     "views.Settings.WalletConfiguration.walletInterface": "Wallet interface",
     "views.Settings.AddEditNode.useTor": "Use Tor",
+    "views.Settings.AddEditNode.torWebsocketWarning": "Tor covers this node's REST calls, but streaming operations (batch channel opens and LSP flows) use WebSockets that connect directly and are not routed over Tor. These features are unavailable for .onion nodes.",
     "views.Settings.AddEditNode.pairingPhrase": "Pairing Phrase",
     "views.Settings.AddEditNode.mailboxServer": "Mailbox Server",
     "views.Settings.AddEditNode.customMailboxServer": "Custom Mailbox Server",

--- a/stores/ChannelBackupStore.ts
+++ b/stores/ChannelBackupStore.ts
@@ -1,5 +1,4 @@
 import { action, observable, runInAction } from 'mobx';
-import ReactNativeBlobUtil from 'react-native-blob-util';
 import * as CryptoJS from 'crypto-js';
 
 import NodeInfoStore from './NodeInfoStore';
@@ -16,6 +15,7 @@ import BackendUtils from '../utils/BackendUtils';
 import { LndMobileEventEmitter } from '../utils/LndMobileUtils';
 import Base64Utils from '../utils/Base64Utils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
+import { networkFetch } from '../utils/NetworkUtils';
 
 import Storage from '../storage';
 
@@ -69,14 +69,15 @@ export default class ChannelBackupStore {
         ).toString();
 
         try {
-            const authResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${BACKUPS_HOST}/api/auth`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const authResponse = await networkFetch({
+                method: 'POST',
+                url: `${BACKUPS_HOST}/api/auth`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
 
             if (authResponse.info().status !== 200) {
                 this.logBackupStatus('ERROR');
@@ -90,17 +91,18 @@ export default class ChannelBackupStore {
             );
             const signature =
                 messageSignData.zbase || messageSignData.signature;
-            const backupResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${BACKUPS_HOST}/api/backup`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const backupResponse = await networkFetch({
+                method: 'POST',
+                url: `${BACKUPS_HOST}/api/backup`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                     message: verification,
                     signature,
                     backup: encryptedBackup
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
             if (
                 backupResponse.info().status === 200 &&
                 backupResponse.json().success
@@ -119,14 +121,15 @@ export default class ChannelBackupStore {
     };
 
     public recoverStaticChannelBackup = async () => {
-        const authResponse = await ReactNativeBlobUtil.fetch(
-            'POST',
-            `${BACKUPS_HOST}/api/auth`,
-            { 'Content-Type': 'application/json' },
-            JSON.stringify({
+        const authResponse = await networkFetch({
+            method: 'POST',
+            url: `${BACKUPS_HOST}/api/auth`,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
                 pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey
-            })
-        );
+            }),
+            enableTor: this.settingsStore.enableTor
+        });
         const authResponseStatus = authResponse.info().status;
         if (authResponseStatus !== 200) {
             throw new Error(`Auth response status code: ${authResponseStatus}`);
@@ -135,16 +138,17 @@ export default class ChannelBackupStore {
 
         const messageSignData = await BackendUtils.signMessage(verification);
         const signature = messageSignData.zbase || messageSignData.signature;
-        const recoverResponse = await ReactNativeBlobUtil.fetch(
-            'POST',
-            `${BACKUPS_HOST}/api/recover`,
-            { 'Content-Type': 'application/json' },
-            JSON.stringify({
+        const recoverResponse = await networkFetch({
+            method: 'POST',
+            url: `${BACKUPS_HOST}/api/recover`,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
                 pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                 message: verification,
                 signature
-            })
-        );
+            }),
+            enableTor: this.settingsStore.enableTor
+        });
         const data = recoverResponse.json();
         const { backup, created_at, success } = data;
         if (recoverResponse.info().status === 200 && success && backup) {
@@ -190,14 +194,15 @@ export default class ChannelBackupStore {
         this.error = false;
         this.backups = [];
         try {
-            const authResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${BACKUPS_HOST}/api/auth`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const authResponse = await networkFetch({
+                method: 'POST',
+                url: `${BACKUPS_HOST}/api/auth`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
             const authResponseStatus = authResponse.info().status;
             if (authResponseStatus !== 200) {
                 throw new Error(
@@ -211,16 +216,17 @@ export default class ChannelBackupStore {
             );
             const signature =
                 messageSignData.zbase || messageSignData.signature;
-            const recoverResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${BACKUPS_HOST}/api/recoverAdvanced`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const recoverResponse = await networkFetch({
+                method: 'POST',
+                url: `${BACKUPS_HOST}/api/recoverAdvanced`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                     message: verification,
                     signature
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
             const data = recoverResponse.json();
             const { backups } = data;
             if (recoverResponse.info().status === 200 && backups) {

--- a/stores/FeeStore.ts
+++ b/stores/FeeStore.ts
@@ -1,5 +1,4 @@
 import { action, observable, runInAction } from 'mobx';
-import ReactNativeBlobUtil from 'react-native-blob-util';
 import BigNumber from 'bignumber.js';
 
 import SettingsStore from './SettingsStore';
@@ -8,6 +7,7 @@ import NodeInfoStore from './NodeInfoStore';
 import BackendUtils from '../utils/BackendUtils';
 import Base64Utils from '../utils/Base64Utils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
+import { networkFetch } from '../utils/NetworkUtils';
 import UrlUtils from '../utils/UrlUtils';
 import ForwardEvent from '../models/ForwardEvent';
 
@@ -53,12 +53,13 @@ export default class FeeStore {
         this.loading = true;
         this.error = false;
         this.recommendedFees = {};
-        return ReactNativeBlobUtil.fetch(
-            'get',
-            `${UrlUtils.getMempoolApiUrl(
+        return networkFetch({
+            method: 'get',
+            url: `${UrlUtils.getMempoolApiUrl(
                 this.nodeInfoStore.nodeInfo
-            )}/v1/fees/recommended`
-        )
+            )}/v1/fees/recommended`,
+            enableTor: this.settingsStore.enableTor
+        })
             .then((response: any) => {
                 const status = response.info().status;
                 if (status == 200) {

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -1,8 +1,8 @@
 import { action, observable, runInAction } from 'mobx';
-import ReactNativeBlobUtil from 'react-native-blob-util';
 import BigNumber from 'bignumber.js';
 
 import SettingsStore from './SettingsStore';
+import { networkFetch } from '../utils/NetworkUtils';
 import {
     SATS_PER_BTC,
     numberWithCommas,
@@ -737,10 +737,11 @@ export default class FiatStore {
 
     private getSelectedFiatRateFromYadio = async (code: string) => {
         try {
-            const response = await ReactNativeBlobUtil.fetch(
-                'GET',
-                `https://api.yadio.io/rate/${code}/BTC`
-            );
+            const response = await networkFetch({
+                method: 'GET',
+                url: `https://api.yadio.io/rate/${code}/BTC`,
+                enableTor: this.settingsStore.enableTor
+            });
             const status = response.info().status;
             if (status == 200) {
                 return {
@@ -759,10 +760,11 @@ export default class FiatStore {
 
     private getFiatRatesFromZeus = async () => {
         try {
-            const response = await ReactNativeBlobUtil.fetch(
-                'GET',
-                'https://pay.zeusln.app/api/rates?storeId=Fjt7gLnGpg4UeBMFccLquy3GTTEz4cHU4PZMU63zqMBo'
-            );
+            const response = await networkFetch({
+                method: 'GET',
+                url: 'https://pay.zeusln.app/api/rates?storeId=Fjt7gLnGpg4UeBMFccLquy3GTTEz4cHU4PZMU63zqMBo',
+                enableTor: this.settingsStore.enableTor
+            });
             const status = response.info().status;
             if (status == 200) {
                 return response.json();

--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -1,5 +1,4 @@
 import { action, observable, reaction, runInAction } from 'mobx';
-import ReactNativeBlobUtil from 'react-native-blob-util';
 import { v4 as uuidv4 } from 'uuid';
 
 import SettingsStore, { getLspConfigForNetwork } from './SettingsStore';
@@ -17,6 +16,7 @@ import { getClientInfo } from '../utils/ClientInfoUtils';
 import { LndMobileEventEmitter } from '../utils/LndMobileUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
+import { networkFetch } from '../utils/NetworkUtils';
 
 import Storage from '../storage';
 
@@ -271,11 +271,12 @@ export default class LSPStore {
 
     public getLSPInfo = () => {
         return new Promise((resolve, reject) => {
-            ReactNativeBlobUtil.fetch(
-                'get',
-                `${this.getFlowHost()}/api/v1/info`,
-                { 'Content-Type': 'application/json' }
-            )
+            networkFetch({
+                method: 'get',
+                url: `${this.getFlowHost()}/api/v1/info`,
+                headers: { 'Content-Type': 'application/json' },
+                enableTor: this.settingsStore.enableTor
+            })
                 .then(async (response: any) => {
                     const status = response.info().status;
                     let data: any;
@@ -349,20 +350,21 @@ export default class LSPStore {
         const { settings } = this.settingsStore;
 
         return new Promise((resolve, reject) => {
-            ReactNativeBlobUtil.fetch(
-                'post',
-                `${this.getFlowHost()}/api/v1/fee`,
-                settings.lspAccessKey
+            networkFetch({
+                method: 'post',
+                url: `${this.getFlowHost()}/api/v1/fee`,
+                headers: settings.lspAccessKey
                     ? {
                           'Content-Type': 'application/json',
                           'x-auth-token': settings.lspAccessKey
                       }
                     : { 'Content-Type': 'application/json' },
-                JSON.stringify({
+                body: JSON.stringify({
                     amount_msat,
                     pubkey: this.nodeInfoStore.nodeInfo.nodeId
-                })
-            )
+                }),
+                enableTor: this.settingsStore.enableTor
+            })
                 .then((response: any) => {
                     const status = response.info().status;
                     let data: any;
@@ -491,24 +493,25 @@ export default class LSPStore {
         const { settings } = this.settingsStore;
 
         return new Promise((resolve, reject) => {
-            ReactNativeBlobUtil.fetch(
-                'post',
-                `${this.getFlowHost()}/api/v1/proposal`,
-                settings.lspAccessKey
+            networkFetch({
+                method: 'post',
+                url: `${this.getFlowHost()}/api/v1/proposal`,
+                headers: settings.lspAccessKey
                     ? {
                           'Content-Type': 'application/json',
                           'x-auth-token': settings.lspAccessKey
                       }
                     : { 'Content-Type': 'application/json' },
-                JSON.stringify({
+                body: JSON.stringify({
                     bolt11,
                     fee_id: this.feeId,
                     simpleTaproot:
                         settings.requestSimpleTaproot &&
                         BackendUtils.supportsSimpleTaprootChannels(),
                     client_info: this.getClientInfo()
-                })
-            )
+                }),
+                enableTor: this.settingsStore.enableTor
+            })
                 .then(async (response: any) => {
                     const status = response.info().status;
                     let data: any;
@@ -739,7 +742,11 @@ export default class LSPStore {
 
         console.log('Fetching data from:', endpoint);
 
-        return ReactNativeBlobUtil.fetch('GET', endpoint)
+        return networkFetch({
+            method: 'GET',
+            url: endpoint,
+            enableTor: this.settingsStore.enableTor
+        })
             .then((response) => {
                 runInAction(() => {
                     if (response.info().status === 200) {
@@ -824,12 +831,13 @@ export default class LSPStore {
         const endpoint = `${this.getLSPS1Rest()}/api/v1/create_order`;
         console.log('Sending data to:', endpoint);
 
-        return ReactNativeBlobUtil.fetch(
-            'POST',
-            endpoint,
-            { 'Content-Type': 'application/json' },
-            data
-        )
+        return networkFetch({
+            method: 'POST',
+            url: endpoint,
+            headers: { 'Content-Type': 'application/json' },
+            body: data,
+            enableTor: this.settingsStore.enableTor
+        })
             .then((response) => {
                 const responseData = JSON.parse(response.data);
                 if (responseData.error) {
@@ -914,8 +922,13 @@ export default class LSPStore {
 
         console.log('Sending data to:', endpoint);
 
-        return ReactNativeBlobUtil.fetch('GET', endpoint, {
-            'Content-Type': 'application/json'
+        return networkFetch({
+            method: 'GET',
+            url: endpoint,
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            enableTor: this.settingsStore.enableTor
         })
             .then((response) => {
                 const responseData = JSON.parse(response.data);

--- a/stores/LightningAddressStore.ts
+++ b/stores/LightningAddressStore.ts
@@ -1,6 +1,5 @@
 import { Platform } from 'react-native';
 import { action, observable, runInAction } from 'mobx';
-import ReactNativeBlobUtil from 'react-native-blob-util';
 import { Notifications } from 'react-native-notifications';
 
 import BigNumber from 'bignumber.js';
@@ -24,6 +23,7 @@ import Base64Utils from '../utils/Base64Utils';
 import { BIP39_WORD_LIST } from '../utils/Bip39Utils';
 import { sleep } from '../utils/SleepUtils';
 import { localeString } from '../utils/LocaleUtils';
+import { networkFetch } from '../utils/NetworkUtils';
 
 import Storage from '../storage';
 
@@ -121,14 +121,15 @@ export default class LightningAddressStore {
         if (this.auth && this.authDate && this.authDate > tenMinutesAgo) {
             return this.auth;
         } else {
-            const authResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${LNURL_HOST}/api/lnurl/auth`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const authResponse = await networkFetch({
+                method: 'POST',
+                url: `${LNURL_HOST}/api/lnurl/auth`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
 
             const authData = authResponse.json();
             if (authResponse.info().status !== 200) throw authData.error;
@@ -267,14 +268,15 @@ export default class LightningAddressStore {
                 ...(nostrSignatures.length > 0 && { nostrSignatures })
             };
 
-            const submitResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${LNURL_HOST}/api/lnurl/submitHashes`,
-                {
+            const submitResponse = await networkFetch({
+                method: 'POST',
+                url: `${LNURL_HOST}/api/lnurl/submitHashes`,
+                headers: {
                     'Content-Type': 'application/json'
                 },
-                JSON.stringify(payload)
-            );
+                body: JSON.stringify(payload),
+                enableTor: this.settingsStore.enableTor
+            });
 
             const submitData = submitResponse.json();
             if (!submitData.success) throw submitData.error;
@@ -316,11 +318,11 @@ export default class LightningAddressStore {
                 )
             );
 
-            const createResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${LNURL_HOST}/api/lnurl/create`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const createResponse = await networkFetch({
+                method: 'POST',
+                url: `${LNURL_HOST}/api/lnurl/create`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                     message: verification,
                     signature,
@@ -328,8 +330,9 @@ export default class LightningAddressStore {
                     relays,
                     relays_sig,
                     address_type: 'zaplocker'
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
 
             const createData = createResponse.json();
             if (createResponse.info().status !== 200 || !createData.success) {
@@ -386,19 +389,20 @@ export default class LightningAddressStore {
                 await this.cashuStore.initializeWallet(mint_url);
             }
 
-            const createResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${LNURL_HOST}/api/lnurl/create`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const createResponse = await networkFetch({
+                method: 'POST',
+                url: `${LNURL_HOST}/api/lnurl/create`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                     cashu_pubkey: this.cashuStore.cashuWallets[mint_url].pubkey,
                     message: verification,
                     signature,
                     mint_url,
                     address_type: 'cashu'
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
 
             const createData = createResponse.json();
             if (createResponse.info().status !== 200 || !createData.success) {
@@ -448,18 +452,19 @@ export default class LightningAddressStore {
         try {
             const { verification, signature } = await this.getAuthData();
 
-            const createResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${LNURL_HOST}/api/lnurl/create`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const createResponse = await networkFetch({
+                method: 'POST',
+                url: `${LNURL_HOST}/api/lnurl/create`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                     message: verification,
                     signature,
                     nwc_string,
                     address_type: 'nwc'
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
 
             const createData = createResponse.json();
             if (createResponse.info().status !== 200 || !createData.success) {
@@ -506,14 +511,15 @@ export default class LightningAddressStore {
         this.loading = true;
 
         try {
-            const createResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${LNURL_HOST}/api/lnurl/nwc/test`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const createResponse = await networkFetch({
+                method: 'POST',
+                url: `${LNURL_HOST}/api/lnurl/nwc/test`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     nwc_string
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
 
             const createData = createResponse.json();
             if (createResponse.info().status !== 200 || !createData.success) {
@@ -551,17 +557,18 @@ export default class LightningAddressStore {
         try {
             const { verification, signature } = await this.getAuthData();
 
-            const updateResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${LNURL_HOST}/api/lnurl/update`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const updateResponse = await networkFetch({
+                method: 'POST',
+                url: `${LNURL_HOST}/api/lnurl/update`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                     message: verification,
                     signature,
                     updates
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
 
             const updateData = updateResponse.json();
             if (updateResponse.info().status !== 200 || !updateData.success) {
@@ -609,16 +616,17 @@ export default class LightningAddressStore {
         try {
             const { verification, signature } = await this.getAuthData();
 
-            const statusResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${LNURL_HOST}/api/lnurl/status`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const statusResponse = await networkFetch({
+                method: 'POST',
+                url: `${LNURL_HOST}/api/lnurl/status`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                     message: verification,
                     signature
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
 
             const statusData = statusResponse.json();
             if (statusResponse.info().status !== 200 || !statusData.success) {
@@ -723,18 +731,19 @@ export default class LightningAddressStore {
         try {
             const { verification, signature } = await this.getAuthData();
 
-            const redeemResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${LNURL_HOST}/api/lnurl/redeem`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const redeemResponse = await networkFetch({
+                method: 'POST',
+                url: `${LNURL_HOST}/api/lnurl/redeem`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                     message: verification,
                     signature,
                     hash,
                     payReq
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
 
             const redeemData = redeemResponse.json();
             if (redeemResponse.info().status !== 200 || !redeemData.success) {
@@ -758,17 +767,18 @@ export default class LightningAddressStore {
     private callRedeemEndpoint = async (quote_id: string) => {
         const { verification, signature } = await this.getAuthData();
 
-        const redeemResponse = await ReactNativeBlobUtil.fetch(
-            'POST',
-            `${LNURL_HOST}/api/lnurl/nuts/redeem`,
-            { 'Content-Type': 'application/json' },
-            JSON.stringify({
+        const redeemResponse = await networkFetch({
+            method: 'POST',
+            url: `${LNURL_HOST}/api/lnurl/nuts/redeem`,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
                 pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                 message: verification,
                 signature,
                 quoteId: quote_id
-            })
-        );
+            }),
+            enableTor: this.settingsStore.enableTor
+        });
 
         const redeemData = redeemResponse.json();
 
@@ -1416,16 +1426,17 @@ export default class LightningAddressStore {
         try {
             const { verification, signature } = await this.getAuthData();
 
-            const deleteResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${LNURL_HOST}/api/lnurl/delete`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const deleteResponse = await networkFetch({
+                method: 'POST',
+                url: `${LNURL_HOST}/api/lnurl/delete`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                     message: verification,
                     signature
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
 
             const deleteData = deleteResponse.json();
             if (deleteResponse.info().status !== 200) throw deleteData.error;
@@ -1460,16 +1471,17 @@ export default class LightningAddressStore {
         try {
             const { verification, signature } = await this.getAuthData();
 
-            const orderResponse = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${LNURL_HOST}/api/plus/order`,
-                { 'Content-Type': 'application/json' },
-                JSON.stringify({
+            const orderResponse = await networkFetch({
+                method: 'POST',
+                url: `${LNURL_HOST}/api/plus/order`,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
                     pubkey: this.nodeInfoStore.nodeInfo.identity_pubkey,
                     message: verification,
                     signature
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
 
             const orderData = orderResponse.json();
             if (orderResponse.info().status !== 200) throw orderData.error;

--- a/stores/Stores.ts
+++ b/stores/Stores.ts
@@ -92,7 +92,7 @@ export const lightningAddressStore = new LightningAddressStore(
 );
 export const posStore = new PosStore(settingsStore, fiatStore, unitsStore);
 export const inventoryStore = new InventoryStore();
-export const sweepStore = new SweepStore(nodeInfoStore);
+export const sweepStore = new SweepStore(nodeInfoStore, settingsStore);
 export const nostrWalletConnectStore = new NostrWalletConnectStore(
     settingsStore,
     balanceStore,

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -1,5 +1,4 @@
 import { action, observable, computed, runInAction, reaction } from 'mobx';
-import ReactNativeBlobUtil from 'react-native-blob-util';
 import { ECPairAPI, ECPairFactory } from 'ecpair';
 import ecc from '@bitcoinerlab/secp256k1';
 import { crypto, initEccLib } from 'bitcoinjs-lib';
@@ -8,6 +7,7 @@ import { mnemonicToSeedSync, generateMnemonic } from '@scure/bip39';
 
 import { themeColor } from '../utils/ThemeUtils';
 import { localeString } from '../utils/LocaleUtils';
+import { networkFetch } from '../utils/NetworkUtils';
 import { BIP39_WORD_LIST } from '../utils/Bip39Utils';
 import {
     SWAPS_KEY,
@@ -203,11 +203,12 @@ export default class SwapStore {
         const host = this.getHost;
         console.log(`Fetching fees from: ${host}`);
         try {
-            const response = await ReactNativeBlobUtil.fetch(
-                'GET',
-                `${host}/swap/submarine`,
-                this.getHeaders
-            );
+            const response = await networkFetch({
+                method: 'GET',
+                url: `${host}/swap/submarine`,
+                headers: this.getHeaders,
+                enableTor: this.settingsStore.enableTor
+            });
             const status = response.info().status;
             if (status == 200) {
                 const data = response.json();
@@ -234,11 +235,12 @@ export default class SwapStore {
         }
 
         try {
-            const response = await ReactNativeBlobUtil.fetch(
-                'GET',
-                `${host}/swap/reverse`,
-                this.getHeaders
-            );
+            const response = await networkFetch({
+                method: 'GET',
+                url: `${host}/swap/reverse`,
+                headers: this.getHeaders,
+                enableTor: this.settingsStore.enableTor
+            });
             const status = response.info().status;
             if (status == 200) {
                 const data = response.json();
@@ -273,11 +275,12 @@ export default class SwapStore {
     public getLockupTransaction = async (id: string, endpoint?: string) => {
         try {
             const host = endpoint || this.getHost;
-            const response = await ReactNativeBlobUtil.fetch(
-                'GET',
-                `${host}/swap/submarine/${id}/transaction`,
-                this.getHeaders
-            );
+            const response = await networkFetch({
+                method: 'GET',
+                url: `${host}/swap/submarine/${id}/transaction`,
+                headers: this.getHeaders,
+                enableTor: this.settingsStore.enableTor
+            });
 
             const status = response.info().status;
             const data = response.json();
@@ -327,20 +330,21 @@ export default class SwapStore {
             );
             const refundPublicKey = Buffer.from(keys.publicKey).toString('hex');
 
-            const response = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${this.getHost}/swap/submarine`,
-                {
+            const response = await networkFetch({
+                method: 'POST',
+                url: `${this.getHost}/swap/submarine`,
+                headers: {
                     'Content-Type': 'application/json'
                 },
-                JSON.stringify({
+                body: JSON.stringify({
                     invoice,
                     to: 'BTC',
                     from: 'BTC',
                     refundPublicKey,
                     ...(this.referralId && { referralId: this.referralId })
-                })
-            );
+                }),
+                enableTor: this.settingsStore.enableTor
+            });
 
             const responseData = JSON.parse(response.data);
             console.log('Parsed Response Data:', responseData);
@@ -462,14 +466,15 @@ export default class SwapStore {
 
             console.log('Data before sending to API:', data);
 
-            const response = await ReactNativeBlobUtil.fetch(
-                'POST',
-                `${this.getHost}/swap/reverse`,
-                {
+            const response = await networkFetch({
+                method: 'POST',
+                url: `${this.getHost}/swap/reverse`,
+                headers: {
                     'Content-Type': 'application/json'
                 },
-                data
-            );
+                body: data,
+                enableTor: this.settingsStore.enableTor
+            });
 
             const responseData = JSON.parse(response.data);
             console.log('Created reverse swap:', responseData);
@@ -639,11 +644,12 @@ export default class SwapStore {
                 const host = swap.endpoint || this.getHost;
 
                 try {
-                    const response = await ReactNativeBlobUtil.fetch(
-                        'GET',
-                        `${host}/swap/${swap.id}`,
-                        this.getHeaders
-                    );
+                    const response = await networkFetch({
+                        method: 'GET',
+                        url: `${host}/swap/${swap.id}`,
+                        headers: this.getHeaders,
+                        enableTor: this.settingsStore.enableTor
+                    });
 
                     const result = await response.json();
                     if (result?.status) {
@@ -879,16 +885,17 @@ export default class SwapStore {
             const xpub = this.getXpub(mnemonic);
 
             try {
-                const response = await ReactNativeBlobUtil.fetch(
-                    'POST',
-                    `${host}/swap/restore`,
-                    {
+                const response = await networkFetch({
+                    method: 'POST',
+                    url: `${host}/swap/restore`,
+                    headers: {
                         'Content-Type': 'application/json'
                     },
-                    JSON.stringify({
+                    body: JSON.stringify({
                         xpub
-                    })
-                );
+                    }),
+                    enableTor: this.settingsStore.enableTor
+                });
 
                 const importedSwaps = JSON.parse(response.data || '[]');
 

--- a/stores/SweepStore.ts
+++ b/stores/SweepStore.ts
@@ -6,9 +6,11 @@ import { getPublicKey } from '@noble/secp256k1';
 import { decode as wifDecode } from 'wif';
 
 import NodeInfoStore from './NodeInfoStore';
+import SettingsStore from './SettingsStore';
 
 import { AddressType } from '../utils/WIFUtils';
 import { localeString } from '../utils/LocaleUtils';
+import { networkFetch } from '../utils/NetworkUtils';
 import UrlUtils from '../utils/UrlUtils';
 import ecc from '../zeus_modules/noble_ecc';
 
@@ -31,9 +33,11 @@ export default class SweepStore {
     @observable bytes: number;
     @observable valueToSend: number;
     nodeInfoStore: NodeInfoStore;
+    settingsStore: SettingsStore;
 
-    constructor(nodeInfoStore: NodeInfoStore) {
+    constructor(nodeInfoStore: NodeInfoStore, settingsStore: SettingsStore) {
         this.nodeInfoStore = nodeInfoStore;
+        this.settingsStore = settingsStore;
     }
 
     @action
@@ -43,12 +47,14 @@ export default class SweepStore {
     }
 
     async getUtxosFromAddress(address: string) {
-        const res = await fetch(
-            `${UrlUtils.getMempoolApiUrl(
+        const res = await networkFetch({
+            method: 'GET',
+            url: `${UrlUtils.getMempoolApiUrl(
                 this.nodeInfoStore.nodeInfo
-            )}/address/${address}/utxo`
-        );
-        if (!res.ok) {
+            )}/address/${address}/utxo`,
+            enableTor: this.settingsStore.enableTor
+        });
+        if (res.info().status !== 200) {
             throw new Error(localeString('views.Wif.errorFetchingUtxos'));
         }
 
@@ -142,13 +148,15 @@ export default class SweepStore {
                 for (const utxo of this.utxos) {
                     const { txid, vout } = utxo;
                     totalSats += utxo.value;
-                    const res = await fetch(
-                        `${UrlUtils.getMempoolApiUrl(
+                    const res = await networkFetch({
+                        method: 'GET',
+                        url: `${UrlUtils.getMempoolApiUrl(
                             this.nodeInfoStore.nodeInfo
-                        )}/tx/${txid}/hex`
-                    );
+                        )}/tx/${txid}/hex`,
+                        enableTor: this.settingsStore.enableTor
+                    });
 
-                    if (!res.ok)
+                    if (res.info().status !== 200)
                         throw new Error(
                             localeString('views.Wif.failedToFetchTxHex', {
                                 txid
@@ -167,12 +175,14 @@ export default class SweepStore {
                 for (const utxo of this.utxos) {
                     const { txid, vout } = utxo;
 
-                    const res = await fetch(
-                        `${UrlUtils.getMempoolApiUrl(
+                    const res = await networkFetch({
+                        method: 'GET',
+                        url: `${UrlUtils.getMempoolApiUrl(
                             this.nodeInfoStore.nodeInfo
-                        )}/tx/${txid}`
-                    );
-                    if (!res.ok)
+                        )}/tx/${txid}`,
+                        enableTor: this.settingsStore.enableTor
+                    });
+                    if (res.info().status !== 200)
                         throw new Error(
                             localeString('views.Wif.failedToFetchTxDetails', {
                                 txid
@@ -211,12 +221,14 @@ export default class SweepStore {
 
                     const value = utxo.value;
                     totalSats += value;
-                    const res = await fetch(
-                        `${UrlUtils.getMempoolApiUrl(
+                    const res = await networkFetch({
+                        method: 'GET',
+                        url: `${UrlUtils.getMempoolApiUrl(
                             this.nodeInfoStore.nodeInfo
-                        )}/tx/${txid}`
-                    );
-                    if (!res.ok)
+                        )}/tx/${txid}`,
+                        enableTor: this.settingsStore.enableTor
+                    });
+                    if (res.info().status !== 200)
                         throw new Error(
                             localeString('views.Wif.failedToFetchTxDetails', {
                                 txid

--- a/stores/SyncStore.ts
+++ b/stores/SyncStore.ts
@@ -1,9 +1,9 @@
 import { action, observable, when, runInAction, computed } from 'mobx';
 import { EmitterSubscription, NativeModules } from 'react-native';
-import ReactNativeBlobUtil from 'react-native-blob-util';
 
 import BackendUtils from '../utils/BackendUtils';
 import { LndMobileToolsEventEmitter } from '../utils/EventListenerUtils';
+import { networkFetch } from '../utils/NetworkUtils';
 import { sleep } from '../utils/SleepUtils';
 import UrlUtils from '../utils/UrlUtils';
 
@@ -116,20 +116,21 @@ export default class SyncStore {
 
     private getBestBlockHeight = async () => {
         await new Promise((resolve, reject) => {
-            ReactNativeBlobUtil.fetch(
-                'get',
+            networkFetch({
+                method: 'get',
                 // nodeInfoStore.nodeInfo isn't populated during initial sync,
                 // so the network comes from settings instead. SyncStore only
                 // runs for embedded LND, which is restricted to
                 // 'Mainnet'/'Testnet' (mutinynet is LDK Node-only, tracked
                 // separately as ldkNetwork), so isMutinynet is always false
                 // here.
-                `${UrlUtils.getMempoolApiUrl({
+                url: `${UrlUtils.getMempoolApiUrl({
                     isMutinynet: false,
                     isTestNet:
                         this.settingsStore.embeddedLndNetwork === 'Testnet'
-                })}/blocks/tip/height`
-            )
+                })}/blocks/tip/height`,
+                enableTor: this.settingsStore.enableTor
+            })
                 .then(async (response: any) => {
                     const status = response.info().status;
                     if (status == 200) {

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -3,7 +3,6 @@ const bitcoin = require('bitcoinjs-lib');
 import { action, observable, runInAction } from 'mobx';
 import { randomBytes } from 'react-native-randombytes';
 import { sha256 } from 'js-sha256';
-import ReactNativeBlobUtil from 'react-native-blob-util';
 
 import FundedPsbt from '../models/FundedPsbt';
 import Transaction from '../models/Transaction';
@@ -17,6 +16,7 @@ import Base64Utils from '../utils/Base64Utils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { checkGraphSyncBeforePayment } from '../utils/GraphSyncUtils';
+import { networkFetch } from '../utils/NetworkUtils';
 import UrlUtils from '../utils/UrlUtils';
 import { RATING_MODAL_TRIGGER_DELAY } from '../utils/RatingUtils';
 
@@ -184,7 +184,13 @@ export default class TransactionsStore {
                 this.nodeInfoStore.nodeInfo
             )}/tx`;
 
-            return ReactNativeBlobUtil.fetch('POST', url, headers, tx_hex)
+            return networkFetch({
+                method: 'post',
+                url,
+                headers,
+                body: tx_hex,
+                enableTor: this.settingsStore.enableTor
+            })
                 .then((response: any) => {
                     const status = response.info().status;
                     const data = response.data;
@@ -876,12 +882,13 @@ export default class TransactionsStore {
             'Access-Control-Allow-Origin': '*',
             'Content-Type': 'text/plain'
         };
-        return ReactNativeBlobUtil.fetch(
-            'POST',
-            `${UrlUtils.getMempoolApiUrl(this.nodeInfoStore.nodeInfo)}/tx`,
+        return networkFetch({
+            method: 'post',
+            url: `${UrlUtils.getMempoolApiUrl(this.nodeInfoStore.nodeInfo)}/tx`,
             headers,
-            raw_tx_hex
-        )
+            body: raw_tx_hex,
+            enableTor: this.settingsStore.enableTor
+        })
             .then((response: any) => {
                 const status = response.info().status;
                 const data = response.data;

--- a/utils/ChannelMigrationUtils.test.ts
+++ b/utils/ChannelMigrationUtils.test.ts
@@ -62,6 +62,12 @@ jest.mock('./SleepUtils', () => ({
 jest.mock('../stores/ChannelBackupStore', () => ({
     BACKUPS_HOST: 'https://backups.example.com'
 }));
+jest.mock('../stores/Stores', () => ({
+    settingsStore: { enableTor: false }
+}));
+jest.mock('./NetworkUtils', () => ({
+    networkFetch: jest.fn()
+}));
 jest.mock('../storage', () => ({
     setItem: jest.fn().mockResolvedValue(undefined),
     getItem: jest.fn().mockResolvedValue(null)

--- a/utils/ChannelMigrationUtils.ts
+++ b/utils/ChannelMigrationUtils.ts
@@ -6,6 +6,7 @@ import ReactNativeBlobUtil from 'react-native-blob-util';
 
 import { localeString } from './LocaleUtils';
 import { stopLnd } from './LndMobileUtils';
+import { networkFetch } from './NetworkUtils';
 import BackendUtils from './BackendUtils';
 import { signMessageNodePubkey } from '../lndmobile/wallet';
 import Base64Utils from './Base64Utils';
@@ -13,6 +14,7 @@ import { sleep } from './SleepUtils';
 import { zipFolder, unzipFile, encryptFile, decryptFile } from './ZipUtils';
 
 import { BACKUPS_HOST } from '../stores/ChannelBackupStore';
+import { settingsStore } from '../stores/Stores';
 
 import Storage from '../storage';
 
@@ -139,12 +141,13 @@ export const uploadChannelBackupToOlympus = async (
 
         // 1. Authentication for status to check for existing backup
         console.log('Authenticating for status check...');
-        const statusAuthResponse = await ReactNativeBlobUtil.fetch(
-            'POST',
-            `${BACKUPS_HOST}/api/auth`,
-            { 'Content-Type': 'application/json' },
-            JSON.stringify({ pubkey })
-        );
+        const statusAuthResponse = await networkFetch({
+            method: 'post',
+            url: `${BACKUPS_HOST}/api/auth`,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ pubkey }),
+            enableTor: settingsStore.enableTor
+        });
 
         if (statusAuthResponse.info().status !== 200) {
             throw new Error('Authentication failed');
@@ -166,16 +169,17 @@ export const uploadChannelBackupToOlympus = async (
                 localeString('views.Tools.migration.export.checkingStatus')
             );
         console.log('Checking backup status...');
-        const statusResponse = await ReactNativeBlobUtil.fetch(
-            'POST',
-            `${BACKUPS_HOST}/api/status`,
-            { 'Content-Type': 'application/json' },
-            JSON.stringify({
+        const statusResponse = await networkFetch({
+            method: 'post',
+            url: `${BACKUPS_HOST}/api/status`,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
                 pubkey,
                 signature: statusSignature,
                 message: statusAuth.verification
-            })
-        );
+            }),
+            enableTor: settingsStore.enableTor
+        });
 
         if (statusResponse.info().status !== 200) {
             throw new Error('Status check failed');
@@ -196,12 +200,13 @@ export const uploadChannelBackupToOlympus = async (
                         )
                     );
                 console.log('Authenticating for uploading backup...');
-                const uploadAuthResponse = await ReactNativeBlobUtil.fetch(
-                    'POST',
-                    `${BACKUPS_HOST}/api/auth`,
-                    { 'Content-Type': 'application/json' },
-                    JSON.stringify({ pubkey })
-                );
+                const uploadAuthResponse = await networkFetch({
+                    method: 'post',
+                    url: `${BACKUPS_HOST}/api/auth`,
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ pubkey }),
+                    enableTor: settingsStore.enableTor
+                });
 
                 if (uploadAuthResponse.info().status !== 200) {
                     throw new Error('Authentication failed');
@@ -266,17 +271,18 @@ export const uploadChannelBackupToOlympus = async (
                         localeString('views.Tools.migration.export.uploading')
                     );
                 console.log('Uploading encrypted backup...');
-                const backupResponse = await ReactNativeBlobUtil.fetch(
-                    'POST',
-                    `${BACKUPS_HOST}/api/channels-backup`,
-                    { 'Content-Type': 'application/json' },
-                    JSON.stringify({
+                const backupResponse = await networkFetch({
+                    method: 'post',
+                    url: `${BACKUPS_HOST}/api/channels-backup`,
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
                         pubkey,
                         message: uploadAuth.verification,
                         signature: uploadSignature,
                         backup: encryptedBase64
-                    })
-                );
+                    }),
+                    enableTor: settingsStore.enableTor
+                });
 
                 const status = backupResponse.info().status;
                 if (status === 413) {
@@ -399,12 +405,13 @@ export const restoreChannelBackupFromOlympus = async (
     try {
         // 1. Authentication for status to check for existing backup
         console.log('Authenticating for status check...');
-        const statusAuthResponse = await ReactNativeBlobUtil.fetch(
-            'POST',
-            `${BACKUPS_HOST}/api/auth`,
-            { 'Content-Type': 'application/json' },
-            JSON.stringify({ pubkey })
-        );
+        const statusAuthResponse = await networkFetch({
+            method: 'post',
+            url: `${BACKUPS_HOST}/api/auth`,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ pubkey }),
+            enableTor: settingsStore.enableTor
+        });
 
         if (statusAuthResponse.info().status !== 200) {
             throw new Error('Authentication failed');
@@ -421,16 +428,17 @@ export const restoreChannelBackupFromOlympus = async (
         const statusSignature = statusSignData.signature;
 
         console.log('Checking backup status...');
-        const statusResponse = await ReactNativeBlobUtil.fetch(
-            'POST',
-            `${BACKUPS_HOST}/api/status`,
-            { 'Content-Type': 'application/json' },
-            JSON.stringify({
+        const statusResponse = await networkFetch({
+            method: 'post',
+            url: `${BACKUPS_HOST}/api/status`,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
                 pubkey,
                 signature: statusSignature,
                 message: statusAuth.verification
-            })
-        );
+            }),
+            enableTor: settingsStore.enableTor
+        });
 
         if (statusResponse.info().status !== 200) {
             throw new Error('Status check failed');
@@ -494,12 +502,13 @@ export const restoreChannelBackupFromOlympus = async (
 
         // 2. Authenticatication for restoring backup
         console.log('Authenticating for restore...');
-        const restoreAuthResponse = await ReactNativeBlobUtil.fetch(
-            'POST',
-            `${BACKUPS_HOST}/api/auth`,
-            { 'Content-Type': 'application/json' },
-            JSON.stringify({ pubkey })
-        );
+        const restoreAuthResponse = await networkFetch({
+            method: 'post',
+            url: `${BACKUPS_HOST}/api/auth`,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ pubkey }),
+            enableTor: settingsStore.enableTor
+        });
 
         if (restoreAuthResponse.info().status !== 200) {
             throw new Error('Authentication failed');
@@ -521,16 +530,17 @@ export const restoreChannelBackupFromOlympus = async (
         const tempEncPath = `${RNFS.CachesDirectoryPath}/zeus-olympus-restore-${timestamp}.enc`;
         const tempZipPath = `${RNFS.CachesDirectoryPath}/zeus-olympus-restore-${timestamp}.zip`;
 
-        const restoreResponse = await ReactNativeBlobUtil.fetch(
-            'POST',
-            `${BACKUPS_HOST}/api/restore-channels`,
-            { 'Content-Type': 'application/json' },
-            JSON.stringify({
+        const restoreResponse = await networkFetch({
+            method: 'post',
+            url: `${BACKUPS_HOST}/api/restore-channels`,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
                 pubkey,
                 message: restoreAuth.verification,
                 signature: restoreSignature
-            })
-        );
+            }),
+            enableTor: settingsStore.enableTor
+        });
 
         const restoreStatus = restoreResponse.info().status;
         if (restoreStatus !== 200) {

--- a/utils/NetworkUtils.test.ts
+++ b/utils/NetworkUtils.test.ts
@@ -1,0 +1,121 @@
+const mockFetch = jest.fn();
+jest.mock('react-native-blob-util', () => ({
+    __esModule: true,
+    default: {
+        fetch: (...args: any[]) => mockFetch(...args)
+    }
+}));
+
+jest.mock('react-native-nitro-tor', () => ({
+    RnTor: {
+        startTorIfNotRunning: jest.fn().mockResolvedValue({ is_success: true }),
+        shutdownService: jest.fn(),
+        httpGet: jest.fn(),
+        httpPost: jest.fn(),
+        httpDelete: jest.fn()
+    }
+}));
+
+jest.mock('react-native-fs', () => ({
+    DocumentDirectoryPath: '/tmp'
+}));
+
+import { RnTor } from 'react-native-nitro-tor';
+import { networkFetch } from './NetworkUtils';
+
+describe('networkFetch', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (RnTor.startTorIfNotRunning as jest.Mock).mockResolvedValue({
+            is_success: true
+        });
+    });
+
+    describe('when Tor is disabled', () => {
+        it('delegates to ReactNativeBlobUtil.fetch and never touches Tor', async () => {
+            const blobResponse = { info: () => ({ status: 200 }) };
+            mockFetch.mockResolvedValue(blobResponse);
+
+            const response = await networkFetch({
+                method: 'POST',
+                url: 'https://example.com/api',
+                headers: { 'Content-Type': 'application/json' },
+                body: '{"a":1}',
+                enableTor: false
+            });
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                'POST',
+                'https://example.com/api',
+                { 'Content-Type': 'application/json' },
+                '{"a":1}'
+            );
+            expect(RnTor.httpGet).not.toHaveBeenCalled();
+            expect(RnTor.httpPost).not.toHaveBeenCalled();
+            expect(response).toBe(blobResponse);
+        });
+    });
+
+    describe('when Tor is enabled', () => {
+        it('routes a GET through the Tor daemon and exposes a blob-util-compatible response', async () => {
+            (RnTor.httpGet as jest.Mock).mockResolvedValue({
+                status_code: 200,
+                body: '{"rate":42}',
+                error: null
+            });
+
+            const response = await networkFetch({
+                method: 'GET',
+                url: 'https://example.com/rate',
+                enableTor: true
+            });
+
+            expect(RnTor.httpGet).toHaveBeenCalledTimes(1);
+            expect(mockFetch).not.toHaveBeenCalled();
+            expect(response.info().status).toBe(200);
+            expect(response.json()).toEqual({ rate: 42 });
+            expect(response.text()).toBe('{"rate":42}');
+            expect(response.data).toBe('{"rate":42}');
+        });
+
+        it('routes a POST body through the Tor daemon', async () => {
+            (RnTor.httpPost as jest.Mock).mockResolvedValue({
+                status_code: 201,
+                body: '{"success":true}',
+                error: null
+            });
+
+            const response = await networkFetch({
+                method: 'POST',
+                url: 'https://example.com/create',
+                headers: { 'Content-Type': 'application/json' },
+                body: '{"pubkey":"abc"}',
+                enableTor: true
+            });
+
+            expect(RnTor.httpPost).toHaveBeenCalledTimes(1);
+            const postArgs = (RnTor.httpPost as jest.Mock).mock.calls[0][0];
+            expect(postArgs.url).toBe('https://example.com/create');
+            expect(postArgs.body).toBe('{"pubkey":"abc"}');
+            expect(response.info().status).toBe(201);
+            expect(response.json()).toEqual({ success: true });
+        });
+
+        it('surfaces a non-2xx status instead of throwing (parity with blob-util)', async () => {
+            (RnTor.httpGet as jest.Mock).mockResolvedValue({
+                status_code: 404,
+                body: '{"error":"not found"}',
+                error: null
+            });
+
+            const response = await networkFetch({
+                method: 'GET',
+                url: 'https://example.com/missing',
+                enableTor: true
+            });
+
+            expect(response.info().status).toBe(404);
+            expect(response.json()).toEqual({ error: 'not found' });
+        });
+    });
+});

--- a/utils/NetworkUtils.ts
+++ b/utils/NetworkUtils.ts
@@ -1,0 +1,72 @@
+import ReactNativeBlobUtil from 'react-native-blob-util';
+
+import { doTorRequestRaw, RequestMethod } from './TorUtils';
+
+// A minimal subset of the ReactNativeBlobUtil fetch response that ancillary
+// call sites rely on. Keeping the Tor branch shaped like a ReactNativeBlobUtil
+// response lets callers keep their existing `.info().status` / `.json()` /
+// `.text()` / `.data` handling unchanged across both transports. The `text`
+// and `data` signatures are deliberately loose to stay structurally
+// compatible with FetchBlobResponse.
+export interface NetworkResponse {
+    info: () => { status: number };
+    json: () => any;
+    text: () => string | Promise<any>;
+    data: any;
+}
+
+type HttpMethod = 'GET' | 'POST' | 'DELETE' | 'get' | 'post' | 'delete';
+
+const toRequestMethod = (method: HttpMethod): RequestMethod => {
+    switch (method.toLowerCase()) {
+        case 'get':
+            return RequestMethod.GET;
+        case 'post':
+            return RequestMethod.POST;
+        case 'delete':
+            return RequestMethod.DELETE;
+        default:
+            throw new Error(`Unsupported method: ${method}`);
+    }
+};
+
+interface NetworkFetchArgs {
+    method: HttpMethod;
+    url: string;
+    headers?: any;
+    body?: string;
+    enableTor?: boolean;
+}
+
+// Transport-agnostic HTTP request for ancillary (non-node) service calls.
+// When Tor is enabled for the active node the request is routed through the
+// embedded Tor daemon; otherwise it uses ReactNativeBlobUtil directly. In both
+// cases the returned value exposes the same ReactNativeBlobUtil-compatible
+// surface, so status-based branching and body parsing at the call site are
+// identical regardless of transport.
+const networkFetch = async ({
+    method,
+    url,
+    headers,
+    body,
+    enableTor
+}: NetworkFetchArgs): Promise<NetworkResponse> => {
+    if (enableTor) {
+        const { status, body: responseBody } = await doTorRequestRaw(
+            url,
+            toRequestMethod(method),
+            body,
+            headers
+        );
+        return {
+            info: () => ({ status }),
+            json: () => JSON.parse(responseBody),
+            text: () => responseBody,
+            data: responseBody
+        };
+    }
+
+    return ReactNativeBlobUtil.fetch(method, url, headers, body);
+};
+
+export { networkFetch };

--- a/utils/TorUtils.ts
+++ b/utils/TorUtils.ts
@@ -62,7 +62,12 @@ const ensureTorStarted = (): Promise<void> => {
     return startPromise;
 };
 
-const doTorRequest = async (
+// Low-level Tor request: performs the HTTP call over the Tor daemon and
+// returns the raw status and body verbatim. Unlike doTorRequest it does
+// NOT parse the body and does NOT throw on a non-2xx status — it only
+// rejects on a transport-level failure. Callers that want status-based
+// branching (mirroring a ReactNativeBlobUtil response) build on this.
+const doTorRequestRaw = async (
     url: string,
     method: RequestMethod,
     data?: string,
@@ -72,7 +77,7 @@ const doTorRequest = async (
     // node holds the connection open for timeout_seconds) must pass a
     // longer timeout or the request dies before the node can answer.
     timeoutMs: number = REQUEST_TIMEOUT_MS
-) => {
+): Promise<{ status: number; body: string }> => {
     await ensureTorStarted();
     const headerStr = headersToString(headers);
 
@@ -123,16 +128,39 @@ const doTorRequest = async (
         throw new Error(response.error);
     }
 
+    return { status: response.status_code, body: response.body };
+};
+
+const doTorRequest = async (
+    url: string,
+    method: RequestMethod,
+    data?: string,
+    headers?: any,
+    trustInvalidCerts: boolean = false,
+    // Callers with a request-scoped deadline (e.g. payments, where the
+    // node holds the connection open for timeout_seconds) must pass a
+    // longer timeout or the request dies before the node can answer.
+    timeoutMs: number = REQUEST_TIMEOUT_MS
+) => {
+    const { status, body } = await doTorRequestRaw(
+        url,
+        method,
+        data,
+        headers,
+        trustInvalidCerts,
+        timeoutMs
+    );
+
     let parsedBody: any;
-    if (response.body) {
+    if (body) {
         try {
-            parsedBody = JSON.parse(response.body);
+            parsedBody = JSON.parse(body);
         } catch {
-            parsedBody = response.body;
+            parsedBody = body;
         }
     }
 
-    if (response.status_code >= 300) {
+    if (status >= 300) {
         const message =
             (parsedBody &&
                 typeof parsedBody === 'object' &&
@@ -140,7 +168,7 @@ const doTorRequest = async (
                     parsedBody.message ||
                     parsedBody.error)) ||
             (typeof parsedBody === 'string' && parsedBody) ||
-            `HTTP ${response.status_code}`;
+            `HTTP ${status}`;
         throw new Error(message);
     }
 
@@ -153,4 +181,10 @@ const restartTor = async () => {
     await ensureTorStarted();
 };
 
-export { doTorRequest, restartTor, isOnionHttpsUrl, RequestMethod };
+export {
+    doTorRequest,
+    doTorRequestRaw,
+    restartTor,
+    isOnionHttpsUrl,
+    RequestMethod
+};

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -2897,12 +2897,40 @@ export default class WalletConfiguration extends React.Component<
                                     </Text>
                                     <Switch
                                         value={enableTor}
-                                        onValueChange={() =>
+                                        onValueChange={() => {
+                                            const enabling = !enableTor;
                                             this.setState({
-                                                enableTor: !enableTor,
+                                                enableTor: enabling,
                                                 saved: false
-                                            })
-                                        }
+                                            });
+                                            // Streaming WebSocket RPCs (batch
+                                            // channel opens, LSP flows) bypass
+                                            // Tor and cannot reach .onion nodes.
+                                            // Warn remote-LND users on enable.
+                                            if (
+                                                enabling &&
+                                                implementation === 'lnd'
+                                            ) {
+                                                Alert.alert(
+                                                    localeString(
+                                                        'general.warning'
+                                                    ),
+                                                    localeString(
+                                                        'views.Settings.AddEditNode.torWebsocketWarning'
+                                                    ),
+                                                    [
+                                                        {
+                                                            text: localeString(
+                                                                'general.ok'
+                                                            ),
+                                                            onPress: () =>
+                                                                void 0
+                                                        }
+                                                    ],
+                                                    { cancelable: false }
+                                                );
+                                            }
+                                        }}
                                     />
                                 </>
                             )}


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-2035**](https://github.com/ZeusLN/zeus/issues/2035)

With per-node **Use Tor** enabled, ZEUS only routed the LND/CLNRest **REST** path through the Tor daemon. Two classes of traffic bypassed it, leaking the user's IP (and, for several calls, the node `identity_pubkey`) to clearnet:

1. **LND WebSocket RPCs** (`wsReq`, `subscribeCustomMessages`, `openChannelStream`, `initChanAcceptor`) use the platform `WebSocket` API, which has no SOCKS wiring. They connect directly and cannot reach `.onion` nodes. This is **LND/LndHub-remote only**; `EmbeddedLND` and `LightningNodeConnect` override these methods natively/over gRPC, and CLNRest does not implement them.
2. **Every ancillary service call** (ZEUS Pay lightning-address auth, channel backups, LSP Flow/LSPS1, fiat rates, on-chain fees, block-tip sync, swaps, WIF sweeps) went direct with no `enableTor` branch. Several send the node `identity_pubkey` in the request body, directly linking IP to node identity.

Routing the platform `WebSocket` over Tor is not feasible without a SOCKS primitive in the Tor library, so that class is addressed with an **enable-time warning**. The ancillary REST calls are now routed through the existing Tor daemon.

## Changes

- **`utils/TorUtils.ts`**: add `doTorRequestRaw` (returns `{status, body}`, does not throw on non-2xx). `doTorRequest` is refactored to build on it with no behavior change for existing callers.
- **`utils/NetworkUtils.ts`** (new): `networkFetch({method, url, headers, body, enableTor})` returns a ReactNativeBlobUtil-compatible response (`.info().status` / `.json()` / `.text()` / `.data`), so call sites keep their existing status/body handling regardless of transport.
- Route **35 ancillary REST sites** through `networkFetch`, gated on `settingsStore.enableTor`: `LightningAddressStore` (12), `ChannelBackupStore` (6), `LSPStore` (6), `SwapStore` (7), `FiatStore` (2), `FeeStore` (1), `SyncStore` (1).
- **`SweepStore`**: add a `settingsStore` constructor arg (wired in `Stores.ts`) and migrate its four esplora fetch sites. **`ConnectivityStore` is intentionally left on clearnet** because Tor defeats its reachability/captive-portal probes.
- **`WalletConfiguration.tsx`**: warn when Tor is enabled on a remote **LND** node that streaming WebSocket RPCs (batch channel opens, LSP flows) bypass Tor and are unavailable for `.onion` nodes. One new `en.json` key.
- **`utils/NetworkUtils.test.ts`**: covers transport selection and the Tor shim's response shape.
- **`TransactionsStore`** (review follow-up): the mempool.space broadcast fallback (taken on backends without `publishTransaction`, e.g. CLNRest) and `broadcastRawTxToMempoolSpace` now go through `networkFetch`, so a signed transaction is no longer published from the user's real IP after Tor-routed reads.
- **`utils/ChannelMigrationUtils.ts`** (review follow-up): its eight `BACKUPS_HOST` calls now use `networkFetch`, matching `ChannelBackupStore` on transport.

## Known limitations (follow-ups)

- `LightningAddressStore`'s `socket.io` connection still emits the `pubkey`; a fetch swap cannot cover a websocket (needs socket.io SOCKS proxying).
- Nodes that reach `enableTor` via `.onion` auto-derivation (rather than the toggle) do not pass through the enable-time warning.
- The `ChannelBackupStore`, `SyncStore`, and `ChannelMigrationUtils` gates are staged but currently unreachable: those flows are embedded-LND only, and embedded LND does not get the per-node Tor toggle, so `settingsStore.enableTor` is never set for it. #4522 wires its `embeddedTor` setting into `SettingsStore.enableTor`, which activates these gates for embedded wallets once both PRs are merged.

This also subsumes the transport half of a separate BTCPay pairing-QR finding (`fetchBTCPayConfig` routes `.onion` via Tor but clearnet direct). That report's two non-transport concerns are **not** addressed here and are worth tracking separately: the config URL is fetched at scan time before confirmation, and `parseBTCPayConfig` silently prefers `adminMacaroon` over `macaroon`.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

`yarn verify` green: 1293 tests, TypeScript, Prettier, ESLint.

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

New `utils/NetworkUtils.test.ts` covers transport selection and the Tor shim's response shape.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Device testing pending, priority order: remote LND with Tor enabled (ancillary calls over Tor, WebSocket warning on enable), remote LND `.onion`, LndHub, CLNRest, plus the ancillary services themselves (ZEUS Pay, channel backups, LSP flows, swaps, fiat rates, fees, sync, sweeps) over Tor.

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

