### PR TITLE
fix(cashu): persist offline send token before deleting proofs

### DIFF
--- a/stores/CashuStore.test.ts
+++ b/stores/CashuStore.test.ts
@@ -1,0 +1,363 @@
+// In-memory backing for the Storage mock plus a shared call-order log so
+// tests can assert persist-before-destroy ordering between Storage writes
+// and CashuDevKit.removeProofs.
+const mockCallLog: string[] = [];
+const mockBacking: Record<string, string> = {};
+const mockProofPool: { current: any[] } = { current: [] };
+
+jest.mock('./Stores', () => ({
+    activityStore: { getSortedActivity: jest.fn() },
+    connectivityStore: {
+        isOffline: true,
+        onReconnect: jest.fn(),
+        start: jest.fn(),
+        stop: jest.fn()
+    },
+    contactStore: {}
+}));
+
+jest.mock('./SettingsStore', () => ({
+    __esModule: true,
+    default: class SettingsStore {},
+    DEFAULT_NOSTR_RELAYS: []
+}));
+
+jest.mock('../storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: jest.fn(async (key: string) =>
+            key in mockBacking ? mockBacking[key] : false
+        ),
+        setItem: jest.fn(async (key: string, value: any) => {
+            mockBacking[key] =
+                typeof value === 'string' ? value : JSON.stringify(value);
+            mockCallLog.push(`setItem:${key}`);
+        }),
+        removeItem: jest.fn(async (key: string) => {
+            delete mockBacking[key];
+        })
+    }
+}));
+
+jest.mock('../cashu-cdk', () => ({
+    __esModule: true,
+    default: {
+        isAvailable: jest.fn(() => true),
+        getUnspentProofs: jest.fn(async () => [...mockProofPool.current]),
+        removeProofs: jest.fn(async (ys: string[]) => {
+            mockCallLog.push(`removeProofs:${ys.join(',')}`);
+            mockProofPool.current = mockProofPool.current.filter(
+                (p) => !ys.includes(p.y)
+            );
+        }),
+        getMintBalance: jest.fn(async () =>
+            mockProofPool.current.reduce((sum, p) => sum + p.amount, 0)
+        ),
+        getBalances: jest.fn(async () => ({})),
+        getTotalBalance: jest.fn(async () =>
+            mockProofPool.current.reduce((sum, p) => sum + p.amount, 0)
+        ),
+        send: jest.fn()
+    }
+}));
+
+jest.mock('@nostr-dev-kit/ndk', () => ({
+    __esModule: true,
+    default: class NDK {},
+    NDKEvent: class NDKEvent {},
+    NDKKind: {}
+}));
+
+jest.mock('react-native-blob-util', () => ({
+    __esModule: true,
+    default: { fs: { dirs: {} } }
+}));
+
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+
+jest.mock('../utils/MigrationUtils', () => ({
+    __esModule: true,
+    default: {}
+}));
+
+jest.mock('../utils/NostrMintBackup', () => ({
+    deriveMintBackupKeypair: jest.fn(),
+    backupMintsToNostr: jest.fn(),
+    restoreMintsFromNostr: jest.fn()
+}));
+
+jest.mock('../utils/ThemeUtils', () => ({
+    themeColor: () => '#000',
+    getUpgradeBackgroundColor: () => '#000'
+}));
+
+jest.mock('../NavigationService', () => ({}));
+
+import CashuDevKit from '../cashu-cdk';
+import Storage from '../storage';
+import CashuStore from './CashuStore';
+
+const mockGetUnspentProofs = CashuDevKit.getUnspentProofs as jest.Mock;
+const mockRemoveProofs = CashuDevKit.removeProofs as jest.Mock;
+const mockGetMintBalance = CashuDevKit.getMintBalance as jest.Mock;
+
+const NODE_DIR = 'testnode';
+const MINT_URL = 'https://mint.example.com';
+const PENDING_KEY = `${NODE_DIR}-cashu-pending-offline-sends`;
+const SENT_KEY = `${NODE_DIR}-cashu-sent-tokens`;
+
+const proof = (amount: number, tag: string) => ({
+    amount,
+    secret: `secret-${tag}`,
+    c: `c-${tag}`,
+    keyset_id: 'keyset-1',
+    y: `y-${tag}`
+});
+
+function buildStore() {
+    const settingsStore: any = {
+        lndDir: NODE_DIR,
+        implementation: 'embedded-lnd'
+    };
+    const store = new CashuStore(
+        settingsStore,
+        {} as any,
+        {} as any,
+        {} as any
+    );
+    store.cdkInitialized = true;
+    store.selectedMintUrl = MINT_URL;
+    store.sentTokens = [];
+    return store;
+}
+
+const getPendingRecords = () =>
+    PENDING_KEY in mockBacking ? JSON.parse(mockBacking[PENDING_KEY]) : [];
+const getSentTokens = () =>
+    SENT_KEY in mockBacking ? JSON.parse(mockBacking[SENT_KEY]) : [];
+
+describe('CashuStore offline send safety', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockCallLog.length = 0;
+        for (const key of Object.keys(mockBacking)) delete mockBacking[key];
+        mockProofPool.current = [];
+        jest.spyOn(console, 'log').mockImplementation(() => undefined);
+        jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    describe('sendTokenCDK offline path', () => {
+        it('persists the pending record before deleting proofs', async () => {
+            mockProofPool.current = [proof(16, 'a')];
+            const store = buildStore();
+
+            const token = await store.sendTokenCDK(MINT_URL, 16);
+
+            const pendingWrite = mockCallLog.indexOf(`setItem:${PENDING_KEY}`);
+            const proofRemoval = mockCallLog.findIndex((entry) =>
+                entry.startsWith('removeProofs:')
+            );
+            expect(pendingWrite).toBeGreaterThanOrEqual(0);
+            expect(proofRemoval).toBeGreaterThanOrEqual(0);
+            expect(pendingWrite).toBeLessThan(proofRemoval);
+
+            // The record written before removal carries everything needed
+            // for recovery: the encoded token and the proofs with y values.
+            expect(token.encoded.startsWith('cashuA')).toBe(true);
+            const [record] = getPendingRecords();
+            expect(record.encodedToken).toBe(token.encoded);
+            expect(record.mintUrl).toBe(MINT_URL);
+            expect(record.value).toBe(16);
+            expect(record.proofs.map((p: any) => p.y)).toEqual(['y-a']);
+        });
+
+        it('greedily selects largest proofs first and reports overpay total', async () => {
+            mockProofPool.current = [proof(4, 'a'), proof(16, 'b')];
+            const store = buildStore();
+
+            const token = await store.sendTokenCDK(MINT_URL, 8);
+
+            expect(token.value).toBe(16);
+            expect(mockRemoveProofs).toHaveBeenCalledWith(['y-b']);
+        });
+
+        it('throws on insufficient proofs without touching storage or proofs', async () => {
+            mockProofPool.current = [proof(4, 'a')];
+            const store = buildStore();
+
+            await expect(store.sendTokenCDK(MINT_URL, 8)).rejects.toThrow(
+                'Insufficient proofs'
+            );
+            expect(getPendingRecords()).toEqual([]);
+            expect(mockRemoveProofs).not.toHaveBeenCalled();
+        });
+
+        it('serializes concurrent offline sends so proofs are never double-selected', async () => {
+            mockProofPool.current = [proof(16, 'a'), proof(16, 'b')];
+            const store = buildStore();
+
+            const [tokenA, tokenB] = await Promise.all([
+                store.sendTokenCDK(MINT_URL, 16),
+                store.sendTokenCDK(MINT_URL, 16)
+            ]);
+
+            const removals = mockRemoveProofs.mock.calls.map(
+                (call) => call[0] as string[]
+            );
+            expect(removals).toHaveLength(2);
+            expect(new Set(removals.flat()).size).toBe(2);
+            expect(tokenA.encoded).not.toBe(tokenB.encoded);
+        });
+
+        it('fails the second concurrent send when the pool is exhausted', async () => {
+            mockProofPool.current = [proof(16, 'a')];
+            const store = buildStore();
+
+            const results = await Promise.allSettled([
+                store.sendTokenCDK(MINT_URL, 16),
+                store.sendTokenCDK(MINT_URL, 16)
+            ]);
+
+            expect(results[0].status).toBe('fulfilled');
+            expect(results[1].status).toBe('rejected');
+            expect(mockRemoveProofs).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('mintToken', () => {
+        it('clears the pending record only after the sent token is persisted', async () => {
+            mockProofPool.current = [proof(16, 'a')];
+            const store = buildStore();
+
+            const result = await store.mintToken({ memo: '', value: '16' });
+
+            expect(result).toBeDefined();
+            expect(getSentTokens()).toHaveLength(1);
+            expect(getSentTokens()[0].encodedToken).toBe(result!.token);
+            expect(getPendingRecords()).toEqual([]);
+
+            const sentWrite = mockCallLog.indexOf(`setItem:${SENT_KEY}`);
+            const finalizeWrite = mockCallLog.lastIndexOf(
+                `setItem:${PENDING_KEY}`
+            );
+            expect(sentWrite).toBeGreaterThanOrEqual(0);
+            expect(finalizeWrite).toBeGreaterThan(sentWrite);
+        });
+
+        it('refuses re-entry while a send is already in flight', async () => {
+            mockProofPool.current = [proof(16, 'a')];
+            const store = buildStore();
+            store.mintingToken = true;
+
+            const result = await store.mintToken({ memo: '', value: '16' });
+
+            expect(result).toBeUndefined();
+            expect(mockGetMintBalance).not.toHaveBeenCalled();
+            expect(mockRemoveProofs).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('reconcilePendingOfflineSends', () => {
+        const seedPendingRecord = (
+            proofs: any[],
+            encodedToken = 'cashuAtest'
+        ) => {
+            mockBacking[PENDING_KEY] = JSON.stringify([
+                {
+                    id: 'r1',
+                    mintUrl: MINT_URL,
+                    encodedToken,
+                    value: proofs.reduce((sum, p) => sum + p.amount, 0),
+                    memo: '',
+                    createdAt: 1754900000000,
+                    proofs
+                }
+            ]);
+        };
+
+        it('drops the record when all proofs survived (crash before removal)', async () => {
+            const proofs = [proof(16, 'a'), proof(8, 'b')];
+            mockProofPool.current = [...proofs];
+            seedPendingRecord(proofs);
+            const store = buildStore();
+
+            await store.reconcilePendingOfflineSends();
+
+            expect(getPendingRecords()).toEqual([]);
+            expect(store.sentTokens).toHaveLength(0);
+            expect(mockRemoveProofs).not.toHaveBeenCalled();
+        });
+
+        it('promotes the token when all proofs are gone (crash before persist)', async () => {
+            const proofs = [proof(16, 'a')];
+            mockProofPool.current = [];
+            seedPendingRecord(proofs);
+            const store = buildStore();
+
+            await store.reconcilePendingOfflineSends();
+
+            expect(getPendingRecords()).toEqual([]);
+            expect(store.sentTokens).toHaveLength(1);
+            const promoted = store.sentTokens![0];
+            expect(promoted.encodedToken).toBe('cashuAtest');
+            expect(promoted.sent).toBe(true);
+            expect(promoted.spent).toBe(false);
+            expect(getSentTokens()).toHaveLength(1);
+            expect(mockRemoveProofs).not.toHaveBeenCalled();
+        });
+
+        it('removes leftover proofs before promoting on partial deletion', async () => {
+            const proofs = [proof(16, 'a'), proof(8, 'b')];
+            mockProofPool.current = [proof(8, 'b')];
+            seedPendingRecord(proofs);
+            const store = buildStore();
+
+            await store.reconcilePendingOfflineSends();
+
+            expect(mockRemoveProofs).toHaveBeenCalledWith(['y-b']);
+            expect(store.sentTokens).toHaveLength(1);
+            expect(getPendingRecords()).toEqual([]);
+        });
+
+        it('does not duplicate a token already recorded in sentTokens', async () => {
+            const proofs = [proof(16, 'a')];
+            mockProofPool.current = [];
+            seedPendingRecord(proofs, 'cashuAdup');
+            const store = buildStore();
+            store.sentTokens = [{ encodedToken: 'cashuAdup' } as any];
+
+            await store.reconcilePendingOfflineSends();
+
+            expect(store.sentTokens).toHaveLength(1);
+            expect(getPendingRecords()).toEqual([]);
+        });
+
+        it('keeps the record for retry when the proof lookup fails', async () => {
+            const proofs = [proof(16, 'a')];
+            seedPendingRecord(proofs);
+            mockGetUnspentProofs.mockRejectedValueOnce(new Error('db error'));
+            const store = buildStore();
+
+            await store.reconcilePendingOfflineSends();
+
+            const records = getPendingRecords();
+            expect(records).toHaveLength(1);
+            expect(records[0].attempts).toBe(1);
+            expect(store.sentTokens).toHaveLength(0);
+        });
+
+        it('is a no-op when CDK is not initialized', async () => {
+            seedPendingRecord([proof(16, 'a')]);
+            const store = buildStore();
+            store.cdkInitialized = false;
+
+            await store.reconcilePendingOfflineSends();
+
+            expect(getPendingRecords()).toHaveLength(1);
+            expect(Storage.getItem).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -119,6 +119,21 @@ export interface MintReview {
     rating?: MintReviewRating;
 }
 
+// Record of an offline send persisted BEFORE its proofs are deleted from the
+// CDK database, so a crash mid-send can be reconciled at next startup instead
+// of silently burning the proofs. Proofs retain `y` so reconciliation can
+// check which ones are still present in the database.
+interface PendingOfflineSend {
+    id: string;
+    mintUrl: string;
+    encodedToken: string;
+    value: number;
+    memo?: string;
+    createdAt: number;
+    attempts?: number;
+    proofs: CDKProofWithY[];
+}
+
 /**
  * Parses a rating from review content in format [n/m] at the beginning.
  * Returns the rating object and the remaining content with the rating stripped.
@@ -293,6 +308,11 @@ export default class CashuStore {
     @observable public offlineSpentTokens: Array<CashuToken> = [];
     @observable public showOfflineSpentAlert: boolean = false;
     private isSweeping: boolean = false;
+    // Serializes proof-destructive offline operations (offline send critical
+    // section, pending-record finalization, startup reconciliation) so two
+    // operations can never select or remove the same proofs. Pattern mirrors
+    // SettingsStore.updateSettingsQueue.
+    private offlineProofOpQueue: Promise<unknown> = Promise.resolve();
 
     settingsStore: SettingsStore;
     invoicesStore: InvoicesStore;
@@ -1522,6 +1542,149 @@ export default class CashuStore {
         }
     };
 
+    private enqueueOfflineProofOp = <T>(fn: () => Promise<T>): Promise<T> => {
+        const task = this.offlineProofOpQueue.then(fn);
+        this.offlineProofOpQueue = task.catch(() => undefined);
+        return task;
+    };
+
+    private pendingOfflineSendsKey = (lndDir?: string) =>
+        `${lndDir ?? this.getNodeDir()}-cashu-pending-offline-sends`;
+
+    private loadPendingOfflineSends = async (
+        key: string
+    ): Promise<PendingOfflineSend[]> => {
+        try {
+            const stored = await Storage.getItem(key);
+            if (!stored) return [];
+            const parsed = JSON.parse(stored);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (e) {
+            console.warn('Failed to load pending offline sends:', e);
+            return [];
+        }
+    };
+
+    private savePendingOfflineSends = async (
+        key: string,
+        records: PendingOfflineSend[]
+    ): Promise<void> => {
+        await Storage.setItem(key, records);
+    };
+
+    /**
+     * Remove the pending record for an offline send once the sent token has
+     * been durably recorded in sent-tokens storage. A record left behind by
+     * a failure here is harmless: reconcilePendingOfflineSends dedupes
+     * against sentTokens at next startup.
+     */
+    private finalizePendingOfflineSend = async (
+        encodedToken: string
+    ): Promise<void> => {
+        const key = this.pendingOfflineSendsKey();
+        return this.enqueueOfflineProofOp(async () => {
+            const records = await this.loadPendingOfflineSends(key);
+            const remaining = records.filter(
+                (r) => r.encodedToken !== encodedToken
+            );
+            if (remaining.length !== records.length) {
+                await this.savePendingOfflineSends(key, remaining);
+            }
+        });
+    };
+
+    /**
+     * Reconcile offline sends interrupted by a crash or app kill.
+     *
+     * The offline send path persists a pending record before deleting the
+     * selected proofs from the CDK database (persist-before-destroy). At
+     * startup, each leftover record is resolved by checking which of its
+     * proofs are still in the database:
+     * - all present: the crash happened before removeProofs, so the token
+     *   was never returned or displayed. Drop the record; funds are intact.
+     * - any missing: proof deletion (at least partially) happened, so the
+     *   token may have been displayed or shared. Remove any leftover proofs
+     *   to restore consistency, then surface the token in sentTokens so the
+     *   user can reshare it or reclaim it once online.
+     * - lookup fails: keep the record and retry at next startup. Never drop
+     *   (loses the token) and never promote without removing proofs (the
+     *   amount would be counted in the balance and shareable at once).
+     */
+    public reconcilePendingOfflineSends = async (): Promise<void> => {
+        if (!this.cdkInitialized) return;
+        const key = this.pendingOfflineSendsKey();
+        return this.enqueueOfflineProofOp(async () => {
+            const records = await this.loadPendingOfflineSends(key);
+            if (records.length === 0) return;
+
+            const keep: PendingOfflineSend[] = [];
+            let mutated = false;
+            for (const record of records) {
+                try {
+                    const unspent = await CashuDevKit.getUnspentProofs(
+                        record.mintUrl
+                    );
+                    const presentYs = new Set(unspent.map((p) => p.y));
+                    const stillPresent = record.proofs
+                        .map((p) => p.y)
+                        .filter((y) => presentYs.has(y));
+
+                    if (stillPresent.length === record.proofs.length) {
+                        // Crash before removeProofs: the token was never
+                        // returned, so no artifact is needed.
+                        continue;
+                    }
+
+                    if (stillPresent.length > 0) {
+                        await CashuDevKit.removeProofs(stillPresent);
+                    }
+
+                    const alreadyRecorded = this.sentTokens?.some(
+                        (t) => t.encodedToken === record.encodedToken
+                    );
+                    if (!alreadyRecorded) {
+                        const decoded = new CashuToken({
+                            mint: record.mintUrl,
+                            memo: record.memo || '',
+                            unit: 'sat',
+                            sent: true,
+                            spent: false,
+                            value: record.value,
+                            encodedToken: record.encodedToken,
+                            proofs: record.proofs.map((p) => ({
+                                amount: p.amount,
+                                secret: p.secret,
+                                c: p.c,
+                                keyset_id: p.keyset_id
+                            })),
+                            created_at: record.createdAt / 1000
+                        });
+                        runInAction(() => {
+                            this.sentTokens?.push(decoded);
+                        });
+                        await Storage.setItem(
+                            `${this.getNodeDir()}-cashu-sent-tokens`,
+                            this.sentTokens
+                        );
+                    }
+                    mutated = true;
+                } catch (e) {
+                    console.warn(
+                        'Failed to reconcile pending offline send, will retry at next startup:',
+                        e
+                    );
+                    keep.push({
+                        ...record,
+                        attempts: (record.attempts || 0) + 1
+                    });
+                }
+            }
+
+            await this.savePendingOfflineSends(key, keep);
+            if (mutated) await this.syncCDKBalances();
+        });
+    };
+
     /**
      * Select proofs to cover a requested amount using a greedy algorithm.
      * Sorts proofs by amount descending and accumulates until sum >= amount.
@@ -1627,28 +1790,54 @@ export default class CashuStore {
                     }
                 );
             }
-            const allProofs = await CashuDevKit.getUnspentProofs(mintUrl);
-            const { selected, total } = this.selectProofsForAmount(
-                allProofs,
-                amount
-            );
-            const encoded = this.buildCashuToken(mintUrl, selected, memo);
-            await CashuDevKit.removeProofs(selected.map((p) => p.y));
-            await this.syncCDKBalances();
+            // Capture the storage key before queueing so a wallet switch
+            // can't redirect a queued send to another node's namespace.
+            const pendingKey = this.pendingOfflineSendsKey(this.getNodeDir());
+            // The critical section is serialized so overlapping sends can't
+            // select the same proofs: the second send re-reads the database
+            // only after the first send's proofs have been removed.
+            return this.enqueueOfflineProofOp(async () => {
+                const allProofs = await CashuDevKit.getUnspentProofs(mintUrl);
+                const { selected, total } = this.selectProofsForAmount(
+                    allProofs,
+                    amount
+                );
+                const encoded = this.buildCashuToken(mintUrl, selected, memo);
 
-            return {
-                encoded,
-                value: total,
-                mint_url: mintUrl,
-                memo: memo || '',
-                unit: 'sat',
-                proofs: selected.map((p) => ({
-                    amount: p.amount,
-                    secret: p.secret,
-                    c: p.c,
-                    keyset_id: p.keyset_id
-                }))
-            };
+                // Persist-before-destroy: record the token before deleting
+                // its proofs so a crash between the two is recoverable by
+                // reconcilePendingOfflineSends at next startup.
+                const records = await this.loadPendingOfflineSends(pendingKey);
+                records.push({
+                    id: `${Date.now()}-${Math.random()
+                        .toString(36)
+                        .slice(2, 10)}`,
+                    mintUrl,
+                    encodedToken: encoded,
+                    value: total,
+                    memo,
+                    createdAt: Date.now(),
+                    proofs: selected
+                });
+                await this.savePendingOfflineSends(pendingKey, records);
+
+                await CashuDevKit.removeProofs(selected.map((p) => p.y));
+                await this.syncCDKBalances();
+
+                return {
+                    encoded,
+                    value: total,
+                    mint_url: mintUrl,
+                    memo: memo || '',
+                    unit: 'sat',
+                    proofs: selected.map((p) => ({
+                        amount: p.amount,
+                        secret: p.secret,
+                        c: p.c,
+                        keyset_id: p.keyset_id
+                    }))
+                };
+            });
         }
 
         // Online path: use CDK's normal send flow
@@ -1779,6 +1968,8 @@ export default class CashuStore {
         this.offlineSpentTokens = [];
         this.showOfflineSpentAlert = false;
         this.isSweeping = false;
+        // Pending offline send records are disk-only (namespaced by nodeDir)
+        // and reconciled at init, so there is no in-memory state to clear.
         this.stopConnectivityMonitoring();
     };
 
@@ -3268,6 +3459,10 @@ export default class CashuStore {
                     throw new Error('CDK wallet initialization returned false');
                 }
                 console.log('CDK initialized during wallet startup');
+
+                // Resolve offline sends interrupted by a crash before the
+                // wallet becomes usable. Local-database pass; works offline.
+                await this.reconcilePendingOfflineSends();
 
                 let localMintUrls = storedMintUrls
                     ? JSON.parse(storedMintUrls)
@@ -5410,6 +5605,9 @@ export default class CashuStore {
         pubkey?: string;
         lockTime?: number;
     }): Promise<{ token: string; decoded: CashuToken } | undefined> => {
+        // A second invocation while one is in flight could select the same
+        // proofs offline and emit two tokens over them.
+        if (this.mintingToken) return;
         runInAction(() => {
             this.mintingToken = true;
             this.mintingTokenError = false;
@@ -5509,6 +5707,15 @@ export default class CashuStore {
                 this.sentTokens
             );
 
+            // The token is now durably recorded; drop the offline pending
+            // record. Must never fail the send at this point: a leftover
+            // record is cleaned up at next startup.
+            try {
+                await this.finalizePendingOfflineSend(token);
+            } catch (e) {
+                console.warn('Failed to finalize pending offline send:', e);
+            }
+
             // CDK handles balance updates internally
             await this.syncCDKBalances();
 
@@ -5570,6 +5777,7 @@ export default class CashuStore {
             await Storage.removeItem(`${lndDir}-cashu-received-tokens`);
             await Storage.removeItem(`${lndDir}-cashu-offline-pending-tokens`);
             await Storage.removeItem(`${lndDir}-cashu-offline-spent-tokens`);
+            await Storage.removeItem(`${lndDir}-cashu-pending-offline-sends`);
             await Storage.removeItem(`${lndDir}-cashu-sent-tokens`);
             await Storage.removeItem(`${lndDir}-cashu-seed-version`);
             await Storage.removeItem(`${lndDir}-cashu-seed-phrase`);


### PR DESCRIPTION
# Description

## Problem

The offline ecash send path (`CashuStore.sendTokenCDK`, offline branch) bypasses CDK's atomic `prepareSend`/`confirmSend` flow and hand-rolls the send: it reads unspent proofs, selects greedily, builds the `cashuA` token in memory, then calls `CashuDevKit.removeProofs`, which hard-deletes the proofs from the native CDK SQLite database on both platforms. The sent-token record is only persisted later, in `mintToken`, after `sendTokenCDK` returns.

Two consequences:

1. **Crash window burns balance silently.** If the app is killed or crashes between `removeProofs` and the sent-tokens write, the proofs are gone from the database and the token existed only in memory: it was never displayed, never stored. The balance drops with no transaction record. The secrets were never spent at the mint, so a seed restore can technically recover them, but nothing tells the user anything went wrong.
2. **Concurrent sends can double-select proofs.** Neither `mintToken` nor `sendTokenCDK` has a re-entrancy guard, and the selection-then-removal section is not serialized. Two overlapping offline sends can read the same unspent proof set and emit two valid-looking tokens over the same proofs; the second recipient to redeem gets nothing. The online path is immune because CDK reserves proofs transactionally.

There is no bridge method to re-add proofs (both native modules hard-code `updateProofs(added: [])`), so recovery has to work without proof restoration.

## Fix

Restore the persist-before-destroy invariant with a two-phase pending record, and serialize all proof-destructive offline operations through one promise queue (same pattern as `SettingsStore.updateSettingsQueue`):

- **Persist first.** The offline branch now writes a pending record (encoded token plus the selected proofs including their `y` values) to a new `<nodeDir>-cashu-pending-offline-sends` storage key before calling `removeProofs`. The record is dropped only after `mintToken` has durably written the token to `<nodeDir>-cashu-sent-tokens`.
- **Serialize.** The whole critical section (read proofs, select, persist record, remove proofs) runs through `offlineProofOpQueue`, so a second concurrent send re-reads the database only after the first send's proofs are gone: it selects disjoint proofs or fails with insufficient funds. `mintToken` additionally refuses re-entry while a send is in flight.
- **Reconcile at startup.** `reconcilePendingOfflineSends` runs during wallet init right after CDK comes up (local database pass, works offline) and resolves any leftover record:
  - all recorded proofs still present: the crash happened before deletion, so the token was never returned or displayed. The record is dropped and funds are intact.
  - any proof missing: deletion at least partially happened, so the token may have been shown or shared. Leftover proofs are removed for consistency and the token is promoted into `sentTokens` (deduplicated by encoded token), where the user can reshare it or reclaim it via the existing Unspent Tokens flow once online.
  - proof lookup fails: the record is kept with an attempt counter and retried at the next startup. It is never dropped (that would lose the token) and never promoted without removal (the amount would be both counted in the balance and shareable).
- `deleteCashuData` clears the new key. Pending records are disk-only and namespaced by node dir, so `reset()` and wallet switches need no extra handling.

No locale, view, or native changes. A follow-up for a native atomic offline send (marshalling `updateProofs(added:)` so selection, pending state, and removal happen in one database transaction) is worth its own issue; this PR makes the existing JS path crash-safe without new native surface.

## Testing notes

New `stores/CashuStore.test.ts` (first test suite for this store) covers:

- pending record written strictly before `removeProofs` (call-order assertion), with the token and `y` values recoverable from the record
- finalize only after the sent-tokens write, leaving no pending record on the happy path
- all three reconciliation outcomes (rollback, promote, partial-deletion cleanup), dedupe against already-recorded tokens, retry-on-error, and the `cdkInitialized` gate
- two concurrent sends never remove the same proof; the second fails cleanly when the pool is exhausted
- `mintToken` re-entrancy guard

Suggested device test (pending): with the device in airplane mode and an ecash balance, start an offline send and kill the app during the spinner, then relaunch: balance should be intact with no phantom token. Repeat but kill the app after the token QR appears: after relaunch the token should be listed under Unspent Tokens and be reclaimable once back online.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
