### PR TITLE
fix: migrate CLN payments from deprecated pay/keysend to xpay/xkeysend

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -410,8 +410,9 @@ export default class CLNRest {
     // xpay and xkeysend only accept an absolute fee cap (maxfee), not
     // maxfeepercent: derive one from the user's max fee percent, decoding
     // the invoice server-side when the caller didn't supply the amount,
-    // and fall back to fee_limit_sat (silent sends). Returning undefined
-    // leaves the cap to xpay's default of max(5000msat, 1%).
+    // and fall back to fee_limit_sat (fixed fee limit mode, silent sends).
+    // Returning undefined leaves the cap to xpay's default of
+    // max(5000msat, 1%).
     private getMaxFeeMsat = async (data: any, invstring?: string) => {
         if (data.max_fee_percent) {
             let amountMsat = data.amt ? Number(data.amt) * 1000 : undefined;
@@ -462,14 +463,21 @@ export default class CLNRest {
         // pay is deprecated in CLN v26.06 and removed in v27.03; use xpay
         // (available since v24.11) when the node has it
         if (!this.supports('v24.11')) {
+            const legacyRequest: any = {
+                bolt11: data.payment_request,
+                amount_msat: Number(data.amt && data.amt * 1000),
+                retry_for: data.timeout_seconds
+            };
+            // pay takes either a percent cap or an absolute maxfee, not
+            // both. maxfee predates clnrest itself, so no version gate.
+            if (data.max_fee_percent) {
+                legacyRequest.maxfeepercent = data.max_fee_percent;
+            } else if (data.fee_limit_sat) {
+                legacyRequest.maxfee = Number(data.fee_limit_sat) * 1000;
+            }
             return this.postRequest(
                 '/v1/pay',
-                {
-                    bolt11: data.payment_request,
-                    amount_msat: Number(data.amt && data.amt * 1000),
-                    maxfeepercent: data.max_fee_percent,
-                    retry_for: data.timeout_seconds
-                },
+                legacyRequest,
                 data.timeout_seconds * 1000
             );
         }
@@ -493,14 +501,32 @@ export default class CLNRest {
         // xkeysend (introduced alongside the deprecation in v26.06) when
         // the node has it
         if (!this.supports('v26.06')) {
+            const legacyRequest: any = {
+                destination: data.pubkey,
+                amount_msat: Number(data.amt && data.amt * 1000),
+                retry_for: data.timeout_seconds
+            };
+            // keysend takes either a percent cap or an absolute maxfee,
+            // not both, and only gained maxfee in v24.11: on older nodes
+            // express the fixed cap as the equivalent percent of the
+            // keysend amount (capped at CLN's 100% param limit)
+            if (data.max_fee_percent) {
+                legacyRequest.maxfeepercent = data.max_fee_percent;
+            } else if (data.fee_limit_sat) {
+                if (this.supports('v24.11')) {
+                    legacyRequest.maxfee = Number(data.fee_limit_sat) * 1000;
+                } else if (data.amt) {
+                    legacyRequest.maxfeepercent = BigNumber.min(
+                        new BigNumber(data.fee_limit_sat)
+                            .times(100)
+                            .dividedBy(data.amt),
+                        100
+                    ).toNumber();
+                }
+            }
             return this.postRequest(
                 '/v1/keysend',
-                {
-                    destination: data.pubkey,
-                    amount_msat: Number(data.amt && data.amt * 1000),
-                    maxfeepercent: data.max_fee_percent,
-                    retry_for: data.timeout_seconds
-                },
+                legacyRequest,
                 data.timeout_seconds * 1000
             );
         }
@@ -766,7 +792,7 @@ export default class CLNRest {
     supportsOffers = () => true;
     supportsListingOffers = () => true;
     supportsBolt12Address = () => true;
-    supportsCustomFeeLimit = () => false;
+    supportsCustomFeeLimit = () => true;
     isLNDBased = () => false;
     supportsForwardingHistory = () => true;
     supportInboundFees = () => false;

--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -408,37 +408,13 @@ export default class CLNRest {
         });
 
     // xpay and xkeysend only accept an absolute fee cap (maxfee), not
-    // maxfeepercent: derive one from the user's max fee percent, decoding
-    // the invoice server-side when the caller didn't supply the amount,
-    // and fall back to fee_limit_sat (fixed fee limit mode, silent sends).
+    // maxfeepercent. fee_limit_sat is the source of truth: FeeLimit
+    // already emits the percent-derived sat amount as fee_limit_sat in
+    // percent mode, so the cap always matches what the fee UI displays.
     // Returning undefined leaves the cap to xpay's default of
     // max(5000msat, 1%).
-    private getMaxFeeMsat = async (data: any, invstring?: string) => {
-        if (data.max_fee_percent) {
-            let amountMsat = data.amt ? Number(data.amt) * 1000 : undefined;
-            if (!amountMsat && invstring) {
-                const decoded = await this.postRequest('/v1/decode', {
-                    string: invstring
-                });
-                // bolt11 decodes carry amount_msat, bolt12 invoices
-                // carry invoice_amount_msat
-                const msat =
-                    decoded?.amount_msat ?? decoded?.invoice_amount_msat;
-                if (msat != null) {
-                    amountMsat = Number(msat.toString().replace('msat', ''));
-                }
-            }
-            if (amountMsat) {
-                return new BigNumber(amountMsat)
-                    .times(data.max_fee_percent)
-                    .dividedBy(100)
-                    .integerValue(BigNumber.ROUND_CEIL)
-                    .toNumber();
-            }
-        }
-        if (data.fee_limit_sat) return Number(data.fee_limit_sat) * 1000;
-        return undefined;
-    };
+    private getMaxFeeMsat = (data: any) =>
+        data.fee_limit_sat ? Number(data.fee_limit_sat) * 1000 : undefined;
 
     // xpay and xkeysend results omit status and payment_hash: synthesize
     // both so handlePayment success detection and payment note keys
@@ -470,10 +446,12 @@ export default class CLNRest {
             };
             // pay takes either a percent cap or an absolute maxfee, not
             // both. maxfee predates clnrest itself, so no version gate.
-            if (data.max_fee_percent) {
-                legacyRequest.maxfeepercent = data.max_fee_percent;
-            } else if (data.fee_limit_sat) {
+            // Prefer fee_limit_sat so the cap matches the fee UI, same
+            // as the xpay path.
+            if (data.fee_limit_sat) {
                 legacyRequest.maxfee = Number(data.fee_limit_sat) * 1000;
+            } else if (data.max_fee_percent) {
+                legacyRequest.maxfeepercent = data.max_fee_percent;
             }
             return this.postRequest(
                 '/v1/pay',
@@ -487,7 +465,7 @@ export default class CLNRest {
             retry_for: data.timeout_seconds
         };
         if (data.amt) request.amount_msat = Number(data.amt) * 1000;
-        const maxfee = await this.getMaxFeeMsat(data, data.payment_request);
+        const maxfee = this.getMaxFeeMsat(data);
         if (maxfee !== undefined) request.maxfee = maxfee;
 
         return this.postRequest(
@@ -536,7 +514,7 @@ export default class CLNRest {
             amount_msat: Number(data.amt && data.amt * 1000),
             retry_for: data.timeout_seconds
         };
-        const maxfee = await this.getMaxFeeMsat(data);
+        const maxfee = this.getMaxFeeMsat(data);
         if (maxfee !== undefined) request.maxfee = maxfee;
 
         return this.postRequest(

--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -407,28 +407,117 @@ export default class CLNRest {
             string: urlParams && urlParams[0]
         });
 
-    payLightningInvoice = (data: any) =>
-        this.postRequest(
-            '/v1/pay',
-            {
-                bolt11: data.payment_request,
-                amount_msat: Number(data.amt && data.amt * 1000),
-                maxfeepercent: data.max_fee_percent,
-                retry_for: data.timeout_seconds
-            },
-            data.timeout_seconds * 1000
-        );
-    sendKeysend = (data: any) => {
+    // xpay and xkeysend only accept an absolute fee cap (maxfee), not
+    // maxfeepercent: derive one from the user's max fee percent, decoding
+    // the invoice server-side when the caller didn't supply the amount,
+    // and fall back to fee_limit_sat (silent sends). Returning undefined
+    // leaves the cap to xpay's default of max(5000msat, 1%).
+    private getMaxFeeMsat = async (data: any, invstring?: string) => {
+        if (data.max_fee_percent) {
+            let amountMsat = data.amt ? Number(data.amt) * 1000 : undefined;
+            if (!amountMsat && invstring) {
+                const decoded = await this.postRequest('/v1/decode', {
+                    string: invstring
+                });
+                // bolt11 decodes carry amount_msat, bolt12 invoices
+                // carry invoice_amount_msat
+                const msat =
+                    decoded?.amount_msat ?? decoded?.invoice_amount_msat;
+                if (msat != null) {
+                    amountMsat = Number(msat.toString().replace('msat', ''));
+                }
+            }
+            if (amountMsat) {
+                return new BigNumber(amountMsat)
+                    .times(data.max_fee_percent)
+                    .dividedBy(100)
+                    .integerValue(BigNumber.ROUND_CEIL)
+                    .toNumber();
+            }
+        }
+        if (data.fee_limit_sat) return Number(data.fee_limit_sat) * 1000;
+        return undefined;
+    };
+
+    // xpay and xkeysend results omit status and payment_hash: synthesize
+    // both so handlePayment success detection and payment note keys
+    // (note-<payment_hash>) keep working. hash = SHA256(preimage), and
+    // xpay only resolves on success (failures reject via the HTTP error
+    // path), so status is always complete here.
+    private formatXpayResult = (result: any) => {
+        const formatted: any = { ...result, status: 'complete' };
+        if (result?.payment_preimage) {
+            formatted.payment_hash = Base64Utils.bytesToHex(
+                Array.from(
+                    new sha256Hash()
+                        .update(Base64Utils.hexToBytes(result.payment_preimage))
+                        .digest()
+                )
+            );
+        }
+        return formatted;
+    };
+
+    payLightningInvoice = async (data: any) => {
+        // pay is deprecated in CLN v26.06 and removed in v27.03; use xpay
+        // (available since v24.11) when the node has it
+        if (!this.supports('v24.11')) {
+            return this.postRequest(
+                '/v1/pay',
+                {
+                    bolt11: data.payment_request,
+                    amount_msat: Number(data.amt && data.amt * 1000),
+                    maxfeepercent: data.max_fee_percent,
+                    retry_for: data.timeout_seconds
+                },
+                data.timeout_seconds * 1000
+            );
+        }
+
+        const request: any = {
+            invstring: data.payment_request,
+            retry_for: data.timeout_seconds
+        };
+        if (data.amt) request.amount_msat = Number(data.amt) * 1000;
+        const maxfee = await this.getMaxFeeMsat(data, data.payment_request);
+        if (maxfee !== undefined) request.maxfee = maxfee;
+
         return this.postRequest(
-            '/v1/keysend',
-            {
-                destination: data.pubkey,
-                amount_msat: Number(data.amt && data.amt * 1000),
-                maxfeepercent: data.max_fee_percent,
-                retry_for: data.timeout_seconds
-            },
+            '/v1/xpay',
+            request,
             data.timeout_seconds * 1000
-        );
+        ).then(this.formatXpayResult);
+    };
+    sendKeysend = async (data: any) => {
+        // keysend is deprecated in CLN v26.06 and removed in v27.03; use
+        // xkeysend (introduced alongside the deprecation in v26.06) when
+        // the node has it
+        if (!this.supports('v26.06')) {
+            return this.postRequest(
+                '/v1/keysend',
+                {
+                    destination: data.pubkey,
+                    amount_msat: Number(data.amt && data.amt * 1000),
+                    maxfeepercent: data.max_fee_percent,
+                    retry_for: data.timeout_seconds
+                },
+                data.timeout_seconds * 1000
+            );
+        }
+
+        const request: any = {
+            destination: data.pubkey,
+            amount_msat: Number(data.amt && data.amt * 1000),
+            retry_for: data.timeout_seconds
+        };
+        const maxfee = await this.getMaxFeeMsat(data);
+        if (maxfee !== undefined) request.maxfee = maxfee;
+
+        return this.postRequest(
+            '/v1/xkeysend',
+            request,
+            data.timeout_seconds * 1000
+        ).then(this.formatXpayResult);
     };
     closeChannel = (urlParams?: Array<string>) => {
         const request = {

--- a/components/FeeLimit.tsx
+++ b/components/FeeLimit.tsx
@@ -18,6 +18,7 @@ import { themeColor } from '../utils/ThemeUtils';
 interface FeeLimitProps {
     onFeeLimitSatChange: (satAmount: string) => void;
     onMaxFeePercentChange?: (maxFeePercent: string) => void;
+    onFeeOptionChange?: (feeOption: string) => void;
     satAmount?: string | number;
     SettingsStore: SettingsStore;
     InvoicesStore?: InvoicesStore;
@@ -179,20 +180,18 @@ export default class FeeLimit extends React.Component<
 
     render() {
         const {
-            SettingsStore,
             onFeeLimitSatChange,
             onMaxFeePercentChange,
+            onFeeOptionChange,
             displayFeeRecommendation,
             satAmount,
             hide
         } = this.props;
         const { feeOption, feeLimitSat, maxFeePercent, percentAmount } =
             this.state;
-        const { implementation } = SettingsStore;
 
         const supportsCustomFeeLimit: boolean =
             BackendUtils.supportsCustomFeeLimit();
-        const isCLightning: boolean = implementation === 'cln-rest';
 
         if (hide) return;
 
@@ -245,6 +244,8 @@ export default class FeeLimit extends React.Component<
                                         feeOption: 'fixed'
                                     });
                                     onFeeLimitSatChange(feeLimitSat);
+                                    if (onFeeOptionChange)
+                                        onFeeOptionChange('fixed');
                                 }}
                             />
                             <TextInput
@@ -281,65 +282,12 @@ export default class FeeLimit extends React.Component<
                                         feeOption: 'percent'
                                     });
                                     onFeeLimitSatChange(percentAmount);
+                                    if (onFeeOptionChange)
+                                        onFeeOptionChange('percent');
                                 }}
                             />
                         </View>
                     </>
-                )}
-
-                {isCLightning && (
-                    <React.Fragment>
-                        <Row justify="space-between">
-                            <Text
-                                style={{
-                                    ...styles.label,
-                                    color: themeColor('text')
-                                }}
-                            >
-                                {localeString('views.PaymentRequest.feeLimit')}
-                            </Text>
-                            <Text
-                                style={{
-                                    ...styles.label,
-                                    color: themeColor('text')
-                                }}
-                            >
-                                <Amount sats={percentAmount} />
-                            </Text>
-                        </Row>
-                        <TextInput
-                            keyboardType="numeric"
-                            value={maxFeePercent}
-                            suffix="%"
-                            onChangeText={(text: string) => {
-                                this.setState(
-                                    {
-                                        maxFeePercent: text
-                                    },
-                                    () => {
-                                        const percentAmount =
-                                            this.calculatePercentAmount(
-                                                satAmount
-                                            );
-
-                                        this.setState({
-                                            percentAmount
-                                        });
-                                        onFeeLimitSatChange(percentAmount);
-
-                                        if (onMaxFeePercentChange)
-                                            onMaxFeePercentChange(text);
-                                    }
-                                );
-                            }}
-                            onPressIn={() => {
-                                this.setState({
-                                    feeOption: 'percent'
-                                });
-                                onFeeLimitSatChange(percentAmount);
-                            }}
-                        />
-                    </React.Fragment>
                 )}
             </React.Fragment>
         );

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -432,6 +432,7 @@ export default class PaymentRequest extends React.Component<
             maxParts,
             maxShardAmt,
             feeLimitSat,
+            feeOption,
             outgoingChanId,
             lastHopPubkey,
             satAmount,
@@ -474,7 +475,12 @@ export default class PaymentRequest extends React.Component<
             max_parts: enableMultiPathPayment ? maxParts : '16',
             max_shard_amt: enableMultiPathPayment ? maxShardAmt : '',
             fee_limit_sat: feeLimitSat,
-            max_fee_percent: isCLightning ? maxFeePercentFormatted : '5.0',
+            // CLN takes either a percent cap or the fixed fee_limit_sat cap,
+            // so only send the percent when that mode is selected
+            max_fee_percent:
+                isCLightning && feeOption === 'percent'
+                    ? maxFeePercentFormatted
+                    : undefined,
             outgoing_chan_id: outgoingChanId ?? '',
             last_hop_pubkey: lastHopPubkey ?? '',
             amp: enableAmp,
@@ -623,7 +629,6 @@ export default class PaymentRequest extends React.Component<
         const enableDonations =
             Platform.OS !== 'ios' && settings?.payments?.enableDonations;
 
-        const isCLightning: boolean = implementation === 'cln-rest';
         const isLdkNode: boolean = implementation === 'ldk-node';
 
         const isNoAmountInvoice: boolean = !requestAmount;
@@ -1032,8 +1037,7 @@ export default class PaymentRequest extends React.Component<
                                     />
                                 )}
 
-                                {(BackendUtils.supportsCustomFeeLimit() ||
-                                    isCLightning) && (
+                                {BackendUtils.supportsCustomFeeLimit() && (
                                     <Accordion
                                         headerLayout="form"
                                         id="payment-request-fee-settings"
@@ -1064,6 +1068,13 @@ export default class PaymentRequest extends React.Component<
                                             ) =>
                                                 this.setState({
                                                     maxFeePercent: value
+                                                })
+                                            }
+                                            onFeeOptionChange={(
+                                                value: string
+                                            ) =>
+                                                this.setState({
+                                                    feeOption: value
                                                 })
                                             }
                                             feeOption={feeOption}
@@ -1312,7 +1323,6 @@ export default class PaymentRequest extends React.Component<
                                         )}
 
                                         {(BackendUtils.supportsCustomFeeLimit() ||
-                                            isCLightning ||
                                             isLdkNode) && (
                                             <>
                                                 <Text
@@ -1342,10 +1352,7 @@ export default class PaymentRequest extends React.Component<
                                         )}
                                     </Accordion>
                                 )}
-                                {!(
-                                    BackendUtils.supportsCustomFeeLimit() ||
-                                    isCLightning
-                                ) && (
+                                {!BackendUtils.supportsCustomFeeLimit() && (
                                     <FeeLimit
                                         satAmount={
                                             isNoAmountInvoice

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -1053,7 +1053,7 @@ export default class PaymentRequest extends React.Component<
                                         <FeeLimit
                                             satAmount={
                                                 isNoAmountInvoice
-                                                    ? customAmount
+                                                    ? this.state.satAmount
                                                     : requestAmount || 0
                                             }
                                             onFeeLimitSatChange={(
@@ -1356,7 +1356,7 @@ export default class PaymentRequest extends React.Component<
                                     <FeeLimit
                                         satAmount={
                                             isNoAmountInvoice
-                                                ? customAmount
+                                                ? this.state.satAmount
                                                 : requestAmount || 0
                                         }
                                         onFeeLimitSatChange={(value: string) =>

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -107,6 +107,7 @@ interface SendState {
     maxShardAmt: string;
     feeLimitSat: string;
     maxFeePercent: string;
+    feeOption: string;
     timeoutSeconds: string;
     message: string;
     enableAtomicMultiPathPayment: boolean;
@@ -181,6 +182,7 @@ export default class Send extends React.Component<SendProps, SendState> {
             maxShardAmt: '',
             feeLimitSat: '100',
             maxFeePercent: '5.0',
+            feeOption: 'fixed',
             timeoutSeconds: '60',
             message: '',
             enableAtomicMultiPathPayment: false,
@@ -555,7 +557,8 @@ export default class Send extends React.Component<SendProps, SendState> {
             message,
             enableAtomicMultiPathPayment,
             feeLimitSat,
-            maxFeePercent
+            maxFeePercent,
+            feeOption
         } = this.state;
 
         // Guard against double-submission: bail if a payment is already in
@@ -578,7 +581,10 @@ export default class Send extends React.Component<SendProps, SendState> {
                 amount: satAmount.toString(),
                 pubkey: destination,
                 fee_limit_sat: feeLimitSat,
-                max_fee_percent: maxFeePercent,
+                // CLN takes either a percent cap or the fixed fee_limit_sat
+                // cap, so only send the percent when that mode is selected
+                max_fee_percent:
+                    feeOption === 'percent' ? maxFeePercent : undefined,
                 message
             });
         }
@@ -1493,6 +1499,11 @@ export default class Send extends React.Component<SendProps, SendState> {
                                     onMaxFeePercentChange={(value: string) =>
                                         this.setState({
                                             maxFeePercent: value
+                                        })
+                                    }
+                                    onFeeOptionChange={(value: string) =>
+                                        this.setState({
+                                            feeOption: value
                                         })
                                     }
                                     SettingsStore={SettingsStore}

--- a/views/Settings/PaymentsSettings.tsx
+++ b/views/Settings/PaymentsSettings.tsx
@@ -126,7 +126,7 @@ export default class PaymentsSettings extends React.Component<
                         marginTop: 5
                     }}
                 >
-                    {BackendUtils.isLNDBased() && (
+                    {BackendUtils.supportsCustomFeeLimit() && (
                         <View style={{ marginBottom: 20 }}>
                             <Text
                                 style={{
@@ -202,45 +202,6 @@ export default class PaymentsSettings extends React.Component<
                                     'views.Settings.Payments.feeLimitMethodExplainer'
                                 )}
                             </Text>
-                        </View>
-                    )}
-
-                    {implementation === 'cln-rest' && (
-                        <View>
-                            <Text
-                                style={{
-                                    fontFamily: 'PPNeueMontreal-Book',
-                                    color: themeColor('secondaryText')
-                                }}
-                            >
-                                {`${localeString(
-                                    'general.lightning'
-                                )} - ${localeString(
-                                    'views.Settings.Payments.defaultFeeLimit'
-                                )}`}
-                            </Text>
-                            <TextInput
-                                keyboardType="numeric"
-                                value={feePercentage}
-                                suffix="%"
-                                onChangeText={async (text: string) => {
-                                    this.setState({
-                                        feePercentage: text
-                                    });
-                                    await updateSettings({
-                                        payments: {
-                                            ...settings.payments,
-                                            defaultFeeMethod: 'percent',
-                                            defaultFeePercentage: text
-                                        }
-                                    });
-                                }}
-                                onPressIn={() =>
-                                    this.setState({
-                                        feeLimitMethod: 'percent'
-                                    })
-                                }
-                            />
                         </View>
                     )}
 


### PR DESCRIPTION
# Description

Relates to issue: #4388

CLN deprecated the `pay` command in v26.06 and will remove it in v27.03. As #4388 reports, ZEUS's CLNRest backend still pays through `POST /v1/pay`, which already fails on nodes running with `allow-deprecated-apis=false`. While auditing every clnrest endpoint ZEUS calls against CLN's [deprecated features list](https://github.com/ElementsProject/lightning/blob/master/doc/developers-guide/deprecated-features.md), I found `keysend` is on the same deprecation clock (v26.06 deprecated, v27.03 removed, replaced by `xkeysend`). No other endpoint ZEUS uses is deprecated.

This PR migrates both send paths, version-gated so older nodes keep working:

- `payLightningInvoice` uses `POST /v1/xpay` when the node is v24.11+ (when `xpay` was introduced), otherwise falls back to the existing `pay` request unchanged
- `sendKeysend` uses `POST /v1/xkeysend` when the node is v26.06+ (when `xkeysend` was introduced), otherwise falls back to the existing `keysend` request unchanged

The gates read node version through the existing `CLNRest.supports()` helper. If a payment is somehow dispatched before `getinfo` resolves, the gate fails toward the legacy path, which remains functional until v27.03.

The migration is not a URL swap; two API differences are handled:

**1. `xpay`/`xkeysend` take an absolute `maxfee` (msat), not `maxfeepercent`.** When the user picks a percent cap, the new `getMaxFeeMsat` helper converts: percent x amount, using the caller-supplied amount when present (zero-amount invoices, keysend) and otherwise decoding the invoice via `/v1/decode` to learn it (works for both bolt11 and bolt12 invoices). Fixed caps and silent sends (donations) pass `fee_limit_sat` instead, which maps directly. If no cap can be derived, `maxfee` is omitted and xpay's default applies (greater of 5000 msat or 1%).

**2. The response omits `status` and `payment_hash`** (xpay returns only `payment_preimage`, `failed_parts`, `successful_parts`, `amount_msat`, `amount_sent_msat`). `formatXpayResult` synthesizes both: `status: 'complete'` is safe because xpay only returns success (failures reject through the HTTP error path into `handlePaymentError`, same as `pay` today), and `payment_hash` is computed as SHA256 of the returned preimage. Without the hash, payment notes saved at send time would key on the preimage while the payments list (which reads `sendpays` via `/v1/sql`) keys on the hash, so notes would silently detach. Fee display is unaffected: `Payment.getFee` derives the fee from `amount_sent_msat - amount_msat`, which xpay provides.

A side benefit: `xpay` accepts bolt12 invoices natively via `invstring`, which is the path CLN offer payments already flow through (`fetchinvoice` then `sendPayment`).

**Update (second commit): fixed fee limits in sats for CLN.** Since `xpay`/`xkeysend` take an absolute `maxfee`, CLN no longer has to be percent-only. `supportsCustomFeeLimit()` is now enabled for CLNRest, so CLN gets the same dual fixed/percent fee limit UI as LND (both on the payment screens and for the default in Settings > Payments), and the CLN-only percent branches in `FeeLimit`, `PaymentRequest`, and `PaymentsSettings` are removed. Because CLN rejects requests carrying both `maxfee` and `maxfeepercent`, the views now only send `max_fee_percent` when the percent option is selected (via a new `onFeeOptionChange` callback on `FeeLimit`); otherwise the fixed `fee_limit_sat` maps to `maxfee`. On the legacy fallback paths: `pay` has supported `maxfee` since before clnrest existed so it is used unconditionally, while `keysend` only gained `maxfee` in v24.11, so on older nodes the fixed cap is converted to the equivalent percent of the keysend amount (capped at CLN's 100% parameter limit).

This pull request is categorized as a:

- [x] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [x] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Planned test matrix (draft until complete), on a CLN v26.06 node with `allow-deprecated-apis=false`:
- fixed-amount bolt11 pay (fee cap honors max fee percent)
- fixed-amount bolt11 pay with a fixed sat fee cap (new dual UI, `maxfee` mapping)
- zero-amount bolt11 pay with user-supplied amount
- bolt12 offer pay
- keysend (both percent and fixed sat caps)
- donation flow (silent send, `fee_limit_sat` mapping)
- payment note persists from send to payments list (synthesized `payment_hash`)
- default fee limit (fixed and percent) set from Settings > Payments carries into the payment screen

Plus one pre-v24.11 node to exercise the legacy fallback leg, including a fixed sat cap through legacy `pay` (`maxfee`) and legacy `keysend` (percent conversion).

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

