### PR TITLE
fix(security): exclude LDK Node data from iOS backups

### DIFF
--- a/utils/LdkNodeUtils.test.ts
+++ b/utils/LdkNodeUtils.test.ts
@@ -1,0 +1,122 @@
+const mockMkdir = jest.fn();
+const mockExists = jest.fn();
+
+jest.mock('react-native', () => ({
+    Platform: { OS: 'ios' }
+}));
+
+jest.mock('react-native-fs', () => ({
+    DocumentDirectoryPath: '/mock/documents',
+    mkdir: (...args: any[]) => mockMkdir(...args),
+    exists: (...args: any[]) => mockExists(...args),
+    unlink: jest.fn()
+}));
+
+jest.mock('../ldknode/LdkNodeInjection', () => ({
+    __esModule: true,
+    default: {}
+}));
+
+jest.mock('./LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+
+jest.mock('./VssAuthUtils', () => ({
+    deriveVssSigningKeyFromSeed: jest.fn()
+}));
+
+import { Platform } from 'react-native';
+import {
+    createLdkNodeDirectory,
+    ensureLdkNodeBackupExclusion,
+    getLdkNodeBaseDirectory,
+    getLdkNodeStoragePath
+} from './LdkNodeUtils';
+
+describe('LdkNodeUtils', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (Platform as any).OS = 'ios';
+    });
+
+    describe('getLdkNodeBaseDirectory', () => {
+        it('returns the shared ldk-node directory under Documents', () => {
+            expect(getLdkNodeBaseDirectory()).toEqual(
+                '/mock/documents/ldk-node'
+            );
+        });
+    });
+
+    describe('getLdkNodeStoragePath', () => {
+        it('returns the wallet directory under the shared base directory', () => {
+            expect(getLdkNodeStoragePath('abc-123')).toEqual(
+                '/mock/documents/ldk-node/abc-123'
+            );
+        });
+    });
+
+    describe('ensureLdkNodeBackupExclusion', () => {
+        it('applies the iOS backup exclusion flag to the base directory', async () => {
+            mockMkdir.mockResolvedValue(undefined);
+
+            await ensureLdkNodeBackupExclusion();
+
+            expect(mockMkdir).toHaveBeenCalledTimes(1);
+            expect(mockMkdir).toHaveBeenCalledWith('/mock/documents/ldk-node', {
+                NSURLIsExcludedFromBackupKey: true
+            });
+        });
+
+        it('does nothing on Android', async () => {
+            (Platform as any).OS = 'android';
+
+            await ensureLdkNodeBackupExclusion();
+
+            expect(mockMkdir).not.toHaveBeenCalled();
+        });
+
+        it('never throws when setting the flag fails', async () => {
+            const warnSpy = jest
+                .spyOn(console, 'warn')
+                .mockImplementation(() => {});
+            mockMkdir.mockRejectedValue(new Error('resource value failed'));
+
+            await expect(
+                ensureLdkNodeBackupExclusion()
+            ).resolves.toBeUndefined();
+
+            expect(warnSpy).toHaveBeenCalled();
+            warnSpy.mockRestore();
+        });
+    });
+
+    describe('createLdkNodeDirectory', () => {
+        it('excludes the base directory and creates a missing wallet directory', async () => {
+            mockMkdir.mockResolvedValue(undefined);
+            mockExists.mockResolvedValue(false);
+
+            const path = await createLdkNodeDirectory('abc-123');
+
+            expect(path).toEqual('/mock/documents/ldk-node/abc-123');
+            expect(mockMkdir).toHaveBeenCalledWith('/mock/documents/ldk-node', {
+                NSURLIsExcludedFromBackupKey: true
+            });
+            expect(mockMkdir).toHaveBeenCalledWith(
+                '/mock/documents/ldk-node/abc-123'
+            );
+        });
+
+        it('still applies the exclusion when the wallet directory exists', async () => {
+            mockMkdir.mockResolvedValue(undefined);
+            mockExists.mockResolvedValue(true);
+
+            const path = await createLdkNodeDirectory('abc-123');
+
+            expect(path).toEqual('/mock/documents/ldk-node/abc-123');
+            expect(mockMkdir).toHaveBeenCalledTimes(1);
+            expect(mockMkdir).toHaveBeenCalledWith('/mock/documents/ldk-node', {
+                NSURLIsExcludedFromBackupKey: true
+            });
+        });
+    });
+});

--- a/utils/LdkNodeUtils.test.ts
+++ b/utils/LdkNodeUtils.test.ts
@@ -41,7 +41,9 @@ describe('LdkNodeUtils', () => {
 
     describe('getLdkNodeBaseDirectory', () => {
         it('returns the shared ldk-node directory under Documents', () => {
-            expect(getLdkNodeBaseDirectory()).toEqual('/mock/documents/ldk-node');
+            expect(getLdkNodeBaseDirectory()).toEqual(
+                '/mock/documents/ldk-node'
+            );
         });
     });
 

--- a/utils/LdkNodeUtils.test.ts
+++ b/utils/LdkNodeUtils.test.ts
@@ -1,0 +1,120 @@
+const mockMkdir = jest.fn();
+const mockExists = jest.fn();
+
+jest.mock('react-native', () => ({
+    Platform: { OS: 'ios' }
+}));
+
+jest.mock('react-native-fs', () => ({
+    DocumentDirectoryPath: '/mock/documents',
+    mkdir: (...args: any[]) => mockMkdir(...args),
+    exists: (...args: any[]) => mockExists(...args),
+    unlink: jest.fn()
+}));
+
+jest.mock('../ldknode/LdkNodeInjection', () => ({
+    __esModule: true,
+    default: {}
+}));
+
+jest.mock('./LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+
+jest.mock('./VssAuthUtils', () => ({
+    deriveVssSigningKeyFromSeed: jest.fn()
+}));
+
+import { Platform } from 'react-native';
+import {
+    createLdkNodeDirectory,
+    ensureLdkNodeBackupExclusion,
+    getLdkNodeBaseDirectory,
+    getLdkNodeStoragePath
+} from './LdkNodeUtils';
+
+describe('LdkNodeUtils', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (Platform as any).OS = 'ios';
+    });
+
+    describe('getLdkNodeBaseDirectory', () => {
+        it('returns the shared ldk-node directory under Documents', () => {
+            expect(getLdkNodeBaseDirectory()).toEqual('/mock/documents/ldk-node');
+        });
+    });
+
+    describe('getLdkNodeStoragePath', () => {
+        it('returns the wallet directory under the shared base directory', () => {
+            expect(getLdkNodeStoragePath('abc-123')).toEqual(
+                '/mock/documents/ldk-node/abc-123'
+            );
+        });
+    });
+
+    describe('ensureLdkNodeBackupExclusion', () => {
+        it('applies the iOS backup exclusion flag to the base directory', async () => {
+            mockMkdir.mockResolvedValue(undefined);
+
+            await ensureLdkNodeBackupExclusion();
+
+            expect(mockMkdir).toHaveBeenCalledTimes(1);
+            expect(mockMkdir).toHaveBeenCalledWith('/mock/documents/ldk-node', {
+                NSURLIsExcludedFromBackupKey: true
+            });
+        });
+
+        it('does nothing on Android', async () => {
+            (Platform as any).OS = 'android';
+
+            await ensureLdkNodeBackupExclusion();
+
+            expect(mockMkdir).not.toHaveBeenCalled();
+        });
+
+        it('never throws when setting the flag fails', async () => {
+            const warnSpy = jest
+                .spyOn(console, 'warn')
+                .mockImplementation(() => {});
+            mockMkdir.mockRejectedValue(new Error('resource value failed'));
+
+            await expect(
+                ensureLdkNodeBackupExclusion()
+            ).resolves.toBeUndefined();
+
+            expect(warnSpy).toHaveBeenCalled();
+            warnSpy.mockRestore();
+        });
+    });
+
+    describe('createLdkNodeDirectory', () => {
+        it('excludes the base directory and creates a missing wallet directory', async () => {
+            mockMkdir.mockResolvedValue(undefined);
+            mockExists.mockResolvedValue(false);
+
+            const path = await createLdkNodeDirectory('abc-123');
+
+            expect(path).toEqual('/mock/documents/ldk-node/abc-123');
+            expect(mockMkdir).toHaveBeenCalledWith('/mock/documents/ldk-node', {
+                NSURLIsExcludedFromBackupKey: true
+            });
+            expect(mockMkdir).toHaveBeenCalledWith(
+                '/mock/documents/ldk-node/abc-123'
+            );
+        });
+
+        it('still applies the exclusion when the wallet directory exists', async () => {
+            mockMkdir.mockResolvedValue(undefined);
+            mockExists.mockResolvedValue(true);
+
+            const path = await createLdkNodeDirectory('abc-123');
+
+            expect(path).toEqual('/mock/documents/ldk-node/abc-123');
+            expect(mockMkdir).toHaveBeenCalledTimes(1);
+            expect(mockMkdir).toHaveBeenCalledWith('/mock/documents/ldk-node', {
+                NSURLIsExcludedFromBackupKey: true
+            });
+        });
+    });
+});

--- a/utils/LdkNodeUtils.test.ts
+++ b/utils/LdkNodeUtils.test.ts
@@ -1,5 +1,6 @@
 const mockMkdir = jest.fn();
 const mockExists = jest.fn();
+const mockStart = jest.fn();
 
 jest.mock('react-native', () => ({
     Platform: { OS: 'ios' }
@@ -14,7 +15,7 @@ jest.mock('react-native-fs', () => ({
 
 jest.mock('../ldknode/LdkNodeInjection', () => ({
     __esModule: true,
-    default: {}
+    default: { node: { start: (...args: any[]) => mockStart(...args) } }
 }));
 
 jest.mock('./LocaleUtils', () => ({
@@ -30,7 +31,8 @@ import {
     createLdkNodeDirectory,
     ensureLdkNodeBackupExclusion,
     getLdkNodeBaseDirectory,
-    getLdkNodeStoragePath
+    getLdkNodeStoragePath,
+    startLdkNodeWallet
 } from './LdkNodeUtils';
 
 describe('LdkNodeUtils', () => {
@@ -117,6 +119,35 @@ describe('LdkNodeUtils', () => {
             expect(mockMkdir).toHaveBeenCalledWith('/mock/documents/ldk-node', {
                 NSURLIsExcludedFromBackupKey: true
             });
+        });
+    });
+
+    describe('startLdkNodeWallet', () => {
+        it('applies the backup exclusion before the node starts', async () => {
+            const warnSpy = jest
+                .spyOn(console, 'warn')
+                .mockImplementation(() => {});
+            mockMkdir.mockResolvedValue(undefined);
+            // 'boom' doesn't match shouldRetry (LDK_NODE_NOT_INITIALIZED)
+            // or the fee-rate branches, so start fails fast and rethrows
+            mockStart.mockRejectedValue(new Error('boom'));
+
+            await expect(
+                startLdkNodeWallet({
+                    nodeDir: 'abc-123',
+                    seedMnemonic: 'x',
+                    network: 'mainnet',
+                    skipInit: true
+                })
+            ).rejects.toThrow('boom');
+
+            expect(mockMkdir).toHaveBeenCalledWith('/mock/documents/ldk-node', {
+                NSURLIsExcludedFromBackupKey: true
+            });
+            expect(mockMkdir.mock.invocationCallOrder[0]).toBeLessThan(
+                mockStart.mock.invocationCallOrder[0]
+            );
+            warnSpy.mockRestore();
         });
     });
 });

--- a/utils/LdkNodeUtils.ts
+++ b/utils/LdkNodeUtils.ts
@@ -4,6 +4,7 @@
  * Utility functions for creating and managing embedded LDK Node wallets.
  */
 
+import { Platform } from 'react-native';
 import RNFS from 'react-native-fs';
 import LdkNode from '../ldknode/LdkNodeInjection';
 import type { Network } from '../ldknode/LdkNode.d';
@@ -72,16 +73,49 @@ const LDK_NODE_NOT_INITIALIZED = 'Node not initialized';
 const LDK_NODE_NOT_RUNNING_YET = 'LDK Node not running yet';
 
 /**
+ * Get the shared base directory that holds every wallet's LDK Node data
+ */
+export function getLdkNodeBaseDirectory(): string {
+    return `${RNFS.DocumentDirectoryPath}/ldk-node`;
+}
+
+/**
  * Get the storage directory path for LDK Node data
  */
 export function getLdkNodeStoragePath(nodeDir: string): string {
-    return `${RNFS.DocumentDirectoryPath}/ldk-node/${nodeDir}`;
+    return `${getLdkNodeBaseDirectory()}/${nodeDir}`;
+}
+
+/**
+ * Exclude the shared ldk-node base directory, and thereby every wallet's
+ * subdirectory, from iOS iCloud/iTunes backups. RNFS.mkdir with
+ * NSURLIsExcludedFromBackupKey creates intermediate directories and
+ * (re)applies the flag even when the directory already exists, so this is
+ * safe to run idempotently on every node start. Non-fatal by design: a
+ * failure to set the flag must never prevent the node from starting; it
+ * is retried on the next start. No-op on Android, where
+ * allowBackup="false" already keeps app data out of backups.
+ */
+export async function ensureLdkNodeBackupExclusion(): Promise<void> {
+    if (Platform.OS !== 'ios') return;
+    try {
+        await RNFS.mkdir(getLdkNodeBaseDirectory(), {
+            NSURLIsExcludedFromBackupKey: true
+        });
+    } catch (e) {
+        console.warn(
+            'LDK Node: failed to exclude data directory from backups:',
+            e
+        );
+    }
 }
 
 /**
  * Create the LDK Node storage directory if it doesn't exist
  */
 export async function createLdkNodeDirectory(nodeDir: string): Promise<string> {
+    await ensureLdkNodeBackupExclusion();
+
     const storagePath = getLdkNodeStoragePath(nodeDir);
 
     const exists = await RNFS.exists(storagePath);
@@ -371,6 +405,10 @@ export async function startLdkNodeWallet({
     skipInit?: boolean;
     onSyncStart?: () => void;
 }): Promise<{ vssError?: string; esploraError?: string; rgsError?: string }> {
+    // Idempotent repair for wallets created before the backup exclusion
+    // existed; never throws, so it cannot block node start
+    await ensureLdkNodeBackupExclusion();
+
     let vssError: string | undefined;
 
     if (!skipInit) {
@@ -530,7 +568,9 @@ export async function deleteLdkNodeWallet(nodeDir: string): Promise<void> {
 }
 
 export default {
+    getLdkNodeBaseDirectory,
     getLdkNodeStoragePath,
+    ensureLdkNodeBackupExclusion,
     createLdkNodeDirectory,
     getNetworkType,
     getEsploraServersForNetwork,


### PR DESCRIPTION
# Description

On iOS, the only backup exclusion in the app covers the embedded LND directory (`excludeLndICloudBackup`, set at wallet creation). The LDK Node data directory at `Documents/ldk-node/<uuid>`, which holds on-chain wallet key material and channel state, carried no `isExcludedFromBackup` flag, so it was included in iCloud and iTunes backups by default. Backup media or Apple ID compromise yielded spendable key material.

This PR applies `NSURLIsExcludedFromBackupKey` to the shared `Documents/ldk-node` parent directory, which excludes every wallet subdirectory:

- on every node start (`startLdkNodeWallet`), so wallets created before this change are repaired idempotently
- at directory creation (`createLdkNodeDirectory`), so new wallets and seed/VSS restores are covered from the first write

No native code was needed: `react-native-fs` 2.20.0's `mkdir` accepts `NSURLIsExcludedFromBackupKey` on iOS, creates intermediate directories, and (re)applies the flag even when the directory already exists. The helper is a no-op on Android, where `allowBackup="false"` already keeps app data out of backups. Failures are logged and never block node start; the flag is simply retried on the next start.

## Behavior change to sign off on

Restoring a phone from an iTunes/iCloud backup will no longer resurrect local LDK Node state. Recovery goes through the keychain-synced wallet config plus VSS (the existing `hasLocalDb` restore-from-seed path in `startLdkNodeWallet`), which is the same model the embedded LND wallet has used since its directory was excluded.

## Non-goals

- The Cashu proof db backup exclusion is handled in #4376.
- `Documents` exposure via `UIFileSharingEnabled` (Files app / paired computers) is not affected by this flag; a companion PR converts the remaining Files-app export flows to share sheets and disables file sharing.
- `tor_data` and contact/wallet photos under Documents are out of scope (no key material).

## Notes for reviewers

- `deleteLdkNodeWallet` and the failed-init cleanup only unlink `ldk-node/<uuid>` child directories, never the parent, so the flag persists across wallet deletion.
- The exclusion helper deliberately swallows errors: worst case is one warning per start and no exclusion until the next attempt.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

New `utils/LdkNodeUtils.test.ts` covers: the flag applied to the base directory on iOS, Android no-op, non-fatal behavior when setting the flag fails, and `createLdkNodeDirectory` in both the fresh and already-exists cases.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Device tests pending (will update):
- iOS: create LDK wallet, restart, verify the exclusion flag on `Documents/ldk-node`; upgrade path from a master build with an existing wallet
- Android: LDK wallet start smoke test (helper no-ops)
- Wallet delete flow regression

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Only LDK Node is affected; the change is iOS filesystem metadata on the LDK Node data directory.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
