### PR TITLE
LSPS1/LSPS7 order screens: fix cleared amount fields re-rendering as 0 and doubled background on gradient themes

### DIFF
--- a/views/LSPS1/OrderResponse.tsx
+++ b/views/LSPS1/OrderResponse.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { inject, observer } from 'mobx-react';
-import { ScrollView, View } from 'react-native';
+import { View } from 'react-native';
 import moment from 'moment';
 import BigNumber from 'bignumber.js';
 
-import Screen from '../../components/Screen';
 import KeyValue from '../../components/KeyValue';
 import Amount from '../../components/Amount';
 import Button from '../../components/Button';
@@ -51,494 +50,439 @@ export default class LSPS1OrderResponse extends React.Component<
         // `isOrderFree` for the full definition.
         const isFreeOrder = isOrderFree(payment);
         return (
-            <Screen>
-                <ScrollView>
-                    <View style={{ paddingHorizontal: 20 }}>
-                        <ChannelItem
-                            localBalance={orderResponse?.client_balance_sat}
-                            remoteBalance={orderResponse?.lsp_balance_sat}
-                            title={localeString('views.LSPS1.yourBalance')}
-                            secondTitle={localeString(
-                                'views.LSPS1.receiveLimit'
+            <View style={{ paddingHorizontal: 20 }}>
+                <ChannelItem
+                    localBalance={orderResponse?.client_balance_sat}
+                    remoteBalance={orderResponse?.lsp_balance_sat}
+                    title={localeString('views.LSPS1.yourBalance')}
+                    secondTitle={localeString('views.LSPS1.receiveLimit')}
+                    noBorder
+                    highlightLabels
+                />
+                {orderResponse?.order_id && (
+                    <KeyValue
+                        keyValue={localeString('views.LSPS1.orderId')}
+                        value={orderResponse?.order_id}
+                    />
+                )}
+                {orderResponse?.lsp_balance_sat &&
+                    orderResponse?.client_balance_sat && (
+                        <KeyValue
+                            keyValue={localeString(
+                                'views.Channel.channelBalance'
                             )}
-                            noBorder
-                            highlightLabels
+                            value={
+                                <Amount
+                                    sats={new BigNumber(
+                                        orderResponse?.client_balance_sat
+                                    )
+                                        .plus(orderResponse?.lsp_balance_sat)
+                                        .toNumber()}
+                                    sensitive
+                                    toggleable
+                                />
+                            }
                         />
-                        {orderResponse?.order_id && (
+                    )}
+                {orderResponse?.announce_channel && (
+                    <KeyValue
+                        keyValue={localeString(
+                            'views.OpenChannel.announceChannel'
+                        )}
+                        value={
+                            orderResponse?.announce_channel
+                                ? localeString('general.true')
+                                : localeString('general.false')
+                        }
+                        color={
+                            orderResponse?.announce_channel
+                                ? 'green'
+                                : '#808000'
+                        }
+                    />
+                )}
+                {orderResponse?.channel_expiry_blocks && (
+                    <KeyValue
+                        keyValue={localeString(
+                            'views.LSPS1.channelExpiryBlocks'
+                        )}
+                        value={numberWithCommas(
+                            orderResponse?.channel_expiry_blocks
+                        )}
+                    />
+                )}
+
+                {orderResponse?.funding_confirms_within_blocks && (
+                    <KeyValue
+                        keyValue={localeString(
+                            'views.LSPS1.confirmWithinBlocks'
+                        )}
+                        value={orderResponse?.funding_confirms_within_blocks}
+                    />
+                )}
+                {orderResponse?.order_state && (
+                    <KeyValue
+                        keyValue={localeString('views.LSPS1.orderState')}
+                        value={orderResponse?.order_state}
+                        color={
+                            orderResponse?.order_state === LSPOrderState.CREATED
+                                ? 'orange'
+                                : orderResponse?.order_state ===
+                                  LSPOrderState.COMPLETED
+                                ? 'green'
+                                : orderResponse?.order_state ===
+                                  LSPOrderState.FAILED
+                                ? 'red'
+                                : ''
+                        }
+                    />
+                )}
+                {orderResponse?.created_at && (
+                    <KeyValue
+                        keyValue={localeString('general.createdAt')}
+                        value={moment(orderResponse?.created_at).format(
+                            'MMM Do YYYY, h:mm:ss a'
+                        )}
+                    />
+                )}
+                {orderResponse?.expires_at && (
+                    <KeyValue
+                        keyValue={localeString('general.expiresAt')}
+                        value={moment(orderResponse?.expires_at).format(
+                            'MMM Do YYYY, h:mm:ss a'
+                        )}
+                    />
+                )}
+                {/* Legacy format */}
+                {payment && !payment.bolt11 && !payment.onchain && (
+                    <>
+                        {!isFreeOrder && (
                             <KeyValue
-                                keyValue={localeString('views.LSPS1.orderId')}
-                                value={orderResponse?.order_id}
+                                keyValue={localeString('views.Payment.title')}
                             />
                         )}
-                        {orderResponse?.lsp_balance_sat &&
-                            orderResponse?.client_balance_sat && (
+                        {payment?.state && (
+                            <KeyValue
+                                keyValue={localeString('general.state')}
+                                value={payment?.state}
+                            />
+                        )}
+                        {payment?.order_total_sat && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.LSPS1.orderTotal'
+                                )}
+                                value={
+                                    <Amount
+                                        sats={payment?.order_total_sat}
+                                        toggleable
+                                        sensitive
+                                    />
+                                }
+                            />
+                        )}
+                        {payment?.fee_total_sat && (
+                            <KeyValue
+                                keyValue={localeString('views.LSPS1.feeTotal')}
+                                value={
+                                    <Amount
+                                        sats={payment?.fee_total_sat}
+                                        sensitive
+                                        toggleable
+                                    />
+                                }
+                            />
+                        )}
+                        {(payment?.lightning_invoice ||
+                            payment?.bolt11_invoice) && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'general.lightningInvoice'
+                                )}
+                                value={
+                                    payment?.lightning_invoice ||
+                                    payment?.bolt11_invoice
+                                }
+                            />
+                        )}
+                        {payment?.min_fee_for_0conf && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.LSPS1.miniFeeFor0Conf'
+                                )}
+                                value={payment?.min_fee_for_0conf}
+                            />
+                        )}
+                        {payment?.min_onchain_payment_confirmations && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.LSPS1.minOnchainPaymentConfirmations'
+                                )}
+                                value={
+                                    payment?.min_onchain_payment_confirmations
+                                }
+                            />
+                        )}
+                        {payment?.onchain_address && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.Settings.AddContact.onchainAddress'
+                                )}
+                                value={payment?.onchain_address}
+                            />
+                        )}
+                        {payment?.onchain_payment && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.LSPS1.onchainPayment'
+                                )}
+                                value={payment?.onchain_payment}
+                            />
+                        )}
+                    </>
+                )}
+                {/* BOLT11 */}
+                {payment && payment.bolt11 && (
+                    <>
+                        <KeyValue
+                            keyValue={localeString('views.LSPS1.bolt11Payment')}
+                        />
+                        {payment?.bolt11.state && (
+                            <KeyValue
+                                keyValue={localeString('general.state')}
+                                value={payment?.bolt11.state}
+                            />
+                        )}
+                        {payment?.bolt11?.order_total_sat && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.LSPS1.orderTotal'
+                                )}
+                                value={
+                                    <Amount
+                                        sats={payment?.bolt11?.order_total_sat}
+                                        toggleable
+                                        sensitive
+                                    />
+                                }
+                            />
+                        )}
+                        {payment?.bolt11?.fee_total_sat &&
+                            payment?.bolt11?.fee_total_sat !==
+                                payment?.bolt11?.order_total_sat && (
                                 <KeyValue
                                     keyValue={localeString(
-                                        'views.Channel.channelBalance'
+                                        'views.LSPS1.feeTotal'
                                     )}
                                     value={
                                         <Amount
-                                            sats={new BigNumber(
-                                                orderResponse?.client_balance_sat
-                                            )
-                                                .plus(
-                                                    orderResponse?.lsp_balance_sat
-                                                )
-                                                .toNumber()}
+                                            sats={
+                                                payment?.bolt11?.fee_total_sat
+                                            }
                                             sensitive
                                             toggleable
                                         />
                                     }
                                 />
                             )}
-                        {orderResponse?.announce_channel && (
-                            <KeyValue
-                                keyValue={localeString(
-                                    'views.OpenChannel.announceChannel'
-                                )}
-                                value={
-                                    orderResponse?.announce_channel
-                                        ? localeString('general.true')
-                                        : localeString('general.false')
-                                }
-                                color={
-                                    orderResponse?.announce_channel
-                                        ? 'green'
-                                        : '#808000'
-                                }
-                            />
-                        )}
-                        {orderResponse?.channel_expiry_blocks && (
-                            <KeyValue
-                                keyValue={localeString(
-                                    'views.LSPS1.channelExpiryBlocks'
-                                )}
-                                value={numberWithCommas(
-                                    orderResponse?.channel_expiry_blocks
-                                )}
-                            />
-                        )}
-
-                        {orderResponse?.funding_confirms_within_blocks && (
-                            <KeyValue
-                                keyValue={localeString(
-                                    'views.LSPS1.confirmWithinBlocks'
-                                )}
-                                value={
-                                    orderResponse?.funding_confirms_within_blocks
-                                }
-                            />
-                        )}
-                        {orderResponse?.order_state && (
-                            <KeyValue
-                                keyValue={localeString(
-                                    'views.LSPS1.orderState'
-                                )}
-                                value={orderResponse?.order_state}
-                                color={
-                                    orderResponse?.order_state ===
-                                    LSPOrderState.CREATED
-                                        ? 'orange'
-                                        : orderResponse?.order_state ===
-                                          LSPOrderState.COMPLETED
-                                        ? 'green'
-                                        : orderResponse?.order_state ===
-                                          LSPOrderState.FAILED
-                                        ? 'red'
-                                        : ''
-                                }
-                            />
-                        )}
-                        {orderResponse?.created_at && (
-                            <KeyValue
-                                keyValue={localeString('general.createdAt')}
-                                value={moment(orderResponse?.created_at).format(
-                                    'MMM Do YYYY, h:mm:ss a'
-                                )}
-                            />
-                        )}
-                        {orderResponse?.expires_at && (
+                        {payment?.bolt11.expires_at && (
                             <KeyValue
                                 keyValue={localeString('general.expiresAt')}
-                                value={moment(orderResponse?.expires_at).format(
-                                    'MMM Do YYYY, h:mm:ss a'
-                                )}
+                                value={moment(
+                                    payment?.bolt11.expires_at
+                                ).format('MMM Do YYYY, h:mm:ss a')}
                             />
                         )}
-                        {/* Legacy format */}
-                        {payment && !payment.bolt11 && !payment.onchain && (
-                            <>
-                                {!isFreeOrder && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.Payment.title'
-                                        )}
-                                    />
-                                )}
-                                {payment?.state && (
-                                    <KeyValue
-                                        keyValue={localeString('general.state')}
-                                        value={payment?.state}
-                                    />
-                                )}
-                                {payment?.order_total_sat && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.orderTotal'
-                                        )}
-                                        value={
-                                            <Amount
-                                                sats={payment?.order_total_sat}
-                                                toggleable
-                                                sensitive
-                                            />
-                                        }
-                                    />
-                                )}
-                                {payment?.fee_total_sat && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.feeTotal'
-                                        )}
-                                        value={
-                                            <Amount
-                                                sats={payment?.fee_total_sat}
-                                                sensitive
-                                                toggleable
-                                            />
-                                        }
-                                    />
-                                )}
-                                {(payment?.lightning_invoice ||
-                                    payment?.bolt11_invoice) && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'general.lightningInvoice'
-                                        )}
-                                        value={
-                                            payment?.lightning_invoice ||
-                                            payment?.bolt11_invoice
-                                        }
-                                    />
-                                )}
-                                {payment?.min_fee_for_0conf && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.miniFeeFor0Conf'
-                                        )}
-                                        value={payment?.min_fee_for_0conf}
-                                    />
-                                )}
-                                {payment?.min_onchain_payment_confirmations && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.minOnchainPaymentConfirmations'
-                                        )}
-                                        value={
-                                            payment?.min_onchain_payment_confirmations
-                                        }
-                                    />
-                                )}
-                                {payment?.onchain_address && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.Settings.AddContact.onchainAddress'
-                                        )}
-                                        value={payment?.onchain_address}
-                                    />
-                                )}
-                                {payment?.onchain_payment && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.onchainPayment'
-                                        )}
-                                        value={payment?.onchain_payment}
-                                    />
-                                )}
-                            </>
+                        {payment?.bolt11.invoice && (
+                            <KeyValue
+                                keyValue={localeString('views.Invoice.title')}
+                                value={payment?.bolt11.invoice}
+                            />
                         )}
-                        {/* BOLT11 */}
-                        {payment && payment.bolt11 && (
-                            <>
-                                <KeyValue
-                                    keyValue={localeString(
-                                        'views.LSPS1.bolt11Payment'
-                                    )}
-                                />
-                                {payment?.bolt11.state && (
-                                    <KeyValue
-                                        keyValue={localeString('general.state')}
-                                        value={payment?.bolt11.state}
-                                    />
-                                )}
-                                {payment?.bolt11?.order_total_sat && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.orderTotal'
-                                        )}
-                                        value={
-                                            <Amount
-                                                sats={
-                                                    payment?.bolt11
-                                                        ?.order_total_sat
-                                                }
-                                                toggleable
-                                                sensitive
-                                            />
-                                        }
-                                    />
-                                )}
-                                {payment?.bolt11?.fee_total_sat &&
-                                    payment?.bolt11?.fee_total_sat !==
-                                        payment?.bolt11?.order_total_sat && (
-                                        <KeyValue
-                                            keyValue={localeString(
-                                                'views.LSPS1.feeTotal'
-                                            )}
-                                            value={
-                                                <Amount
-                                                    sats={
-                                                        payment?.bolt11
-                                                            ?.fee_total_sat
-                                                    }
-                                                    sensitive
-                                                    toggleable
-                                                />
-                                            }
-                                        />
-                                    )}
-                                {payment?.bolt11.expires_at && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'general.expiresAt'
-                                        )}
-                                        value={moment(
-                                            payment?.bolt11.expires_at
-                                        ).format('MMM Do YYYY, h:mm:ss a')}
-                                    />
-                                )}
-                                {payment?.bolt11.invoice && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.Invoice.title'
-                                        )}
-                                        value={payment?.bolt11.invoice}
-                                    />
-                                )}
-                            </>
-                        )}
-                        {/* On-chain */}
-                        {payment && payment.onchain && (
-                            <>
-                                <KeyValue
-                                    keyValue={localeString(
-                                        'views.LSPS1.onchainPayment'
-                                    )}
-                                />
-                                {payment?.onchain.fee_total_sat && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.Transaction.totalFees'
-                                        )}
-                                        value={
-                                            <Amount
-                                                sats={
-                                                    payment?.onchain
-                                                        .fee_total_sat
-                                                }
-                                                sensitive
-                                                toggleable
-                                            />
-                                        }
-                                    />
-                                )}
-                                {payment?.onchain.order_total_sat && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.totalOrderValue'
-                                        )}
-                                        value={
-                                            <Amount
-                                                sats={
-                                                    payment?.onchain
-                                                        .order_total_sat
-                                                }
-                                                toggleable
-                                                sensitive
-                                            />
-                                        }
-                                    />
-                                )}
-                                {payment?.onchain.expires_at && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'general.expiresAt'
-                                        )}
-                                        value={moment(
-                                            payment?.onchain.expires_at
-                                        ).format('MMM Do YYYY, h:mm:ss a')}
-                                    />
-                                )}
-                                {payment?.onchain.address && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'general.address'
-                                        )}
-                                        value={payment?.onchain.address}
-                                    />
-                                )}
-                                {payment?.onchain.min_fee_for_0conf && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.miniFeeFor0Conf'
-                                        )}
-                                        value={
-                                            payment?.onchain.min_fee_for_0conf
-                                        }
-                                    />
-                                )}
-                                {payment?.onchain
-                                    .min_onchain_payment_confirmations && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.minOnchainPaymentConfirmations'
-                                        )}
-                                        value={
-                                            payment?.onchain
-                                                .min_onchain_payment_confirmations
-                                        }
-                                    />
-                                )}
-                            </>
-                        )}
-                        {channel && (
-                            <>
-                                <KeyValue
-                                    keyValue={localeString(
-                                        'views.Channel.title'
-                                    )}
-                                />
-                                <KeyValue
-                                    keyValue={localeString(
-                                        'views.LSPS1.fundingOutpoint'
-                                    )}
-                                    value={channel?.funding_outpoint}
-                                    sensitive
-                                    color={themeColor('highlight')}
-                                    mempoolLink={() =>
-                                        UrlUtils.goToBlockExplorerTXID(
-                                            channel?.funding_outpoint,
-                                            testnet
-                                        )
-                                    }
-                                />
-                                <KeyValue
-                                    keyValue={localeString(
-                                        'views.LSPS1.fundedAt'
-                                    )}
-                                    value={moment(channel?.funded_at).format(
-                                        'MMM Do YYYY, h:mm:ss a'
-                                    )}
-                                />
-                                <KeyValue
-                                    keyValue={localeString('general.expiresAt')}
-                                    value={moment(channel?.expires_at).format(
-                                        'MMM Do YYYY, h:mm:ss a'
-                                    )}
-                                />
-                            </>
-                        )}
-                        {orderResponse?.order_state === LSPOrderState.CREATED &&
-                            isFreeOrder && (
-                                <SuccessMessage
-                                    message={localeString(
-                                        'views.LSPS1.freeChannel'
-                                    )}
-                                />
+                    </>
+                )}
+                {/* On-chain */}
+                {payment && payment.onchain && (
+                    <>
+                        <KeyValue
+                            keyValue={localeString(
+                                'views.LSPS1.onchainPayment'
                             )}
-                        {orderResponse?.order_state ===
-                            LSPOrderState.FAILED && (
-                            <ErrorMessage
-                                message={localeString(
-                                    'views.LSPS1.channelOpenFailed'
+                        />
+                        {payment?.onchain.fee_total_sat && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.Transaction.totalFees'
                                 )}
+                                value={
+                                    <Amount
+                                        sats={payment?.onchain.fee_total_sat}
+                                        sensitive
+                                        toggleable
+                                    />
+                                }
                             />
                         )}
-                        {orderResponse?.order_state === LSPOrderState.CREATED &&
-                            orderView &&
-                            !isFreeOrder && (
+                        {payment?.onchain.order_total_sat && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.LSPS1.totalOrderValue'
+                                )}
+                                value={
+                                    <Amount
+                                        sats={payment?.onchain.order_total_sat}
+                                        toggleable
+                                        sensitive
+                                    />
+                                }
+                            />
+                        )}
+                        {payment?.onchain.expires_at && (
+                            <KeyValue
+                                keyValue={localeString('general.expiresAt')}
+                                value={moment(
+                                    payment?.onchain.expires_at
+                                ).format('MMM Do YYYY, h:mm:ss a')}
+                            />
+                        )}
+                        {payment?.onchain.address && (
+                            <KeyValue
+                                keyValue={localeString('general.address')}
+                                value={payment?.onchain.address}
+                            />
+                        )}
+                        {payment?.onchain.min_fee_for_0conf && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.LSPS1.miniFeeFor0Conf'
+                                )}
+                                value={payment?.onchain.min_fee_for_0conf}
+                            />
+                        )}
+                        {payment?.onchain.min_onchain_payment_confirmations && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.LSPS1.minOnchainPaymentConfirmations'
+                                )}
+                                value={
+                                    payment?.onchain
+                                        .min_onchain_payment_confirmations
+                                }
+                            />
+                        )}
+                    </>
+                )}
+                {channel && (
+                    <>
+                        <KeyValue
+                            keyValue={localeString('views.Channel.title')}
+                        />
+                        <KeyValue
+                            keyValue={localeString(
+                                'views.LSPS1.fundingOutpoint'
+                            )}
+                            value={channel?.funding_outpoint}
+                            sensitive
+                            color={themeColor('highlight')}
+                            mempoolLink={() =>
+                                UrlUtils.goToBlockExplorerTXID(
+                                    channel?.funding_outpoint,
+                                    testnet
+                                )
+                            }
+                        />
+                        <KeyValue
+                            keyValue={localeString('views.LSPS1.fundedAt')}
+                            value={moment(channel?.funded_at).format(
+                                'MMM Do YYYY, h:mm:ss a'
+                            )}
+                        />
+                        <KeyValue
+                            keyValue={localeString('general.expiresAt')}
+                            value={moment(channel?.expires_at).format(
+                                'MMM Do YYYY, h:mm:ss a'
+                            )}
+                        />
+                    </>
+                )}
+                {orderResponse?.order_state === LSPOrderState.CREATED &&
+                    isFreeOrder && (
+                        <SuccessMessage
+                            message={localeString('views.LSPS1.freeChannel')}
+                        />
+                    )}
+                {orderResponse?.order_state === LSPOrderState.FAILED && (
+                    <ErrorMessage
+                        message={localeString('views.LSPS1.channelOpenFailed')}
+                    />
+                )}
+                {orderResponse?.order_state === LSPOrderState.CREATED &&
+                    orderView &&
+                    !isFreeOrder && (
+                        <>
+                            {(payment.bolt11?.invoice ||
+                                payment.lightning_invoice ||
+                                payment.bolt11_invoice) && (
                                 <>
-                                    {(payment.bolt11?.invoice ||
-                                        payment.lightning_invoice ||
-                                        payment.bolt11_invoice) && (
-                                        <>
-                                            <Button
-                                                title={
-                                                    payment.onchain
-                                                        ? localeString(
-                                                              'views.LSPS1.makePaymentLN'
-                                                          )
-                                                        : localeString(
-                                                              'views.LSPS1.makePayment'
-                                                          )
-                                                }
-                                                containerStyle={{
-                                                    paddingVertical: 20
-                                                }}
-                                                onPress={() => {
-                                                    navigation.navigate(
-                                                        'LSPS1PaymentAwait',
-                                                        buildPaymentAwaitParams(
-                                                            payment,
-                                                            orderResponse?.order_id,
-                                                            LSPService.LSPS1
-                                                        )
-                                                    );
-                                                }}
-                                            />
-                                        </>
-                                    )}
-                                    {payment.onchain?.address &&
-                                        payment.onchain?.fee_total_sat && (
-                                            <>
-                                                <Button
-                                                    title={
-                                                        payment.bolt11
-                                                            ? localeString(
-                                                                  'views.LSPS1.makePaymentOnchain'
-                                                              )
-                                                            : localeString(
-                                                                  'views.LSPS1.makePayment'
-                                                              )
-                                                    }
-                                                    containerStyle={{
-                                                        paddingVertical: 20
-                                                    }}
-                                                    onPress={() => {
-                                                        navigation.navigate(
-                                                            'Send',
-                                                            {
-                                                                destination:
-                                                                    payment
-                                                                        .onchain
-                                                                        ?.address,
-                                                                satAmount:
-                                                                    payment
-                                                                        .onchain
-                                                                        ?.fee_total_sat,
-                                                                transactionType:
-                                                                    'On-chain'
-                                                            }
-                                                        );
-                                                    }}
-                                                />
-                                            </>
-                                        )}
+                                    <Button
+                                        title={
+                                            payment.onchain
+                                                ? localeString(
+                                                      'views.LSPS1.makePaymentLN'
+                                                  )
+                                                : localeString(
+                                                      'views.LSPS1.makePayment'
+                                                  )
+                                        }
+                                        containerStyle={{
+                                            paddingVertical: 20
+                                        }}
+                                        onPress={() => {
+                                            navigation.navigate(
+                                                'LSPS1PaymentAwait',
+                                                buildPaymentAwaitParams(
+                                                    payment,
+                                                    orderResponse?.order_id,
+                                                    LSPService.LSPS1
+                                                )
+                                            );
+                                        }}
+                                    />
                                 </>
                             )}
-                    </View>
-                </ScrollView>
-            </Screen>
+                            {payment.onchain?.address &&
+                                payment.onchain?.fee_total_sat && (
+                                    <>
+                                        <Button
+                                            title={
+                                                payment.bolt11
+                                                    ? localeString(
+                                                          'views.LSPS1.makePaymentOnchain'
+                                                      )
+                                                    : localeString(
+                                                          'views.LSPS1.makePayment'
+                                                      )
+                                            }
+                                            containerStyle={{
+                                                paddingVertical: 20
+                                            }}
+                                            onPress={() => {
+                                                navigation.navigate('Send', {
+                                                    destination:
+                                                        payment.onchain
+                                                            ?.address,
+                                                    satAmount:
+                                                        payment.onchain
+                                                            ?.fee_total_sat,
+                                                    transactionType: 'On-chain'
+                                                });
+                                            }}
+                                        />
+                                    </>
+                                )}
+                        </>
+                    )}
+            </View>
         );
     }
 }

--- a/views/LSPS1/index.tsx
+++ b/views/LSPS1/index.tsx
@@ -747,7 +747,13 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                         placeholder={`${localeString(
                                             'views.LSPS1.initialLSPBalance'
                                         )} (${localeString('general.sats')})`}
-                                        value={numberWithCommas(lspBalanceSat)}
+                                        value={
+                                            lspBalanceSat === ''
+                                                ? ''
+                                                : numberWithCommas(
+                                                      lspBalanceSat
+                                                  )
+                                        }
                                         onChangeText={(text: any) => {
                                             const value = text.replace(
                                                 /,/g,
@@ -830,9 +836,13 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                             placeholder={localeString(
                                                 'views.LSPS1.channelExpiryBlocks'
                                             )}
-                                            value={numberWithCommas(
-                                                channelExpiryBlocks
-                                            )}
+                                            value={
+                                                channelExpiryBlocks === ''
+                                                    ? ''
+                                                    : numberWithCommas(
+                                                          channelExpiryBlocks
+                                                      )
+                                            }
                                             onChangeText={(text: any) => {
                                                 let newValue: string | number =
                                                     parseInt(
@@ -921,9 +931,14 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                                         )} (${localeString(
                                                             'general.sats'
                                                         )})`}
-                                                        value={numberWithCommas(
-                                                            clientBalanceSat
-                                                        ).toString()}
+                                                        value={
+                                                            clientBalanceSat ===
+                                                            ''
+                                                                ? ''
+                                                                : numberWithCommas(
+                                                                      clientBalanceSat
+                                                                  )
+                                                        }
                                                         onChangeText={(
                                                             text: any
                                                         ) => {

--- a/views/LSPS7/OrderResponse.tsx
+++ b/views/LSPS7/OrderResponse.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { ScrollView, View } from 'react-native';
+import { View } from 'react-native';
 import moment from 'moment';
 
-import Screen from '../../components/Screen';
 import KeyValue from '../../components/KeyValue';
 import Amount from '../../components/Amount';
 import Button from '../../components/Button';
@@ -40,377 +39,331 @@ export default class LSPS7OrderResponse extends React.Component<
         const isFreeOrder = isOrderFree(payment);
 
         return (
-            <Screen>
-                <ScrollView>
-                    <View style={{ paddingHorizontal: 20 }}>
-                        {orderResponse?.order_id && (
-                            <KeyValue
-                                keyValue={localeString('views.LSPS1.orderId')}
-                                value={orderResponse?.order_id}
-                            />
-                        )}
+            <View style={{ paddingHorizontal: 20 }}>
+                {orderResponse?.order_id && (
+                    <KeyValue
+                        keyValue={localeString('views.LSPS1.orderId')}
+                        value={orderResponse?.order_id}
+                    />
+                )}
 
-                        {orderResponse?.channel_extension_expiry_blocks && (
+                {orderResponse?.channel_extension_expiry_blocks && (
+                    <KeyValue
+                        keyValue={localeString(
+                            'views.LSPS7.channelExtensionBlocks'
+                        )}
+                        value={numberWithCommas(
+                            orderResponse.channel_extension_expiry_blocks
+                        )}
+                    />
+                )}
+
+                {orderResponse?.new_channel_expiry_block && (
+                    <KeyValue
+                        keyValue={localeString(
+                            'views.LSPS7.proposedExpirationBlock'
+                        )}
+                        value={numberWithCommas(
+                            orderResponse.new_channel_expiry_block
+                        )}
+                    />
+                )}
+                {orderResponse?.order_state && (
+                    <KeyValue
+                        keyValue={localeString('views.LSPS1.orderState')}
+                        value={orderResponse?.order_state}
+                        color={
+                            orderResponse?.order_state === LSPOrderState.CREATED
+                                ? 'orange'
+                                : orderResponse?.order_state ===
+                                  LSPOrderState.COMPLETED
+                                ? 'green'
+                                : orderResponse?.order_state ===
+                                  LSPOrderState.FAILED
+                                ? 'red'
+                                : ''
+                        }
+                    />
+                )}
+                {orderResponse?.created_at && (
+                    <KeyValue
+                        keyValue={localeString('general.createdAt')}
+                        value={moment(orderResponse?.created_at).format(
+                            'MMM Do YYYY, h:mm:ss a'
+                        )}
+                    />
+                )}
+                {channel && (
+                    <>
+                        <KeyValue
+                            keyValue={localeString('views.Channel.title')}
+                        />
+                        <KeyValue
+                            keyValue={localeString('views.Channel.scid')}
+                            value={channel.short_channel_id}
+                        />
+                        <KeyValue
+                            keyValue={localeString(
+                                'views.LSPS7.maxChannelExtensionExpiryBlocks'
+                            )}
+                            value={numberWithCommas(
+                                channel.max_channel_extension_expiry_blocks
+                            )}
+                        />
+                        {channel.expiration_block !== 0 && (
                             <KeyValue
                                 keyValue={localeString(
-                                    'views.LSPS7.channelExtensionBlocks'
+                                    'views.LSPS7.expirationBlock'
                                 )}
                                 value={numberWithCommas(
-                                    orderResponse.channel_extension_expiry_blocks
+                                    channel.expiration_block
                                 )}
                             />
                         )}
-
-                        {orderResponse?.new_channel_expiry_block && (
+                        {channel.original_order && (
+                            <>
+                                <KeyValue
+                                    keyValue={localeString(
+                                        'views.LSPS7.originalOrderId'
+                                    )}
+                                    value={channel.original_order.id}
+                                />
+                                <KeyValue
+                                    keyValue={localeString(
+                                        'views.LSPS7.originalService'
+                                    )}
+                                    value={channel.original_order.service}
+                                />
+                            </>
+                        )}
+                        {channel.extension_order_ids &&
+                            channel.extension_order_ids.length !== 0 && (
+                                <KeyValue
+                                    keyValue={localeString(
+                                        'views.LSPS7.extensionOrderIds'
+                                    )}
+                                    value={channel.extension_order_ids.join(
+                                        ', '
+                                    )}
+                                />
+                            )}
+                    </>
+                )}
+                {/* BOLT11 */}
+                {payment && payment.bolt11 && (
+                    <>
+                        {!isFreeOrder && (
                             <KeyValue
                                 keyValue={localeString(
-                                    'views.LSPS7.proposedExpirationBlock'
-                                )}
-                                value={numberWithCommas(
-                                    orderResponse.new_channel_expiry_block
+                                    'views.LSPS1.bolt11Payment'
                                 )}
                             />
                         )}
-                        {orderResponse?.order_state && (
+                        {payment?.bolt11.state && (
+                            <KeyValue
+                                keyValue={localeString('general.state')}
+                                value={payment?.bolt11.state}
+                            />
+                        )}
+                        {payment?.bolt11?.order_total_sat && (
                             <KeyValue
                                 keyValue={localeString(
-                                    'views.LSPS1.orderState'
+                                    'views.LSPS1.orderTotal'
                                 )}
-                                value={orderResponse?.order_state}
-                                color={
-                                    orderResponse?.order_state ===
-                                    LSPOrderState.CREATED
-                                        ? 'orange'
-                                        : orderResponse?.order_state ===
-                                          LSPOrderState.COMPLETED
-                                        ? 'green'
-                                        : orderResponse?.order_state ===
-                                          LSPOrderState.FAILED
-                                        ? 'red'
-                                        : ''
+                                value={
+                                    <Amount
+                                        sats={payment?.bolt11?.order_total_sat}
+                                        toggleable
+                                        sensitive
+                                    />
                                 }
                             />
                         )}
-                        {orderResponse?.created_at && (
+                        {payment?.bolt11?.fee_total_sat &&
+                            payment?.bolt11?.fee_total_sat !==
+                                payment?.bolt11?.order_total_sat && (
+                                <KeyValue
+                                    keyValue={localeString(
+                                        'views.LSPS1.feeTotal'
+                                    )}
+                                    value={
+                                        <Amount
+                                            sats={
+                                                payment?.bolt11?.fee_total_sat
+                                            }
+                                            sensitive
+                                            toggleable
+                                        />
+                                    }
+                                />
+                            )}
+                        {payment?.bolt11.expires_at && (
                             <KeyValue
-                                keyValue={localeString('general.createdAt')}
-                                value={moment(orderResponse?.created_at).format(
-                                    'MMM Do YYYY, h:mm:ss a'
+                                keyValue={localeString('general.expiresAt')}
+                                value={moment(
+                                    payment?.bolt11.expires_at
+                                ).format('MMM Do YYYY, h:mm:ss a')}
+                            />
+                        )}
+                        {payment?.bolt11.invoice && (
+                            <KeyValue
+                                keyValue={localeString('views.Invoice.title')}
+                                value={payment?.bolt11.invoice}
+                            />
+                        )}
+                    </>
+                )}
+                {/* On-chain */}
+                {payment && payment.onchain && (
+                    <>
+                        {!isFreeOrder && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.LSPS1.onchainPayment'
                                 )}
                             />
                         )}
-                        {channel && (
-                            <>
-                                <KeyValue
-                                    keyValue={localeString(
-                                        'views.Channel.title'
-                                    )}
-                                />
-                                <KeyValue
-                                    keyValue={localeString(
-                                        'views.Channel.scid'
-                                    )}
-                                    value={channel.short_channel_id}
-                                />
-                                <KeyValue
-                                    keyValue={localeString(
-                                        'views.LSPS7.maxChannelExtensionExpiryBlocks'
-                                    )}
-                                    value={numberWithCommas(
-                                        channel.max_channel_extension_expiry_blocks
-                                    )}
-                                />
-                                {channel.expiration_block !== 0 && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS7.expirationBlock'
-                                        )}
-                                        value={numberWithCommas(
-                                            channel.expiration_block
-                                        )}
-                                    />
+                        {payment?.onchain.fee_total_sat && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.Transaction.totalFees'
                                 )}
-                                {channel.original_order && (
+                                value={
+                                    <Amount
+                                        sats={payment?.onchain.fee_total_sat}
+                                        sensitive
+                                        toggleable
+                                    />
+                                }
+                            />
+                        )}
+                        {payment?.onchain.order_total_sat && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.LSPS1.totalOrderValue'
+                                )}
+                                value={
+                                    <Amount
+                                        sats={payment?.onchain.order_total_sat}
+                                        toggleable
+                                        sensitive
+                                    />
+                                }
+                            />
+                        )}
+                        {payment?.onchain.expires_at && (
+                            <KeyValue
+                                keyValue={localeString('general.expiresAt')}
+                                value={moment(
+                                    payment?.onchain.expires_at
+                                ).format('MMM Do YYYY, h:mm:ss a')}
+                            />
+                        )}
+                        {payment?.onchain.address && (
+                            <KeyValue
+                                keyValue={localeString('general.address')}
+                                value={payment?.onchain.address}
+                            />
+                        )}
+                        {payment?.onchain.min_fee_for_0conf && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.LSPS1.miniFeeFor0Conf'
+                                )}
+                                value={payment?.onchain.min_fee_for_0conf}
+                            />
+                        )}
+                        {payment?.onchain.min_onchain_payment_confirmations && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.LSPS1.minOnchainPaymentConfirmations'
+                                )}
+                                value={
+                                    payment?.onchain
+                                        .min_onchain_payment_confirmations
+                                }
+                            />
+                        )}
+                    </>
+                )}
+                {orderResponse?.order_state === LSPOrderState.CREATED &&
+                    isFreeOrder && (
+                        <SuccessMessage
+                            message={localeString('views.LSPS7.freeExtension')}
+                        />
+                    )}
+                {orderResponse?.order_state === LSPOrderState.FAILED && (
+                    <ErrorMessage
+                        message={localeString('views.LSPS7.extensionFailed')}
+                    />
+                )}
+                {orderResponse?.order_state === LSPOrderState.CREATED &&
+                    orderView &&
+                    !isFreeOrder && (
+                        <>
+                            {(payment.bolt11?.invoice ||
+                                payment.lightning_invoice ||
+                                payment.bolt11_invoice) && (
+                                <>
+                                    <Button
+                                        title={
+                                            payment.onchain
+                                                ? localeString(
+                                                      'views.LSPS1.makePaymentLN'
+                                                  )
+                                                : localeString(
+                                                      'views.LSPS1.makePayment'
+                                                  )
+                                        }
+                                        containerStyle={{
+                                            paddingVertical: 20
+                                        }}
+                                        onPress={() => {
+                                            navigation.navigate(
+                                                'LSPS7PaymentAwait',
+                                                buildPaymentAwaitParams(
+                                                    payment,
+                                                    orderResponse?.order_id,
+                                                    LSPService.LSPS7
+                                                )
+                                            );
+                                        }}
+                                    />
+                                </>
+                            )}
+                            {payment.onchain?.address &&
+                                payment.onchain?.fee_total_sat && (
                                     <>
-                                        <KeyValue
-                                            keyValue={localeString(
-                                                'views.LSPS7.originalOrderId'
-                                            )}
-                                            value={channel.original_order.id}
-                                        />
-                                        <KeyValue
-                                            keyValue={localeString(
-                                                'views.LSPS7.originalService'
-                                            )}
-                                            value={
-                                                channel.original_order.service
+                                        <Button
+                                            title={
+                                                payment.bolt11
+                                                    ? localeString(
+                                                          'views.LSPS1.makePaymentOnchain'
+                                                      )
+                                                    : localeString(
+                                                          'views.LSPS1.makePayment'
+                                                      )
                                             }
+                                            containerStyle={{
+                                                paddingVertical: 20
+                                            }}
+                                            onPress={() => {
+                                                navigation.navigate('Send', {
+                                                    destination:
+                                                        payment.onchain
+                                                            ?.address,
+                                                    satAmount:
+                                                        payment.onchain
+                                                            ?.fee_total_sat,
+                                                    transactionType: 'On-chain'
+                                                });
+                                            }}
                                         />
                                     </>
                                 )}
-                                {channel.extension_order_ids &&
-                                    channel.extension_order_ids.length !==
-                                        0 && (
-                                        <KeyValue
-                                            keyValue={localeString(
-                                                'views.LSPS7.extensionOrderIds'
-                                            )}
-                                            value={channel.extension_order_ids.join(
-                                                ', '
-                                            )}
-                                        />
-                                    )}
-                            </>
-                        )}
-                        {/* BOLT11 */}
-                        {payment && payment.bolt11 && (
-                            <>
-                                {!isFreeOrder && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.bolt11Payment'
-                                        )}
-                                    />
-                                )}
-                                {payment?.bolt11.state && (
-                                    <KeyValue
-                                        keyValue={localeString('general.state')}
-                                        value={payment?.bolt11.state}
-                                    />
-                                )}
-                                {payment?.bolt11?.order_total_sat && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.orderTotal'
-                                        )}
-                                        value={
-                                            <Amount
-                                                sats={
-                                                    payment?.bolt11
-                                                        ?.order_total_sat
-                                                }
-                                                toggleable
-                                                sensitive
-                                            />
-                                        }
-                                    />
-                                )}
-                                {payment?.bolt11?.fee_total_sat &&
-                                    payment?.bolt11?.fee_total_sat !==
-                                        payment?.bolt11?.order_total_sat && (
-                                        <KeyValue
-                                            keyValue={localeString(
-                                                'views.LSPS1.feeTotal'
-                                            )}
-                                            value={
-                                                <Amount
-                                                    sats={
-                                                        payment?.bolt11
-                                                            ?.fee_total_sat
-                                                    }
-                                                    sensitive
-                                                    toggleable
-                                                />
-                                            }
-                                        />
-                                    )}
-                                {payment?.bolt11.expires_at && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'general.expiresAt'
-                                        )}
-                                        value={moment(
-                                            payment?.bolt11.expires_at
-                                        ).format('MMM Do YYYY, h:mm:ss a')}
-                                    />
-                                )}
-                                {payment?.bolt11.invoice && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.Invoice.title'
-                                        )}
-                                        value={payment?.bolt11.invoice}
-                                    />
-                                )}
-                            </>
-                        )}
-                        {/* On-chain */}
-                        {payment && payment.onchain && (
-                            <>
-                                {!isFreeOrder && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.onchainPayment'
-                                        )}
-                                    />
-                                )}
-                                {payment?.onchain.fee_total_sat && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.Transaction.totalFees'
-                                        )}
-                                        value={
-                                            <Amount
-                                                sats={
-                                                    payment?.onchain
-                                                        .fee_total_sat
-                                                }
-                                                sensitive
-                                                toggleable
-                                            />
-                                        }
-                                    />
-                                )}
-                                {payment?.onchain.order_total_sat && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.totalOrderValue'
-                                        )}
-                                        value={
-                                            <Amount
-                                                sats={
-                                                    payment?.onchain
-                                                        .order_total_sat
-                                                }
-                                                toggleable
-                                                sensitive
-                                            />
-                                        }
-                                    />
-                                )}
-                                {payment?.onchain.expires_at && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'general.expiresAt'
-                                        )}
-                                        value={moment(
-                                            payment?.onchain.expires_at
-                                        ).format('MMM Do YYYY, h:mm:ss a')}
-                                    />
-                                )}
-                                {payment?.onchain.address && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'general.address'
-                                        )}
-                                        value={payment?.onchain.address}
-                                    />
-                                )}
-                                {payment?.onchain.min_fee_for_0conf && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.miniFeeFor0Conf'
-                                        )}
-                                        value={
-                                            payment?.onchain.min_fee_for_0conf
-                                        }
-                                    />
-                                )}
-                                {payment?.onchain
-                                    .min_onchain_payment_confirmations && (
-                                    <KeyValue
-                                        keyValue={localeString(
-                                            'views.LSPS1.minOnchainPaymentConfirmations'
-                                        )}
-                                        value={
-                                            payment?.onchain
-                                                .min_onchain_payment_confirmations
-                                        }
-                                    />
-                                )}
-                            </>
-                        )}
-                        {orderResponse?.order_state === LSPOrderState.CREATED &&
-                            isFreeOrder && (
-                                <SuccessMessage
-                                    message={localeString(
-                                        'views.LSPS7.freeExtension'
-                                    )}
-                                />
-                            )}
-                        {orderResponse?.order_state ===
-                            LSPOrderState.FAILED && (
-                            <ErrorMessage
-                                message={localeString(
-                                    'views.LSPS7.extensionFailed'
-                                )}
-                            />
-                        )}
-                        {orderResponse?.order_state === LSPOrderState.CREATED &&
-                            orderView &&
-                            !isFreeOrder && (
-                                <>
-                                    {(payment.bolt11?.invoice ||
-                                        payment.lightning_invoice ||
-                                        payment.bolt11_invoice) && (
-                                        <>
-                                            <Button
-                                                title={
-                                                    payment.onchain
-                                                        ? localeString(
-                                                              'views.LSPS1.makePaymentLN'
-                                                          )
-                                                        : localeString(
-                                                              'views.LSPS1.makePayment'
-                                                          )
-                                                }
-                                                containerStyle={{
-                                                    paddingVertical: 20
-                                                }}
-                                                onPress={() => {
-                                                    navigation.navigate(
-                                                        'LSPS7PaymentAwait',
-                                                        buildPaymentAwaitParams(
-                                                            payment,
-                                                            orderResponse?.order_id,
-                                                            LSPService.LSPS7
-                                                        )
-                                                    );
-                                                }}
-                                            />
-                                        </>
-                                    )}
-                                    {payment.onchain?.address &&
-                                        payment.onchain?.fee_total_sat && (
-                                            <>
-                                                <Button
-                                                    title={
-                                                        payment.bolt11
-                                                            ? localeString(
-                                                                  'views.LSPS1.makePaymentOnchain'
-                                                              )
-                                                            : localeString(
-                                                                  'views.LSPS1.makePayment'
-                                                              )
-                                                    }
-                                                    containerStyle={{
-                                                        paddingVertical: 20
-                                                    }}
-                                                    onPress={() => {
-                                                        navigation.navigate(
-                                                            'Send',
-                                                            {
-                                                                destination:
-                                                                    payment
-                                                                        .onchain
-                                                                        ?.address,
-                                                                satAmount:
-                                                                    payment
-                                                                        .onchain
-                                                                        ?.fee_total_sat,
-                                                                transactionType:
-                                                                    'On-chain'
-                                                            }
-                                                        );
-                                                    }}
-                                                />
-                                            </>
-                                        )}
-                                </>
-                            )}
-                    </View>
-                </ScrollView>
-            </Screen>
+                        </>
+                    )}
+            </View>
         );
     }
 }

--- a/views/LSPS7/index.tsx
+++ b/views/LSPS7/index.tsx
@@ -498,9 +498,13 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
                                             )}
                                         </Text>
                                         <TextInput
-                                            value={numberWithCommas(
-                                                channelExtensionBlocks
-                                            )}
+                                            value={
+                                                channelExtensionBlocks === ''
+                                                    ? ''
+                                                    : numberWithCommas(
+                                                          channelExtensionBlocks
+                                                      )
+                                            }
                                             onChangeText={(text: any) => {
                                                 let newValue: string | number =
                                                     parseInt(


### PR DESCRIPTION
# Description

Two UI fixes for the LSPS1/LSPS7 order screens:

**1. Cleared amount fields no longer re-render as `0`**

Deleting the value in the LSP balance, client balance, or channel expiry blocks fields on the LSPS1 order screen (and the channel extension blocks field on the LSPS7 order screen) immediately re-rendered the field as `0`, forcing users to fight the stray digit when entering an amount manually. The cause is `numberWithCommas`, which falls back to `'0'` for empty input. The empty state is now guarded at the input bindings, so a cleared field stays empty and shows its placeholder. `numberWithCommas` itself is unchanged, since its `'0'` fallback is relied on for display elsewhere.

**2. Order content no longer paints a second background over the gradient**

`LSPS1OrderResponse` and `LSPS7OrderResponse` wrapped their content in `<Screen>` (the full-screen theme background wrapper) plus their own `<ScrollView>`, but all four call sites (`views/LSPS1/index.tsx`, `views/LSPS1/Order.tsx`, `views/LSPS7/index.tsx`, `views/LSPS7/Order.tsx`) already render them inside a host `Screen` and `ScrollView`. The nested `Screen` painted a second copy of the theme background sized to the content pane. On solid themes this is invisible (same color over same color), but on gradient themes the gradient restarts mid-screen and reads as a second background behind the order details. The components now render their content `View` directly; the diff is large only because removing the two wrapper levels re-indents the whole render body. This also removes a same-direction nested `ScrollView`.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
