### PR TITLE
fix(security): harden Cashu proof db at rest and on delete

### DIFF
--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -1770,6 +1770,41 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
     }
 
     // ========================================================================
+    // Database Deletion
+    // ========================================================================
+
+    /**
+     * Closes the repository/database handles and deletes the proof db (and its
+     * WAL/SHM sidecars) from disk. Used by "Delete Cashu data" so plaintext
+     * bearer proofs do not survive the user's deletion. Nulling the repository
+     * and db references (and dropping the per-mint wallet handles) releases the
+     * underlying SQLite connection before the files are unlinked. Resolves
+     * false if no database was opened this session.
+     */
+    @ReactMethod
+    fun deleteWalletDatabase(promise: Promise) {
+        val path = currentDbPath
+        repo = null
+        db = null
+        wallets.clear()
+        preparedSends.clear()
+        isInitialized = false
+        if (path == null) {
+            promise.resolve(false)
+            return
+        }
+        for (p in listOf(path, "$path-wal", "$path-shm")) {
+            try {
+                File(p).takeIf { it.exists() }?.delete()
+            } catch (e: Exception) {
+                Log.w(TAG, "deleteWalletDatabase: failed to delete $p", e)
+            }
+        }
+        currentDbPath = null
+        promise.resolve(true)
+    }
+
+    // ========================================================================
     // Cleanup
     // ========================================================================
 

--- a/cashu-cdk/CashuDevKit.ts
+++ b/cashu-cdk/CashuDevKit.ts
@@ -834,6 +834,22 @@ class CashuDevKit {
             throw mapCDKError(error);
         }
     }
+
+    /**
+     * Close the wallet/database handles and delete the proof database (and its
+     * WAL/SHM sidecars) from disk. Used by "Delete Cashu data" so plaintext
+     * bearer proofs do not survive deletion. Resolves false if no database was
+     * opened this session.
+     */
+    async deleteWalletDatabase(): Promise<boolean> {
+        try {
+            const deleted = await CashuDevKitModule.deleteWalletDatabase();
+            this.initialized = false;
+            return deleted;
+        } catch (error) {
+            throw mapCDKError(error);
+        }
+    }
 }
 
 // Export singleton instance

--- a/cashu-cdk/types.ts
+++ b/cashu-cdk/types.ts
@@ -333,4 +333,7 @@ export interface CashuDevKitNativeModule {
 
     // Database
     getDatabasePath(): Promise<string>;
+    // Closes the wallet/db handles and deletes the proof db (+ WAL/SHM).
+    // Resolves false if no database was opened this session.
+    deleteWalletDatabase(): Promise<boolean>;
 }

--- a/ios/CashuDevKit/CashuDevKitModule.m
+++ b/ios/CashuDevKit/CashuDevKitModule.m
@@ -14,6 +14,10 @@
 RCT_EXTERN_METHOD(getDatabasePath:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+// Database Deletion (close handles + unlink db/wal/shm)
+RCT_EXTERN_METHOD(deleteWalletDatabase:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 // Wallet Management
 RCT_EXTERN_METHOD(initializeWallet:(NSString *)mnemonic
                   unit:(NSString *)unit

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -203,6 +203,34 @@ class CashuDevKitModule: RCTEventEmitter {
         return dbPath.path
     }
 
+    /// Hardens a Cashu proof database file at rest. Proofs are bearer assets, so
+    /// the plaintext SQLite file must not leave the device via iCloud/iTunes
+    /// backup, and should be encrypted by the OS when the device is locked.
+    /// Applied to the main db and its WAL/SHM sidecars (guarded on existence).
+    private func secureDatabaseFile(atPath path: String) {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: path) else { return }
+        // Exclude from iCloud/iTunes backup
+        do {
+            var url = URL(fileURLWithPath: path)
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            try url.setResourceValues(values)
+        } catch {
+            print("CashuDevKit: isExcludedFromBackup failed for \(path): \(error)")
+        }
+        // At-rest protection: unreadable until first unlock after boot, which
+        // protects a powered-off/stolen device without breaking background use.
+        do {
+            try fm.setAttributes(
+                [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+                ofItemAtPath: path
+            )
+        } catch {
+            print("CashuDevKit: setProtection failed for \(path): \(error)")
+        }
+    }
+
     private func encodeToJson(_ object: Any) -> String? {
         guard let data = try? JSONSerialization.data(withJSONObject: object) else {
             return nil
@@ -445,6 +473,14 @@ class CashuDevKitModule: RCTEventEmitter {
                     self.walletUnit = currencyUnit
                     self.wallets.removeAll()
                     self.isInitialized = true
+                }
+
+                // Harden the freshly created proof db at rest (bearer assets):
+                // exclude from backup and set file protection. WAL mode means
+                // the -wal/-shm sidecars exist once migrations have run, so
+                // apply after the database and repository are constructed.
+                for p in [dbPath, dbPath + "-wal", dbPath + "-shm"] {
+                    self.secureDatabaseFile(atPath: p)
                 }
 
                 resolve(nil)
@@ -1599,6 +1635,43 @@ class CashuDevKitModule: RCTEventEmitter {
                 reject("REMOVE_PROOFS_ERROR", error.localizedDescription, error)
             }
         }
+    }
+
+    // MARK: - Database Deletion
+
+    /// Closes the repository/database handles and deletes the proof db (and
+    /// its WAL/SHM sidecars) from disk. Used by "Delete Cashu data" so
+    /// plaintext bearer proofs do not survive the user's deletion. Dropping
+    /// the repository, db, and per-mint wallet references releases the
+    /// underlying SQLite connection before the files are unlinked. Resolves
+    /// false if no database was opened this session (nothing to delete).
+    @objc(deleteWalletDatabase:rejecter:)
+    func deleteWalletDatabase(_ resolve: @escaping RCTPromiseResolveBlock,
+                              reject: @escaping RCTPromiseRejectBlock) {
+        let path = self.currentDbPath
+        walletQueue.sync {
+            self.repo = nil
+            self.db = nil
+            self.wallets.removeAll()
+            self.preparedSends.removeAll()
+            self.isInitialized = false
+        }
+        guard let dbPath = path else {
+            resolve(false)
+            return
+        }
+        let fm = FileManager.default
+        for p in [dbPath, dbPath + "-wal", dbPath + "-shm"] {
+            if fm.fileExists(atPath: p) {
+                do {
+                    try fm.removeItem(atPath: p)
+                } catch {
+                    print("CashuDevKit: failed to delete \(p): \(error)")
+                }
+            }
+        }
+        self.currentDbPath = nil
+        resolve(true)
     }
 
     // MARK: - Cleanup

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -5632,6 +5632,18 @@ export default class CashuStore {
                 await Storage.removeItem(`${walletId}-pubkey`);
             }
 
+            // Close the CDK handles and delete the proof database file itself.
+            // removeMint above only clears rows; the plaintext SQLite file (with
+            // its bearer proofs) must be unlinked or it survives "Delete Cashu
+            // data". Native uses the tracked db path, so this is independent of
+            // the seed-phrase key removed below. A failure here must not abort
+            // the rest of the cleanup.
+            try {
+                await CashuDevKit.deleteWalletDatabase();
+            } catch (e) {
+                console.warn('CDK: Failed to delete wallet database:', e);
+            }
+
             // Clean up legacy storage keys (may exist from migration)
             await Storage.removeItem(`${lndDir}-cashu-mintUrls`);
             await Storage.removeItem(`${lndDir}-cashu-totalBalanceSats`);

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -5644,9 +5644,21 @@ export default class CashuStore {
                 console.warn('CDK: Failed to delete wallet database:', e);
             }
 
-            // Clean up legacy storage keys (may exist from migration)
-            await Storage.removeItem(`${lndDir}-cashu-mintUrls`);
+            // Persist an empty mint list instead of removing the key.
+            // Boot treats a missing key as a fresh install or recovery and
+            // restores the mint list from the Nostr backup (and re-adds the
+            // onboarding mints); since nostrBackupMints never publishes an
+            // empty list, the stale backup would resurrect every deleted
+            // mint on the next launch. An empty list records that the user
+            // deliberately deleted their mints, matching removeMint
+            await Storage.setItem(
+                `${lndDir}-cashu-mintUrls`,
+                JSON.stringify([])
+            );
             await Storage.removeItem(`${lndDir}-cashu-totalBalanceSats`);
+            await Storage.removeItem(
+                `${lndDir}-cashu-nostrMintBackupTimestamp`
+            );
 
             // Clean up app-specific storage
             await Storage.removeItem(`${lndDir}-cashu-selectedMintUrl`);


### PR DESCRIPTION
# Description

Ecash proofs are bearer assets: possession of a proof's `secret` + `C` lets anyone spend it from any Cashu wallet, with no seed or PIN required. Despite that, the CDK SQLite proof database (`cashu_wallet_<hash>.db`) was:

1. stored in plaintext (no encryption at rest),
2. swept into iOS iCloud/iTunes backups (the only `isExcludedFromBackup` in the tree is scoped to the LND folder, not the Cashu DB, which sits beside it in `Application Support`), and
3. left on disk by the user-facing "Delete Cashu data" action (`CashuStore.deleteCashuData` removed mints and storage keys but never deleted the DB file).

This PR closes the Zeus-side portion of that gap:

- **iOS backup exclusion + at-rest file protection.** New `secureDatabaseFile(atPath:)` in `CashuDevKitModule.swift` sets `isExcludedFromBackup` and `FileProtectionType.completeUntilFirstUserAuthentication` on the proof DB and its `-wal`/`-shm` sidecars, right after the DB is created in `initializeWallet` (mirrors the existing `LndMobileTools.excludeLndICloudBackup` pattern). `completeUntilFirstUserAuthentication` protects a powered-off/stolen device without breaking background DB access after first unlock. Android is already covered by `allowBackup="false"` plus OS file-based encryption.
- **DB deletion on "Delete Cashu data."** New native `deleteWalletDatabase()` (iOS Swift + Obj-C bridge, Android `@ReactMethod`) closes the wallet/db handles (releasing the SQLite connection) and unlinks the DB plus `-wal`/`-shm` using the tracked `currentDbPath`. Exposed through `cashu-cdk/CashuDevKit.ts` + `types.ts` and called from `CashuStore.deleteCashuData` after the mint-removal loop, wrapped so a native failure never aborts the rest of the cleanup.

**Out of scope (follow-up):** true app-keyed SQLCipher encryption is not reachable from Zeus. The prebuilt cdk-ffi (v0.14.2) opens SQLite with a keyless `WalletSqliteDatabase(filePath:)` constructor and no key crosses the RN bridge, so it requires an upstream CDK change (fork/patch `cdk-ffi` + `cdk-sqlite`, rebuild the pinned binaries, bump hashes). `NSFileProtection` is the interim at-rest control. The full-wipe wrong-filename bug is addressed separately in the orphaned-key-material PR.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

Changes are in native modules (Swift/Kotlin), the CDK RN wrapper, and a store method. There is no existing CashuStore test harness (stores are untested by repo convention), so no unit test was added. `tsc`, `eslint`, and `prettier` pass.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Device testing is still pending (native changes require a build). Planned checks: iOS confirm `isExcludedFromBackup`/protection attributes on the created DB and that "Delete Cashu data" removes the DB + sidecars without crashing; Android confirm file removal.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

Note: native module code changed (iOS + Android), so a native rebuild is required, but no JS dependencies were added or changed.

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
