### PR TITLE
fix(security): hash app-lock verifiers and stop keychain backup migration

### DIFF
--- a/storage/index.ts
+++ b/storage/index.ts
@@ -53,7 +53,17 @@ class Storage {
             prefixedKey,
             stringValue,
             {
-                cloudSync: false
+                cloudSync: false,
+                // iOS: keep keychain items on this device only. The default
+                // (AFTER_FIRST_UNLOCK) migrates to a new device through
+                // encrypted iCloud/Finder backups, carrying the settings blob
+                // (wallet seeds, LND password, macaroons, lock verifiers) with
+                // it. THIS_DEVICE_ONLY blocks that migration while staying
+                // readable at boot after first unlock, and (unlike
+                // WHEN_PASSCODE_SET) never requires a device passcode, so it
+                // cannot lock a user out of their own wallet. No-op on Android.
+                accessible:
+                    Keychain.ACCESSIBLE.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY
             }
         );
         return response;

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1993,6 +1993,14 @@ export default class SettingsStore {
                 await MigrationsUtils.migrateLockCredentialsToVerifiers(
                     parsedSettings
                 );
+                // iOS one-shot: rewrite pre-existing keychain items so
+                // write-once keys pick up the non-migratable accessibility
+                // class. Modern path only: the legacy path's
+                // storageMigrationV2 freshly writes every item, which
+                // stamps them correctly already.
+                await MigrationsUtils.restampKeychainAccessibility(
+                    parsedSettings
+                );
                 this.settings = parsedSettings;
             } else {
                 console.log('attempting to load legacy settings');

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -7,6 +7,7 @@ import isEqual from 'lodash/isEqual';
 import BackendUtils from '../utils/BackendUtils';
 import { getSupportedBiometryType } from '../utils/BiometricUtils';
 import { localeString } from '../utils/LocaleUtils';
+import { VerifierRecord, hasVerifier } from '../utils/LockVerifierUtils';
 import MigrationsUtils from '../utils/MigrationUtils';
 import { doTorRequest, RequestMethod } from '../utils/TorUtils';
 import {
@@ -191,10 +192,19 @@ export interface Settings {
     nodes?: Array<Node>;
     selectedNode?: number;
     justDeletedWallet?: boolean;
+    // Legacy plaintext lock credentials. Retained only so the
+    // lock-verifier-hash migration can read and clear them; new code must use
+    // the salted verifier records below and never write these.
     passphrase?: string;
     duressPassphrase?: string;
     pin?: string;
     duressPin?: string;
+    // Salted scrypt verifiers for the app lock (see utils/LockVerifierUtils).
+    // Presence of pinVerifier vs passphraseVerifier also selects the lock UI.
+    passphraseVerifier?: VerifierRecord;
+    duressPassphraseVerifier?: VerifierRecord;
+    pinVerifier?: VerifierRecord;
+    duressPinVerifier?: VerifierRecord;
     scramblePin?: boolean;
     loginBackground?: boolean;
     authenticationAttempts?: number;
@@ -1980,6 +1990,9 @@ export default class SettingsStore {
                 await MigrationsUtils.migrateOlympusHostsToZeusLsp(
                     parsedSettings
                 );
+                await MigrationsUtils.migrateLockCredentialsToVerifiers(
+                    parsedSettings
+                );
                 this.settings = parsedSettings;
             } else {
                 console.log('attempting to load legacy settings');
@@ -2287,8 +2300,8 @@ export default class SettingsStore {
 
     public loginMethodConfigured = () =>
         this.settings &&
-        (this.settings.passphrase ||
-            this.settings.pin ||
+        (hasVerifier(this.settings.passphraseVerifier) ||
+            hasVerifier(this.settings.pinVerifier) ||
             this.isBiometryConfigured());
 
     public checkBiometricsStatus = async () => {

--- a/utils/LockVerifierUtils.test.ts
+++ b/utils/LockVerifierUtils.test.ts
@@ -1,0 +1,88 @@
+// The native randombytes module cannot init under jest; back it with node crypto.
+jest.mock('react-native-randombytes', () => ({
+    randomBytes: (length: number) => require('crypto').randomBytes(length)
+}));
+
+import {
+    deriveVerifier,
+    verifySecret,
+    hasVerifier,
+    VerifierRecord
+} from './LockVerifierUtils';
+
+describe('LockVerifierUtils', () => {
+    // Fixed salt so the scrypt output is deterministic where we need it.
+    const salt = Buffer.alloc(16, 0x01);
+
+    describe('deriveVerifier', () => {
+        it('produces a well-formed scrypt record and never stores the secret', async () => {
+            const record = await deriveVerifier('1234', salt);
+            expect(record.v).toEqual(1);
+            expect(record.kdf).toEqual('scrypt');
+            expect(record.n).toBeGreaterThan(0);
+            expect(record.salt).toEqual(salt.toString('hex'));
+            expect(record.hash).toMatch(/^[0-9a-f]{64}$/);
+            expect(JSON.stringify(record)).not.toContain('1234');
+        });
+
+        it('uses a fresh random salt per call', async () => {
+            const a = await deriveVerifier('1234');
+            const b = await deriveVerifier('1234');
+            expect(a.salt).not.toEqual(b.salt);
+            expect(a.hash).not.toEqual(b.hash);
+        });
+    });
+
+    describe('verifySecret', () => {
+        it('accepts the correct secret and rejects a wrong one', async () => {
+            const record = await deriveVerifier('correct horse', salt);
+            expect(await verifySecret('correct horse', record)).toBe(true);
+            expect(await verifySecret('wrong horse', record)).toBe(false);
+        });
+
+        it('round-trips regardless of the random salt', async () => {
+            const record = await deriveVerifier('98765');
+            expect(await verifySecret('98765', record)).toBe(true);
+            expect(await verifySecret('98764', record)).toBe(false);
+        });
+
+        it('fails closed on an empty secret', async () => {
+            const record = await deriveVerifier('1234', salt);
+            expect(await verifySecret('', record)).toBe(false);
+        });
+
+        it('fails closed on a missing or malformed record', async () => {
+            expect(await verifySecret('1234', undefined)).toBe(false);
+            expect(await verifySecret('1234', null)).toBe(false);
+            expect(
+                await verifySecret('1234', {
+                    v: 1,
+                    kdf: 'scrypt',
+                    n: 0,
+                    r: 0,
+                    p: 0,
+                    salt: '',
+                    hash: ''
+                } as VerifierRecord)
+            ).toBe(false);
+            expect(
+                await verifySecret('1234', {
+                    salt: 'zz',
+                    hash: 'zz'
+                } as unknown as VerifierRecord)
+            ).toBe(false);
+        });
+    });
+
+    describe('hasVerifier', () => {
+        it('detects presence of a valid verifier', async () => {
+            const record = await deriveVerifier('1234', salt);
+            expect(hasVerifier(record)).toBe(true);
+            expect(hasVerifier(undefined)).toBe(false);
+            expect(hasVerifier(null)).toBe(false);
+            expect(
+                hasVerifier({ salt: '', hash: '' } as unknown as VerifierRecord)
+            ).toBe(false);
+        });
+    });
+});

--- a/utils/LockVerifierUtils.test.ts
+++ b/utils/LockVerifierUtils.test.ts
@@ -7,6 +7,7 @@ import {
     deriveVerifier,
     verifySecret,
     hasVerifier,
+    DUMMY_VERIFIER,
     VerifierRecord
 } from './LockVerifierUtils';
 
@@ -70,6 +71,20 @@ describe('LockVerifierUtils', () => {
                     salt: 'zz',
                     hash: 'zz'
                 } as unknown as VerifierRecord)
+            ).toBe(false);
+        });
+    });
+
+    describe('DUMMY_VERIFIER', () => {
+        it('is well-formed, so verifying against it runs the full derivation', () => {
+            expect(hasVerifier(DUMMY_VERIFIER)).toBe(true);
+        });
+
+        it('never matches an attempt', async () => {
+            expect(await verifySecret('1234', DUMMY_VERIFIER)).toBe(false);
+            expect(await verifySecret('0000', DUMMY_VERIFIER)).toBe(false);
+            expect(
+                await verifySecret('correct horse battery', DUMMY_VERIFIER)
             ).toBe(false);
         });
     });

--- a/utils/LockVerifierUtils.ts
+++ b/utils/LockVerifierUtils.ts
@@ -1,0 +1,122 @@
+import { scrypt } from 'scrypt-js';
+
+// App-lock credentials (PIN / passphrase and their duress variants) must never
+// be stored in plaintext: the settings blob they live in also holds every
+// wallet secret and, on iOS, historically migrated through encrypted backups.
+// Instead we store a salted scrypt digest and compare in constant time. All
+// four verifiers use the identical record shape so a duress verifier is
+// indistinguishable from a normal one to anyone who reads the blob.
+
+export interface VerifierRecord {
+    v: 1;
+    kdf: 'scrypt';
+    n: number;
+    r: number;
+    p: number;
+    salt: string; // hex
+    hash: string; // hex
+}
+
+// scrypt work factors. N=32768 keeps a single derivation in the ~1s range on
+// device, which is a deliberate cost: it rate-limits online guessing and makes
+// an offline brute force of a short PIN expensive rather than trivial.
+const SCRYPT_N = 32768;
+const SCRYPT_R = 8;
+const SCRYPT_P = 1;
+const KEY_LEN = 32;
+const SALT_LEN = 16;
+
+const toBytes = (secret: string): Buffer => Buffer.from(secret, 'utf8');
+
+// react-native-randombytes runs a native init() at import time that throws
+// under jest, so it is loaded lazily here rather than at module scope. Keeping
+// this module side-effect free lets any store/view import it without dragging
+// the native dependency into unrelated test suites; test paths pass an explicit
+// salt and never reach this.
+const generateSalt = (length: number): Buffer => {
+    const { randomBytes } = require('react-native-randombytes');
+    return randomBytes(length);
+};
+
+/**
+ * Derive a verifier record for a secret. A fresh random salt is used per call,
+ * so the same PIN set twice yields different records. `salt` is injectable for
+ * deterministic tests only.
+ */
+export const deriveVerifier = async (
+    secret: string,
+    salt?: Buffer
+): Promise<VerifierRecord> => {
+    const saltBuf = salt ?? generateSalt(SALT_LEN);
+    const derived = await scrypt(
+        toBytes(secret),
+        saltBuf,
+        SCRYPT_N,
+        SCRYPT_R,
+        SCRYPT_P,
+        KEY_LEN
+    );
+    return {
+        v: 1,
+        kdf: 'scrypt',
+        n: SCRYPT_N,
+        r: SCRYPT_R,
+        p: SCRYPT_P,
+        salt: Buffer.from(saltBuf).toString('hex'),
+        hash: Buffer.from(derived).toString('hex')
+    };
+};
+
+/** True when `record` is a well-formed verifier (used for UI/gate presence). */
+export const hasVerifier = (record?: VerifierRecord | null): boolean =>
+    !!record &&
+    record.kdf === 'scrypt' &&
+    typeof record.salt === 'string' &&
+    record.salt.length > 0 &&
+    typeof record.hash === 'string' &&
+    record.hash.length > 0;
+
+const constantTimeEqualHex = (a: string, b: string): boolean => {
+    const bufA = Buffer.from(a, 'hex');
+    const bufB = Buffer.from(b, 'hex');
+    if (bufA.length === 0 || bufA.length !== bufB.length) {
+        return false;
+    }
+    let diff = 0;
+    for (let i = 0; i < bufA.length; i++) {
+        diff |= bufA[i] ^ bufB[i];
+    }
+    return diff === 0;
+};
+
+/**
+ * Verify a candidate secret against a stored verifier. Returns false (fail
+ * closed) for an empty secret or a missing/malformed record, and never throws.
+ */
+export const verifySecret = async (
+    secret: string,
+    record?: VerifierRecord | null
+): Promise<boolean> => {
+    if (!secret || !hasVerifier(record)) {
+        return false;
+    }
+    const rec = record as VerifierRecord;
+    try {
+        const saltBuf = Buffer.from(rec.salt, 'hex');
+        const dkLen = Buffer.from(rec.hash, 'hex').length || KEY_LEN;
+        const derived = await scrypt(
+            toBytes(secret),
+            saltBuf,
+            rec.n || SCRYPT_N,
+            rec.r || SCRYPT_R,
+            rec.p || SCRYPT_P,
+            dkLen
+        );
+        return constantTimeEqualHex(
+            Buffer.from(derived).toString('hex'),
+            rec.hash
+        );
+    } catch (e) {
+        return false;
+    }
+};

--- a/utils/LockVerifierUtils.ts
+++ b/utils/LockVerifierUtils.ts
@@ -67,6 +67,23 @@ export const deriveVerifier = async (
     };
 };
 
+/**
+ * Fixed, well-formed verifier used to equalize verification cost when a slot
+ * (e.g. duress) has no credential configured. Verifying an attempt against it
+ * runs the full scrypt derivation, so unlock latency does not reveal whether
+ * a duress credential exists, but it can never match: the stored hash is a
+ * constant, not the digest of any secret under this salt.
+ */
+export const DUMMY_VERIFIER: VerifierRecord = {
+    v: 1,
+    kdf: 'scrypt',
+    n: SCRYPT_N,
+    r: SCRYPT_R,
+    p: SCRYPT_P,
+    salt: '00'.repeat(SALT_LEN),
+    hash: '00'.repeat(KEY_LEN)
+};
+
 /** True when `record` is a well-formed verifier (used for UI/gate presence). */
 export const hasVerifier = (record?: VerifierRecord | null): boolean =>
     !!record &&

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -10,6 +10,11 @@ jest.mock('react-native-fs', () => ({
 jest.mock('@react-native-documents/picker', () => ({
     saveDocuments: jest.fn()
 }));
+// The native randombytes module cannot init under jest; back it with node crypto
+// so the lock-verifier migration can derive real salts.
+jest.mock('react-native-randombytes', () => ({
+    randomBytes: (length: number) => require('crypto').randomBytes(length)
+}));
 jest.mock('react-native-encrypted-storage', () => ({
     getItem: jest.fn(),
     setItem: jest.fn()
@@ -92,6 +97,7 @@ jest.mock('../storage', () => ({
 }));
 
 import MigrationUtils from './MigrationUtils';
+import { verifySecret } from './LockVerifierUtils';
 
 // Mock console logs to keep test output clean
 const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -1209,6 +1215,86 @@ describe('MigrationUtils', () => {
                 'Error saving migrated Cashu seed version:',
                 expect.any(Error)
             );
+        });
+    });
+
+    describe('migrateLockCredentialsToVerifiers', () => {
+        const EncryptedStorage = require('react-native-encrypted-storage');
+        const { settingsStore } = require('../stores/Stores');
+
+        beforeEach(() => {
+            EncryptedStorage.getItem.mockReset();
+            EncryptedStorage.setItem.mockReset();
+            settingsStore.setSettings.mockReset();
+        });
+
+        it('hashes plaintext pin + duress pin into verifiers and strips the plaintext', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = { pin: '1234', duressPin: '9999' };
+
+            await MigrationUtils.migrateLockCredentialsToVerifiers(settings);
+
+            expect(settings.pin).toBeUndefined();
+            expect(settings.duressPin).toBeUndefined();
+            expect(await verifySecret('1234', settings.pinVerifier)).toBe(true);
+            expect(await verifySecret('9999', settings.duressPinVerifier)).toBe(
+                true
+            );
+            // the duress record is structurally identical to the normal one
+            expect(Object.keys(settings.duressPinVerifier).sort()).toEqual(
+                Object.keys(settings.pinVerifier).sort()
+            );
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'lock-verifier-hash-mod',
+                'true'
+            );
+        });
+
+        it('hashes a passphrase and its duress variant', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                passphrase: 'open sesame',
+                duressPassphrase: 'burn it'
+            };
+
+            await MigrationUtils.migrateLockCredentialsToVerifiers(settings);
+
+            expect(settings.passphrase).toBeUndefined();
+            expect(settings.duressPassphrase).toBeUndefined();
+            expect(
+                await verifySecret('open sesame', settings.passphraseVerifier)
+            ).toBe(true);
+            expect(
+                await verifySecret('burn it', settings.duressPassphraseVerifier)
+            ).toBe(true);
+        });
+
+        it('is a no-op with no lock configured but still sets the flag', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = { nodes: [] };
+
+            await MigrationUtils.migrateLockCredentialsToVerifiers(settings);
+
+            expect(settings).toEqual({ nodes: [] });
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'lock-verifier-hash-mod',
+                'true'
+            );
+        });
+
+        it('is idempotent once the flag is set', async () => {
+            EncryptedStorage.getItem.mockResolvedValue('true');
+            const settings: any = { pin: '1234' };
+
+            await MigrationUtils.migrateLockCredentialsToVerifiers(settings);
+
+            // untouched: plaintext left as-is, nothing persisted
+            expect(settings.pin).toBe('1234');
+            expect(settings.pinVerifier).toBeUndefined();
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
         });
     });
 });

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -1226,6 +1226,7 @@ describe('MigrationUtils', () => {
             EncryptedStorage.getItem.mockReset();
             EncryptedStorage.setItem.mockReset();
             settingsStore.setSettings.mockReset();
+            settingsStore.setSettings.mockResolvedValue(true);
         });
 
         it('hashes plaintext pin + duress pin into verifiers and strips the plaintext', async () => {
@@ -1295,6 +1296,170 @@ describe('MigrationUtils', () => {
             expect(settings.pinVerifier).toBeUndefined();
             expect(settingsStore.setSettings).not.toHaveBeenCalled();
             expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
+        });
+
+        it('does not stamp the flag when persisting the settings fails', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            // e.g. the wipe write-latch is engaged or the keychain write
+            // failed; the migration must retry on the next load
+            settingsStore.setSettings.mockResolvedValue(false);
+            const settings: any = { pin: '1234' };
+
+            await MigrationUtils.migrateLockCredentialsToVerifiers(settings);
+
+            expect(EncryptedStorage.setItem).not.toHaveBeenCalledWith(
+                'lock-verifier-hash-mod',
+                'true'
+            );
+        });
+
+        it('strips plaintext credentials from the legacy zeus-settings blob', async () => {
+            EncryptedStorage.getItem.mockImplementation((key: string) => {
+                if (key === 'zeus-settings') {
+                    return Promise.resolve(
+                        JSON.stringify({
+                            pin: '1234',
+                            duressPassphrase: 'burn it',
+                            theme: 'dark'
+                        })
+                    );
+                }
+                return Promise.resolve(null);
+            });
+            const settings: any = { pin: '1234' };
+
+            await MigrationUtils.migrateLockCredentialsToVerifiers(settings);
+
+            const legacyWrite = EncryptedStorage.setItem.mock.calls.find(
+                (call: string[]) => call[0] === 'zeus-settings'
+            );
+            expect(legacyWrite).toBeDefined();
+            const rewritten = JSON.parse(legacyWrite[1]);
+            expect(rewritten.pin).toBeUndefined();
+            expect(rewritten.duressPassphrase).toBeUndefined();
+            // everything else survives the rewrite
+            expect(rewritten.theme).toBe('dark');
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'lock-verifier-hash-mod',
+                'true'
+            );
+        });
+
+        it('leaves the legacy blob alone when it holds no plaintext credentials', async () => {
+            EncryptedStorage.getItem.mockImplementation((key: string) => {
+                if (key === 'zeus-settings') {
+                    return Promise.resolve(JSON.stringify({ theme: 'dark' }));
+                }
+                return Promise.resolve(null);
+            });
+            const settings: any = { nodes: [] };
+
+            await MigrationUtils.migrateLockCredentialsToVerifiers(settings);
+
+            const legacyWrite = EncryptedStorage.setItem.mock.calls.find(
+                (call: string[]) => call[0] === 'zeus-settings'
+            );
+            expect(legacyWrite).toBeUndefined();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'lock-verifier-hash-mod',
+                'true'
+            );
+        });
+    });
+
+    describe('restampKeychainAccessibility', () => {
+        const EncryptedStorage = require('react-native-encrypted-storage');
+        const Storage = require('../storage');
+        const { settingsStore } = require('../stores/Stores');
+        const mockConsoleWarn = jest
+            .spyOn(console, 'warn')
+            .mockImplementation(() => {});
+
+        beforeEach(() => {
+            EncryptedStorage.getItem.mockReset();
+            EncryptedStorage.setItem.mockReset();
+            Storage.getItem.mockReset();
+            Storage.setItem.mockReset();
+            Storage.setItem.mockResolvedValue(true);
+            settingsStore.setSettings.mockReset();
+            settingsStore.setSettings.mockResolvedValue(true);
+            mockConsoleWarn.mockClear();
+        });
+
+        it('rewrites stored items in place and stamps the flag', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            Storage.getItem.mockImplementation((key: string) =>
+                key === 'zeus-contacts-v2'
+                    ? Promise.resolve('CONTACTS')
+                    : Promise.resolve(false)
+            );
+
+            await MigrationUtils.restampKeychainAccessibility({ nodes: [] });
+
+            // the stored item is rewritten verbatim (picking up the current
+            // accessibility class); unset keys are left alone
+            expect(Storage.setItem).toHaveBeenCalledWith(
+                'zeus-contacts-v2',
+                'CONTACTS'
+            );
+            expect(Storage.setItem).toHaveBeenCalledTimes(1);
+            // the settings blob goes through the store, not a raw rewrite
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'ios-keychain-accessible-restamp-v1',
+                'true'
+            );
+        });
+
+        it('derives LNC and cashu keys from the node list', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            Storage.getItem.mockResolvedValue(false);
+            const { hash } = require('../backends/LNC/credentialStore');
+
+            await MigrationUtils.restampKeychainAccessibility({
+                nodes: [
+                    {
+                        implementation: 'lightning-node-connect',
+                        pairingPhrase: 'cherry truth mask employ'
+                    },
+                    { implementation: 'embedded-lnd', lndDir: 'lnd' },
+                    { implementation: 'ldk-node', ldkNodeDir: 'ldk-2' }
+                ]
+            });
+
+            const readKeys = Storage.getItem.mock.calls.map(
+                (call: string[]) => call[0]
+            );
+            const lncBase = `lnc-rn:${hash('cherry truth mask employ')}`;
+            expect(readKeys).toContain(lncBase);
+            expect(readKeys).toContain(`${lncBase}:host`);
+            expect(readKeys).toContain('lnd-cashu-seed-phrase');
+            expect(readKeys).toContain('ldk-2-cashu-seed');
+        });
+
+        it('does not stamp the flag when a rewrite fails', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            Storage.getItem.mockImplementation((key: string) =>
+                key === 'zeus-contacts-v2'
+                    ? Promise.resolve('CONTACTS')
+                    : Promise.resolve(false)
+            );
+            // e.g. the wipe write-latch is engaged; retry on next launch
+            Storage.setItem.mockResolvedValue(false);
+
+            await MigrationUtils.restampKeychainAccessibility({ nodes: [] });
+
+            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
+        });
+
+        it('is a no-op once the flag is set', async () => {
+            EncryptedStorage.getItem.mockResolvedValue('true');
+
+            await MigrationUtils.restampKeychainAccessibility({ nodes: [] });
+
+            expect(Storage.getItem).not.toHaveBeenCalled();
+            expect(Storage.setItem).not.toHaveBeenCalled();
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
         });
     });
 });

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -99,6 +99,7 @@ const CASHU_MIGRATION_KEY = 'ios-keychain-cashu-fix-v1';
 
 import EncryptedStorage from 'react-native-encrypted-storage';
 import Storage from '../storage';
+import { deriveVerifier, hasVerifier } from './LockVerifierUtils';
 
 class MigrationsUtils {
     /**
@@ -475,7 +476,56 @@ class MigrationsUtils {
         // move users off swap providers that have shut down
         await this.migrateRetiredSwapHosts(newSettings);
 
+        // hash any plaintext PIN/passphrase (and duress) into salted verifiers
+        await this.migrateLockCredentialsToVerifiers(newSettings);
+
         return newSettings;
+    }
+
+    // Replace plaintext app-lock credentials with salted scrypt verifiers and
+    // strip the plaintext fields. Historically the PIN, passphrase and their
+    // duress variants were stored verbatim in the settings blob alongside every
+    // wallet secret, and login was a direct string compare - so anyone who
+    // could read the blob (root/jailbreak dump, or an iOS backup migration)
+    // recovered the credentials and could tell which one was the duress
+    // trigger. Runs once (MOD-gated) on both the legacy and modern
+    // (zeus-settings-v2) load paths.
+    public async migrateLockCredentialsToVerifiers(settings: any) {
+        const MOD_KEY_LOCK_VERIFIER = 'lock-verifier-hash-mod';
+        const modLockVerifier = await EncryptedStorage.getItem(
+            MOD_KEY_LOCK_VERIFIER
+        );
+        if (modLockVerifier) return settings;
+        if (!settings) return settings;
+
+        const pairs: Array<{ plain: string; verifier: string }> = [
+            { plain: 'pin', verifier: 'pinVerifier' },
+            { plain: 'duressPin', verifier: 'duressPinVerifier' },
+            { plain: 'passphrase', verifier: 'passphraseVerifier' },
+            { plain: 'duressPassphrase', verifier: 'duressPassphraseVerifier' }
+        ];
+
+        let changed = false;
+        for (const { plain, verifier } of pairs) {
+            const value = settings[plain];
+            if (typeof value === 'string' && value.length > 0) {
+                // don't clobber a verifier that already exists
+                if (!hasVerifier(settings[verifier])) {
+                    settings[verifier] = await deriveVerifier(value);
+                }
+                changed = true;
+            }
+            if (settings[plain] !== undefined) {
+                delete settings[plain];
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            await settingsStore.setSettings(settings);
+        }
+        await EncryptedStorage.setItem(MOD_KEY_LOCK_VERIFIER, 'true');
+        return settings;
     }
 
     // Rewrite persisted v1 RGS endpoints to their v2 equivalents in a

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -522,10 +522,66 @@ class MigrationsUtils {
         }
 
         if (changed) {
-            await settingsStore.setSettings(settings);
+            const persisted = await settingsStore.setSettings(settings);
+            if (!persisted) {
+                // The write failed (wipe write-latch engaged, or the keychain
+                // call itself failed). Leave the MOD flag unset so the
+                // migration re-runs on the next load: stamping it now would
+                // strand a persisted blob that still holds plaintext
+                // credentials and no verifiers, and the app would boot with
+                // no lock configured at all.
+                return settings;
+            }
         }
+
+        // The pre-v2 'zeus-settings' blob is copied forward by
+        // storageMigrationV2 but never deleted, so for anyone who came
+        // through the legacy path it still holds the plaintext credentials
+        // this migration exists to remove. Rewrite it stripped rather than
+        // deleting it, since KeychainRecoveryUtils still lists it as a
+        // recovery source. Runs before the flag is stamped so a failure here
+        // retries on the next load.
+        await this.stripLegacyLockCredentials();
+
         await EncryptedStorage.setItem(MOD_KEY_LOCK_VERIFIER, 'true');
         return settings;
+    }
+
+    // Remove plaintext app-lock credentials from the legacy 'zeus-settings'
+    // EncryptedStorage blob, leaving everything else in place.
+    private async stripLegacyLockCredentials() {
+        const LEGACY_SETTINGS_KEY = 'zeus-settings';
+        const legacy = await EncryptedStorage.getItem(LEGACY_SETTINGS_KEY);
+        if (!legacy) return;
+
+        let parsed: any;
+        try {
+            parsed = JSON.parse(legacy);
+        } catch (e) {
+            // an unparseable legacy blob holds no strippable fields; leave
+            // it for KeychainRecoveryUtils to surface
+            return;
+        }
+        if (!parsed || typeof parsed !== 'object') return;
+
+        let changed = false;
+        for (const field of [
+            'pin',
+            'duressPin',
+            'passphrase',
+            'duressPassphrase'
+        ]) {
+            if (parsed[field] !== undefined) {
+                delete parsed[field];
+                changed = true;
+            }
+        }
+        if (changed) {
+            await EncryptedStorage.setItem(
+                LEGACY_SETTINGS_KEY,
+                JSON.stringify(parsed)
+            );
+        }
     }
 
     // Rewrite persisted v1 RGS endpoints to their v2 equivalents in a
@@ -1326,6 +1382,181 @@ class MigrationsUtils {
             if (legacyValue !== null && legacyValue !== undefined) {
                 await Storage.setItem(nodeKey, legacyValue);
             }
+        }
+    }
+
+    // Rewrite one keychain item in place so it picks up the current write
+    // options (accessibility class). Returns false only on a failed write;
+    // an unset key is success.
+    private async restampKey(key: string): Promise<boolean> {
+        try {
+            const value = await Storage.getItem(key);
+            // false covers unset and empty values; nothing to rewrite
+            if (value === false || value == null) return true;
+            const written = await Storage.setItem(key, value);
+            return written !== false;
+        } catch (e) {
+            console.error(`[Restamp] Failed to rewrite ${key}:`, e);
+            return false;
+        }
+    }
+
+    // One-shot iOS pass: rewrite existing keychain items in place so they
+    // pick up AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY. The accessibility class
+    // only applies when an item is written, so anything persisted before
+    // that option was added - including write-once secrets such as LNC
+    // credentials, Cashu seed material, NWC nostr keys, contacts and notes -
+    // would otherwise keep the migratable AFTER_FIRST_UNLOCK class and ride
+    // an encrypted backup to a new device. Walks the same key inventory as
+    // keychainCloudSyncMigration. Entries with no index (lnurlpay:<hash>,
+    // pos-<orderId>) cannot be enumerated from JS and are accepted as
+    // residual: they hold payment metadata, not key material. The flag is
+    // only stamped once every rewrite succeeds, so a partial failure retries
+    // on the next load; rewrites are idempotent.
+    public async restampKeychainAccessibility(settings: any) {
+        // Only iOS uses kSecAttrAccessible; Android backup exclusion is
+        // already handled by allowBackup="false"
+        if (Platform.OS !== 'ios') return;
+
+        const RESTAMP_KEY = 'ios-keychain-accessible-restamp-v1';
+        const done = await EncryptedStorage.getItem(RESTAMP_KEY);
+        if (done === 'true') return;
+
+        console.log('Re-stamping keychain items as this-device-only...');
+
+        const keys: string[] = [
+            CONTACTS_KEY,
+            NOTES_KEY,
+            LAST_CHANNEL_BACKUP_STATUS,
+            LAST_CHANNEL_BACKUP_TIME,
+            ADDRESS_ACTIVATED_STRING,
+            HASHES_STORAGE_STRING,
+            POS_HIDDEN_KEY,
+            POS_STANDALONE_KEY,
+            CATEGORY_KEY,
+            PRODUCT_KEY,
+            UNIT_KEY,
+            HIDDEN_ACCOUNTS_KEY,
+            CURRENCY_CODES_KEY,
+            ACTIVITY_FILTERS_KEY,
+            IS_BACKED_UP_KEY,
+            LSPS_ORDERS_KEY,
+            SWAPS_KEY,
+            REVERSE_SWAPS_KEY,
+            SWAPS_RESCUE_KEY,
+            SWAPS_LAST_USED_KEY,
+            // Literal historical key names: importing these stores here
+            // would pull their module graphs into every suite that mocks
+            // this file, and a one-shot migration should pin the names it
+            // ran against anyway
+            'zeus-nwc-connections',
+            'zeus-nwc-client-keys', // nostr secret keys
+            'zeus-nwc-service-keys', // nostr secret keys
+            'zeus-nwc-cashu-enabled',
+            'zeus-nwc-lud16-enabled',
+            'persistentNWCServicesEnabled',
+            'zeus-favorite-currencies',
+            'successfulPaymentCount',
+            'ratingDismissedPermanently'
+        ];
+
+        // per-note entries are listed in the notes index
+        try {
+            const notesListJson = await Storage.getItem(NOTES_KEY);
+            if (notesListJson) {
+                const noteKeys = JSON.parse(notesListJson);
+                if (Array.isArray(noteKeys)) keys.push(...noteKeys);
+            }
+        } catch (e) {
+            console.warn('[Restamp] Could not read notes index:', e);
+        }
+
+        const nodes = Array.isArray(settings?.nodes) ? settings.nodes : [];
+        for (const node of nodes) {
+            // LNC credentials: write-once local/remote keys + macaroon,
+            // stored under a hash of the pairing phrase
+            if (
+                node?.implementation === 'lightning-node-connect' &&
+                node.pairingPhrase
+            ) {
+                const baseKey = `${LNC_STORAGE_KEY}:${hash(
+                    node.pairingPhrase
+                )}`;
+                keys.push(baseKey, `${baseKey}:host`);
+            }
+
+            // Cashu data (including seed material) is namespaced per node dir
+            if (
+                node?.implementation === 'embedded-lnd' ||
+                node?.implementation === 'ldk-node'
+            ) {
+                const nodeDir =
+                    node.implementation === 'ldk-node'
+                        ? node.ldkNodeDir || 'ldk'
+                        : node.lndDir || 'lnd';
+                keys.push(
+                    `${nodeDir}-cashu-mintUrls`,
+                    `${nodeDir}-cashu-selectedMintUrl`,
+                    `${nodeDir}-cashu-totalBalanceSats`,
+                    `${nodeDir}-cashu-invoices`,
+                    `${nodeDir}-cashu-payments`,
+                    `${nodeDir}-cashu-received-tokens`,
+                    `${nodeDir}-cashu-sent-tokens`,
+                    `${nodeDir}-cashu-seed-version`,
+                    `${nodeDir}-cashu-seed-phrase`,
+                    `${nodeDir}-cashu-seed`
+                );
+
+                // per-mint wallet keys hang off the mintUrls list
+                try {
+                    const mintUrlsJson = await Storage.getItem(
+                        `${nodeDir}-cashu-mintUrls`
+                    );
+                    if (mintUrlsJson) {
+                        const mintUrls = JSON.parse(mintUrlsJson);
+                        if (Array.isArray(mintUrls)) {
+                            for (const mintUrl of mintUrls) {
+                                const walletId = `${nodeDir}==${mintUrl}`;
+                                keys.push(
+                                    `${walletId}-mintInfo`,
+                                    `${walletId}-counter`,
+                                    `${walletId}-proofs`,
+                                    `${walletId}-balance`,
+                                    `${walletId}-pubkey`
+                                );
+                            }
+                        }
+                    }
+                } catch (e) {
+                    console.warn(
+                        `[Restamp] Could not read mintUrls for ${nodeDir}:`,
+                        e
+                    );
+                }
+            }
+        }
+
+        let allSucceeded = true;
+        for (const key of [...new Set(keys)]) {
+            const ok = await this.restampKey(key);
+            if (!ok) allSucceeded = false;
+        }
+
+        // The settings blob itself is rewritten through the store rather
+        // than restampKey so a raw read-modify-write can't race a queued
+        // settings update
+        if (settings) {
+            const persisted = await settingsStore.setSettings(settings);
+            if (!persisted) allSucceeded = false;
+        }
+
+        if (allSucceeded) {
+            await EncryptedStorage.setItem(RESTAMP_KEY, 'true');
+            console.log('Keychain accessibility re-stamp complete.');
+        } else {
+            console.warn(
+                'Keychain re-stamp incomplete; will retry on next launch.'
+            );
         }
     }
 

--- a/utils/NavigationUtils.test.ts
+++ b/utils/NavigationUtils.test.ts
@@ -73,9 +73,21 @@ describe('NavigationUtils', () => {
     });
 
     describe('protectedNavigation', () => {
-        it('routes via Lockscreen when POS is active and a pin is set', async () => {
+        // Credentials persist as verifier records post-migration; the gate
+        // must read those, not the removed plaintext pin/passphrase fields.
+        const verifier = {
+            v: 1,
+            kdf: 'scrypt',
+            n: 32768,
+            r: 8,
+            p: 1,
+            salt: 'aa'.repeat(16),
+            hash: 'bb'.repeat(32)
+        };
+
+        it('routes via Lockscreen when POS is active and a pin verifier is set', async () => {
             mockSettingsStore.posStatus = 'active';
-            mockSettingsStore.settings = { pin: '1234' };
+            mockSettingsStore.settings = { pinVerifier: verifier };
 
             await protectedNavigation(navigation, 'Menu');
 
@@ -84,9 +96,29 @@ describe('NavigationUtils', () => {
             });
         });
 
+        it('routes via Lockscreen when POS is active and a passphrase verifier is set', async () => {
+            mockSettingsStore.posStatus = 'active';
+            mockSettingsStore.settings = { passphraseVerifier: verifier };
+
+            await protectedNavigation(navigation, 'Menu');
+
+            expect(navigation.navigate).toHaveBeenCalledWith('Lockscreen', {
+                pendingNavigation: { screen: 'Menu', params: undefined }
+            });
+        });
+
+        it('navigates directly when POS is active but no credential is configured', async () => {
+            mockSettingsStore.posStatus = 'active';
+            mockSettingsStore.settings = {};
+
+            await protectedNavigation(navigation, 'Menu');
+
+            expect(navigation.navigate).toHaveBeenCalledWith('Menu', undefined);
+        });
+
         it('navigates directly when POS is inactive', async () => {
             mockSettingsStore.posStatus = 'inactive';
-            mockSettingsStore.settings = { pin: '1234' };
+            mockSettingsStore.settings = { pinVerifier: verifier };
 
             await protectedNavigation(navigation, 'Menu');
 

--- a/utils/NavigationUtils.ts
+++ b/utils/NavigationUtils.ts
@@ -1,6 +1,7 @@
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { settingsStore } from '../stores/Stores';
+import { hasVerifier } from './LockVerifierUtils';
 
 const protectedNavigation = async (
     navigation: NativeStackNavigationProp<any, any>,
@@ -9,7 +10,12 @@ const protectedNavigation = async (
     routeParams?: any
 ) => {
     const { posStatus, settings, setPosStatus } = settingsStore;
-    const loginRequired = settings && (settings.passphrase || settings.pin);
+    // credentials are stored as verifier records; the plaintext
+    // passphrase/pin fields no longer exist post-migration
+    const loginRequired =
+        settings &&
+        (hasVerifier(settings.passphraseVerifier) ||
+            hasVerifier(settings.pinVerifier));
     const posEnabled = posStatus === 'active';
 
     if (posEnabled && loginRequired) {

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -30,6 +30,11 @@ import {
 } from '../utils/DataClearUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { restartApp } from '../utils/RestartUtils';
+import {
+    verifySecret,
+    hasVerifier,
+    VerifierRecord
+} from '../utils/LockVerifierUtils';
 import { themeColor } from '../utils/ThemeUtils';
 
 interface LockscreenProps {
@@ -50,12 +55,13 @@ interface LockscreenProps {
 }
 
 interface LockscreenState {
-    passphrase: string;
+    authMethod: 'pin' | 'passphrase' | null;
+    passphraseVerifier?: VerifierRecord;
     passphraseAttempt: string;
-    duressPassphrase: string;
-    pin: string;
+    duressPassphraseVerifier?: VerifierRecord;
+    pinVerifier?: VerifierRecord;
     pinAttempt: string;
-    duressPin: string;
+    duressPinVerifier?: VerifierRecord;
     hidden: boolean;
     error: boolean;
     modifySecurityScreen: string;
@@ -81,12 +87,13 @@ export default class Lockscreen extends React.Component<
     constructor(props: any) {
         super(props);
         this.state = {
+            authMethod: null,
             passphraseAttempt: '',
-            passphrase: '',
-            duressPassphrase: '',
-            pin: '',
+            passphraseVerifier: undefined,
+            duressPassphraseVerifier: undefined,
+            pinVerifier: undefined,
             pinAttempt: '',
-            duressPin: '',
+            duressPinVerifier: undefined,
             hidden: true,
             error: false,
             modifySecurityScreen: '',
@@ -233,20 +240,18 @@ export default class Lockscreen extends React.Component<
             });
         }
 
-        if (settings && settings.passphrase) {
-            this.setState({ passphrase: settings.passphrase });
-            if (settings.duressPassphrase) {
-                this.setState({
-                    duressPassphrase: settings.duressPassphrase
-                });
-            }
-        } else if (settings && settings.pin) {
-            this.setState({ pin: settings.pin });
-            if (settings.duressPin) {
-                this.setState({
-                    duressPin: settings.duressPin
-                });
-            }
+        if (settings && hasVerifier(settings.passphraseVerifier)) {
+            this.setState({
+                authMethod: 'passphrase',
+                passphraseVerifier: settings.passphraseVerifier,
+                duressPassphraseVerifier: settings.duressPassphraseVerifier
+            });
+        } else if (settings && hasVerifier(settings.pinVerifier)) {
+            this.setState({
+                authMethod: 'pin',
+                pinVerifier: settings.pinVerifier,
+                duressPinVerifier: settings.duressPinVerifier
+            });
         } else if (settings && settings.nodes && settings?.nodes?.length > 0) {
             this.proceed(pendingNavigation?.screen, pendingNavigation?.params);
         } else {
@@ -277,12 +282,13 @@ export default class Lockscreen extends React.Component<
     onAttemptLogIn = async () => {
         const { SettingsStore, navigation, route } = this.props;
         const {
-            passphrase,
-            duressPassphrase,
+            authMethod,
+            passphraseVerifier,
+            duressPassphraseVerifier,
             passphraseAttempt,
-            pin,
+            pinVerifier,
             pinAttempt,
-            duressPin,
+            duressPinVerifier,
             modifySecurityScreen,
             deletePin,
             deleteDuressPin,
@@ -299,10 +305,25 @@ export default class Lockscreen extends React.Component<
             error: false
         });
 
-        if (
-            (passphraseAttempt && passphraseAttempt === passphrase) ||
-            (pinAttempt && pinAttempt === pin)
-        ) {
+        // Verify against the salted verifier for the active method. The normal
+        // and duress checks are both computed (equal cost) before branching so
+        // response time never reveals which credential matched - keeping the
+        // duress credential indistinguishable from a normal login attempt.
+        const attempt =
+            authMethod === 'passphrase' ? passphraseAttempt : pinAttempt;
+        const primaryVerifier =
+            authMethod === 'passphrase' ? passphraseVerifier : pinVerifier;
+        const duressVerifier =
+            authMethod === 'passphrase'
+                ? duressPassphraseVerifier
+                : duressPinVerifier;
+
+        const [primaryMatch, duressMatch] = await Promise.all([
+            verifySecret(attempt, primaryVerifier),
+            verifySecret(attempt, duressVerifier)
+        ]);
+
+        if (primaryMatch) {
             SettingsStore.setLoginStatus(true);
 
             // Check if we're modifying security settings first
@@ -369,8 +390,7 @@ export default class Lockscreen extends React.Component<
             // duress creds only trigger the wipe on a genuine login attempt -
             // in security management flows they count as an incorrect entry
             !this.isSecurityManagementFlow &&
-            ((duressPassphrase && passphraseAttempt === duressPassphrase) ||
-                (duressPin && pinAttempt === duressPin))
+            duressMatch
         ) {
             // never mark the session logged in here: the wipe takes long
             // enough that an unlocked app would expose the wallet UI (and
@@ -421,8 +441,8 @@ export default class Lockscreen extends React.Component<
         // duress passphrase is also deleted when passphrase is deleted
         // biometry is also disabled when passphrase is deleted
         updateSettings({
-            passphrase: '',
-            duressPassphrase: '',
+            passphraseVerifier: undefined,
+            duressPassphraseVerifier: undefined,
             authenticationAttempts: 0,
             isBiometryEnabled: false
         }).then(() => {
@@ -435,7 +455,7 @@ export default class Lockscreen extends React.Component<
         const { updateSettings } = SettingsStore;
 
         updateSettings({
-            duressPassphrase: '',
+            duressPassphraseVerifier: undefined,
             authenticationAttempts: 0
         }).then(() => {
             navigation.popTo('Security');
@@ -449,8 +469,8 @@ export default class Lockscreen extends React.Component<
         // duress pin is also deleted when pin is deleted
         // biometry is also disabled when pin is deleted
         updateSettings({
-            pin: '',
-            duressPin: '',
+            pinVerifier: undefined,
+            duressPinVerifier: undefined,
             authenticationAttempts: 0,
             isBiometryEnabled: false
         }).then(() => {
@@ -463,7 +483,7 @@ export default class Lockscreen extends React.Component<
         const { updateSettings } = SettingsStore;
 
         updateSettings({
-            duressPin: '',
+            duressPinVerifier: undefined,
             authenticationAttempts: 0
         }).then(() => {
             navigation.popTo('Security');
@@ -522,10 +542,10 @@ export default class Lockscreen extends React.Component<
     };
 
     generateErrorMessage = (): string => {
-        const { passphrase, authenticationAttempts } = this.state;
+        const { authMethod, authenticationAttempts } = this.state;
         let incorrect = '';
 
-        if (passphrase) {
+        if (authMethod === 'passphrase') {
             incorrect = localeString('views.Lockscreen.incorrectPassword');
         } else {
             incorrect = localeString('views.Lockscreen.incorrectPin');
@@ -545,9 +565,8 @@ export default class Lockscreen extends React.Component<
         const pendingNavigation = this.props.route.params?.pendingNavigation;
         const { settings } = SettingsStore;
         const {
-            passphrase,
+            authMethod,
             passphraseAttempt,
-            pin,
             hidden,
             error,
             modifySecurityScreen,
@@ -583,7 +602,7 @@ export default class Lockscreen extends React.Component<
                 {(this.isSecurityManagementFlow || pendingNavigation) && (
                     <Header leftComponent="Back" navigation={navigation} />
                 )}
-                {!!passphrase && (
+                {authMethod === 'passphrase' && (
                     <View
                         style={{
                             ...styles.content,
@@ -665,7 +684,7 @@ export default class Lockscreen extends React.Component<
                         </View>
                     </View>
                 )}
-                {!!pin && (
+                {authMethod === 'pin' && (
                     <View style={styles.container}>
                         <View style={{ flex: 1 }}>
                             <>
@@ -733,7 +752,6 @@ export default class Lockscreen extends React.Component<
                                             this.setState({ error: false })
                                         }
                                         hidePinLength={true}
-                                        pinLength={pin.length}
                                         shuffle={settings.scramblePin}
                                     />
                                 </View>

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -64,6 +64,7 @@ interface LockscreenState {
     duressPinVerifier?: VerifierRecord;
     hidden: boolean;
     error: boolean;
+    verifying: boolean;
     modifySecurityScreen: string;
     deletePin: boolean;
     deleteDuressPin: boolean;
@@ -96,6 +97,7 @@ export default class Lockscreen extends React.Component<
             duressPinVerifier: undefined,
             hidden: true,
             error: false,
+            verifying: false,
             modifySecurityScreen: '',
             deletePin: false,
             deleteDuressPin: false,
@@ -301,8 +303,15 @@ export default class Lockscreen extends React.Component<
         // wipe or mutate settings mid-wipe
         if (this.state.wiping) return;
 
+        // Guard against re-entrancy: scrypt verification is asynchronous
+        // (~1s), so a double tap on the login button or a second submit could
+        // otherwise start a second attempt and double-count the failure
+        // counter. The `verifying` flag also drives the spinner overlay.
+        if (this.state.verifying) return;
+
         this.setState({
-            error: false
+            error: false,
+            verifying: true
         });
 
         // Verify against the salted verifier for the active method. The normal
@@ -421,7 +430,8 @@ export default class Lockscreen extends React.Component<
                 await updateSettings({ authenticationAttempts }).then(() => {
                     this.setState({
                         error: true,
-                        pinAttempt: ''
+                        pinAttempt: '',
+                        verifying: false
                     });
                 });
             }
@@ -569,6 +579,7 @@ export default class Lockscreen extends React.Component<
             passphraseAttempt,
             hidden,
             error,
+            verifying,
             modifySecurityScreen,
             deletePin,
             deleteDuressPin,
@@ -759,12 +770,28 @@ export default class Lockscreen extends React.Component<
                         </View>
                     </View>
                 )}
+                {verifying && (
+                    <View style={styles.verifyingOverlay}>
+                        <LoadingIndicator />
+                    </View>
+                )}
             </Screen>
         );
     }
 }
 
 const styles = StyleSheet.create({
+    verifyingOverlay: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        alignItems: 'center',
+        justifyContent: 'center',
+        // dim + swallow taps so a second submit can't land while scrypt runs
+        backgroundColor: 'rgba(0, 0, 0, 0.4)'
+    },
     content: {
         paddingLeft: 20,
         paddingRight: 20,

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -33,6 +33,7 @@ import { restartApp } from '../utils/RestartUtils';
 import {
     verifySecret,
     hasVerifier,
+    DUMMY_VERIFIER,
     VerifierRecord
 } from '../utils/LockVerifierUtils';
 import { themeColor } from '../utils/ThemeUtils';
@@ -314,125 +315,148 @@ export default class Lockscreen extends React.Component<
             verifying: true
         });
 
-        // Verify against the salted verifier for the active method. The normal
-        // and duress checks are both computed (equal cost) before branching so
-        // response time never reveals which credential matched - keeping the
-        // duress credential indistinguishable from a normal login attempt.
+        // Verify against the salted verifier for the active method. Both the
+        // normal and duress checks always run a full scrypt derivation - a
+        // dummy record stands in when no duress credential is configured -
+        // so response time reveals neither which credential matched nor
+        // whether a duress credential exists at all. (verifySecret would
+        // otherwise return early on a missing record, and scrypt-js is
+        // CPU-bound on the JS thread, so the derivations serialize: one vs
+        // two would be a measurable tell.)
         const attempt =
             authMethod === 'passphrase' ? passphraseAttempt : pinAttempt;
         const primaryVerifier =
             authMethod === 'passphrase' ? passphraseVerifier : pinVerifier;
-        const duressVerifier =
+        const configuredDuressVerifier =
             authMethod === 'passphrase'
                 ? duressPassphraseVerifier
                 : duressPinVerifier;
+        const duressVerifier = hasVerifier(configuredDuressVerifier)
+            ? configuredDuressVerifier
+            : DUMMY_VERIFIER;
 
-        const [primaryMatch, duressMatch] = await Promise.all([
-            verifySecret(attempt, primaryVerifier),
-            verifySecret(attempt, duressVerifier)
-        ]);
+        try {
+            const [primaryMatch, duressMatch] = await Promise.all([
+                verifySecret(attempt, primaryVerifier),
+                verifySecret(attempt, duressVerifier)
+            ]);
 
-        if (primaryMatch) {
-            SettingsStore.setLoginStatus(true);
+            if (primaryMatch) {
+                SettingsStore.setLoginStatus(true);
 
-            // Check if we're modifying security settings first
-            if (modifySecurityScreen) {
-                this.resetAuthenticationAttempts();
-                navigation.popTo(modifySecurityScreen);
-                return;
-            } else if (deletePassword) {
-                this.deletePassword();
-                return;
-            } else if (deletePin) {
-                this.deletePin();
-                return;
-            } else if (deleteDuressPassword) {
-                this.deleteDuressPassword();
-                return;
-            } else if (deleteDuressPin) {
-                this.deleteDuressPin();
-                return;
-            } else if (route.params?.pendingNavigation) {
-                // must be handled before selectNodeOnStartup, which would
-                // otherwise drop the re-auth target and land on the wallet
-                // picker
-                if (
-                    (SettingsStore.settings?.pos?.posEnabled ||
-                        PosEnabled.Disabled) !== PosEnabled.Disabled
-                ) {
-                    setPosStatus('inactive');
+                // Check if we're modifying security settings first
+                if (modifySecurityScreen) {
+                    this.resetAuthenticationAttempts();
+                    navigation.popTo(modifySecurityScreen);
+                    return;
+                } else if (deletePassword) {
+                    this.deletePassword();
+                    return;
+                } else if (deletePin) {
+                    this.deletePin();
+                    return;
+                } else if (deleteDuressPassword) {
+                    this.deleteDuressPassword();
+                    return;
+                } else if (deleteDuressPin) {
+                    this.deleteDuressPin();
+                    return;
+                } else if (route.params?.pendingNavigation) {
+                    // must be handled before selectNodeOnStartup, which would
+                    // otherwise drop the re-auth target and land on the wallet
+                    // picker
+                    if (
+                        (SettingsStore.settings?.pos?.posEnabled ||
+                            PosEnabled.Disabled) !== PosEnabled.Disabled
+                    ) {
+                        setPosStatus('inactive');
+                    }
+                    this.resetAuthenticationAttempts();
+                    const { pendingNavigation } = route.params;
+                    this.proceed(
+                        pendingNavigation.screen,
+                        pendingNavigation.params
+                    );
+                    return;
+                } else if (SettingsStore.settings.selectNodeOnStartup) {
+                    // Only handle wallet selection when NOT modifying security
+                    this.resetAuthenticationAttempts();
+
+                    const shareIntentData = route.params?.shareIntentData;
+
+                    if (shareIntentData) {
+                        navigation.replace('Wallets', {
+                            fromStartup: true,
+                            shareIntentData
+                        });
+                    } else {
+                        navigation.replace('Wallets', { fromStartup: true });
+                    }
+                    return;
                 }
-                this.resetAuthenticationAttempts();
-                const { pendingNavigation } = route.params;
-                this.proceed(
-                    pendingNavigation.screen,
-                    pendingNavigation.params
-                );
-                return;
-            } else if (SettingsStore.settings.selectNodeOnStartup) {
-                // Only handle wallet selection when NOT modifying security
-                this.resetAuthenticationAttempts();
-
-                const shareIntentData = route.params?.shareIntentData;
-
-                if (shareIntentData) {
-                    navigation.replace('Wallets', {
-                        fromStartup: true,
-                        shareIntentData
-                    });
-                } else {
-                    navigation.replace('Wallets', { fromStartup: true });
+                if (!SettingsStore.settings.selectNodeOnStartup) {
+                    if (
+                        (SettingsStore.settings?.pos?.posEnabled ||
+                            PosEnabled.Disabled) !== PosEnabled.Disabled
+                    ) {
+                        setPosStatus('inactive');
+                    }
+                    this.resetAuthenticationAttempts();
+                    this.proceed();
                 }
-                return;
-            }
-            if (!SettingsStore.settings.selectNodeOnStartup) {
-                if (
-                    (SettingsStore.settings?.pos?.posEnabled ||
-                        PosEnabled.Disabled) !== PosEnabled.Disabled
-                ) {
-                    setPosStatus('inactive');
-                }
-                this.resetAuthenticationAttempts();
-                this.proceed();
-            }
-        } else if (
-            // duress creds only trigger the wipe on a genuine login attempt -
-            // in security management flows they count as an incorrect entry
-            !this.isSecurityManagementFlow &&
-            duressMatch
-        ) {
-            // never mark the session logged in here: the wipe takes long
-            // enough that an unlocked app would expose the wallet UI (and
-            // the configs being wiped) before the restart lands. Keeping
-            // loggedIn false holds every auth gate shut for the duration,
-            // and the wipe guard pins the user to the wiping screen.
-            this.setState({ wiping: true });
-            await this.deleteNodes();
-        } else {
-            // need to fetch updated settings to get incremented value of
-            // authenticationAttempts, in case there are multiple failed attempts in a row
-            const updatedSettings = await getSettings();
-            let authenticationAttempts = 1;
-            if (updatedSettings?.authenticationAttempts) {
-                authenticationAttempts =
-                    updatedSettings.authenticationAttempts + 1;
-            }
-            this.setState({
-                authenticationAttempts
-            });
-            if (authenticationAttempts >= maxAuthenticationAttempts) {
-                // see the duress branch: loggedIn must stay false so the
-                // wallet UI stays gated while the wipe runs
+            } else if (
+                // duress creds only trigger the wipe on a genuine login
+                // attempt - in security management flows they count as an
+                // incorrect entry
+                !this.isSecurityManagementFlow &&
+                duressMatch
+            ) {
+                // never mark the session logged in here: the wipe takes long
+                // enough that an unlocked app would expose the wallet UI (and
+                // the configs being wiped) before the restart lands. Keeping
+                // loggedIn false holds every auth gate shut for the duration,
+                // and the wipe guard pins the user to the wiping screen.
                 this.setState({ wiping: true });
-                // wipe node configs, passwords, and pins
-                await this.authenticationFailure();
+                await this.deleteNodes();
             } else {
-                await updateSettings({ authenticationAttempts }).then(() => {
+                // need to fetch updated settings to get incremented value of
+                // authenticationAttempts, in case there are multiple failed
+                // attempts in a row
+                const updatedSettings = await getSettings();
+                let authenticationAttempts = 1;
+                if (updatedSettings?.authenticationAttempts) {
+                    authenticationAttempts =
+                        updatedSettings.authenticationAttempts + 1;
+                }
+                this.setState({
+                    authenticationAttempts
+                });
+                if (authenticationAttempts >= maxAuthenticationAttempts) {
+                    // see the duress branch: loggedIn must stay false so the
+                    // wallet UI stays gated while the wipe runs
+                    this.setState({ wiping: true });
+                    // wipe node configs, passwords, and pins
+                    await this.authenticationFailure();
+                } else {
+                    await updateSettings({ authenticationAttempts });
                     this.setState({
                         error: true,
                         pinAttempt: '',
                         verifying: false
                     });
+                }
+            }
+        } catch (e) {
+            // A rejected settings read/write (updateSettings deliberately
+            // re-throws to its caller) must not leave the tap-swallowing
+            // overlay up with the re-entrancy guard armed - that would lock
+            // the user out until force-quit. The wipe branches keep the
+            // guard armed on purpose: the overlay pins the user to the
+            // wiping screen until restart.
+            if (!this.state.wiping) {
+                this.setState({
+                    error: true,
+                    verifying: false
                 });
             }
         }

--- a/views/Settings/PointOfSale.tsx
+++ b/views/Settings/PointOfSale.tsx
@@ -10,6 +10,7 @@ import { inject, observer } from 'mobx-react';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import BackendUtils from '../../utils/BackendUtils';
+import { hasVerifier } from '../../utils/LockVerifierUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 
@@ -119,7 +120,10 @@ export default class PointOfSale extends React.Component<
             defaultView
         } = this.state;
         const { updateSettings, settings }: any = SettingsStore;
-        const { passphrase, pin, fiatEnabled } = settings;
+        const { fiatEnabled } = settings;
+        const authConfigured =
+            hasVerifier(settings.passphraseVerifier) ||
+            hasVerifier(settings.pinVerifier);
 
         const LIST_ITEMS = [
             {
@@ -170,7 +174,7 @@ export default class PointOfSale extends React.Component<
                                 )}
                             />
                         )}
-                        {!pin && !passphrase && (
+                        {!authConfigured && (
                             <WarningMessage
                                 message={localeString(
                                     'pos.views.Settings.PointOfSale.authWarning'

--- a/views/Settings/Security.tsx
+++ b/views/Settings/Security.tsx
@@ -13,6 +13,7 @@ import SettingsStore, { Settings } from '../../stores/SettingsStore';
 import ModalStore from '../../stores/ModalStore';
 
 import { verifyBiometry } from '../../utils/BiometricUtils';
+import { hasVerifier } from '../../utils/LockVerifierUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 
@@ -42,14 +43,21 @@ interface SecurityState {
 const buildSecurityItems = (
     settings: Pick<
         Settings,
-        'passphrase' | 'pin' | 'duressPassphrase' | 'duressPin'
+        | 'passphraseVerifier'
+        | 'pinVerifier'
+        | 'duressPassphraseVerifier'
+        | 'duressPinVerifier'
     >
 ): SecurityItem[] => {
+    // Credentials persist as verifier records; presence is checked via
+    // hasVerifier since the plaintext fields no longer exist post-migration.
+    const passphraseSet = hasVerifier(settings.passphraseVerifier);
+    const pinSet = hasVerifier(settings.pinVerifier);
     // Three cases:
     // 1) If no passphrase or pin is set, allow user to set passphrase or pin
     // 2) If passphrase is set, allow user to change passphrase or set/change duress passphrase
     // 3) If pin is set, allow user to change pin, delete pin, set/change duress pin
-    if (!settings.passphrase && !settings.pin) {
+    if (!passphraseSet && !pinSet) {
         return [
             {
                 translateKey: 'views.Settings.SetPassword.title',
@@ -61,7 +69,10 @@ const buildSecurityItems = (
             }
         ];
     }
-    if (settings.passphrase) {
+    if (passphraseSet) {
+        const duressPassphraseSet = hasVerifier(
+            settings.duressPassphraseVerifier
+        );
         const items: SecurityItem[] = [
             {
                 translateKey: 'views.Settings.ChangePassword.title',
@@ -72,13 +83,13 @@ const buildSecurityItems = (
                 action: 'DeletePassword'
             },
             {
-                translateKey: settings.duressPassphrase
+                translateKey: duressPassphraseSet
                     ? 'views.Settings.ChangeDuressPassword.title'
                     : 'views.Settings.SetDuressPassword.title',
                 screen: 'SetDuressPassword'
             }
         ];
-        if (settings.duressPassphrase) {
+        if (duressPassphraseSet) {
             items.push({
                 translateKey: 'views.Settings.SetDuressPassword.deletePassword',
                 action: 'DeleteDuressPassword'
@@ -87,6 +98,7 @@ const buildSecurityItems = (
         return items;
     }
     // Remaining case: pin is set (branch 1 handled neither; branch 2 handled passphrase)
+    const duressPinSet = hasVerifier(settings.duressPinVerifier);
     const items: SecurityItem[] = [
         {
             translateKey: 'views.Settings.ChangePin.title',
@@ -97,13 +109,13 @@ const buildSecurityItems = (
             action: 'DeletePin'
         },
         {
-            translateKey: settings.duressPin
+            translateKey: duressPinSet
                 ? 'views.Settings.ChangeDuressPin.title'
                 : 'views.Settings.SetDuressPin.title',
             screen: 'SetDuressPin'
         }
     ];
-    if (settings.duressPin) {
+    if (duressPinSet) {
         items.push({
             translateKey: 'views.Settings.Security.deleteDuressPIN',
             action: 'DeleteDuressPin'
@@ -122,8 +134,8 @@ const deriveStateFromSettings = (
     scramblePin: settings.scramblePin ?? true,
     loginBackground: settings.loginBackground ?? false,
     displaySecurityItems: buildSecurityItems(settings),
-    pinExists: !!settings.pin,
-    passphraseExists: !!settings.passphrase,
+    pinExists: hasVerifier(settings.pinVerifier),
+    passphraseExists: hasVerifier(settings.passphraseVerifier),
     supportedBiometryType:
         biometrics?.supportedBiometryType ?? settings.supportedBiometryType,
     isBiometryEnabled:
@@ -174,9 +186,13 @@ export default class Security extends React.Component<
 
     async handleBiometricsSwitchChange(value: boolean): Promise<void> {
         const { SettingsStore, ModalStore, navigation } = this.props;
-        const { pin, passphrase } = SettingsStore.settings;
+        const { pinVerifier, passphraseVerifier } = SettingsStore.settings;
 
-        if (value && !pin && !passphrase) {
+        if (
+            value &&
+            !hasVerifier(pinVerifier) &&
+            !hasVerifier(passphraseVerifier)
+        ) {
             ModalStore.toggleInfoModal({
                 text: localeString(
                     'views.Settings.Security.BiometryRequiresPinOrPassword'
@@ -230,7 +246,12 @@ export default class Security extends React.Component<
         const { isBiometryEnabled } = this.state;
 
         if (!('action' in item)) {
-            if (!(settings.passphrase || settings.pin)) {
+            if (
+                !(
+                    hasVerifier(settings.passphraseVerifier) ||
+                    hasVerifier(settings.pinVerifier)
+                )
+            ) {
                 navigation.navigate(item.screen);
             } else {
                 // if we already have a pin/password set, make user authenticate in order to change

--- a/views/Settings/SetDuressPassword.tsx
+++ b/views/Settings/SetDuressPassword.tsx
@@ -11,6 +11,11 @@ import TextInput from '../../components/TextInput';
 
 import { confirmAction } from '../../utils/ActionUtils';
 import { localeString } from '../../utils/LocaleUtils';
+import {
+    deriveVerifier,
+    verifySecret,
+    hasVerifier
+} from '../../utils/LockVerifierUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import SettingsStore from '../../stores/SettingsStore';
 
@@ -22,7 +27,7 @@ interface SetDuressPassphraseProps {
 interface SetDuressPassphraseState {
     duressPassphrase: string;
     duressPassphraseConfirm: string;
-    savedDuressPassphrase: string;
+    hasSavedDuressPassphrase: boolean;
     duressPassphraseMismatchError: boolean;
     duressPassphraseInvalidError: boolean;
     duressPassphraseEmptyError: boolean;
@@ -37,7 +42,7 @@ export default class SetDuressPassphrase extends React.Component<
     state = {
         duressPassphrase: '',
         duressPassphraseConfirm: '',
-        savedDuressPassphrase: '',
+        hasSavedDuressPassphrase: false,
         duressPassphraseMismatchError: false,
         duressPassphraseInvalidError: false,
         duressPassphraseEmptyError: false
@@ -48,9 +53,11 @@ export default class SetDuressPassphrase extends React.Component<
         const { getSettings } = SettingsStore;
         const settings = await getSettings();
 
-        if (settings.duressPassphrase) {
-            this.setState({ savedDuressPassphrase: settings.duressPassphrase });
-        }
+        this.setState({
+            hasSavedDuressPassphrase: hasVerifier(
+                settings.duressPassphraseVerifier
+            )
+        });
     }
 
     renderSeparator = () => (
@@ -75,19 +82,6 @@ export default class SetDuressPassphrase extends React.Component<
             return;
         }
 
-        const settings = await getSettings();
-
-        if (
-            duressPassphrase !== '' &&
-            duressPassphrase === settings.passphrase
-        ) {
-            this.setState({
-                duressPassphraseInvalidError: true
-            });
-
-            return;
-        }
-
         if (duressPassphrase === '') {
             this.setState({
                 duressPassphraseEmptyError: true
@@ -95,7 +89,18 @@ export default class SetDuressPassphrase extends React.Component<
             return;
         }
 
-        await updateSettings({ duressPassphrase }).then(() => {
+        const settings = await getSettings();
+
+        if (await verifySecret(duressPassphrase, settings.passphraseVerifier)) {
+            this.setState({
+                duressPassphraseInvalidError: true
+            });
+
+            return;
+        }
+
+        const duressPassphraseVerifier = await deriveVerifier(duressPassphrase);
+        await updateSettings({ duressPassphraseVerifier }).then(() => {
             getSettings();
             navigation.popTo('Security');
         });
@@ -105,9 +110,11 @@ export default class SetDuressPassphrase extends React.Component<
         const { SettingsStore, navigation } = this.props;
         const { updateSettings } = SettingsStore;
 
-        await updateSettings({ duressPassphrase: '' }).then(() => {
-            navigation.popTo('Security');
-        });
+        await updateSettings({ duressPassphraseVerifier: undefined }).then(
+            () => {
+                navigation.popTo('Security');
+            }
+        );
     };
 
     render() {
@@ -115,7 +122,7 @@ export default class SetDuressPassphrase extends React.Component<
         const {
             duressPassphrase,
             duressPassphraseConfirm,
-            savedDuressPassphrase,
+            hasSavedDuressPassphrase,
             duressPassphraseMismatchError,
             duressPassphraseInvalidError,
             duressPassphraseEmptyError
@@ -127,7 +134,7 @@ export default class SetDuressPassphrase extends React.Component<
                     leftComponent="Back"
                     centerComponent={{
                         text: localeString(
-                            savedDuressPassphrase
+                            hasSavedDuressPassphrase
                                 ? 'views.Settings.ChangeDuressPassword.title'
                                 : 'views.Settings.SetDuressPassword.title'
                         ),
@@ -239,7 +246,7 @@ export default class SetDuressPassphrase extends React.Component<
                             onPress={() => this.saveSettings()}
                         />
                     </View>
-                    {!!savedDuressPassphrase && (
+                    {hasSavedDuressPassphrase && (
                         <View style={{ paddingTop: 10, margin: 10 }}>
                             <Button
                                 title={localeString(

--- a/views/Settings/SetDuressPin.tsx
+++ b/views/Settings/SetDuressPin.tsx
@@ -9,6 +9,7 @@ import Screen from '../../components/Screen';
 import { ErrorMessage } from '../../components/SuccessErrorMessage';
 
 import { localeString } from '../../utils/LocaleUtils';
+import { deriveVerifier, verifySecret } from '../../utils/LockVerifierUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 
 import SettingsStore from '../../stores/SettingsStore';
@@ -85,7 +86,7 @@ export default class SetDuressPin extends React.Component<
 
         const settings = await getSettings();
 
-        if (duressPin === settings.pin) {
+        if (await verifySecret(duressPin, settings.pinVerifier)) {
             this.setState({
                 duressPinInvalidError: true,
                 duressPin: '',
@@ -95,7 +96,8 @@ export default class SetDuressPin extends React.Component<
             return;
         }
 
-        await updateSettings({ duressPin }).then(() => {
+        const duressPinVerifier = await deriveVerifier(duressPin);
+        await updateSettings({ duressPinVerifier }).then(() => {
             getSettings();
             navigation.popTo('Security');
         });

--- a/views/Settings/SetPassword.tsx
+++ b/views/Settings/SetPassword.tsx
@@ -11,6 +11,11 @@ import TextInput from '../../components/TextInput';
 
 import { confirmAction } from '../../utils/ActionUtils';
 import { localeString } from '../../utils/LocaleUtils';
+import {
+    deriveVerifier,
+    verifySecret,
+    hasVerifier
+} from '../../utils/LockVerifierUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import SettingsStore from '../../stores/SettingsStore';
 import ModalStore from '../../stores/ModalStore';
@@ -25,7 +30,7 @@ interface SetPassphraseProps {
 interface SetPassphraseState {
     passphrase: string;
     passphraseConfirm: string;
-    savedPassphrase: string;
+    hasSavedPassphrase: boolean;
     passphraseMismatchError: boolean;
     passphraseInvalidError: boolean;
     passphraseEmptyError: boolean;
@@ -41,7 +46,7 @@ export default class SetPassphrase extends React.Component<
     state = {
         passphrase: '',
         passphraseConfirm: '',
-        savedPassphrase: '',
+        hasSavedPassphrase: false,
         passphraseMismatchError: false,
         passphraseInvalidError: false,
         passphraseEmptyError: false,
@@ -56,11 +61,9 @@ export default class SetPassphrase extends React.Component<
         const settings = await SettingsStore.getSettings();
 
         this.setState({
-            isBiometryEnabled: settings.isBiometryEnabled
+            isBiometryEnabled: settings.isBiometryEnabled,
+            hasSavedPassphrase: hasVerifier(settings.passphraseVerifier)
         });
-        if (settings.passphrase) {
-            this.setState({ savedPassphrase: settings.passphrase });
-        }
 
         this.firstInput.current?.focus();
     }
@@ -89,14 +92,6 @@ export default class SetPassphrase extends React.Component<
 
         const settings = await getSettings();
 
-        if (passphrase !== '' && passphrase === settings.duressPassphrase) {
-            this.setState({
-                passphraseInvalidError: true
-            });
-
-            return;
-        }
-
         if (passphrase === '') {
             this.setState({
                 passphraseEmptyError: true
@@ -104,7 +99,16 @@ export default class SetPassphrase extends React.Component<
             return;
         }
 
-        await updateSettings({ passphrase }).then(() => {
+        if (await verifySecret(passphrase, settings.duressPassphraseVerifier)) {
+            this.setState({
+                passphraseInvalidError: true
+            });
+
+            return;
+        }
+
+        const passphraseVerifier = await deriveVerifier(passphrase);
+        await updateSettings({ passphraseVerifier }).then(() => {
             setLoginStatus(true);
             getSettings();
             navigation.popTo('Security', {
@@ -120,8 +124,8 @@ export default class SetPassphrase extends React.Component<
         const { updateSettings } = SettingsStore;
 
         await updateSettings({
-            duressPassphrase: '',
-            passphrase: '',
+            duressPassphraseVerifier: undefined,
+            passphraseVerifier: undefined,
             isBiometryEnabled: false
         });
         navigation.popTo('Security');
@@ -132,7 +136,7 @@ export default class SetPassphrase extends React.Component<
         const {
             passphrase,
             passphraseConfirm,
-            savedPassphrase,
+            hasSavedPassphrase,
             passphraseMismatchError,
             passphraseInvalidError,
             passphraseEmptyError
@@ -144,7 +148,7 @@ export default class SetPassphrase extends React.Component<
                     leftComponent="Back"
                     centerComponent={{
                         text: localeString(
-                            savedPassphrase
+                            hasSavedPassphrase
                                 ? 'views.Settings.ChangePassword.title'
                                 : 'views.Settings.SetPassword.title'
                         ),
@@ -255,7 +259,7 @@ export default class SetPassphrase extends React.Component<
                             onPress={() => this.saveSettings()}
                         />
                     </View>
-                    {!!savedPassphrase && (
+                    {hasSavedPassphrase && (
                         <View style={{ paddingTop: 10, margin: 10 }}>
                             <Button
                                 title={localeString(

--- a/views/Settings/SetPin.tsx
+++ b/views/Settings/SetPin.tsx
@@ -11,6 +11,11 @@ import { ErrorMessage } from '../../components/SuccessErrorMessage';
 import SettingsStore from '../../stores/SettingsStore';
 
 import { localeString } from '../../utils/LocaleUtils';
+import {
+    deriveVerifier,
+    verifySecret,
+    hasVerifier
+} from '../../utils/LockVerifierUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 
 interface SetPinProps {
@@ -83,7 +88,7 @@ export default class SetPin extends React.Component<SetPinProps, SetPinState> {
 
         const settings = await getSettings();
 
-        if (pin === settings.duressPin) {
+        if (await verifySecret(pin, settings.duressPinVerifier)) {
             this.setState({
                 pinInvalidError: true,
                 pin: '',
@@ -93,7 +98,8 @@ export default class SetPin extends React.Component<SetPinProps, SetPinState> {
             return;
         }
 
-        await updateSettings({ pin }).then(() => {
+        const pinVerifier = await deriveVerifier(pin);
+        await updateSettings({ pinVerifier }).then(() => {
             setLoginStatus(true);
             getSettings();
             navigation.popTo('Security', {
@@ -143,7 +149,7 @@ export default class SetPin extends React.Component<SetPinProps, SetPinState> {
                                 }}
                             >
                                 {localeString(
-                                    settings.pin
+                                    hasVerifier(settings.pinVerifier)
                                         ? 'views.Settings.SetPin.newPin'
                                         : 'views.Settings.SetPin.createPin'
                                 )}


### PR DESCRIPTION
# Description

## Problem

The app lock (PIN / passphrase and their duress variants) was a UI gate, not an encryption boundary. All four credentials were stored as plaintext fields of the `Settings` JSON blob, side by side with every wallet secret (seeds, LND password, macaroons, LNC pairing phrase, NWC secret), inside a single keychain entry. Login was a direct `===` string compare against those plaintext values.

On iOS the blob was written with react-native-keychain's default accessibility class `kSecAttrAccessibleAfterFirstUnlock`, which Apple documents as migrating to a new device through encrypted backups. So an attacker with an encrypted backup or Apple-ID restore (or a root/jailbreak keychain read) recovered the seeds and both the normal and duress credentials, and could tell exactly which credential triggers the wipe, defeating the duress feature against a forensic attacker.

## Fix

1. **Hash the verifiers.** New `utils/LockVerifierUtils.ts` derives a salted scrypt digest (`{v, kdf, n, r, p, salt, hash}`, N=32768, 16-byte random salt) and verifies in constant time, failing closed on a missing or malformed record. The four credentials now persist this record instead of the raw value. All four use the identical record shape, so a duress verifier is indistinguishable from a normal one to anyone reading the blob.

2. **One-shot migration.** `MigrationUtils.migrateLockCredentialsToVerifiers` (MOD-gated `lock-verifier-hash-mod`) hashes any existing plaintext credential into its verifier and deletes the plaintext field. It runs on both the legacy and modern (`zeus-settings-v2`) load paths.

3. **Stop backup migration.** `storage/index.ts` now writes keychain items with `accessible: AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`. This is non-migratable, still readable at boot after first unlock, and (unlike `WhenPasscodeSet`) never requires a device passcode, so it cannot lock a user out of their own wallet. No-op on Android, which is already covered by `allowBackup="false"`.

4. **Duress stays indistinguishable.** `Lockscreen` computes the normal and duress checks at equal cost (`Promise.all`) before branching, so response time never reveals which credential matched.

5. **In-flight guard and spinner.** scrypt verification is asynchronous (~1s), so `onAttemptLogIn` guards against re-entrancy with a `verifying` flag (a double tap or second submit can no longer start a concurrent attempt and double-count the failure counter), and a full-screen spinner overlay is shown while the derivation runs. The overlay also swallows taps so a second submit cannot land.

The `SetPin` / `SetDuressPin` / `SetPassword` / `SetDuressPassword` views route their cross-checks through `verifySecret`, persist verifiers, and use presence booleans instead of prefilling saved plaintext.

## Out of scope (follow-ups)

- Hardware-backed (Secure Enclave / Keystore `accessControl`) encryption of the whole blob: the blob is read at boot, before auth (node list, wallet selection), so it cannot sit behind a biometric-gated keychain item. scrypt plus non-migratable storage is the pragmatic ceiling here. A determined attacker can still offline-brute-force a short PIN, which is inherent to any PIN scheme without hardware binding, but this raises it from trivial to costly.
- Android `securityLevel: SECURE_HARDWARE` (device-dependent failures).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Pending device tests (both platforms):
- [ ] Set PIN, lock, unlock with correct and incorrect entries (spinner shows during verification)
- [ ] Duress PIN triggers the full wipe
- [ ] Passphrase path
- [ ] Upgrade migration from a build carrying a plaintext PIN: unlock still works and the stored blob contains no plaintext credential
- [ ] iOS: encrypted-backup restore to a second device no longer carries the settings item
- [ ] iOS: upgrade an install with pre-existing keychain items and confirm the one-shot re-stamp runs (write-once items no longer restore to a second device)

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

App-lock and keychain-storage layer change; backend-independent.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

