### PR TITLE
Warn before adding a cleartext HTTP Cashu mint

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2257,6 +2257,7 @@
     "views.Cashu.AddMint.enableAndAdd": "Enable Cashu + Add mint",
     "views.Cashu.AddMint.errorMintAlreadyAdded": "Mint already added",
     "views.Cashu.AddMint.errorInvalidUrl": "Mint URL is invalid",
+    "views.Cashu.AddMint.cleartextHttpWarning": "This mint uses unencrypted HTTP. Your invoices, ecash proofs, and mint traffic will be sent in cleartext and can be read or tampered with by anyone on the network path. Only proceed if you trust the entire connection, such as a local or VPN-only link.",
     "views.Cashu.AddMint.discover": "Discover mints",
     "views.Cashu.AddMint.discover.explainer": "These mints were recommended by other Nostr users. Read reviews at bitcoinmints.com. Be careful and do your own research before using a mint.",
     "views.Cashu.AddMint.discover.explainerZeus": "These mints were recommended by Nostr users that ZEUS follows. Be careful and do your own research before using a mint.",

--- a/utils/UrlUtils.test.ts
+++ b/utils/UrlUtils.test.ts
@@ -318,4 +318,90 @@ describe('UrlUtils', () => {
             expect(UrlUtils.isValidUrl(undefined as any)).toBe(false);
         });
     });
+
+    describe('isCleartextHttpTransport', () => {
+        it('flags http:// to a public host', () => {
+            expect(
+                UrlUtils.isCleartextHttpTransport('http://example.com')
+            ).toBe(true);
+            expect(
+                UrlUtils.isCleartextHttpTransport('http://192.168.1.5:3338')
+            ).toBe(true);
+            expect(
+                UrlUtils.isCleartextHttpTransport(
+                    'http://mint.example.com/path?q=1'
+                )
+            ).toBe(true);
+            expect(
+                UrlUtils.isCleartextHttpTransport('HTTP://EXAMPLE.COM')
+            ).toBe(true);
+        });
+
+        it('does not flag https:// or scheme-less input', () => {
+            expect(
+                UrlUtils.isCleartextHttpTransport('https://example.com')
+            ).toBe(false);
+            expect(UrlUtils.isCleartextHttpTransport('example.com')).toBe(
+                false
+            );
+            expect(UrlUtils.isCleartextHttpTransport('')).toBe(false);
+            expect(UrlUtils.isCleartextHttpTransport(undefined)).toBe(false);
+        });
+
+        it('exempts loopback hosts', () => {
+            expect(
+                UrlUtils.isCleartextHttpTransport('http://localhost:3338')
+            ).toBe(false);
+            expect(UrlUtils.isCleartextHttpTransport('http://LOCALHOST')).toBe(
+                false
+            );
+            expect(UrlUtils.isCleartextHttpTransport('http://127.0.0.1')).toBe(
+                false
+            );
+            expect(
+                UrlUtils.isCleartextHttpTransport('http://127.8.9.10:8080')
+            ).toBe(false);
+            expect(UrlUtils.isCleartextHttpTransport('http://[::1]:3338')).toBe(
+                false
+            );
+            // URL parser canonicalizes IPv4 shorthand to dotted-quad form
+            expect(UrlUtils.isCleartextHttpTransport('http://127.1')).toBe(
+                false
+            );
+            expect(UrlUtils.isCleartextHttpTransport('http://0x7f.1')).toBe(
+                false
+            );
+        });
+
+        it('exempts Tor onion services', () => {
+            expect(
+                UrlUtils.isCleartextHttpTransport(
+                    'http://someonionaddress.onion'
+                )
+            ).toBe(false);
+            expect(
+                UrlUtils.isCleartextHttpTransport(
+                    'http://someonionaddress.onion:3338/path'
+                )
+            ).toBe(false);
+        });
+
+        it('is not fooled by hosts that impersonate exempt hosts', () => {
+            // loopback-looking subdomain of an attacker domain
+            expect(
+                UrlUtils.isCleartextHttpTransport('http://127.0.0.1.evil.com')
+            ).toBe(true);
+            // exempt-looking userinfo in front of the real host
+            expect(
+                UrlUtils.isCleartextHttpTransport('http://127.0.0.1@evil.com')
+            ).toBe(true);
+            expect(
+                UrlUtils.isCleartextHttpTransport('http://foo.onion@evil.com')
+            ).toBe(true);
+            // exempt-looking fragment after the real host
+            expect(
+                UrlUtils.isCleartextHttpTransport('http://evil.com#foo.onion')
+            ).toBe(true);
+        });
+    });
 });

--- a/utils/UrlUtils.ts
+++ b/utils/UrlUtils.ts
@@ -125,6 +125,43 @@ const isValidUrl = (url: string): boolean => {
     }
 };
 
+// Returns true when an explicit http:// scheme would carry traffic across
+// the network in cleartext. Onion services are authenticated and encrypted
+// at the Tor layer and loopback never leaves the device, so neither counts.
+// Parses with URL so hosts hidden behind userinfo (http://127.0.0.1@evil.com),
+// fragments (http://evil.com#foo.onion), or spoofed prefixes
+// (http://127.0.0.1.evil.com) are not mistaken for exempt hosts.
+const isCleartextHttpTransport = (urlString?: string): boolean => {
+    if (!urlString) return false;
+    const trimmed = urlString.trim();
+    if (!trimmed.toLowerCase().startsWith('http://')) return false;
+
+    let hostname: string;
+    try {
+        hostname = new URL(trimmed).hostname;
+    } catch {
+        // Unparseable http:// input: fail closed and warn.
+        return true;
+    }
+
+    if (hostname.endsWith('.onion')) return false;
+
+    // Loopback: localhost, ::1 (URL serializes IPv6 hosts in brackets), or
+    // an IPv4 address in 127.0.0.0/8. The URL parser canonicalizes IPv4
+    // shorthand (127.1, 0x7f.1) to dotted-quad form before this check.
+    if (hostname === 'localhost' || hostname === '[::1]') return false;
+    const octets = hostname.split('.');
+    if (
+        octets.length === 4 &&
+        octets.every((o) => /^\d{1,3}$/.test(o) && Number(o) <= 255) &&
+        octets[0] === '127'
+    ) {
+        return false;
+    }
+
+    return true;
+};
+
 const goToBlockExplorerTXID = (txid: string, testnet?: boolean) =>
     goToBlockExplorer('tx', txid, testnet);
 const goToBlockExplorerAddress = (address: string, testnet?: boolean) =>
@@ -169,6 +206,7 @@ const leaveZeus = (url: string) => {
 export default {
     isValidUrl,
     withScheme,
+    isCleartextHttpTransport,
     getMempoolApiUrl,
     getMempoolInstanceHost,
     goToBlockExplorerTXID,

--- a/views/Cashu/AddMint.tsx
+++ b/views/Cashu/AddMint.tsx
@@ -84,40 +84,6 @@ export default class AddMint extends React.Component<
         CashuStore.error = false;
     }
 
-    // Returns true when an explicit http:// scheme would carry mint traffic
-    // (invoices, ecash proofs, quote state) to a host that is neither loopback
-    // nor a Tor onion service, i.e. it would cross the network in cleartext.
-    private isCleartextHttpMint = (urlString?: string): boolean => {
-        if (!urlString) return false;
-        const trimmed = urlString.trim().toLowerCase();
-        if (!trimmed.startsWith('http://')) return false;
-
-        // Isolate the host: strip scheme, then any path/query, then a
-        // trailing :port (handling IPv6 bracket notation).
-        let hostPart = trimmed
-            .slice('http://'.length)
-            .split('/')[0]
-            .split('?')[0];
-        if (hostPart.startsWith('[')) {
-            hostPart = hostPart.slice(1).split(']')[0];
-        } else {
-            hostPart = hostPart.split(':')[0];
-        }
-
-        // Onion services are authenticated at the Tor layer and loopback
-        // never leaves the device, so neither exposes mint traffic.
-        if (hostPart.endsWith('.onion')) return false;
-        if (
-            hostPart === 'localhost' ||
-            hostPart === '::1' ||
-            hostPart.startsWith('127.')
-        ) {
-            return false;
-        }
-
-        return true;
-    };
-
     getMintInfo = async () => {
         const { mintUrl } = this.state;
         if (!mintUrl.trim()) {
@@ -154,7 +120,7 @@ export default class AddMint extends React.Component<
         // A cleartext http:// mint exposes invoices, proofs, and quote state
         // to any network observer and lets a MITM fabricate quote/melt
         // outcomes, so require an explicit confirmation before contacting it.
-        if (this.isCleartextHttpMint(mintUrl)) {
+        if (UrlUtils.isCleartextHttpTransport(mintUrl)) {
             confirmAction(
                 localeString('general.warning'),
                 localeString('views.Cashu.AddMint.cleartextHttpWarning'),

--- a/views/Cashu/AddMint.tsx
+++ b/views/Cashu/AddMint.tsx
@@ -23,6 +23,7 @@ import Screen from '../../components/Screen';
 import { ErrorMessage } from '../../components/SuccessErrorMessage';
 import TextInput from '../../components/TextInput';
 
+import { confirmAction } from '../../utils/ActionUtils';
 import { font } from '../../utils/FontUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
@@ -83,6 +84,40 @@ export default class AddMint extends React.Component<
         CashuStore.error = false;
     }
 
+    // Returns true when an explicit http:// scheme would carry mint traffic
+    // (invoices, ecash proofs, quote state) to a host that is neither loopback
+    // nor a Tor onion service, i.e. it would cross the network in cleartext.
+    private isCleartextHttpMint = (urlString?: string): boolean => {
+        if (!urlString) return false;
+        const trimmed = urlString.trim().toLowerCase();
+        if (!trimmed.startsWith('http://')) return false;
+
+        // Isolate the host: strip scheme, then any path/query, then a
+        // trailing :port (handling IPv6 bracket notation).
+        let hostPart = trimmed
+            .slice('http://'.length)
+            .split('/')[0]
+            .split('?')[0];
+        if (hostPart.startsWith('[')) {
+            hostPart = hostPart.slice(1).split(']')[0];
+        } else {
+            hostPart = hostPart.split(':')[0];
+        }
+
+        // Onion services are authenticated at the Tor layer and loopback
+        // never leaves the device, so neither exposes mint traffic.
+        if (hostPart.endsWith('.onion')) return false;
+        if (
+            hostPart === 'localhost' ||
+            hostPart === '::1' ||
+            hostPart.startsWith('127.')
+        ) {
+            return false;
+        }
+
+        return true;
+    };
+
     getMintInfo = async () => {
         const { mintUrl } = this.state;
         if (!mintUrl.trim()) {
@@ -115,6 +150,33 @@ export default class AddMint extends React.Component<
             });
             return;
         }
+
+        // A cleartext http:// mint exposes invoices, proofs, and quote state
+        // to any network observer and lets a MITM fabricate quote/melt
+        // outcomes, so require an explicit confirmation before contacting it.
+        if (this.isCleartextHttpMint(mintUrl)) {
+            confirmAction(
+                localeString('general.warning'),
+                localeString('views.Cashu.AddMint.cleartextHttpWarning'),
+                {
+                    text: localeString('general.proceed'),
+                    style: 'destructive',
+                    onPress: () => this.performGetMintInfo()
+                },
+                {
+                    text: localeString('general.cancel'),
+                    onPress: () => void 0,
+                    isPreferred: true
+                }
+            );
+            return;
+        }
+
+        this.performGetMintInfo();
+    };
+
+    private performGetMintInfo = async () => {
+        const { mintUrl } = this.state;
         this.setState({
             loading: true,
             error: false,


### PR DESCRIPTION
# Description

The manual Add Mint flow accepted any `http://` or `https://` URL that `UrlUtils.isValidUrl` parsed, then contacted the mint over that scheme with no warning. A cleartext `http://` mint sends invoices, ecash proof Y values, and quote/melt state over an unencrypted connection: any observer on the network path can surveil the traffic, and an active MITM can fabricate quote/melt outcomes (CDK does not verify the melt preimage against the invoice payment hash).

This gates `getMintInfo` on a cleartext-transport check that mirrors the node credential warning added for wallet configuration: if the mint host uses an explicit `http://` scheme and is neither loopback nor a Tor onion service, an explicit confirmation is required before fetching mint info. Loopback never leaves the device and onion services are authenticated at the Tor layer, so both are exempt. The fetch path is extracted into `performGetMintInfo` so it can run either directly or from the confirm callback.

### Scope

This closes the manual-entry vector only. Two related vectors are already handled separately: a ZEUS-Pay-supplied `mint_url` has a native HTTPS/internal-host guard, and a token-embedded mint is no longer polled on view. Out of scope here: the melt preimage-fabrication is an upstream CDK behavior (transport independent, since a malicious mint can already do it over HTTPS), and the app transport-security configs are intentionally permissive to support LND/LNC/LAN/onion node connections.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Manual test plan (device tests pending):

- [ ] Add a mint with an explicit `http://` non-loopback host: confirmation dialog appears; Cancel aborts, Proceed continues to lookup.
- [ ] Add an `http://127.0.0.1` / `http://localhost` mint: no warning (loopback exempt).
- [ ] Add an `http://<host>.onion` mint: no warning (onion exempt).
- [ ] Add a normal `https://` mint: no warning, unchanged behavior.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
