### PR TITLE
fix(ldk): real UTXO confirmations in coin control, anchor reserve no longer shown as pending

### DIFF
--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -259,12 +259,20 @@ export default class LdkNode {
      */
     getBlockchainBalance = async (): Promise<any> => {
         const balances = await LdkNodeInjection.node.listBalances();
+        // spendableOnchainBalanceSats excludes the anchor channel reserve,
+        // which is confirmed but held back - it must not be counted as
+        // unconfirmed or the balance shows as pending forever
+        const anchorReserve = balances.totalAnchorChannelsReserveSats || 0;
+        let unconfirmed = new BigNumber(balances.totalOnchainBalanceSats)
+            .minus(balances.spendableOnchainBalanceSats)
+            .minus(anchorReserve);
+        if (unconfirmed.lt(0)) unconfirmed = new BigNumber(0);
         return {
             total_balance: balances.totalOnchainBalanceSats.toString(),
-            confirmed_balance: balances.spendableOnchainBalanceSats.toString(),
-            unconfirmed_balance: new BigNumber(balances.totalOnchainBalanceSats)
-                .minus(balances.spendableOnchainBalanceSats)
-                .toString()
+            confirmed_balance: new BigNumber(balances.totalOnchainBalanceSats)
+                .minus(unconfirmed)
+                .toString(),
+            unconfirmed_balance: unconfirmed.toString()
         };
     };
 

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -1090,17 +1090,45 @@ export default class LdkNode {
      * Get UTXOs for coin control
      */
     getUTXOs = async (): Promise<any> => {
-        const utxos = await LdkNodeInjection.onchain.listUtxos();
+        const [utxos, payments, status] = await Promise.all([
+            LdkNodeInjection.onchain.listUtxos(),
+            LdkNodeInjection.payments.listPayments(),
+            LdkNodeInjection.node.status()
+        ]);
+        const bestBlockHeight = status.currentBestBlock_height;
+
+        // WalletUtxo carries no confirmation height, so look it up from
+        // the on-chain payment that created each UTXO
+        const confirmationHeights: { [txid: string]: number } = {};
+        for (const payment of payments) {
+            if (
+                payment.kind.type === 'onchain' &&
+                payment.kind.txid &&
+                payment.kind.confirmationHeight
+            ) {
+                confirmationHeights[payment.kind.txid] =
+                    payment.kind.confirmationHeight;
+            }
+        }
+
         return {
-            utxos: utxos.map((u) => ({
-                outpoint: {
-                    txid_str: u.txid,
-                    output_index: u.vout
-                },
-                address: u.address,
-                amount_sat: u.value_sats,
-                confirmations: u.is_spent ? '0' : '1'
-            }))
+            utxos: utxos
+                .filter((u) => !u.is_spent)
+                .map((u) => {
+                    const confirmationHeight = confirmationHeights[u.txid];
+                    const confirmations = confirmationHeight
+                        ? bestBlockHeight - confirmationHeight + 1
+                        : 0;
+                    return {
+                        outpoint: {
+                            txid_str: u.txid,
+                            output_index: u.vout
+                        },
+                        address: u.address,
+                        amount_sat: u.value_sats,
+                        confirmations: confirmations.toString()
+                    };
+                })
         };
     };
 

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -263,16 +263,40 @@ export default class LdkNode {
         // which is confirmed but held back - it must not be counted as
         // unconfirmed or the balance shows as pending forever
         const anchorReserve = balances.totalAnchorChannelsReserveSats || 0;
-        let unconfirmed = new BigNumber(balances.totalOnchainBalanceSats)
-            .minus(balances.spendableOnchainBalanceSats)
-            .minus(anchorReserve);
-        if (unconfirmed.lt(0)) unconfirmed = new BigNumber(0);
+        const total = new BigNumber(balances.totalOnchainBalanceSats);
+
+        let confirmed: BigNumber;
+        if (balances.spendableOnchainBalanceSats > 0) {
+            // spendable is the trusted balance minus the reserve, so adding
+            // the reserve back recovers the confirmed balance exactly
+            confirmed = BigNumber.min(
+                new BigNumber(balances.spendableOnchainBalanceSats).plus(
+                    anchorReserve
+                ),
+                total
+            );
+        } else if (total.isZero()) {
+            confirmed = new BigNumber(0);
+        } else {
+            // spendable saturates at 0 once the trusted balance falls below
+            // the reserve (e.g. right after a fund-max channel open), which
+            // makes confirmed unrecoverable from the aggregate balances -
+            // sum confirmed UTXOs directly instead
+            const utxos = await this.listUnspentWithConfirmations();
+            confirmed = BigNumber.min(
+                utxos.reduce(
+                    (sum, u) =>
+                        u.confirmations > 0 ? sum.plus(u.value_sats) : sum,
+                    new BigNumber(0)
+                ),
+                total
+            );
+        }
+
         return {
             total_balance: balances.totalOnchainBalanceSats.toString(),
-            confirmed_balance: new BigNumber(balances.totalOnchainBalanceSats)
-                .minus(unconfirmed)
-                .toString(),
-            unconfirmed_balance: unconfirmed.toString()
+            confirmed_balance: confirmed.toString(),
+            unconfirmed_balance: total.minus(confirmed).toString()
         };
     };
 
@@ -1095,9 +1119,11 @@ export default class LdkNode {
     };
 
     /**
-     * Get UTXOs for coin control
+     * List unspent outputs with confirmation counts. WalletUtxo carries no
+     * confirmation height, so look it up from the on-chain payment that
+     * created each UTXO; outputs whose height is unknown report 0.
      */
-    getUTXOs = async (): Promise<any> => {
+    private listUnspentWithConfirmations = async () => {
         const [utxos, payments, status] = await Promise.all([
             LdkNodeInjection.onchain.listUtxos(),
             LdkNodeInjection.payments.listPayments(),
@@ -1105,8 +1131,6 @@ export default class LdkNode {
         ]);
         const bestBlockHeight = status.currentBestBlock_height;
 
-        // WalletUtxo carries no confirmation height, so look it up from
-        // the on-chain payment that created each UTXO
         const confirmationHeights: { [txid: string]: number } = {};
         for (const payment of payments) {
             if (
@@ -1119,24 +1143,34 @@ export default class LdkNode {
             }
         }
 
-        return {
-            utxos: utxos
-                .filter((u) => !u.is_spent)
-                .map((u) => {
-                    const confirmationHeight = confirmationHeights[u.txid];
-                    const confirmations = confirmationHeight
+        return utxos
+            .filter((u) => !u.is_spent)
+            .map((u) => {
+                const confirmationHeight = confirmationHeights[u.txid];
+                return {
+                    ...u,
+                    confirmations: confirmationHeight
                         ? bestBlockHeight - confirmationHeight + 1
-                        : 0;
-                    return {
-                        outpoint: {
-                            txid_str: u.txid,
-                            output_index: u.vout
-                        },
-                        address: u.address,
-                        amount_sat: u.value_sats,
-                        confirmations: confirmations.toString()
-                    };
-                })
+                        : 0
+                };
+            });
+    };
+
+    /**
+     * Get UTXOs for coin control
+     */
+    getUTXOs = async (): Promise<any> => {
+        const utxos = await this.listUnspentWithConfirmations();
+        return {
+            utxos: utxos.map((u) => ({
+                outpoint: {
+                    txid_str: u.txid,
+                    output_index: u.vout
+                },
+                address: u.address,
+                amount_sat: u.value_sats,
+                confirmations: u.confirmations.toString()
+            }))
         };
     };
 

--- a/ldknode/LdkNode.d.ts
+++ b/ldknode/LdkNode.d.ts
@@ -166,6 +166,7 @@ export interface PendingSweepBalance {
 export interface BalanceDetails {
     totalOnchainBalanceSats: number;
     spendableOnchainBalanceSats: number;
+    totalAnchorChannelsReserveSats: number;
     totalLightningBalanceSats: number;
     lightningBalances: LightningBalance[];
     pendingBalancesFromChannelClosures: PendingSweepBalance[];


### PR DESCRIPTION
# Description

Relates to issue: **#4394**

Fixes both LDK Node display bugs reported in #4394:

**1. UTXOs always showed 1 confirmation in the Coins screen**

`getUTXOs` hardcoded `confirmations: u.is_spent ? '0' : '1'`. The underlying `WalletUtxo` type carries no confirmation height, so the real depth is now derived by joining each UTXO's txid against the on-chain payment that created it (every wallet UTXO originates from a tracked inbound receive or outbound change) and computing `bestBlockHeight - confirmationHeight + 1`. This is the same data source `formatOnchainTransaction` already uses, which is why the Activity screen was correct all along. UTXOs with no confirmed payment record show 0 confirmations, matching LND behavior for unconfirmed outputs. Spent outputs are now filtered out of coin control instead of being listed with "0 confirmations".

**2. Confirmed anchor channel reserve classified as pending forever**

`getBlockchainBalance` computed `unconfirmed = total - spendable`, but ldk-node's `spendableOnchainBalanceSats` excludes `totalAnchorChannelsReserveSats`. Once an anchor channel is open, the fully confirmed reserve was permanently reported as unconfirmed, so the wallet balance showed the pending clock indefinitely. The reserve (already forwarded by both native bridges, it was just missing from the TS interface) is now subtracted when deriving unconfirmed and folded into confirmed. This matches LND semantics, where `confirmed_balance` includes the anchor reserve. If the reserve is temporarily backed by unconfirmed funds, unconfirmed is clamped at 0 rather than going negative.

No native code changes; both fixes are in the JS mapping layer.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Device testing pending; will update the matrix after verifying on an LDK Node wallet with an open anchor channel and aged UTXOs.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
