### PR TITLE
fix: require explicit mint consent in ecash onboarding

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -751,6 +751,8 @@
     "views.MintDiscovery.subtitle": "Choose how to discover Cashu mints",
     "views.MintDiscovery.topMints": "Top recommended mints",
     "views.MintDiscovery.tapToReadReviews": "Tap a mint to read reviews",
+    "views.MintDiscovery.tapToToggleSelection": "Tap a mint to add or remove it. Tap the review icon to read its reviews.",
+    "views.MintDiscovery.custodyWarning": "Ecash mints hold your funds in custody and can freeze or lose them. These mints are recommended by nostr users, not vetted by ZEUS. Only keep a mint selected if you trust it.",
     "views.MintDiscovery.fetchMints": "Find mints",
     "views.MintDiscovery.chooseLater": "Choose later",
     "views.MintDiscovery.chooseLater.description": "Skip mint selection for now and choose mints later in settings",

--- a/utils/MintSelectionUtils.test.ts
+++ b/utils/MintSelectionUtils.test.ts
@@ -1,0 +1,53 @@
+import { resolveSelectedMintUrls } from './MintSelectionUtils';
+
+describe('MintSelectionUtils', () => {
+    const recommended = [
+        'https://mint-a.example',
+        'https://mint-b.example',
+        'https://mint-c.example'
+    ];
+
+    describe('resolveSelectedMintUrls', () => {
+        it('selects every recommended mint when the user has not touched the selection', () => {
+            expect(resolveSelectedMintUrls(null, recommended)).toEqual(
+                recommended
+            );
+        });
+
+        it('returns a copy, not the same array reference, for the default case', () => {
+            const result = resolveSelectedMintUrls(null, recommended);
+            expect(result).not.toBe(recommended);
+        });
+
+        it('honors an explicit subset selection', () => {
+            expect(
+                resolveSelectedMintUrls(
+                    ['https://mint-a.example', 'https://mint-c.example'],
+                    recommended
+                )
+            ).toEqual(['https://mint-a.example', 'https://mint-c.example']);
+        });
+
+        it('honors an explicit empty selection (user deselected every mint)', () => {
+            // This is the security-relevant case: recommended mints must not be
+            // trusted with funds when the user has deselected them all.
+            expect(resolveSelectedMintUrls([], recommended)).toEqual([]);
+        });
+
+        it('drops stale selections that are no longer recommended', () => {
+            expect(
+                resolveSelectedMintUrls(
+                    ['https://mint-a.example', 'https://mint-gone.example'],
+                    recommended
+                )
+            ).toEqual(['https://mint-a.example']);
+        });
+
+        it('returns empty when there are no recommendations to choose from', () => {
+            expect(
+                resolveSelectedMintUrls(['https://mint-a.example'], [])
+            ).toEqual([]);
+            expect(resolveSelectedMintUrls(null, [])).toEqual([]);
+        });
+    });
+});

--- a/utils/MintSelectionUtils.ts
+++ b/utils/MintSelectionUtils.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolves which recommended mints the user has opted into during onboarding.
+ *
+ * Mint recommendations come from a permissionless nostr popularity/rating signal
+ * and are never trusted with funds unless the user keeps them ticked. A `null`
+ * selection means the user has not touched the checkboxes yet, so every
+ * recommended mint is treated as selected (the low-friction default). Once the
+ * user has made an explicit selection we honor it verbatim, filtered to the
+ * mints currently on offer. The result may be empty when the user deselected
+ * every mint.
+ *
+ * @param selectedMintUrls the user's explicit selection, or null if untouched
+ * @param recommendedMintUrls the mint URLs currently shown as recommendations
+ */
+export const resolveSelectedMintUrls = (
+    selectedMintUrls: string[] | null,
+    recommendedMintUrls: string[]
+): string[] => {
+    if (selectedMintUrls === null) {
+        return [...recommendedMintUrls];
+    }
+    return selectedMintUrls.filter((url) => recommendedMintUrls.includes(url));
+};

--- a/views/Onboarding/MintDiscovery.tsx
+++ b/views/Onboarding/MintDiscovery.tsx
@@ -7,6 +7,7 @@ import {
     TouchableOpacity
 } from 'react-native';
 import { inject, observer } from 'mobx-react';
+import { Icon } from '@rneui/themed';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Route } from '@react-navigation/native';
 
@@ -17,10 +18,12 @@ import MintReviewsModal from '../../components/MintReviewsModal';
 import Screen from '../../components/Screen';
 import Text from '../../components/Text';
 import TextInput from '../../components/TextInput';
+import { WarningMessage } from '../../components/SuccessErrorMessage';
 
 import CashuStore, { ScoredMint } from '../../stores/CashuStore';
 
 import { localeString } from '../../utils/LocaleUtils';
+import { resolveSelectedMintUrls } from '../../utils/MintSelectionUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 
 import MintAvatar from '../../components/MintAvatar';
@@ -48,6 +51,10 @@ interface MintDiscoveryState {
     hasFetched: boolean;
     showReviewsModal: boolean;
     reviewsMintUrl: string;
+    // null = user has not touched the selection yet (all recommended mints are
+    // selected by default). A non-null array is the explicit set the user chose,
+    // which may be empty (they deselected every mint).
+    selectedMintUrls: string[] | null;
 }
 
 @inject('CashuStore')
@@ -62,7 +69,8 @@ export default class MintDiscovery extends React.Component<
         npubError: '',
         hasFetched: false,
         showReviewsModal: false,
-        reviewsMintUrl: ''
+        reviewsMintUrl: '',
+        selectedMintUrls: null
     };
 
     componentDidMount() {
@@ -96,11 +104,28 @@ export default class MintDiscovery extends React.Component<
     };
 
     handleDiscoverSelect = (mode: DiscoverMode) => {
-        this.setState({ discoverMode: mode }, () => {
+        // Switching source resets the selection back to "all recommended", since
+        // the list of recommended mints is about to change.
+        this.setState({ discoverMode: mode, selectedMintUrls: null }, () => {
             if (mode !== 'custom' && mode !== 'later') {
                 this.handleFetchMints();
             }
         });
+    };
+
+    // A mint is selected when the user has not touched the selection yet
+    // (null => default all selected) or when it is present in the explicit set.
+    isMintSelected = (url: string) => {
+        const { selectedMintUrls } = this.state;
+        return selectedMintUrls === null || selectedMintUrls.includes(url);
+    };
+
+    toggleMintSelection = (url: string, allUrls: string[]) => {
+        const base = this.state.selectedMintUrls ?? allUrls;
+        const next = base.includes(url)
+            ? base.filter((u) => u !== url)
+            : [...base, url];
+        this.setState({ selectedMintUrls: next });
     };
 
     handleFetchMints = (forceRefresh?: boolean) => {
@@ -124,11 +149,11 @@ export default class MintDiscovery extends React.Component<
             !forceRefresh &&
             CashuStore.restoreCachedRecommendations(cacheKey)
         ) {
-            this.setState({ hasFetched: true });
+            this.setState({ hasFetched: true, selectedMintUrls: null });
             return;
         }
 
-        this.setState({ hasFetched: true });
+        this.setState({ hasFetched: true, selectedMintUrls: null });
 
         if (discoverMode === 'all') {
             CashuStore.fetchMints();
@@ -160,13 +185,23 @@ export default class MintDiscovery extends React.Component<
                 5,
                 discoverMode === 'all' ? 'all' : 'zeus'
             );
-            initialMintUrls = topMints.map((m: ScoredMint) => m.url);
+            const allUrls = topMints.map((m: ScoredMint) => m.url);
+            // Only add the mints the user actually left selected. Recommended
+            // mints are not trusted with funds unless kept ticked.
+            initialMintUrls = resolveSelectedMintUrls(
+                this.state.selectedMintUrls,
+                allUrls
+            );
         }
 
+        // Pressing Select is an explicit selection decision, even when the
+        // resulting set is empty. mintSelectionMade lets downstream screens
+        // distinguish "user chose no mints" from "user never opened discovery".
         if (returnTo) {
             navigation.popTo(returnTo, {
                 discoverMode,
-                initialMintUrls
+                initialMintUrls,
+                mintSelectionMade: true
             });
         } else {
             navigation.navigate('WalletSettings', {
@@ -388,9 +423,20 @@ export default class MintDiscovery extends React.Component<
                                 }}
                             >
                                 {localeString(
-                                    'views.MintDiscovery.tapToReadReviews'
+                                    'views.MintDiscovery.tapToToggleSelection'
                                 )}
                             </Text>
+
+                            {!isLoading && topMints.length > 0 && (
+                                <View style={{ marginBottom: 10 }}>
+                                    <WarningMessage
+                                        message={localeString(
+                                            'views.MintDiscovery.custodyWarning'
+                                        )}
+                                        fontSize={13}
+                                    />
+                                </View>
+                            )}
 
                             {isLoading ? (
                                 <View style={{ padding: 20 }}>
@@ -402,6 +448,12 @@ export default class MintDiscovery extends React.Component<
                                         CashuStore.mintInfoCache.get(mint.url);
                                     const iconUrl = mintInfo?.icon_url;
                                     const mintName = mintInfo?.name;
+                                    const isSelected = this.isMintSelected(
+                                        mint.url
+                                    );
+                                    const allUrls = topMints.map(
+                                        (m: ScoredMint) => m.url
+                                    );
 
                                     return (
                                         <TouchableOpacity
@@ -416,13 +468,31 @@ export default class MintDiscovery extends React.Component<
                                                 }
                                             ]}
                                             onPress={() =>
-                                                this.setState({
-                                                    showReviewsModal: true,
-                                                    reviewsMintUrl: mint.url
-                                                })
+                                                this.toggleMintSelection(
+                                                    mint.url,
+                                                    allUrls
+                                                )
                                             }
                                             activeOpacity={0.7}
                                         >
+                                            <Icon
+                                                name={
+                                                    isSelected
+                                                        ? 'check-box'
+                                                        : 'check-box-outline-blank'
+                                                }
+                                                color={
+                                                    isSelected
+                                                        ? themeColor(
+                                                              'highlight'
+                                                          )
+                                                        : themeColor(
+                                                              'secondaryText'
+                                                          )
+                                                }
+                                                size={24}
+                                                style={{ marginRight: 10 }}
+                                            />
                                             <MintAvatar
                                                 iconUrl={iconUrl}
                                                 name={mintName || mint.url}
@@ -466,6 +536,29 @@ export default class MintDiscovery extends React.Component<
                                                     )}
                                                 </RNText>
                                             </View>
+                                            <TouchableOpacity
+                                                onPress={() =>
+                                                    this.setState({
+                                                        showReviewsModal: true,
+                                                        reviewsMintUrl: mint.url
+                                                    })
+                                                }
+                                                hitSlop={{
+                                                    top: 10,
+                                                    bottom: 10,
+                                                    left: 10,
+                                                    right: 10
+                                                }}
+                                                style={{ marginLeft: 8 }}
+                                            >
+                                                <Icon
+                                                    name="rate-review"
+                                                    color={themeColor(
+                                                        'secondaryText'
+                                                    )}
+                                                    size={22}
+                                                />
+                                            </TouchableOpacity>
                                         </TouchableOpacity>
                                     );
                                 })

--- a/views/Onboarding/RecommendedSettings.tsx
+++ b/views/Onboarding/RecommendedSettings.tsx
@@ -37,6 +37,7 @@ interface RecommendedSettingsProps {
             enableCashu?: boolean;
             discoverMode?: DiscoverMode;
             initialMintUrls?: string[];
+            mintSelectionMade?: boolean;
             clipboard?: boolean;
             fiatEnabled?: boolean;
             selectedCurrency?: string;
@@ -54,6 +55,10 @@ interface RecommendedSettingsState {
     selectedCurrency: string;
     fiatRatesSource: string;
     initialMintUrls: string[];
+    // True once the user has explicitly chosen mints in MintDiscovery. When set,
+    // we honor initialMintUrls verbatim (including empty) instead of falling back
+    // to the recommended top mints.
+    mintSelectionMade: boolean;
     implementation: string;
     choosingPeers: boolean;
     creatingWallet: boolean;
@@ -74,6 +79,7 @@ export default class RecommendedSettings extends React.Component<
         selectedCurrency: DEFAULT_FIAT,
         fiatRatesSource: DEFAULT_FIAT_RATES_SOURCE,
         initialMintUrls: [],
+        mintSelectionMade: false,
         implementation: 'ldk-node',
         choosingPeers: false,
         creatingWallet: false,
@@ -123,6 +129,9 @@ export default class RecommendedSettings extends React.Component<
         if (params.initialMintUrls) {
             this.setState({ initialMintUrls: params.initialMintUrls });
         }
+        if (params.mintSelectionMade !== undefined) {
+            this.setState({ mintSelectionMade: params.mintSelectionMade });
+        }
         if (params.clipboard !== undefined) {
             this.setState({ clipboard: params.clipboard });
         }
@@ -150,12 +159,16 @@ export default class RecommendedSettings extends React.Component<
             selectedCurrency,
             fiatRatesSource,
             initialMintUrls,
+            mintSelectionMade,
             implementation
         } = this.state;
 
-        // Use stored mint URLs or compute from top scored mints
+        // Use the mints the user chose. Only fall back to the recommended top
+        // mints when the user never opened MintDiscovery; once they have made an
+        // explicit selection we honor it verbatim, including an empty set (they
+        // deselected every recommended mint).
         let mintUrls = initialMintUrls;
-        if (enableCashu && mintUrls.length === 0) {
+        if (enableCashu && mintUrls.length === 0 && !mintSelectionMade) {
             const topMints = CashuStore.getTopScoredMints(
                 5,
                 discoverMode === 'all' ? 'all' : 'zeus'
@@ -216,6 +229,7 @@ export default class RecommendedSettings extends React.Component<
             fiatEnabled,
             selectedCurrency,
             initialMintUrls,
+            mintSelectionMade,
             implementation,
             choosingPeers,
             creatingWallet,
@@ -289,11 +303,13 @@ export default class RecommendedSettings extends React.Component<
             discoverMode !== 'zeus' ||
             implementation !== 'ldk-node';
 
-        // Use initialMintUrls from MintDiscovery when available,
-        // otherwise compute from the store
+        // Use initialMintUrls from MintDiscovery when available, otherwise
+        // compute from the store. Once the user has made an explicit selection
+        // we mirror it exactly (including empty) rather than re-adding the
+        // recommended top mints they deselected.
         let displayMintUrls: string[] = [];
         if (enableCashu && !isLater) {
-            if (initialMintUrls.length > 0) {
+            if (initialMintUrls.length > 0 || mintSelectionMade) {
                 displayMintUrls = initialMintUrls;
             } else {
                 const topMints = CashuStore.getTopScoredMints(

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1249,13 +1249,18 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             }
         }
 
-        // Auto-create Cashu Lightning address on first connection
-        // if Cashu was enabled during onboarding but no address exists yet
+        // Auto-create Cashu Lightning address on first connection if Cashu was
+        // enabled during onboarding and the user selected exactly one mint. We
+        // only bind the address when there is a single, unambiguous mint choice:
+        // the address commits all inbound payments to one custodial mint, so we
+        // never pick one on the user's behalf from a multi-mint set. Users with
+        // zero or multiple mints create the address later from Settings, where
+        // they explicitly choose the mint.
         if (
             connecting &&
             settings?.ecash?.enableCashu &&
             !lightningAddress.enabled &&
-            (settings?.ecash?.initialMintUrls?.length ?? 0) > 0 &&
+            settings?.ecash?.initialMintUrls?.length === 1 &&
             !NodeInfoStore.testnet &&
             BackendUtils.supportsCashuWallet()
         ) {


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

Ecash onboarding derived mint trust from a permissionless NIP-87 nostr popularity/rating signal and applied it with a single generic tap. The top-5 scored mints were added to custody verbatim (tapping a mint only opened its reviews, there was no per-mint opt-in), and the rank-1 mint silently received the auto-created ZEUS Pay Cashu lightning address with auto-accept enabled.

The scoring has no Sybil resistance (nostr identities are free, ratings are self-reported strings in the same unsigned events, and the popularity count is per-event). A sockpuppet campaign could land an attacker's mint into first-deposit custody and, at rank-1, capture the user's new lightning address so all inbound payments minted ecash at the attacker's mint.

This PR makes mint custody and lightning-address binding an informed, explicit choice, without removing the low-friction default flow:

- **MintDiscovery**: recommended mints are now removable checkboxes (all pre-selected by default) with a custody warning that names the source. Only the mints the user leaves selected become `initialMintUrls`. Reading reviews moved from a whole-row tap to a dedicated review-icon button.
- **RecommendedSettings**: threads a new `mintSelectionMade` flag so an explicit empty selection (the user deselected every mint) is honored instead of silently re-adding the recommended top-5.
- **Wallet**: the auto-created Cashu lightning address is now created only when the user selected exactly one mint (an unambiguous choice). With zero or multiple mints, auto-creation is skipped and the user creates the address later from Settings, explicitly choosing the mint. The default multi-mint flow no longer binds the address to anyone.
- Extracted `resolveSelectedMintUrls` into `utils/MintSelectionUtils.ts` with unit tests.

Hardening the recommendation ranking itself against Sybil influence (web-of-trust distance, count caps, or a curated allowlist) is intentionally out of scope and tracked separately; this PR removes the silent auto-trust, which is the reported issue.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [x] Yes

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Device testing pending. Cases to verify on mainnet ecash onboarding:
1. Default flow (keep all mints selected) -> all added, no lightning address auto-created.
2. Deselect down to one mint -> that mint added, address auto-created and bound to it with auto-accept.
3. Deselect all -> no mints added, no address (choose-later path).
4. Reviews still open via the review icon; custody warning is visible.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
