### PR TITLE
fix(nwc): scope list_transactions and lookup_invoice to connection activity

### DIFF
--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -844,6 +844,41 @@ describe('NostrWalletConnectStore connection data scoping', () => {
         expect(response.result?.preimage).toBe(PREIMAGE);
         expect(response.result?.state).toBe('settled');
     });
+
+    it('lookup_invoice includes preimage after invoice rehydration from storage', async () => {
+        const PREIMAGE = hex64('a');
+        const { store } = buildScopedStore();
+        const connection = seedReadOnlyConnection(store, {
+            activity: [
+                {
+                    id: CONNECTION_INVOICE,
+                    type: 'make_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    satAmount: 50,
+                    paymentHash: CONNECTION_HASH,
+                    preimage: PREIMAGE,
+                    invoice: {
+                        r_hash: Base64Utils.hexToBase64(CONNECTION_HASH),
+                        payment_request: CONNECTION_INVOICE,
+                        creation_date: String(1_700_000_000),
+                        expiry: String(3600),
+                        value: '1000',
+                        settled: true,
+                        settle_date: String(1_700_000_500)
+                    }
+                }
+            ]
+        });
+
+        const response = await (store as any).handleLookupInvoice(connection, {
+            payment_hash: CONNECTION_HASH
+        });
+
+        expect(response.error).toBeUndefined();
+        expect(response.result?.preimage).toBe(PREIMAGE);
+        expect(response.result?.state).toBe('settled');
+    });
 });
 
 describe('NostrWalletConnectStore connection expiry enforcement', () => {

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -57,6 +57,8 @@ jest.mock('../storage', () => ({
 
 import Storage from '../storage';
 import NWCConnection, { BudgetRenewalType } from '../models/NWCConnection';
+import Invoice from '../models/Invoice';
+import Base64Utils from '../utils/Base64Utils';
 import NostrConnectUtils from '../utils/NostrConnectUtils';
 import NostrWalletConnectStore, {
     NWC_CLIENT_KEYS
@@ -805,6 +807,42 @@ describe('NostrWalletConnectStore connection data scoping', () => {
         expect(response.error).toBeUndefined();
         expect(response.result?.payment_hash).toBe(CONNECTION_HASH);
         expect(response.result?.type).toBe('incoming');
+    });
+
+    it('lookup_invoice includes preimage for a settled make_invoice', async () => {
+        const PREIMAGE = hex64('a');
+        const { store } = buildScopedStore();
+        const settledInvoice = new Invoice({
+            r_hash: Base64Utils.hexToBase64(CONNECTION_HASH),
+            payment_request: CONNECTION_INVOICE,
+            creation_date: String(1_700_000_000),
+            expiry: String(3600),
+            value: '1000',
+            settled: true,
+            settle_date: String(1_700_000_500),
+            r_preimage: Base64Utils.hexToBase64(PREIMAGE)
+        });
+        const connection = seedReadOnlyConnection(store, {
+            activity: [
+                {
+                    id: CONNECTION_INVOICE,
+                    type: 'make_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    satAmount: 50,
+                    paymentHash: CONNECTION_HASH,
+                    invoice: settledInvoice
+                }
+            ]
+        });
+
+        const response = await (store as any).handleLookupInvoice(connection, {
+            payment_hash: CONNECTION_HASH
+        });
+
+        expect(response.error).toBeUndefined();
+        expect(response.result?.preimage).toBe(PREIMAGE);
+        expect(response.result?.state).toBe('settled');
     });
 });
 

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -642,6 +642,172 @@ describe('NostrWalletConnectStore pay_invoice activity upsert', () => {
     });
 });
 
+describe('NostrWalletConnectStore connection data scoping', () => {
+    const WALLET_ONLY_HASH = hex64('f');
+    const CONNECTION_HASH = hex64('e');
+    const CONNECTION_INVOICE = 'lnbc1connection-only';
+
+    function buildScopedStore() {
+        const paymentsStore = {
+            getPayments: jest.fn().mockResolvedValue(undefined),
+            payments: [
+                {
+                    paymentHash: WALLET_ONLY_HASH,
+                    getAmount: '1000',
+                    getPaymentRequest: 'lnbc1wallet-payment',
+                    getTimestamp: 1_700_000_000
+                }
+            ]
+        };
+        const invoicesStore = {
+            getInvoices: jest.fn().mockResolvedValue(undefined),
+            invoices: [
+                {
+                    getRHash: WALLET_ONLY_HASH,
+                    getAmount: '2000',
+                    getPaymentRequest: 'lnbc1wallet-invoice',
+                    getCreationDate: 1_700_000_000
+                }
+            ]
+        };
+        const transactionsStore = {
+            getTransactions: jest.fn().mockResolvedValue(undefined),
+            transactions: [
+                {
+                    tx_hash: 'onchain-wallet-tx',
+                    amount: 50_000,
+                    dest_addresses: ['bcrt1qsecretaddress'],
+                    raw_tx_hex: 'deadbeef',
+                    time_stamp: 1_700_000_000,
+                    num_confirmations: 1
+                }
+            ]
+        };
+        const settingsStore: any = {
+            connecting: false,
+            implementation: 'lnd',
+            settings: {
+                locale: 'en',
+                ecash: { enableCashu: false },
+                lightningAddress: { enabled: false }
+            }
+        };
+        const store = new NostrWalletConnectStore(
+            settingsStore,
+            {} as any,
+            {
+                nodeInfo: { nodeId: NODE_PUBKEY },
+                getNodeInfo: jest.fn()
+            } as any,
+            transactionsStore as any,
+            {} as any,
+            invoicesStore as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            paymentsStore as any
+        );
+
+        jest.spyOn(store as any, 'scheduleSave').mockImplementation(
+            () => undefined
+        );
+        jest.spyOn(
+            store as any,
+            'reconcilePendingPayInvoiceActivities'
+        ).mockResolvedValue(false);
+
+        return { store, paymentsStore, invoicesStore, transactionsStore };
+    }
+
+    function seedReadOnlyConnection(
+        store: NostrWalletConnectStore,
+        overrides: Record<string, unknown> = {}
+    ) {
+        const connection = new NWCConnection({
+            id: 'conn-readonly',
+            name: 'Read Only App',
+            pubkey: OLD_PUBKEY,
+            relayUrl: OLD_RELAY,
+            permissions: ['lookup_invoice', 'list_transactions'],
+            createdAt: new Date('2024-01-01T00:00:00Z'),
+            totalSpendSats: 0,
+            nodePubkey: NODE_PUBKEY,
+            implementation: 'lnd',
+            activity: [],
+            ...overrides
+        } as any);
+        store.connections = [connection];
+        return connection;
+    }
+
+    it('list_transactions returns only the connection activity for read-only connections', async () => {
+        const { store, paymentsStore, invoicesStore, transactionsStore } =
+            buildScopedStore();
+        const connection = seedReadOnlyConnection(store, {
+            activity: [
+                {
+                    id: CONNECTION_INVOICE,
+                    type: 'make_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    satAmount: 50,
+                    paymentHash: CONNECTION_HASH
+                }
+            ]
+        });
+
+        const response = await (store as any).handleListTransactions(
+            connection,
+            {}
+        );
+
+        expect(response.error).toBeUndefined();
+        expect(response.result?.transactions).toHaveLength(1);
+        expect(response.result?.transactions[0].payment_hash).toBe(
+            CONNECTION_HASH
+        );
+        expect(paymentsStore.getPayments).not.toHaveBeenCalled();
+        expect(invoicesStore.getInvoices).not.toHaveBeenCalled();
+        expect(transactionsStore.getTransactions).not.toHaveBeenCalled();
+    });
+
+    it('lookup_invoice rejects hashes outside the connection activity', async () => {
+        const { store } = buildScopedStore();
+        const connection = seedReadOnlyConnection(store);
+
+        const response = await (store as any).handleLookupInvoice(connection, {
+            payment_hash: WALLET_ONLY_HASH
+        });
+
+        expect(response.result).toBeUndefined();
+        expect(response.error?.code).toBe('NOT_FOUND');
+    });
+
+    it('lookup_invoice returns invoices recorded on the connection', async () => {
+        const { store } = buildScopedStore();
+        const connection = seedReadOnlyConnection(store, {
+            activity: [
+                {
+                    id: CONNECTION_INVOICE,
+                    type: 'make_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    satAmount: 50,
+                    paymentHash: CONNECTION_HASH
+                }
+            ]
+        });
+
+        const response = await (store as any).handleLookupInvoice(connection, {
+            payment_hash: CONNECTION_HASH
+        });
+
+        expect(response.error).toBeUndefined();
+        expect(response.result?.payment_hash).toBe(CONNECTION_HASH);
+        expect(response.result?.type).toBe('incoming');
+    });
+});
+
 describe('NostrWalletConnectStore connection expiry enforcement', () => {
     function buildStore() {
         const settingsStore: any = {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -93,8 +93,6 @@ const SAVE_CONNECTIONS_DEBOUNCE_MS = 500;
 const PENDING_PAYMENT_STATUS_MIN_AGE_MS = 5_000;
 /** Per-connection debounce for pending pay_invoice status refresh in getActivities */
 const PENDING_PAYMENT_STATUS_REFRESH_MS = 30_000;
-/** Debounce for lookup_invoice outgoing-payment fetches (NWC client polling) */
-const LOOKUP_PAYMENTS_CACHE_MS = 5_000;
 
 export const DEFAULT_NOSTR_RELAYS = [
     'wss://relay.getalby.com/v1',
@@ -179,8 +177,6 @@ export default class NostrWalletConnectStore {
         string,
         number
     >();
-    private lookupPaymentsCache: Payment[] | null = null;
-    private lookupPaymentsFetchedAt = 0;
 
     settingsStore: SettingsStore;
     balanceStore: BalanceStore;
@@ -1115,52 +1111,9 @@ export default class NostrWalletConnectStore {
             )
         ) {
             await Promise.all(
-                pendingCashuInvoiceActivities.map(async (activity) => {
-                    const cashuInv = activity.invoice as
-                        | CashuInvoice
-                        | undefined;
-                    const quote = cashuInv?.quote;
-                    if (!quote || !cashuInv) return;
-
-                    try {
-                        const result = await this.cashuStore.checkInvoicePaid(
-                            quote,
-                            cashuInv.mintUrl,
-                            undefined,
-                            true
-                        );
-                        runInAction(() => {
-                            if (result.isPaid) {
-                                activity.status = 'success';
-                                const updated =
-                                    result.updatedInvoice ||
-                                    this.cashuStore.invoices?.find(
-                                        (inv) => inv.quote === quote
-                                    );
-                                if (updated) {
-                                    activity.invoice = updated;
-                                }
-                                const paidSats = Math.floor(
-                                    Number(result.amtSat) || 0
-                                );
-                                if (
-                                    paidSats > 0 &&
-                                    (!activity.satAmount ||
-                                        activity.satAmount <= 0)
-                                ) {
-                                    activity.satAmount = paidSats;
-                                }
-                            } else if (cashuInv.isExpired) {
-                                activity.status = 'expired';
-                            }
-                        });
-                    } catch (err) {
-                        console.error(
-                            'NWC: failed to refresh cashu make_invoice status:',
-                            err
-                        );
-                    }
-                })
+                pendingCashuInvoiceActivities.map((activity) =>
+                    this.reconcilePendingCashuMakeInvoice(activity)
+                )
             );
             this.lastPendingInvoiceStatusFetchByConnection.set(
                 connectionId,
@@ -1408,7 +1361,7 @@ export default class NostrWalletConnectStore {
             if (connection.hasPermission('lookup_invoice')) {
                 handler.lookupInvoice = (request: Nip47LookupInvoiceRequest) =>
                     this.withGlobalHandler(connection.id, () =>
-                        this.handleLookupInvoice(request)
+                        this.handleLookupInvoice(connection, request)
                     );
             }
 
@@ -1922,20 +1875,16 @@ export default class NostrWalletConnectStore {
     }
 
     private async handleLookupInvoice(
+        connection: NWCConnection,
         request: Nip47LookupInvoiceRequest
     ): NWCWalletServiceResponsePromise<Nip47Transaction> {
         try {
-            const result = await NostrConnectUtils.lookupInvoiceTransaction({
-                request,
-                isCashu: this.isCashuConfigured,
-                getCashuInvoices: () =>
-                    Promise.resolve(this.cashuStore.invoices || []),
-                getCashuPayments: () =>
-                    Promise.resolve(this.cashuStore.payments || []),
-                getLightningPayments: () => this.getPaymentsForLookup()
-            });
-
-            if (!result) {
+            const activity =
+                await NostrConnectUtils.findConnectionActivityByLookupRequest(
+                    connection.activity,
+                    request
+                );
+            if (!activity) {
                 return NostrConnectUtils.createNip47Error(
                     localeString(
                         'stores.NostrWalletConnectStore.error.invoiceNotFound'
@@ -1943,6 +1892,13 @@ export default class NostrWalletConnectStore {
                     Nip47ErrorCode.NOT_FOUND
                 );
             }
+
+            await this.refreshActivityForLookup(connection, activity);
+
+            const result =
+                NostrConnectUtils.convertConnectionActivityToNip47Transaction(
+                    activity
+                );
 
             return { result, error: undefined };
         } catch (error) {
@@ -1953,59 +1909,99 @@ export default class NostrWalletConnectStore {
         }
     }
 
+    private async refreshActivityForLookup(
+        connection: NWCConnection,
+        activity: ConnectionActivity
+    ): Promise<void> {
+        if (
+            activity.type === 'pay_invoice' &&
+            activity.status === 'pending' &&
+            activity.payment_source !== 'cashu'
+        ) {
+            await this.reconcilePendingPayInvoiceActivities(connection);
+            return;
+        }
+
+        if (activity.type === 'make_invoice' && activity.status === 'pending') {
+            await this.reconcilePendingMakeInvoiceActivity(activity);
+        }
+    }
+
+    private async reconcilePendingMakeInvoiceActivity(
+        activity: ConnectionActivity
+    ): Promise<void> {
+        if (activity.payment_source === 'cashu') {
+            await this.reconcilePendingCashuMakeInvoice(activity);
+            return;
+        }
+
+        await this.reconcilePendingLightningMakeInvoice(activity);
+    }
+
+    private async reconcilePendingCashuMakeInvoice(
+        activity: ConnectionActivity
+    ): Promise<void> {
+        const cashuInv = activity.invoice as CashuInvoice | undefined;
+        const quote = cashuInv?.quote;
+        if (!quote || !cashuInv || !this.isCashuConfigured) return;
+
+        try {
+            const result = await this.cashuStore.checkInvoicePaid(
+                quote,
+                cashuInv.mintUrl,
+                undefined,
+                true
+            );
+            runInAction(() => {
+                if (result.isPaid) {
+                    activity.status = 'success';
+                    const updated =
+                        result.updatedInvoice ||
+                        this.cashuStore.invoices?.find(
+                            (inv) => inv.quote === quote
+                        );
+                    if (updated) {
+                        activity.invoice = updated;
+                    }
+                    const paidSats = Math.floor(Number(result.amtSat) || 0);
+                    if (
+                        paidSats > 0 &&
+                        (!activity.satAmount || activity.satAmount <= 0)
+                    ) {
+                        activity.satAmount = paidSats;
+                    }
+                } else if (cashuInv.isExpired) {
+                    activity.status = 'expired';
+                }
+            });
+        } catch (err) {
+            console.error(
+                'NWC: failed to refresh cashu make_invoice status:',
+                err
+            );
+        }
+    }
+
     private async handleListTransactions(
         connection: NWCConnection,
         request: Nip47ListTransactionsRequest
     ): NWCWalletServiceResponsePromise<Nip47ListTransactionsResponse> {
         try {
-            let nip47Transactions: Nip47Transaction[] = [];
-
-            if (connection.hasPaymentPermissions()) {
-                const reconciled =
-                    await this.reconcilePendingPayInvoiceActivities(connection);
-                if (reconciled) {
-                    this.scheduleSave();
-                }
-                nip47Transactions = connection.activity
-                    .map((activity) =>
-                        NostrConnectUtils.convertConnectionActivityToNip47Transaction(
-                            activity
-                        )
-                    )
-                    .filter((tx) => tx.amount > 0)
-                    .sort((a, b) => b.created_at - a.created_at);
-            } else {
-                await Promise.all([
-                    this.paymentsStore.getPayments(),
-                    this.invoicesStore.getInvoices(),
-                    this.transactionsStore.getTransactions()
-                ]);
-                const lightningTransactions =
-                    NostrConnectUtils.convertLightningDataToNip47Transactions({
-                        payments: this.paymentsStore.payments || [],
-                        invoices: this.invoicesStore.invoices || []
-                    });
-                const onChainTransactions =
-                    NostrConnectUtils.convertOnChainTransactionsToNip47Transactions(
-                        this.transactionsStore.transactions || []
-                    );
-                let cashuTransactions: Nip47Transaction[] = [];
-                if (this.isCashuConfigured) {
-                    cashuTransactions =
-                        NostrConnectUtils.convertCashuDataToNip47Transactions({
-                            payments: this.cashuStore.payments || [],
-                            invoices: this.cashuStore.invoices || [],
-                            receivedTokens:
-                                this.cashuStore.receivedTokens || [],
-                            sentTokens: this.cashuStore.sentTokens || []
-                        });
-                }
-                nip47Transactions = [
-                    ...lightningTransactions,
-                    ...onChainTransactions,
-                    ...cashuTransactions
-                ].sort((a, b) => b.created_at - a.created_at);
+            const reconciled = await this.reconcilePendingPayInvoiceActivities(
+                connection
+            );
+            if (reconciled) {
+                this.scheduleSave();
             }
+
+            const nip47Transactions = connection.activity
+                .map((activity) =>
+                    NostrConnectUtils.convertConnectionActivityToNip47Transaction(
+                        activity
+                    )
+                )
+                .filter((tx) => tx.amount > 0)
+                .sort((a, b) => b.created_at - a.created_at);
 
             // Filter and paginate transactions
             const { transactions, totalCount } =
@@ -2586,7 +2582,6 @@ export default class NostrWalletConnectStore {
         }
 
         if (changed) {
-            this.lookupPaymentsCache = null;
             this.scheduleMaxBudgetRefresh();
             this.findAndUpdateConnection(connection);
         }
@@ -2620,39 +2615,6 @@ export default class NostrWalletConnectStore {
         await this.paymentsStore.getPayments();
         this.lastPendingPaymentStatusFetchByConnection.set(connectionId, now);
         return this.paymentsStore.payments || [];
-    }
-
-    /**
-     * Outgoing payments for lookup_invoice — fetched lazily after the invoice
-     * path misses, without touching paymentsStore (that overwrites the wallet
-     * activity list and toggles its loading flag).
-     */
-    private async getPaymentsForLookup(): Promise<Payment[]> {
-        const now = Date.now();
-        if (
-            this.lookupPaymentsCache &&
-            now - this.lookupPaymentsFetchedAt < LOOKUP_PAYMENTS_CACHE_MS
-        ) {
-            return this.lookupPaymentsCache;
-        }
-
-        try {
-            const data = await BackendUtils.getPayments({
-                maxPayments: 100,
-                // lndmobile spreads this conditionally; omitting it leaves the
-                // protobuf default of false and embedded LND returns the oldest page
-                reversed: true
-            });
-            if (!data?.payments) {
-                return this.lookupPaymentsCache || [];
-            }
-            const payments = data.payments.map((p: any) => new Payment(p));
-            this.lookupPaymentsCache = payments;
-            this.lookupPaymentsFetchedAt = now;
-            return payments;
-        } catch {
-            return this.lookupPaymentsCache || [];
-        }
     }
 
     private findLightningInvoiceInStore(invoice: Invoice): Invoice | undefined {
@@ -2914,7 +2876,6 @@ export default class NostrWalletConnectStore {
             });
         });
         this.scheduleMaxBudgetRefresh();
-        this.lookupPaymentsCache = null;
         NostrConnectUtils.notifyOutgoingNwcPayment(amountSats, connection.name);
     }
 
@@ -2962,8 +2923,6 @@ export default class NostrWalletConnectStore {
                 // isBudgetDebited intentionally unset — held via pendingSpendSats
             });
         });
-
-        this.lookupPaymentsCache = null;
     }
 
     private async recordFailedPayment({

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1087,12 +1087,19 @@ export default class NostrWalletConnectStore {
         }
 
         const stalePaidLightningInvoiceActivities = connection.activity.filter(
-            (activity) =>
-                activity.type === 'make_invoice' &&
-                activity.status === 'success' &&
-                activity.payment_source !== 'cashu' &&
-                activity.invoice instanceof Invoice &&
-                !activity.invoice.isPaid
+            (activity) => {
+                if (
+                    activity.type !== 'make_invoice' ||
+                    activity.status !== 'success' ||
+                    activity.payment_source === 'cashu'
+                ) {
+                    return false;
+                }
+                const invoice = NostrConnectUtils.coerceLightningInvoice(
+                    activity.invoice
+                );
+                return !!invoice && !invoice.isPaid;
+            }
         );
         if (stalePaidLightningInvoiceActivities.length > 0) {
             await Promise.all(
@@ -1893,7 +1900,13 @@ export default class NostrWalletConnectStore {
                 );
             }
 
-            await this.refreshActivityForLookup(connection, activity);
+            const refreshed = await this.refreshActivityForLookup(
+                connection,
+                activity
+            );
+            if (refreshed) {
+                this.scheduleSave();
+            }
 
             const result =
                 NostrConnectUtils.convertConnectionActivityToNip47Transaction(
@@ -1912,19 +1925,22 @@ export default class NostrWalletConnectStore {
     private async refreshActivityForLookup(
         connection: NWCConnection,
         activity: ConnectionActivity
-    ): Promise<void> {
+    ): Promise<boolean> {
         if (
             activity.type === 'pay_invoice' &&
             activity.status === 'pending' &&
             activity.payment_source !== 'cashu'
         ) {
-            await this.reconcilePendingPayInvoiceActivities(connection);
-            return;
+            return this.reconcilePendingPayInvoiceActivities(connection);
         }
 
         if (activity.type === 'make_invoice' && activity.status === 'pending') {
+            const statusBefore = activity.status;
             await this.reconcilePendingMakeInvoiceActivity(activity);
+            return activity.status !== statusBefore;
         }
+
+        return false;
     }
 
     private async reconcilePendingMakeInvoiceActivity(
@@ -2655,7 +2671,9 @@ export default class NostrWalletConnectStore {
     private async reconcilePendingLightningMakeInvoice(
         activity: ConnectionActivity
     ): Promise<void> {
-        const invoice = activity.invoice as Invoice | undefined;
+        const invoice = NostrConnectUtils.coerceLightningInvoice(
+            activity.invoice
+        );
         if (!invoice) return;
 
         const settled =
@@ -2670,8 +2688,13 @@ export default class NostrWalletConnectStore {
             );
             runInAction(() => {
                 activity.status = 'success';
+                const paidInvoice = refreshed || invoice;
                 if (refreshed) {
                     activity.invoice = refreshed;
+                }
+                const preimage = paidInvoice.getRPreimage;
+                if (preimage) {
+                    activity.preimage = preimage;
                 }
             });
             return;
@@ -2690,20 +2713,27 @@ export default class NostrWalletConnectStore {
         if (
             activity.type !== 'make_invoice' ||
             activity.status !== 'success' ||
-            activity.payment_source === 'cashu' ||
-            !(activity.invoice instanceof Invoice) ||
-            activity.invoice.isPaid
+            activity.payment_source === 'cashu'
         ) {
             return;
         }
 
-        const refreshed = await this.refreshLightningInvoiceFromNode(
+        const invoice = NostrConnectUtils.coerceLightningInvoice(
             activity.invoice
         );
+        if (!invoice || invoice.isPaid) {
+            return;
+        }
+
+        const refreshed = await this.refreshLightningInvoiceFromNode(invoice);
         if (!refreshed?.isPaid) return;
 
         runInAction(() => {
             activity.invoice = refreshed;
+            const preimage = refreshed.getRPreimage;
+            if (preimage) {
+                activity.preimage = preimage;
+            }
         });
     }
 

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -846,6 +846,47 @@ describe('NostrConnectUtils', () => {
                 expect(tx.description_hash).toBe(DESCRIPTION_HASH);
                 expect(tx.settled_at).toBe(SETTLE_DATE);
             });
+
+            it('returns preimage from a rehydrated plain-object invoice', () => {
+                const activity: ConnectionActivity = {
+                    id: INVOICE_A,
+                    type: 'make_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    invoice: lndInvoice({
+                        settled: true,
+                        settle_date: String(SETTLE_DATE),
+                        r_preimage: Base64Utils.hexToBase64(PREIMAGE)
+                    }) as any
+                };
+
+                const tx =
+                    NostrConnectUtils.convertConnectionActivityToNip47Transaction(
+                        activity
+                    );
+
+                expect(tx.preimage).toBe(PREIMAGE);
+                expect(tx.state).toBe('settled');
+            });
+
+            it('prefers activity.preimage over invoice fields', () => {
+                const STORED_PREIMAGE = hex64('c');
+                const activity: ConnectionActivity = {
+                    id: INVOICE_A,
+                    type: 'make_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    preimage: STORED_PREIMAGE,
+                    invoice: lndInvoice({ settled: true }) as any
+                };
+
+                const tx =
+                    NostrConnectUtils.convertConnectionActivityToNip47Transaction(
+                        activity
+                    );
+
+                expect(tx.preimage).toBe(STORED_PREIMAGE);
+            });
         });
     });
 
@@ -914,6 +955,37 @@ describe('NostrConnectUtils', () => {
                 );
 
             expect(found).toBeUndefined();
+        });
+
+        it('finds activity by payment hash decoded from request.invoice', async () => {
+            const BOLT11 =
+                'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr';
+            const BOLT11_HASH =
+                '0001020304050607080900010203040506070809000102030405060708090102';
+            const activity = makeInvoiceActivity({
+                id: 'different-id',
+                paymentHash: BOLT11_HASH
+            });
+
+            const found =
+                await NostrConnectUtils.findConnectionActivityByLookupRequest(
+                    [activity],
+                    { invoice: BOLT11 }
+                );
+
+            expect(found).toBe(activity);
+        });
+
+        it('matches invoice-only lookups case-insensitively', async () => {
+            const activity = makeInvoiceActivity({ id: INVOICE_A });
+
+            const found =
+                await NostrConnectUtils.findConnectionActivityByLookupRequest(
+                    [activity],
+                    { invoice: INVOICE_A.toUpperCase() }
+                );
+
+            expect(found).toBe(activity);
         });
     });
 

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -41,7 +41,6 @@ import Invoice from '../models/Invoice';
 import Base64Utils from './Base64Utils';
 import type { ConnectionActivity } from '../models/NWCConnection';
 import CashuPayment from '../models/CashuPayment';
-import CashuInvoice from '../models/CashuInvoice';
 
 // Stable hex values: repeat a hex digit 64 times to fill 32 bytes
 const hex64 = (c: string) => c.repeat(64);
@@ -785,118 +784,7 @@ describe('NostrConnectUtils', () => {
             ...overrides
         });
 
-        const lookupLightningInvoice = (rawInvoice: object) =>
-            NostrConnectUtils.lightningInvoiceToNip47Transaction(
-                new Invoice(rawInvoice),
-                { fallbackHash: HASH_A }
-            );
-
-        describe('lookup_invoice', () => {
-            it('reads the payment hash from the LND r_hash field', () => {
-                const tx = lookupLightningInvoice(lndInvoice());
-
-                expect(tx.payment_hash).toBe(HASH_A);
-            });
-
-            it('reports expiry as creation plus expiry, not the creation date', () => {
-                const tx = lookupLightningInvoice(lndInvoice());
-
-                expect(tx.created_at).toBe(CREATION_DATE);
-                expect(tx.expires_at).toBe(CREATION_DATE + EXPIRY_SECONDS);
-            });
-
-            it('marks an unpaid invoice past its expiry as failed', () => {
-                const tx = lookupLightningInvoice(lndInvoice());
-
-                expect(tx.state).toBe('failed');
-            });
-
-            it('returns preimage and settle time for a settled invoice', () => {
-                const tx = lookupLightningInvoice(
-                    lndInvoice({
-                        settled: true,
-                        settle_date: String(SETTLE_DATE),
-                        r_preimage: Base64Utils.hexToBase64(PREIMAGE)
-                    })
-                );
-
-                expect(tx.state).toBe('settled');
-                expect(tx.preimage).toBe(PREIMAGE);
-                expect(tx.settled_at).toBe(SETTLE_DATE);
-            });
-
-            it('reads Core Lightning payment_hash and payment_preimage', () => {
-                const tx = lookupLightningInvoice({
-                    payment_hash: HASH_A,
-                    payment_preimage: PREIMAGE,
-                    bolt11: INVOICE_A,
-                    created_at: CREATION_DATE,
-                    expires_at: CREATION_DATE + EXPIRY_SECONDS,
-                    paid_at: SETTLE_DATE,
-                    status: 'paid',
-                    msatoshi: 1000000
-                });
-
-                expect(tx.payment_hash).toBe(HASH_A);
-                expect(tx.preimage).toBe(PREIMAGE);
-                expect(tx.expires_at).toBe(CREATION_DATE + EXPIRY_SECONDS);
-            });
-
-            it('does not report a settle time for an unpaid invoice', () => {
-                const tx = lookupLightningInvoice({
-                    payment_hash: HASH_A,
-                    bolt11: INVOICE_A,
-                    created_at: CREATION_DATE,
-                    timestamp: CREATION_DATE,
-                    expires_at: CREATION_DATE + EXPIRY_SECONDS,
-                    status: 'unpaid'
-                });
-
-                expect(tx.state).not.toBe('settled');
-                expect(tx.settled_at).toBe(0);
-            });
-
-            it('derives created_at from BOLT11 when CLN listinvoices omits a creation timestamp', () => {
-                // Real CLN listinvoices shape: no created_at/creation_date
-                const BOLT11 =
-                    'lnbcrt1230n1pj429x7pp57t97q4awqj3f529snr0pa6senk83sq5pp760qf5a4jzvd7xgwcksdqqcqzzsxqrrsssp57eqtv7vxr46arupna3w4ct0lkf2mqmz9wt044cwkks0rwlnhfr5s9qyyssqragwpwav7nfwv2xyuuamxxj4pnnpzv2hlw7j473repd3sq7st698ta9kmzmygt0w7tmncl56a6mnma0w7e5dlpqd0wy6x3v35rssldspjhh8p0';
-                const BOLT11_TIMESTAMP = 1700074718;
-                const tx = lookupLightningInvoice({
-                    label: 'zeus.123456',
-                    bolt11: BOLT11,
-                    payment_hash:
-                        'f2cbe056ae04a29a28b098de1eea199d8f1802900fb4f0269dac84c6f8c8762d',
-                    amount_msat: 123000,
-                    status: 'unpaid',
-                    description: 'test invoice',
-                    expires_at: BOLT11_TIMESTAMP + EXPIRY_SECONDS,
-                    created_index: 7
-                });
-
-                expect(tx.created_at).toBe(BOLT11_TIMESTAMP);
-                expect(tx.expires_at).toBe(BOLT11_TIMESTAMP + EXPIRY_SECONDS);
-            });
-        });
-
-        describe('list_transactions', () => {
-            it('derives payment_hash from r_hash for LND invoices', () => {
-                const [tx] =
-                    NostrConnectUtils.convertLightningDataToNip47Transactions({
-                        invoices: [new Invoice(lndInvoice())]
-                    });
-
-                expect(tx.payment_hash).toBe(HASH_A);
-            });
-
-            it('reports the same expiry as lookup_invoice', () => {
-                const [tx] =
-                    NostrConnectUtils.convertLightningDataToNip47Transactions({
-                        invoices: [new Invoice(lndInvoice())]
-                    });
-
-                expect(tx.expires_at).toBe(CREATION_DATE + EXPIRY_SECONDS);
-            });
-
+        describe('connection activity conversion', () => {
             it('never reports the payment request as a payment hash', () => {
                 const activity: ConnectionActivity = {
                     id: INVOICE_A,
@@ -961,91 +849,6 @@ describe('NostrConnectUtils', () => {
         });
     });
 
-    describe('cashuPaymentToNip47Transaction', () => {
-        const TIMESTAMP = 1700000000;
-        const PREIMAGE = hex64('e');
-
-        /**
-         * Mirrors what CashuStore builds after a successful melt: the decoded
-         * payment request spread in, bolt11, amount, fee and the mint preimage
-         */
-        const cashuPayment = (overrides: object = {}) =>
-            new CashuPayment({
-                payment_hash: HASH_A,
-                timestamp: TIMESTAMP,
-                bolt11: INVOICE_A,
-                amount: 2000,
-                fee: 3,
-                payment_preimage: PREIMAGE,
-                mintUrl: 'https://mint.example.com',
-                ...overrides
-            });
-
-        const lookup = (request: object, payments?: CashuPayment[]) => {
-            const payment = NostrConnectUtils.findPaymentByLookupRequest(
-                payments ?? [cashuPayment()],
-                request as never
-            );
-            return payment
-                ? NostrConnectUtils.cashuPaymentToNip47Transaction(payment)
-                : undefined;
-        };
-
-        it('finds a melted payment by payment hash', () => {
-            const tx = lookup({ payment_hash: HASH_A });
-
-            expect(tx?.payment_hash).toBe(HASH_A);
-            expect(tx?.type).toBe('outgoing');
-        });
-
-        it('finds a melted payment by payment request', () => {
-            const tx = lookup({ invoice: INVOICE_A });
-
-            expect(tx?.type).toBe('outgoing');
-        });
-
-        it('reports the mint fee in msats and no expiry', () => {
-            const tx = lookup({ payment_hash: HASH_A });
-
-            expect(tx?.amount).toBe(2000000);
-            expect(tx?.fees_paid).toBe(3000);
-            expect(tx?.expires_at).toBe(0);
-        });
-
-        it('reports the mint preimage and a settled state', () => {
-            const tx = lookup({ payment_hash: HASH_A });
-
-            expect(tx?.state).toBe('settled');
-            expect(tx?.preimage).toBe(PREIMAGE);
-            expect(tx?.settled_at).toBe(TIMESTAMP);
-        });
-
-        it('leaves the preimage empty when the mint returned none', () => {
-            const tx = lookup({ payment_hash: HASH_A }, [
-                cashuPayment({ payment_preimage: '' })
-            ]);
-
-            expect(tx?.preimage).toBe('');
-            expect(tx?.state).toBe('settled');
-        });
-
-        it('does not match an unrelated hash', () => {
-            expect(lookup({ payment_hash: HASH_B })).toBeUndefined();
-        });
-
-        it('returns undefined when there are no payments', () => {
-            expect(lookup({ payment_hash: HASH_A }, [])).toBeUndefined();
-        });
-
-        it('matches a base64-encoded payment hash from the request', () => {
-            const tx = lookup({
-                payment_hash: Base64Utils.hexToBase64(HASH_A)
-            });
-
-            expect(tx?.payment_hash).toBe(HASH_A);
-        });
-    });
-
     describe('payment hash normalization', () => {
         // ZEUS's own NWC backend sends payment_hash base64-encoded, while
         // stored hashes are hex — see backends/NostrWalletConnect.ts
@@ -1063,50 +866,6 @@ describe('NostrConnectUtils', () => {
         it('returns undefined for a missing or blank hash', () => {
             expect(normalize(undefined)).toBeUndefined();
             expect(normalize('   ')).toBeUndefined();
-        });
-    });
-
-    describe('findCashuInvoiceByLookupRequest', () => {
-        // BOLT11 spec reference vector; hash confirmed by decoding it
-        const BOLT11 =
-            'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr';
-        const BOLT11_HASH =
-            '0001020304050607080900010203040506070809000102030405060708090102';
-
-        const invoices = () => [
-            new CashuInvoice({ quote: 'quote-1', request: BOLT11 })
-        ];
-
-        it('matches a hex payment hash', async () => {
-            const found =
-                await NostrConnectUtils.findCashuInvoiceByLookupRequest(
-                    invoices(),
-                    { payment_hash: BOLT11_HASH } as never
-                );
-
-            expect(found?.getPaymentRequest).toBe(BOLT11);
-        });
-
-        it('matches a base64-encoded payment hash', async () => {
-            const found =
-                await NostrConnectUtils.findCashuInvoiceByLookupRequest(
-                    invoices(),
-                    {
-                        payment_hash: Base64Utils.hexToBase64(BOLT11_HASH)
-                    } as never
-                );
-
-            expect(found?.getPaymentRequest).toBe(BOLT11);
-        });
-
-        it('does not match an unrelated hash', async () => {
-            const found =
-                await NostrConnectUtils.findCashuInvoiceByLookupRequest(
-                    invoices(),
-                    { payment_hash: hex64('f') } as never
-                );
-
-            expect(found).toBeUndefined();
         });
     });
 

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -930,6 +930,34 @@ describe('NostrConnectUtils', () => {
 
                 expect(tx.expires_at).toBe(CREATION_DATE + EXPIRY_SECONDS);
             });
+
+            it('returns preimage and description_hash for a settled make_invoice activity', () => {
+                const DESCRIPTION_HASH = hex64('b');
+                const activity: ConnectionActivity = {
+                    id: INVOICE_A,
+                    type: 'make_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    invoice: new Invoice(
+                        lndInvoice({
+                            settled: true,
+                            settle_date: String(SETTLE_DATE),
+                            r_preimage: Base64Utils.hexToBase64(PREIMAGE),
+                            description_hash: DESCRIPTION_HASH
+                        })
+                    )
+                };
+
+                const tx =
+                    NostrConnectUtils.convertConnectionActivityToNip47Transaction(
+                        activity
+                    );
+
+                expect(tx.state).toBe('settled');
+                expect(tx.preimage).toBe(PREIMAGE);
+                expect(tx.description_hash).toBe(DESCRIPTION_HASH);
+                expect(tx.settled_at).toBe(SETTLE_DATE);
+            });
         });
     });
 

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -39,7 +39,6 @@ import NostrConnectUtils from './NostrConnectUtils';
 import Payment from '../models/Payment';
 import Invoice from '../models/Invoice';
 import Base64Utils from './Base64Utils';
-import BackendUtils from './BackendUtils';
 import type { ConnectionActivity } from '../models/NWCConnection';
 import CashuPayment from '../models/CashuPayment';
 import CashuInvoice from '../models/CashuInvoice';
@@ -1083,91 +1082,51 @@ describe('NostrConnectUtils', () => {
         });
     });
 
-    describe('lookupInvoiceTransaction', () => {
-        const TIMESTAMP = 1700000000;
-        const getLightningPayments = (payments: Payment[] = []) =>
-            jest.fn().mockResolvedValue(payments);
-        const getCashuPayments = (payments: CashuPayment[] = []) =>
-            jest.fn().mockResolvedValue(payments);
-        const getCashuInvoices = (invoices: CashuInvoice[] = []) =>
-            jest.fn().mockResolvedValue(invoices);
-
-        it('finds a Lightning invoice from the node by payment hash', async () => {
-            (BackendUtils as any).lookupInvoice = jest.fn().mockResolvedValue({
-                r_hash: Base64Utils.hexToBase64(HASH_A),
-                payment_request: INVOICE_A,
-                creation_date: String(TIMESTAMP),
-                expiry: '3600',
-                value: '1000',
-                settled: false
-            });
-            const getPayments = getLightningPayments();
-
-            const tx = await NostrConnectUtils.lookupInvoiceTransaction({
-                request: { payment_hash: HASH_A },
-                isCashu: false,
-                getCashuInvoices: getCashuInvoices(),
-                getCashuPayments: getCashuPayments(),
-                getLightningPayments: getPayments
-            });
-
-            expect(tx?.type).toBe('incoming');
-            expect(tx?.payment_hash).toBe(HASH_A);
-            expect(getPayments).not.toHaveBeenCalled();
+    describe('findConnectionActivityByLookupRequest', () => {
+        const makeInvoiceActivity = (
+            overrides: Partial<ConnectionActivity> = {}
+        ): ConnectionActivity => ({
+            id: INVOICE_A,
+            type: 'make_invoice',
+            payment_source: 'lightning',
+            status: 'success',
+            paymentHash: HASH_A,
+            satAmount: 1000,
+            ...overrides
         });
 
-        it('falls back to an outgoing Lightning payment when the node has no invoice', async () => {
-            (BackendUtils as any).lookupInvoice = jest
-                .fn()
-                .mockRejectedValue(new Error('not found'));
-            const payment = new Payment({
-                payment_hash: HASH_A,
-                timestamp: TIMESTAMP,
-                value: '2000',
-                fee: '2'
-            });
-            const getPayments = getLightningPayments([payment]);
+        it('finds activity by payment hash', async () => {
+            const activity = makeInvoiceActivity();
 
-            const tx = await NostrConnectUtils.lookupInvoiceTransaction({
-                request: { payment_hash: HASH_A },
-                isCashu: false,
-                getCashuInvoices: getCashuInvoices(),
-                getCashuPayments: getCashuPayments(),
-                getLightningPayments: getPayments
-            });
+            const found =
+                await NostrConnectUtils.findConnectionActivityByLookupRequest(
+                    [activity],
+                    { payment_hash: HASH_A }
+                );
 
-            expect(tx?.type).toBe('outgoing');
-            expect(tx?.payment_hash).toBe(HASH_A);
-            expect(BackendUtils.lookupInvoice).toHaveBeenCalled();
-            expect(getPayments).toHaveBeenCalledTimes(1);
+            expect(found).toBe(activity);
         });
 
-        it('resolves an invoice-only Lightning request from the BOLT11 string', async () => {
-            const BOLT11 =
-                'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr';
-            (BackendUtils as any).lookupInvoice = jest.fn().mockResolvedValue({
-                payment_hash:
-                    '0001020304050607080900010203040506070809000102030405060708090102',
-                bolt11: BOLT11,
-                created_at: TIMESTAMP,
-                expires_at: TIMESTAMP + 3600,
-                status: 'unpaid'
-            });
-            const getPayments = getLightningPayments();
+        it('finds activity by BOLT11 invoice string', async () => {
+            const activity = makeInvoiceActivity();
 
-            const tx = await NostrConnectUtils.lookupInvoiceTransaction({
-                request: { invoice: BOLT11 },
-                isCashu: false,
-                getCashuInvoices: getCashuInvoices(),
-                getCashuPayments: getCashuPayments(),
-                getLightningPayments: getPayments
-            });
+            const found =
+                await NostrConnectUtils.findConnectionActivityByLookupRequest(
+                    [activity],
+                    { invoice: INVOICE_A }
+                );
 
-            expect(tx?.type).toBe('incoming');
-            expect(BackendUtils.lookupInvoice).toHaveBeenCalledWith({
-                r_hash: '0001020304050607080900010203040506070809000102030405060708090102'
-            });
-            expect(getPayments).not.toHaveBeenCalled();
+            expect(found).toBe(activity);
+        });
+
+        it('returns undefined when the hash is not in connection activity', async () => {
+            const found =
+                await NostrConnectUtils.findConnectionActivityByLookupRequest(
+                    [makeInvoiceActivity()],
+                    { payment_hash: hex64('f') }
+                );
+
+            expect(found).toBeUndefined();
         });
     });
 

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -19,9 +19,6 @@ import {
 import Invoice from '../models/Invoice';
 import Payment from '../models/Payment';
 import CashuPayment from '../models/CashuPayment';
-import CashuInvoice from '../models/CashuInvoice';
-import CashuToken from '../models/CashuToken';
-import Transaction from '../models/Transaction';
 
 import Base64Utils from './Base64Utils';
 import { localeString } from './LocaleUtils';
@@ -614,38 +611,6 @@ export default class NostrConnectUtils {
         return hash.includes('=') ? Base64Utils.base64ToHex(hash) : hash;
     }
 
-    /** Resolve a lookup hash from payment_hash and/or invoice on the request. */
-    static async resolveLookupPaymentHash(
-        request: Nip47LookupInvoiceRequest,
-        paymentRequest?: string
-    ): Promise<string | undefined> {
-        const fromRequest = NostrConnectUtils.normalizePaymentHash(
-            request.payment_hash
-        );
-        if (fromRequest) return fromRequest;
-
-        const invoice = request.invoice || paymentRequest;
-        if (!invoice) return undefined;
-
-        try {
-            const decoded = await NostrConnectUtils.decodeInvoiceTags(invoice);
-            return decoded.paymentHash || undefined;
-        } catch {
-            return undefined;
-        }
-    }
-
-    static findPaymentByLookupRequest<T extends Payment>(
-        payments: T[],
-        request: Nip47LookupInvoiceRequest
-    ): T | undefined {
-        return NostrConnectUtils.findPaymentForInvoice(
-            request.invoice || '',
-            payments,
-            NostrConnectUtils.normalizePaymentHash(request.payment_hash)
-        );
-    }
-
     /** Whether a BOLT11 string matches a NIP-47 lookup request (invoice or hash). */
     static async paymentRequestMatchesLookupRequest(
         paymentRequest: string,
@@ -669,88 +634,6 @@ export default class NostrConnectUtils {
         }
     }
 
-    /**
-     * Finds a Cashu invoice matching NIP-47 lookup_invoice (BOLT11 and/or payment_hash).
-     */
-    static async findCashuInvoiceByLookupRequest(
-        invoices: CashuInvoice[],
-        request: Nip47LookupInvoiceRequest
-    ): Promise<CashuInvoice | undefined> {
-        const normalizedHash = NostrConnectUtils.normalizePaymentHash(
-            request.payment_hash
-        );
-        for (const inv of invoices) {
-            if (
-                await NostrConnectUtils.paymentRequestMatchesLookupRequest(
-                    inv.getPaymentRequest,
-                    request,
-                    normalizedHash
-                )
-            ) {
-                return inv;
-            }
-        }
-        return undefined;
-    }
-
-    static cashuInvoicePaymentHash(invoice: CashuInvoice): string {
-        try {
-            const decoded = Bolt11Utils.decode(invoice.getPaymentRequest);
-            return decoded.payment_hash || '';
-        } catch {
-            return invoice.quote || '';
-        }
-    }
-
-    static cashuPaymentToNip47Transaction(
-        payment: CashuPayment
-    ): Nip47Transaction {
-        const timestamp = NostrConnectUtils.paymentTimestamp(payment);
-
-        return NostrConnectUtils.createNip47Transaction({
-            type: 'outgoing',
-            state: 'settled',
-            invoice: payment.getPaymentRequest || '',
-            payment_hash: payment.paymentHash || '',
-            amount: satsToMillisats(Number(payment.getAmount) || 0),
-            description: payment.getMemo,
-            preimage: payment.getPreimage,
-            fees_paid: satsToMillisats(Number(payment.getFee) || 0),
-            settled_at: timestamp,
-            created_at: timestamp,
-            expires_at: 0
-        });
-    }
-
-    static cashuInvoiceToNip47Transaction(
-        invoice: CashuInvoice,
-        paymentHash?: string
-    ): Nip47Transaction {
-        const isPaid = invoice.isPaid || false;
-        const timestamp = Math.floor(
-            Number(invoice.getTimestamp) || dateTimeUtils.getCurrentTimestamp()
-        );
-        const expiresAt =
-            Number(invoice.expires_at) ||
-            timestamp + DEFAULT_INVOICE_EXPIRY_SECONDS;
-
-        return NostrConnectUtils.createNip47Transaction({
-            type: 'incoming',
-            state: isPaid ? 'settled' : 'pending',
-            invoice: invoice.getPaymentRequest,
-            payment_hash:
-                NostrConnectUtils.normalizePaymentHash(paymentHash) ||
-                NostrConnectUtils.cashuInvoicePaymentHash(invoice),
-            amount: satsToMillisats(invoice.getAmount || 0),
-            description: invoice.getMemo,
-            settled_at: isPaid
-                ? Math.floor(invoice.settleDate.getTime() / 1000)
-                : 0,
-            created_at: timestamp,
-            expires_at: expiresAt
-        });
-    }
-
     static lightningInvoiceExpiresAt(
         invoice: Invoice,
         createdAt: number
@@ -762,77 +645,6 @@ export default class NostrConnectUtils {
             return createdAt + Number(invoice.expiry);
         }
         return 0;
-    }
-
-    static lightningInvoiceState(
-        invoice: Invoice,
-        now: number,
-        expiresAt: number
-    ): 'settled' | 'pending' | 'failed' {
-        if (invoice.isPaid) return 'settled';
-        if (expiresAt > 0 && expiresAt < now) return 'failed';
-        return 'pending';
-    }
-
-    static lightningInvoiceToNip47Transaction(
-        invoice: Invoice,
-        opts?: { fallbackHash?: string; now?: number }
-    ): Nip47Transaction {
-        const now = opts?.now ?? Math.floor(Date.now() / 1000);
-        const createdAt = Math.floor(invoice.getCreationDate.getTime() / 1000);
-        const expiresAt = NostrConnectUtils.lightningInvoiceExpiresAt(
-            invoice,
-            createdAt
-        );
-        const state = NostrConnectUtils.lightningInvoiceState(
-            invoice,
-            now,
-            expiresAt
-        );
-
-        return NostrConnectUtils.createNip47Transaction({
-            type: 'incoming',
-            state,
-            invoice: invoice.getPaymentRequest,
-            payment_hash: invoice.getRHash || opts?.fallbackHash || '',
-            amount: satsToMillisats(invoice.getAmount),
-            description: invoice.getMemo,
-            ...(invoice.isPaid && {
-                preimage: invoice.getRPreimage
-            }),
-            description_hash: invoice.getDescriptionHash,
-            settled_at: invoice.isPaid
-                ? Math.floor(invoice.settleDate.getTime() / 1000)
-                : 0,
-            created_at: createdAt,
-            expires_at: expiresAt
-        });
-    }
-
-    static lightningPaymentToNip47Transaction(
-        payment: Payment
-    ): Nip47Transaction {
-        const timestamp = NostrConnectUtils.paymentTimestamp(payment);
-        let state: 'settled' | 'pending' | 'failed' = 'pending';
-        if (payment.isFailed) {
-            state = 'failed';
-        } else if (!payment.isIncomplete) {
-            state = 'settled';
-        }
-
-        return NostrConnectUtils.createNip47Transaction({
-            type: 'outgoing',
-            state,
-            invoice: payment.getPaymentRequest || '',
-            payment_hash: payment.paymentHash || '',
-            amount: satsToMillisats(Number(payment.getAmount) || 0),
-            description: payment.getMemo || '',
-            preimage: payment.getPreimage || '',
-            fees_paid: satsToMillisats(Number(payment.getFee) || 0),
-            settled_at: state === 'settled' ? timestamp : 0,
-            created_at: timestamp,
-            expires_at: 0
-        });
     }
 
     static async findConnectionActivityByLookupRequest(
@@ -891,12 +703,6 @@ export default class NostrConnectUtils {
         }
 
         return false;
-    }
-
-    private static paymentTimestamp(payment: Payment): number {
-        return Math.floor(
-            Number(payment.getTimestamp) || dateTimeUtils.getCurrentTimestamp()
-        );
     }
 
     static async decodeInvoiceTagsForMakeInvoice(
@@ -1489,180 +1295,6 @@ export default class NostrConnectUtils {
             settled_at,
             created_at,
             expires_at
-        });
-    }
-
-    /**
-     * Converts Cashu payments, invoices, and tokens to NIP-47 transactions
-     * @param cashuData - Object containing Cashu payments, invoices, and tokens
-     * @returns Array of NIP-47 transactions
-     */
-    static convertCashuDataToNip47Transactions(cashuData: {
-        payments?: CashuPayment[];
-        invoices?: CashuInvoice[];
-        receivedTokens?: CashuToken[];
-        sentTokens?: CashuToken[];
-    }): Nip47Transaction[] {
-        const transactions: Nip47Transaction[] = [];
-
-        // Convert Cashu payments
-        if (cashuData.payments) {
-            transactions.push(
-                ...cashuData.payments.map(
-                    NostrConnectUtils.cashuPaymentToNip47Transaction
-                )
-            );
-        }
-
-        // Convert Cashu invoices
-        if (cashuData.invoices) {
-            transactions.push(
-                ...cashuData.invoices.map((invoice) =>
-                    NostrConnectUtils.cashuInvoiceToNip47Transaction(invoice)
-                )
-            );
-        }
-
-        // Convert received tokens
-        if (cashuData.receivedTokens) {
-            const receivedTokenTransactions = cashuData.receivedTokens.map(
-                (token) => {
-                    const receivedAt =
-                        Number(token.received_at) || Date.now() / 1000;
-                    const createdAt = Number(token.created_at) || receivedAt;
-                    return NostrConnectUtils.createNip47Transaction({
-                        type: 'incoming',
-                        state: 'settled',
-                        invoice: '',
-                        payment_hash: token.encodedToken || '',
-                        amount: satsToMillisats(token.getAmount || 0),
-                        description:
-                            token.memo ||
-                            localeString(
-                                'stores.NostrWalletConnectStore.receivedCashuToken'
-                            ),
-                        settled_at: Math.floor(receivedAt),
-                        created_at: Math.floor(createdAt),
-                        expires_at: 0
-                    });
-                }
-            );
-            transactions.push(...receivedTokenTransactions);
-        }
-
-        // Convert sent tokens
-        if (cashuData.sentTokens) {
-            const sentTokenTransactions = cashuData.sentTokens.map((token) => {
-                const createdAt = Number(token.created_at) || Date.now() / 1000;
-                return NostrConnectUtils.createNip47Transaction({
-                    type: 'outgoing',
-                    state: token.spent ? 'settled' : 'pending',
-                    invoice: '',
-                    payment_hash: token.encodedToken || '',
-                    amount: satsToMillisats(token.getAmount || 0),
-                    description:
-                        token.memo ||
-                        localeString(
-                            'stores.NostrWalletConnectStore.sentCashuToken'
-                        ),
-                    settled_at: token.spent
-                        ? Math.floor(
-                              Number(token.received_at) ||
-                                  Number(token.created_at) ||
-                                  Date.now() / 1000
-                          )
-                        : 0,
-                    created_at: Math.floor(createdAt),
-                    expires_at: 0
-                });
-            });
-            transactions.push(...sentTokenTransactions);
-        }
-
-        return transactions;
-    }
-
-    /**
-     * Converts Lightning payments and invoices to NIP-47 transactions
-     * @param lightningData - Object containing Lightning payments and invoices
-     * @returns Array of NIP-47 transactions
-     */
-    static convertLightningDataToNip47Transactions(lightningData: {
-        payments?: Payment[];
-        invoices?: Invoice[];
-    }): Nip47Transaction[] {
-        const transactions: Nip47Transaction[] = [];
-
-        // Convert Lightning payments
-        if (lightningData.payments) {
-            transactions.push(
-                ...lightningData.payments.map(
-                    NostrConnectUtils.lightningPaymentToNip47Transaction
-                )
-            );
-        }
-
-        // Convert Lightning invoices
-        if (lightningData.invoices) {
-            transactions.push(
-                ...lightningData.invoices.map((invoice) =>
-                    NostrConnectUtils.lightningInvoiceToNip47Transaction(
-                        invoice
-                    )
-                )
-            );
-        }
-
-        return transactions;
-    }
-
-    /**
-     * Converts on-chain transactions to NIP-47 transactions
-     * @param transactions - Array of on-chain transactions
-     * @returns Array of NIP-47 transactions
-     */
-    static convertOnChainTransactionsToNip47Transactions(
-        transactions: Transaction[]
-    ): Nip47Transaction[] {
-        return (transactions || []).map((tx: Transaction) => {
-            const amount = Number(tx.amount);
-            const type: 'incoming' | 'outgoing' =
-                amount >= 0 ? 'incoming' : 'outgoing';
-
-            let state: 'settled' | 'pending' | 'failed' = 'pending';
-            if (
-                tx.status &&
-                (tx.status === 'failed' ||
-                    tx.status === 'FAILED' ||
-                    tx.status.toLowerCase().includes('fail'))
-            ) {
-                state = 'failed';
-            } else if (tx.num_confirmations > 0) {
-                state = 'settled';
-            }
-
-            const amountMsats = satsToMillisats(Math.abs(amount));
-            const feesMsats = satsToMillisats(Number(tx.total_fees) || 0);
-            const timestamp = Number(tx.time_stamp) || 0;
-            const txHash = tx.tx_hash || tx.txid || '';
-
-            return NostrConnectUtils.createNip47Transaction({
-                type,
-                state,
-                invoice: '',
-                payment_hash: txHash,
-                amount: amountMsats,
-                description: tx.note || undefined,
-                fees_paid: feesMsats,
-                settled_at: state === 'settled' ? timestamp : 0,
-                created_at: timestamp,
-                expires_at: 0, // On-chain transactions don't expire
-                metadata: {
-                    block_height: tx.block_height,
-                    block_hash: tx.block_hash,
-                    num_confirmations: tx.num_confirmations
-                }
-            });
         });
     }
 

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -108,14 +108,6 @@ export function parseNwcActivityNotif(
 
 export const DEFAULT_INVOICE_EXPIRY_SECONDS = 3600;
 
-export interface Nip47LookupInvoiceContext {
-    request: Nip47LookupInvoiceRequest;
-    isCashu: boolean;
-    getCashuInvoices: () => Promise<CashuInvoice[]>;
-    getCashuPayments: () => Promise<CashuPayment[]>;
-    getLightningPayments: () => Promise<Payment[]>;
-}
-
 export enum Nip47ErrorCode {
     INTERNAL_ERROR = 'INTERNAL_ERROR',
     RATE_LIMITED = 'RATE_LIMITED',
@@ -843,80 +835,62 @@ export default class NostrConnectUtils {
         });
     }
 
-    /**
-     * NIP-47 lookup_invoice: incoming invoice first, then outgoing payment.
-     * Returns undefined when nothing matches so the caller can emit NOT_FOUND.
-     */
-    static async lookupInvoiceTransaction(
-        ctx: Nip47LookupInvoiceContext
-    ): Promise<Nip47Transaction | undefined> {
-        return ctx.isCashu
-            ? NostrConnectUtils.lookupCashuInvoiceTransaction(ctx)
-            : NostrConnectUtils.lookupLightningInvoiceTransaction(ctx);
-    }
-
-    private static async lookupCashuInvoiceTransaction(
-        ctx: Nip47LookupInvoiceContext
-    ): Promise<Nip47Transaction | undefined> {
-        const { request } = ctx;
-        const cashuInvoice =
-            await NostrConnectUtils.findCashuInvoiceByLookupRequest(
-                await ctx.getCashuInvoices(),
-                request
-            );
-        if (cashuInvoice) {
-            const paymentHash =
-                await NostrConnectUtils.resolveLookupPaymentHash(
+    static async findConnectionActivityByLookupRequest(
+        activities: ConnectionActivity[],
+        request: Nip47LookupInvoiceRequest
+    ): Promise<ConnectionActivity | undefined> {
+        const normalizedHash = NostrConnectUtils.normalizePaymentHash(
+            request.payment_hash
+        );
+        for (const activity of activities) {
+            if (
+                await NostrConnectUtils.connectionActivityMatchesLookupRequest(
+                    activity,
                     request,
-                    cashuInvoice.getPaymentRequest
-                );
-            return NostrConnectUtils.cashuInvoiceToNip47Transaction(
-                cashuInvoice,
-                paymentHash
-            );
+                    normalizedHash
+                )
+            ) {
+                return activity;
+            }
         }
-
-        const cashuPayment = NostrConnectUtils.findPaymentByLookupRequest(
-            await ctx.getCashuPayments(),
-            request
-        );
-        return cashuPayment
-            ? NostrConnectUtils.cashuPaymentToNip47Transaction(cashuPayment)
-            : undefined;
+        return undefined;
     }
 
-    private static async lookupLightningInvoiceTransaction(
-        ctx: Nip47LookupInvoiceContext
-    ): Promise<Nip47Transaction | undefined> {
-        const { request } = ctx;
-        const paymentHash = await NostrConnectUtils.resolveLookupPaymentHash(
-            request
-        );
-        if (paymentHash) {
-            try {
-                const rawInvoice = await BackendUtils.lookupInvoice({
-                    r_hash: paymentHash
-                });
-                if (rawInvoice && typeof rawInvoice === 'object') {
-                    return NostrConnectUtils.lightningInvoiceToNip47Transaction(
-                        new Invoice(rawInvoice),
-                        { fallbackHash: paymentHash }
-                    );
-                }
-            } catch {
-                // Outgoing payments share the hash but are not node invoices.
+    static async connectionActivityMatchesLookupRequest(
+        activity: ConnectionActivity,
+        request: Nip47LookupInvoiceRequest,
+        normalizedHash?: string
+    ): Promise<boolean> {
+        const hash =
+            normalizedHash ??
+            NostrConnectUtils.normalizePaymentHash(request.payment_hash);
+        const paymentRequest =
+            activity.invoice?.getPaymentRequest ||
+            activity.payment?.getPaymentRequest;
+
+        if (request.invoice) {
+            if (activity.id === request.invoice) return true;
+            if (paymentRequest === request.invoice) return true;
+            if (
+                paymentRequest &&
+                (await NostrConnectUtils.paymentRequestMatchesLookupRequest(
+                    paymentRequest,
+                    request,
+                    hash
+                ))
+            ) {
+                return true;
             }
         }
 
-        const lightningPayment = NostrConnectUtils.findPaymentByLookupRequest(
-            await ctx.getLightningPayments(),
-            request
-        );
-        return lightningPayment
-            ? NostrConnectUtils.lightningPaymentToNip47Transaction(
-                  lightningPayment
-              )
-            : undefined;
+        if (hash) {
+            const activityHash = NostrConnectUtils.normalizePaymentHash(
+                NostrConnectUtils.extractPaymentHashFromActivity(activity)
+            );
+            if (activityHash && activityHash === hash) return true;
+        }
+
+        return false;
     }
 
     private static paymentTimestamp(payment: Payment): number {
@@ -1677,9 +1651,7 @@ export default class NostrConnectUtils {
                 metadata: {
                     block_height: tx.block_height,
                     block_hash: tx.block_hash,
-                    num_confirmations: tx.num_confirmations,
-                    dest_addresses: tx.dest_addresses,
-                    raw_tx_hex: tx.raw_tx_hex
+                    num_confirmations: tx.num_confirmations
                 }
             });
         });

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -1456,11 +1456,19 @@ export default class NostrConnectUtils {
             ? satsToMillisats(Number(activity.payment.getFee) || 0)
             : 0;
 
+        const lightningInvoice =
+            activity.invoice instanceof Invoice ? activity.invoice : undefined;
+
         const description =
             activity.invoice?.getMemo || activity.payment?.getMemo || '';
 
+        const description_hash = lightningInvoice?.getDescriptionHash || '';
+
         const preimage =
-            activity.preimage || activity.payment?.getPreimage || '';
+            activity.preimage ||
+            activity.payment?.getPreimage ||
+            (lightningInvoice?.isPaid ? lightningInvoice.getRPreimage : '') ||
+            '';
 
         const settled_at =
             state === 'settled'
@@ -1475,6 +1483,7 @@ export default class NostrConnectUtils {
             payment_hash: paymentHash,
             amount,
             description,
+            description_hash,
             preimage,
             fees_paid: feesPaid,
             settled_at,

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -19,6 +19,7 @@ import {
 import Invoice from '../models/Invoice';
 import Payment from '../models/Payment';
 import CashuPayment from '../models/CashuPayment';
+import CashuInvoice from '../models/CashuInvoice';
 
 import Base64Utils from './Base64Utils';
 import { localeString } from './LocaleUtils';
@@ -611,13 +612,47 @@ export default class NostrConnectUtils {
         return hash.includes('=') ? Base64Utils.base64ToHex(hash) : hash;
     }
 
+    /** Wrap a persisted plain-object invoice as an Invoice when needed. */
+    static coerceLightningInvoice(
+        invoice: Invoice | CashuInvoice | null | undefined
+    ): Invoice | undefined {
+        if (!invoice) return undefined;
+        if (invoice instanceof Invoice) return invoice;
+        if (invoice instanceof CashuInvoice) return undefined;
+        return new Invoice(invoice as any);
+    }
+
+    /** Resolve a lookup hash from payment_hash and/or invoice on the request. */
+    static async resolveLookupPaymentHash(
+        request: Nip47LookupInvoiceRequest,
+        paymentRequest?: string
+    ): Promise<string | undefined> {
+        const fromRequest = NostrConnectUtils.normalizePaymentHash(
+            request.payment_hash
+        );
+        if (fromRequest) return fromRequest;
+
+        const invoice = request.invoice || paymentRequest;
+        if (!invoice) return undefined;
+
+        try {
+            const decoded = await NostrConnectUtils.decodeInvoiceTags(invoice);
+            return decoded.paymentHash || undefined;
+        } catch {
+            return undefined;
+        }
+    }
+
     /** Whether a BOLT11 string matches a NIP-47 lookup request (invoice or hash). */
     static async paymentRequestMatchesLookupRequest(
         paymentRequest: string,
         request: Nip47LookupInvoiceRequest,
         normalizedHash?: string
     ): Promise<boolean> {
-        if (request.invoice && paymentRequest === request.invoice) {
+        if (
+            request.invoice &&
+            paymentRequest.toLowerCase() === request.invoice.toLowerCase()
+        ) {
             return true;
         }
         const hash =
@@ -651,8 +686,8 @@ export default class NostrConnectUtils {
         activities: ConnectionActivity[],
         request: Nip47LookupInvoiceRequest
     ): Promise<ConnectionActivity | undefined> {
-        const normalizedHash = NostrConnectUtils.normalizePaymentHash(
-            request.payment_hash
+        const normalizedHash = await NostrConnectUtils.resolveLookupPaymentHash(
+            request
         );
         for (const activity of activities) {
             if (
@@ -681,8 +716,11 @@ export default class NostrConnectUtils {
             activity.payment?.getPaymentRequest;
 
         if (request.invoice) {
-            if (activity.id === request.invoice) return true;
-            if (paymentRequest === request.invoice) return true;
+            const requestInvoiceLower = request.invoice.toLowerCase();
+            if (activity.id.toLowerCase() === requestInvoiceLower) return true;
+            if (paymentRequest?.toLowerCase() === requestInvoiceLower) {
+                return true;
+            }
             if (
                 paymentRequest &&
                 (await NostrConnectUtils.paymentRequestMatchesLookupRequest(
@@ -1163,12 +1201,15 @@ export default class NostrConnectUtils {
         }
 
         if (activity.invoice) {
-            if (activity.invoice instanceof Invoice) {
+            const lightningInvoice = NostrConnectUtils.coerceLightningInvoice(
+                activity.invoice
+            );
+            if (lightningInvoice) {
                 const createdAt = Math.floor(
-                    activity.invoice.getCreationDate.getTime() / 1000
+                    lightningInvoice.getCreationDate.getTime() / 1000
                 );
                 return NostrConnectUtils.lightningInvoiceExpiresAt(
-                    activity.invoice,
+                    lightningInvoice,
                     createdAt
                 );
             }
@@ -1263,7 +1304,9 @@ export default class NostrConnectUtils {
             : 0;
 
         const lightningInvoice =
-            activity.invoice instanceof Invoice ? activity.invoice : undefined;
+            activity.payment_source === 'cashu'
+                ? undefined
+                : NostrConnectUtils.coerceLightningInvoice(activity.invoice);
 
         const description =
             activity.invoice?.getMemo || activity.payment?.getMemo || '';


### PR DESCRIPTION
# Description

Fixes a medium-severity NWC data-scoping vulnerability where read-only connections could export the full wallet history and look up arbitrary invoices by hash.

- Scope `list_transactions` to each connection’s own `activity` log for all permission tiers (removes the inverted branch that returned wallet-wide Lightning, on-chain, and Cashu history for read-only connections).
- Scope `lookup_invoice` to invoices/payments recorded in the calling connection’s activity (no more node-wide `BackendUtils.lookupInvoice` or payment-store scans).
- Remove the wallet-wide on-chain conversion path from `list_transactions` (read-only connections no longer receive on-chain history at all).
- Deduplicate Cashu `make_invoice` status refresh into `reconcilePendingCashuMakeInvoice`, shared by activity refresh and `lookup_invoice` polling.
- Restore preimage/description_hash on activity-scoped `lookup_invoice` via shape-tolerant invoice coercion and persisted `activity.preimage` after reconcile.

Connection expiry and missing-connection rejection (`withGlobalHandler` → `RESTRICTED` / `UNAUTHORIZED`, orphaned subscription cleanup) landed on master in #4360; this branch inherits that behavior and does not duplicate it.

## Security impact

**Before:** A read-only NWC connection string (`get_info`, `get_balance`, `lookup_invoice`, `list_transactions`) could:
- Receive the wallet’s complete Lightning payment/invoice history, all on-chain transactions (including destination addresses and raw tx hex), and full Cashu history via `list_transactions`.
- Resolve any payment hash or invoice created outside NWC via `lookup_invoice`.

**After:** Each connection only sees and can look up records it owns (its `activity` log). Read-only connections with no activity get an empty history and `NOT_FOUND` on foreign hashes.

## Test plan

- [x] `yarn test`
- [ ] Read-only `list_transactions` returns only connection activity and does not call wallet stores
- [ ] `lookup_invoice` returns `NOT_FOUND` for wallet-only hashes
- [ ] `lookup_invoice` succeeds for hashes in connection activity
- [ ] Expired/missing connections are rejected and unsubscribed
- [ ] Manual: connect a read-only NWC client and confirm it cannot enumerate wallet history or probe arbitrary invoice hashes
- [ ] Manual: confirm paying/invoice-creating connections still see their own activity via `list_transactions` and `lookup_invoice`



This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
