### PR TITLE
deps: Bump Cashu Dev Kit to 0.17.3: fix ecash operations against cdk-mintd 0.17 mints (Minibits)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,8 @@ ios/LndMobileLibZipFile
 
 # Cashu CDK binaries
 android/cdk/cashudevkit.aar
-ios/Cdk/cdkFFI.xcframework
+android/cdk/cdk-jvm.jar
+ios/Cdk/CashuDevKitFFI.xcframework
 ios/CashuDevKitLibZipFile
 ios/CashuDevKit/CashuDevKit.swift
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -204,8 +204,10 @@ dependencies {
 
     implementation fileTree(dir: "libs", include: ["*.jar", "*.aar"])
 
-    // CashuDevKit - Cashu wallet FFI bindings
+    // CashuDevKit - native libs (cdk-android) + Kotlin bindings (cdk-jvm),
+    // vendored from Maven Central by fetch-libraries.sh
     implementation files("../cdk/cashudevkit.aar")
+    implementation files("../cdk/cdk-jvm.jar")
     // Zeus Cashu Restore - standalone NUT-13 restore for v1 legacy seeds
     implementation files("../zeus-restore/zeus-cashu-restore.aar")
     // CDK / LDK Node dependencies

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -835,7 +835,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                 // Create the MintQuote object
                 // For external quotes that are PAID, we set amountPaid = amount
                 val zeroAmount = Amount(0UL)
-                val quote = MintQuote(
+                fun makeQuote(version: UInt) = MintQuote(
                     id = quoteId,
                     mintUrl = url,
                     amount = amt,
@@ -849,13 +849,25 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     paymentMethod = PaymentMethod.Bolt11,
                     secretKey = if (useSeedPrefixMarker) null else storedSecretKey,
                     usedByOperation = null,
-                    version = 0u
+                    version = version
                 )
 
                 Log.d(TAG, "addExternalMintQuote: Adding quote $quoteId to database")
 
-                // Add to database
-                db!!.addMintQuote(quote)
+                // addMintQuote is a CAS upsert: the update only applies while
+                // the stored row still has the version we write, and a failed
+                // mint attempt leaves the row bumped by the saga's claim.
+                // Reuse the stored version (0 for a fresh insert) so retries
+                // do not die with ConcurrentUpdate before minting
+                val storedVersion = db!!.getMintQuote(quoteId)?.version ?: 0u
+                try {
+                    db!!.addMintQuote(makeQuote(storedVersion))
+                } catch (e: FfiException) {
+                    // Lost the CAS race between read and write; re-read and
+                    // retry once
+                    val retryVersion = db!!.getMintQuote(quoteId)?.version ?: 0u
+                    db!!.addMintQuote(makeQuote(retryVersion))
+                }
 
                 Log.d(TAG, "addExternalMintQuote: Successfully added quote $quoteId")
 

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -445,10 +445,19 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
             try {
                 val normalized = normalizeMintUrl(mintUrl)
                 val url = MintUrl(normalized)
-                // removeWallet only drops the in-memory wallet; tolerate a
-                // mint the repository does not know (parity with the
-                // non-throwing 0.14.x removeMint)
-                runCatching { repo.removeWallet(url, walletUnit) }
+                // load_wallets creates one wallet per supported unit, so
+                // drop every unit's wallet for this mint, not just the
+                // configured one: a leftover handle keeps the mint in
+                // getMintUrls, and the persisted list then re-adds the
+                // mint at the next boot's reconcile. Compare
+                // case-insensitively since cdk canonicalizes scheme and
+                // host casing. removeWallet failures are tolerated (parity
+                // with the non-throwing 0.14.x removeMint)
+                repo.getWallets().forEach { wallet ->
+                    val wUrl = runCatching { wallet.mintUrl() }.getOrNull() ?: return@forEach
+                    if (!wUrl.url.equals(normalized, ignoreCase = true)) return@forEach
+                    runCatching { repo.removeWallet(wUrl, wallet.unit()) }
+                }
                 wallets.remove(normalized)
                 db!!.removeMint(url)
 

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -793,7 +793,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
+                val url = MintUrl(normalizeMintUrl(mintUrl))
                 val amt = Amount(amount.toLong().toULong())
 
                 // Map state string to QuoteState enum

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -151,9 +151,11 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         }
 
         val url = MintUrl(normalized)
-        if (!currentRepo.hasMint(url)) {
-            currentRepo.createWallet(url, walletUnit, null)
-        }
+        // hasMint matches any unit for the URL while getWallet is keyed on
+        // (URL, unit), so a mint loaded only under a non-sat unit would skip
+        // creation here and then miss. createWallet is a no-network map
+        // insert, so create unconditionally instead of guarding
+        currentRepo.createWallet(url, walletUnit, null)
         val wallet = currentRepo.getWallet(url, walletUnit)
         wallets[normalized] = wallet
         return wallet

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -151,12 +151,19 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         }
 
         val url = MintUrl(normalized)
-        // hasMint matches any unit for the URL while getWallet is keyed on
-        // (URL, unit), so a mint loaded only under a non-sat unit would skip
-        // creation here and then miss. createWallet is a no-network map
-        // insert, so create unconditionally instead of guarding
-        currentRepo.createWallet(url, walletUnit, null)
-        val wallet = currentRepo.getWallet(url, walletUnit)
+        // Try the (URL, unit)-keyed lookup first and only create on a miss:
+        // creating unconditionally would overwrite a wallet configured by
+        // addMint (e.g. a custom targetProofCount) with a default-config
+        // handle. The FFI does not expose the unit-keyed hasWallet, so a
+        // failed get is the miss signal; createWallet is a no-network map
+        // insert, and a concurrent double-create is a benign same-config
+        // overwrite
+        val wallet = try {
+            currentRepo.getWallet(url, walletUnit)
+        } catch (e: FfiException) {
+            currentRepo.createWallet(url, walletUnit, null)
+            currentRepo.getWallet(url, walletUnit)
+        }
         wallets[normalized] = wallet
         return wallet
     }
@@ -407,7 +414,10 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         scope.launch {
             try {
                 val url = MintUrl(normalizeMintUrl(mintUrl))
-                repo.createWallet(url, walletUnit, targetProofCount?.toUInt())
+                // 0 is the JS sentinel for "use default"; match iOS, which
+                // maps it to null rather than a target of zero proofs
+                val count = targetProofCount?.takeIf { it > 0 }?.toUInt()
+                repo.createWallet(url, walletUnit, count)
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(null)

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -777,6 +777,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         state: String,
         expiry: Double,
         secretKey: String?,
+        useSeedPrefixMarker: Boolean,
         promise: Promise
     ) {
         if (!isInitialized || db == null) {
@@ -798,18 +799,25 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     else -> QuoteState.PAID // Default to PAID for external quotes
                 }
 
-                // ZEUS Pay locks quotes to the wallet's seed-prefix key
-                // (seed[0..32]), which is byte-identical to cdk's "legacy
-                // NpubCash" key. Storing that key on the quote makes cdk's
-                // mint saga scrub it mid-flight (a version bump), and the
-                // saga's post-mint write then dies with ConcurrentUpdate
-                // AFTER the mint has issued the signatures. Instead, store
-                // the quote with no key and write cdk's NpubCash quote-key
-                // marker: at signing time cdk re-derives the identical
-                // seed-prefix key from the marker, with no mid-saga write.
+                // For v2-bip39 wallets, ZEUS Pay locks quotes to the seed-
+                // prefix key (seed[0..32]), which is byte-identical to cdk's
+                // "legacy NpubCash" key. Storing that key on the quote makes
+                // cdk's mint saga scrub it mid-flight (a version bump), and
+                // the saga's post-mint write then dies with ConcurrentUpdate
+                // AFTER the mint has issued the signatures. For those quotes
+                // (useSeedPrefixMarker, decided by JS via byte comparison),
+                // store the quote with no key and write cdk's NpubCash
+                // quote-key marker: at signing time cdk re-derives the
+                // identical seed-prefix key from the marker, with no mid-saga
+                // write. v1 wallets sign with a different key (LND seed
+                // bytes [32:64]), so the marker would derive the wrong key
+                // for them; their key is stored on the quote instead, which
+                // is safe because the scrub only triggers on byte equality
+                // with the seed prefix.
                 // Upstream bug: https://github.com/cashubtc/cdk/issues/2335
                 // Remove when fixed: https://github.com/ZeusLN/zeus/issues/4402
-                if (!secretKey.isNullOrEmpty()) {
+                val storedSecretKey = secretKey?.takeIf { it.isNotEmpty() }
+                if (storedSecretKey != null && useSeedPrefixMarker) {
                     db!!.kvWrite(
                         primaryNamespace = "npubcash",
                         secondaryNamespace = "quotes",
@@ -833,7 +841,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     amountIssued = if (quoteState == QuoteState.ISSUED) amt else zeroAmount,
                     estimatedBlocks = null,
                     paymentMethod = PaymentMethod.Bolt11,
-                    secretKey = null,
+                    secretKey = if (useSeedPrefixMarker) null else storedSecretKey,
                     usedByOperation = null,
                     version = 0u
                 )

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -807,6 +807,8 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                 // the quote with no key and write cdk's NpubCash quote-key
                 // marker: at signing time cdk re-derives the identical
                 // seed-prefix key from the marker, with no mid-saga write.
+                // Upstream bug: https://github.com/cashubtc/cdk/issues/2335
+                // Remove when fixed: https://github.com/ZeusLN/zeus/issues/4402
                 if (!secretKey.isNullOrEmpty()) {
                     db!!.kvWrite(
                         primaryNamespace = "npubcash",

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -504,10 +504,13 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
         scope.launch {
             try {
+                // getBalances() is keyed by (mint URL, unit) and load_wallets
+                // creates a wallet per supported unit, so only fold this
+                // wallet's unit; other units must not count toward the total
                 val balances = repo.getBalances()
                 var total: ULong = 0UL
-                balances.values.forEach { amount ->
-                    total += amount.value
+                balances.forEach { (key, amount) ->
+                    if (key.unit == walletUnit) total += amount.value
                 }
 
                 withContext(Dispatchers.Main) {
@@ -537,6 +540,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                 val balances = repo.getBalances()
                 val totals = mutableMapOf<String, Long>()
                 balances.forEach { (key, amount) ->
+                    if (key.unit != walletUnit) return@forEach
                     val url = key.mintUrl.url
                     totals[url] = (totals[url] ?: 0L) + amount.value.toLong()
                 }

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -9,6 +9,7 @@ import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
 import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
 
 import org.cashudevkit.*
 import uniffi.zeus_cashu_restore.restoreFromSeed as zeusRestoreFromSeed
@@ -17,13 +18,25 @@ import uniffi.zeus_cashu_restore.RestoreException
 /**
  * CashuDevKit Native Module for React Native
  * Provides bridge to CDK FFI bindings
+ *
+ * CDK 0.15+ replaced the MultiMintWallet with a WalletRepository plus
+ * per-mint Wallet objects, and one-shot melts with a two-phase
+ * prepare/confirm flow. This module adapts the new API behind the
+ * pre-existing bridge contract: method names, parameters and resolved
+ * JSON shapes are unchanged from the 0.14.x module.
  */
 class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext) {
 
-    private var wallet: MultiMintWallet? = null
+    @Volatile
+    private var repo: WalletRepository? = null
+    @Volatile
     private var db: WalletSqliteDatabase? = null
-    private val preparedSends = mutableMapOf<String, PreparedSend>()
+    @Volatile
+    private var walletUnit: CurrencyUnit = CurrencyUnit.Sat
+    private val wallets = ConcurrentHashMap<String, Wallet>()
+    private val preparedSends = ConcurrentHashMap<String, PreparedSend>()
+    @Volatile
     private var isInitialized = false
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
@@ -106,13 +119,43 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
     }
 
     /**
-     * Returns the initialized wallet or rejects with NO_WALLET error and returns null
+     * Returns the initialized wallet repository or rejects with NO_WALLET
+     * error and returns null
      */
-    private fun getInitializedWallet(promise: Promise): MultiMintWallet? {
-        if (!isInitialized || wallet == null) {
+    private fun getInitializedRepo(promise: Promise): WalletRepository? {
+        val current = repo
+        if (!isInitialized || current == null) {
             promise.reject("NO_WALLET", "Wallet not initialized")
             return null
         }
+        return current
+    }
+
+    private fun normalizeMintUrl(mintUrl: String): String = mintUrl.trimEnd('/')
+
+    /**
+     * Get (or lazily create) the per-mint Wallet for a mint URL.
+     *
+     * The repository only creates an in-memory Wallet handle here; no
+     * network request is made until the wallet is used. Creating on
+     * demand preserves the 0.14.x MultiMintWallet behavior where
+     * receive/restore operated with allowUntrusted: true.
+     */
+    private suspend fun getWallet(mintUrl: String): Wallet {
+        val normalized = normalizeMintUrl(mintUrl)
+        wallets[normalized]?.let { return it }
+
+        val currentRepo = repo
+        if (!isInitialized || currentRepo == null) {
+            throw FfiException.Internal("Wallet not initialized")
+        }
+
+        val url = MintUrl(normalized)
+        if (!currentRepo.hasMint(url)) {
+            currentRepo.createWallet(url, walletUnit, null)
+        }
+        val wallet = currentRepo.getWallet(url, walletUnit)
+        wallets[normalized] = wallet
         return wallet
     }
 
@@ -145,6 +188,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
             is CurrencyUnit.Eur -> "eur"
             is CurrencyUnit.Auth -> "auth"
             is CurrencyUnit.Custom -> unit.unit
+            else -> "sat"
         }
     }
 
@@ -157,38 +201,42 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         }
     }
 
-    private fun proofStateToString(state: ProofState): String {
-        return when (state) {
-            ProofState.UNSPENT -> "Unspent"
-            ProofState.PENDING -> "Pending"
-            ProofState.SPENT -> "Spent"
-            ProofState.RESERVED -> "Reserved"
-            ProofState.PENDING_SPENT -> "PendingSpent"
+    /**
+     * Map the CDK FFI exception to the legacy bridge error codes that JS
+     * consumers were written against. CDK 0.15+ collapsed the previous
+     * 19 error variants into Cdk(code, errorMessage) with Cashu protocol
+     * error codes, plus Internal(errorMessage) for infrastructure errors.
+     */
+    private fun mapFfiException(e: FfiException): Pair<String, String> {
+        return when (e) {
+            is FfiException.Cdk ->
+                legacyErrorCode(e.code, e.errorMessage) to e.errorMessage
+            is FfiException.Internal ->
+                legacyErrorCode(null, e.errorMessage) to e.errorMessage
         }
     }
 
-    private fun mapFfiException(e: FfiException): Pair<String, String> {
-        return when (e) {
-            is FfiException.Generic -> "GENERIC_ERROR" to (e.message ?: "Generic error")
-            is FfiException.AmountOverflow -> "AMOUNT_OVERFLOW" to (e.message ?: "Amount overflow")
-            is FfiException.PaymentFailed -> "PAYMENT_FAILED" to (e.message ?: "Payment failed")
-            is FfiException.PaymentPending -> "PAYMENT_PENDING" to (e.message ?: "Payment pending")
-            is FfiException.InsufficientFunds -> "INSUFFICIENT_FUNDS" to (e.message ?: "Insufficient funds")
-            is FfiException.Database -> "DATABASE_ERROR" to (e.message ?: "Database error")
-            is FfiException.Network -> "NETWORK_ERROR" to (e.message ?: "Network error")
-            is FfiException.InvalidToken -> "INVALID_TOKEN" to (e.message ?: "Invalid token")
-            is FfiException.Wallet -> "WALLET_ERROR" to (e.message ?: "Wallet error")
-            is FfiException.KeysetUnknown -> "KEYSET_UNKNOWN" to (e.message ?: "Keyset unknown")
-            is FfiException.UnitNotSupported -> "UNIT_NOT_SUPPORTED" to (e.message ?: "Unit not supported")
-            is FfiException.InvalidMnemonic -> "INVALID_MNEMONIC" to (e.message ?: "Invalid mnemonic")
-            is FfiException.InvalidUrl -> "INVALID_URL" to (e.message ?: "Invalid URL")
-            is FfiException.DivisionByZero -> "DIVISION_BY_ZERO" to (e.message ?: "Division by zero")
-            is FfiException.Amount -> "AMOUNT_ERROR" to (e.message ?: "Amount error")
-            is FfiException.RuntimeTaskJoin -> "RUNTIME_ERROR" to (e.message ?: "Runtime error")
-            is FfiException.InvalidHex -> "INVALID_HEX" to (e.message ?: "Invalid hex")
-            is FfiException.InvalidCryptographicKey -> "INVALID_KEY" to (e.message ?: "Invalid key")
-            is FfiException.Serialization -> "SERIALIZATION_ERROR" to (e.message ?: "Serialization error")
-            else -> "UNKNOWN_ERROR" to (e.message ?: "Unknown error")
+    private fun legacyErrorCode(protocolCode: UInt?, message: String): String {
+        when (protocolCode?.toInt()) {
+            10003, 11001, 11002, 11007 ->
+                // Token verification / already spent / unbalanced / duplicate inputs
+                return "INVALID_TOKEN"
+            11005 -> return "UNIT_NOT_SUPPORTED"
+            12001, 12002 -> return "KEYSET_UNKNOWN"
+            20005 -> return "PAYMENT_PENDING"
+            in 20000..20999 -> return "PAYMENT_FAILED"
+        }
+
+        val lowered = message.lowercase()
+        return when {
+            lowered.contains("insufficient funds") -> "INSUFFICIENT_FUNDS"
+            lowered.contains("payment failed") -> "PAYMENT_FAILED"
+            lowered.contains("payment pending") || lowered.contains("quote pending") -> "PAYMENT_PENDING"
+            lowered.contains("network") || lowered.contains("connection") || lowered.contains("transport") -> "NETWORK_ERROR"
+            lowered.contains("database") -> "DATABASE_ERROR"
+            lowered.contains("mnemonic") -> "INVALID_MNEMONIC"
+            lowered.contains("invalid url") -> "INVALID_URL"
+            else -> "GENERIC_ERROR"
         }
     }
 
@@ -213,11 +261,13 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
             put("fee_reserve", quote.feeReserve.value.toLong())
             put("state", quoteStateToString(quote.state))
             put("expiry", quote.expiry)
-            quote.paymentPreimage?.let { put("payment_preimage", it) }
+            // Upstream renamed payment_preimage to payment_proof; the bridge
+            // key is part of the JS contract and keeps the old name
+            quote.paymentProof?.let { put("payment_preimage", it) }
         }
     }
 
-    private fun encodeMelted(melted: Melted): JSONObject {
+    private fun encodeMelted(melted: FinalizedMelt): JSONObject {
         return JSONObject().apply {
             put("state", quoteStateToString(melted.state))
             put("amount", melted.amount.value.toLong())
@@ -241,15 +291,21 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
     }
 
     private suspend fun encodeToken(token: Token): JSONObject {
-        val mintUrl = token.mintUrl();
+        val mintUrl = token.mintUrl()
         val proofsArray = JSONArray()
-        val w = wallet
-        if (w != null) {
+        val currentRepo = repo
+        if (isInitialized && currentRepo != null) {
             try {
-                val keysets = w.getMintKeysets(mintUrl) ?: emptyList()
-                val proofs = token.proofs(keysets)
-                proofs.forEach { proof ->
-                    proofsArray.put(encodeProof(proof))
+                // Only resolve proofs through a wallet the mint is already
+                // part of; decoding a foreign token must not add its mint or
+                // contact it
+                if (currentRepo.hasMint(MintUrl(normalizeMintUrl(mintUrl.url)))) {
+                    val wallet = getWallet(mintUrl.url)
+                    val keysets = wallet.getMintKeysets(KeysetFilter.ALL)
+                    val proofs = token.proofs(keysets)
+                    proofs.forEach { proof ->
+                        proofsArray.put(encodeProof(proof))
+                    }
                 }
             } catch (_: Exception) {
                 // Mint may not be known to the wallet yet (e.g. decoding a
@@ -307,17 +363,21 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                 val dbPath = getDatabasePath(mnemonic)
                 currentDbPath = dbPath
                 val database = WalletSqliteDatabase(dbPath)
-                db = database
 
                 val currencyUnit = parseCurrencyUnit(unit)
 
-                val newWallet = MultiMintWallet(
-                    unit = currencyUnit,
+                // WalletSqliteDatabase conforms to WalletDatabase; passing
+                // it via WalletStore.Custom keeps the same handle available
+                // for the direct database methods below
+                val newRepo = WalletRepository(
                     mnemonic = mnemonic,
-                    db = database
+                    store = WalletStore.Custom(database)
                 )
 
-                wallet = newWallet
+                db = database
+                repo = newRepo
+                walletUnit = currencyUnit
+                wallets.clear()
                 isInitialized = true
 
                 withContext(Dispatchers.Main) {
@@ -340,12 +400,12 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun addMint(mintUrl: String, targetProofCount: Int?, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        val repo = getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
-                wallet.addMint(url, targetProofCount?.toUInt())
+                val url = MintUrl(normalizeMintUrl(mintUrl))
+                repo.createWallet(url, walletUnit, targetProofCount?.toUInt())
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(null)
@@ -367,12 +427,17 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun removeMint(mintUrl: String, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        val repo = getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
-                wallet.removeMint(url)
+                val normalized = normalizeMintUrl(mintUrl)
+                val url = MintUrl(normalized)
+                // removeWallet only drops the in-memory wallet; tolerate a
+                // mint the repository does not know (parity with the
+                // non-throwing 0.14.x removeMint)
+                runCatching { repo.removeWallet(url, walletUnit) }
+                wallets.remove(normalized)
                 db!!.removeMint(url)
 
                 withContext(Dispatchers.Main) {
@@ -395,11 +460,18 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun getMintUrls(promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        val repo = getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val urls = wallet.getMintUrls() ?: emptyList()
+                val urls = mutableListOf<String>()
+                val seen = mutableSetOf<String>()
+                repo.getWallets().forEach { wallet ->
+                    val url = runCatching { wallet.mintUrl().url }.getOrNull() ?: return@forEach
+                    if (seen.add(url)) {
+                        urls.add(url)
+                    }
+                }
 
                 val array = Arguments.createArray()
                 urls.forEach { array.pushString(it) }
@@ -428,11 +500,11 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun getTotalBalance(promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        val repo = getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val balances = wallet.getBalances() ?: emptyMap()
+                val balances = repo.getBalances()
                 var total: ULong = 0UL
                 balances.values.forEach { amount ->
                     total += amount.value
@@ -458,14 +530,19 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun getBalances(promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        val repo = getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val balances = wallet.getBalances() ?: emptyMap()
+                val balances = repo.getBalances()
+                val totals = mutableMapOf<String, Long>()
+                balances.forEach { (key, amount) ->
+                    val url = key.mintUrl.url
+                    totals[url] = (totals[url] ?: 0L) + amount.value.toLong()
+                }
                 val result = JSONObject()
-                balances.forEach { (mintUrl, amount) ->
-                    result.put(mintUrl, amount.value.toLong())
+                totals.forEach { (url, value) ->
+                    result.put(url, value)
                 }
 
                 withContext(Dispatchers.Main) {
@@ -531,12 +608,12 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun getMintKeysets(mintUrl: String, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
-                val keysets = wallet.getMintKeysets(url) ?: emptyList()
+                val wallet = getWallet(mintUrl)
+                val keysets = wallet.getMintKeysets(KeysetFilter.ALL)
 
                 val array = JSONArray()
                 keysets.forEach { keyset ->
@@ -567,13 +644,18 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun createMintQuote(mintUrl: String, amount: Double, description: String?, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
                 val amt = Amount(amount.toLong().toULong())
-                val quote = wallet!!.mintQuote(url, amt, description)
+                val wallet = getWallet(mintUrl)
+                val quote = wallet.mintQuote(
+                    paymentMethod = PaymentMethod.Bolt11,
+                    amount = amt,
+                    description = description,
+                    extra = null
+                )
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(encodeMintQuote(quote).toString())
@@ -595,12 +677,12 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun checkMintQuote(mintUrl: String, quoteId: String, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
-                val quote = wallet!!.checkMintQuote(url, quoteId)
+                val wallet = getWallet(mintUrl)
+                val quote = wallet.checkMintQuote(quoteId)
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(encodeMintQuote(quote).toString())
@@ -730,8 +812,11 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     expiry = expiry.toLong().toULong(),
                     amountPaid = if (quoteState == QuoteState.PAID || quoteState == QuoteState.ISSUED) amt else zeroAmount,
                     amountIssued = if (quoteState == QuoteState.ISSUED) amt else zeroAmount,
+                    estimatedBlocks = null,
                     paymentMethod = PaymentMethod.Bolt11,
-                    secretKey = secretKey
+                    secretKey = secretKey,
+                    usedByOperation = null,
+                    version = 0u
                 )
 
                 Log.d(TAG, "addExternalMintQuote: Adding quote $quoteId to database")
@@ -765,15 +850,18 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
      */
     @ReactMethod
     fun mintExternal(mintUrl: String, quoteId: String, amount: Double, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
-
                 Log.d(TAG, "mintExternal: Attempting to mint quote $quoteId from $mintUrl")
 
-                val proofs = wallet!!.mint(url, quoteId, null)
+                val wallet = getWallet(mintUrl)
+                val proofs = wallet.mint(
+                    quoteId = quoteId,
+                    amountSplitTarget = SplitTarget.None,
+                    spendingConditions = null
+                )
 
                 val array = JSONArray()
                 proofs.forEach { proof ->
@@ -802,19 +890,22 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun mint(mintUrl: String, quoteId: String, conditionsJson: String?, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
-
                 // Parse spending conditions if provided
                 val conditions = conditionsJson?.let { json ->
                     runCatching {
                         parseP2PKConditions(JSONObject(json))
                     }.getOrNull()
                 }
-                val proofs = wallet!!.mint(url, quoteId, conditions)
+                val wallet = getWallet(mintUrl)
+                val proofs = wallet.mint(
+                    quoteId = quoteId,
+                    amountSplitTarget = SplitTarget.None,
+                    spendingConditions = conditions
+                )
 
                 val array = JSONArray()
 
@@ -846,13 +937,18 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun createMeltQuote(mintUrl: String, request: String, optionsJson: String?, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
                 val options = parseMeltOptions(optionsJson)
-                val quote = wallet!!.meltQuote(url, request, options)
+                val wallet = getWallet(mintUrl)
+                val quote = wallet.meltQuote(
+                    method = PaymentMethod.Bolt11,
+                    request = request,
+                    options = options,
+                    extra = null
+                )
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(encodeMeltQuote(quote).toString())
@@ -874,12 +970,12 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun checkMeltQuote(mintUrl: String, quoteId: String, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
-                val quote = wallet!!.checkMeltQuote(url, quoteId)
+                val wallet = getWallet(mintUrl)
+                val quote = wallet.checkMeltQuoteStatus(quoteId)
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(encodeMeltQuote(quote).toString())
@@ -901,12 +997,13 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun melt(mintUrl: String, quoteId: String, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
-                val melted = wallet!!.meltWithMint(url, quoteId)
+                val wallet = getWallet(mintUrl)
+                val prepared = wallet.prepareMelt(quoteId)
+                val melted = prepared.confirm()
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(encodeMelted(melted).toString())
@@ -927,56 +1024,40 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun meltMpp(bolt11: String, optionsJson: String?, maxFee: Double, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
-
-        scope.launch {
-            try {
-                val options = parseMeltOptions(optionsJson)
-                val fee = if (maxFee > 0) Amount(maxFee.toULong()) else null
-                val melted = wallet!!.melt(bolt11, options, fee)
-
-                withContext(Dispatchers.Main) {
-                    promise.resolve(encodeMelted(melted).toString())
-                }
-            } catch (e: FfiException) {
-                val (code, message) = mapFfiException(e)
-                Log.e(TAG, "meltMpp error: $message", e)
-                withContext(Dispatchers.Main) {
-                    promise.reject(code, message, e)
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "meltMpp error", e)
-                withContext(Dispatchers.Main) {
-                    promise.reject("MELT_MPP_ERROR", e.message, e)
-                }
-            }
-        }
-    }
-
-    @ReactMethod
     fun meltPartial(mintUrl: String, bolt11: String, mppAmountMsat: Double, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
                 val mppAmount = Amount(mppAmountMsat.toLong().toULong())
-                val normalizedUrl = mintUrl.trimEnd('/')
+                val wallet = getWallet(mintUrl)
 
                 // Step 1: Create melt quote via CDK with MPP options
                 val options = MeltOptions.Mpp(mppAmount)
-                val quote = wallet!!.meltQuote(url, bolt11, options)
+                val quote = wallet.meltQuote(
+                    method = PaymentMethod.Bolt11,
+                    request = bolt11,
+                    options = options,
+                    extra = null
+                )
 
-                // Step 2: Get all proofs for this mint
-                val allProofs = wallet!!.listProofs()
-                val mintProofs = mutableListOf<org.cashudevkit.Proof>()
-                for ((key, proofs) in allProofs) {
-                    if (key.trimEnd('/') == normalizedUrl) {
-                        mintProofs.addAll(proofs)
-                        break
+                // Step 2: Gather this mint's unspent proofs —
+                // the mint knows the MPP partial amount from the quote
+                val database = db
+                if (database == null) {
+                    withContext(Dispatchers.Main) {
+                        promise.reject("NO_WALLET", "Wallet not initialized")
                     }
+                    return@launch
                 }
+                val url = MintUrl(normalizeMintUrl(mintUrl))
+                val proofInfos = database.getProofs(
+                    mintUrl = url,
+                    unit = CurrencyUnit.Sat,
+                    state = listOf(ProofState.UNSPENT),
+                    spendingConditions = null
+                )
+                val mintProofs = proofInfos.map { it.proof }
 
                 if (mintProofs.isEmpty()) {
                     withContext(Dispatchers.Main) {
@@ -985,8 +1066,9 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     return@launch
                 }
 
-                // Step 3: Try CDK's meltProofs (keeps proof DB in sync)
-                val melted = wallet!!.meltProofs(url, quote.id, mintProofs)
+                // Step 3: Two-phase melt with the selected proofs
+                val prepared = wallet.prepareMeltProofs(quote.id, mintProofs)
+                val melted = prepared.confirm()
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(encodeMelted(melted).toString())
@@ -1012,11 +1094,10 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun prepareSend(mintUrl: String, amount: Double, optionsJson: String?, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
                 val amt = Amount(amount.toLong().toULong())
 
                 // Parse options if provided; be defensive so malformed JSON doesn't crash
@@ -1046,27 +1127,23 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     }
                 }
 
-                val innerSendOptions = SendOptions(
+                val sendOptions = SendOptions(
                     memo = null,
                     conditions = conditions,
                     amountSplitTarget = SplitTarget.None,
                     sendKind = sendKind,
                     includeFee = includeFee,
+                    useP2bk = false,
                     maxProofs = 0U,
-                    metadata = emptyMap()
+                    metadata = emptyMap(),
+                    p2pkSigningKeys = emptyList(),
+                    p2pkLockedProofSendMode = P2pkLockedProofSendMode.SWAP
                 )
 
-                val sendOptions = MultiMintSendOptions(
-                    allowTransfer = false,
-                    maxTransferAmount = Amount(0UL),
-                    allowedMints = emptyList(),
-                    excludedMints = emptyList(),
-                    sendOptions = innerSendOptions
-                )
+                val wallet = getWallet(mintUrl)
+                val prepared = wallet.prepareSend(amt, sendOptions)
 
-                val prepared = wallet!!.prepareSend(url, amt, sendOptions)
-
-                val preparedId = prepared.id()
+                val preparedId = prepared.operationId()
                 val preparedAmount = prepared.amount().value.toLong()
                 val preparedFee = prepared.fee().value.toLong()
 
@@ -1106,7 +1183,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         scope.launch {
             try {
                 val token = prepared.confirm(memo)
-                val encodedTokenJson = encodeToken(token)  
+                val encodedTokenJson = encodeToken(token)
                 withContext(Dispatchers.Main) {
                     promise.resolve(encodedTokenJson.toString())
                 }
@@ -1162,14 +1239,14 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun receive(encodedToken: String, optionsJson: String?, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
                 val token = Token.fromString(encodedToken)
 
                 // Parse options if provided; be defensive so malformed JSON doesn't crash
-                var innerReceiveOptions = ReceiveOptions(
+                var receiveOptions = ReceiveOptions(
                     amountSplitTarget = SplitTarget.None,
                     p2pkSigningKeys = emptyList(),
                     preimages = emptyList(),
@@ -1194,7 +1271,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                             }
                         } ?: emptyList()
 
-                    innerReceiveOptions = ReceiveOptions(
+                    receiveOptions = ReceiveOptions(
                         amountSplitTarget = SplitTarget.None,
                         p2pkSigningKeys = p2pkKeys ?: emptyList(),
                         preimages = preimages,
@@ -1202,13 +1279,10 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     )
                 }
 
-                val receiveOptions = MultiMintReceiveOptions(
-                    allowUntrusted = true,
-                    transferToMint = null,
-                    receiveOptions = innerReceiveOptions
-                )
-
-                val amount = wallet!!.receive(token, receiveOptions)
+                // The token's mint is added on demand, matching the 0.14.x
+                // MultiMintWallet behavior of allowUntrusted: true
+                val wallet = getWallet(token.mintUrl().url)
+                val amount = wallet.receive(token, receiveOptions)
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(amount.value.toDouble())
@@ -1272,15 +1346,17 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun restore(mintUrl: String, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
-                val amount = wallet!!.restore(url)
+                val wallet = getWallet(mintUrl)
+                // Restored splits the result into spent/unspent/pending;
+                // the bridge contract is the recovered spendable amount
+                val restored = wallet.restore()
 
                 withContext(Dispatchers.Main) {
-                    promise.resolve(amount.value.toDouble())
+                    promise.resolve(restored.unspent.value.toDouble())
                 }
             } catch (e: FfiException) {
                 val (code, message) = mapFfiException(e)
@@ -1299,7 +1375,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun restoreFromSeed(mintUrl: String, seedHex: String, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
@@ -1317,18 +1393,14 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                 // Step 2: Feed the token into CDK's receive to import proofs into the wallet
                 val token = Token.fromString(tokenString)
 
-                val innerReceiveOptions = ReceiveOptions(
+                val receiveOptions = ReceiveOptions(
                     amountSplitTarget = SplitTarget.None,
                     p2pkSigningKeys = emptyList(),
                     preimages = emptyList(),
                     metadata = emptyMap()
                 )
-                val receiveOptions = MultiMintReceiveOptions(
-                    allowUntrusted = true,
-                    transferToMint = null,
-                    receiveOptions = innerReceiveOptions
-                )
 
+                val wallet = getWallet(mintUrl)
                 val amount = wallet.receive(token, receiveOptions)
 
                 withContext(Dispatchers.Main) {
@@ -1360,12 +1432,10 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun checkProofsState(mintUrl: String, proofsJson: String, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
-
                 // Parse proofs from JSON
                 val proofsArray = JSONArray(proofsJson)
                 val proofs = mutableListOf<Proof>()
@@ -1377,16 +1447,18 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                         c = proofJson.getString("c"),
                         keysetId = proofJson.getString("keyset_id"),
                         witness = null,
-                        dleq = null
+                        dleq = null,
+                        p2pkE = null
                     )
                     proofs.add(proof)
                 }
 
-                val states = wallet!!.checkProofsState(url, proofs)
+                val wallet = getWallet(mintUrl)
+                val spentFlags = wallet.checkProofsSpent(proofs)
 
                 val result = JSONArray()
-                states.forEach { state ->
-                    result.put(JSONObject().put("state", proofStateToString(state)))
+                spentFlags.forEach { spent ->
+                    result.put(JSONObject().put("state", if (spent) "Spent" else "Unspent"))
                 }
 
                 withContext(Dispatchers.Main) {
@@ -1413,15 +1485,19 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun createMintBolt12Quote(mintUrl: String, amount: Double?, description: String?, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
                 val amt = amount?.let { Amount(it.toLong().toULong()) } ?: Amount(0UL)
 
-                // Note: BOLT12 mint quote uses the same mintQuote API
-                val quote = wallet!!.mintQuote(url, amt, description)
+                val wallet = getWallet(mintUrl)
+                val quote = wallet.mintQuote(
+                    paymentMethod = PaymentMethod.Bolt12,
+                    amount = amt,
+                    description = description,
+                    extra = null
+                )
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(encodeMintQuote(quote).toString())
@@ -1443,13 +1519,18 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun createMeltBolt12Quote(mintUrl: String, request: String, optionsJson: String?, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
                 val options = parseMeltOptions(optionsJson)
-                val quote = wallet!!.meltQuote(url, request, options)
+                val wallet = getWallet(mintUrl)
+                val quote = wallet.meltQuote(
+                    method = PaymentMethod.Bolt12,
+                    request = request,
+                    options = options,
+                    extra = null
+                )
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(encodeMeltQuote(quote).toString())
@@ -1471,12 +1552,16 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun createMeltHumanReadableQuote(mintUrl: String, address: String, amountMsat: Double, promise: Promise) {
-        val wallet = getInitializedWallet(promise) ?: return
+        getInitializedRepo(promise) ?: return
 
         scope.launch {
             try {
-                val url = MintUrl(mintUrl)
-                val quote = wallet!!.meltHumanReadableQuote(url, address, amountMsat.toLong().toULong())
+                val wallet = getWallet(mintUrl)
+                val quote = wallet.meltHumanReadableQuote(
+                    address = address,
+                    amountMsat = Amount(amountMsat.toLong().toULong()),
+                    network = BitcoinNetwork.BITCOIN
+                )
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(encodeMeltQuote(quote).toString())
@@ -1502,7 +1587,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun listTransactions(direction: String?, promise: Promise) {
-        if (!isInitialized || wallet == null || db == null) {
+        if (!isInitialized || repo == null || db == null) {
             promise.reject("NO_WALLET", "Wallet not initialized")
             return
         }
@@ -1648,8 +1733,9 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     override fun onCatalystInstanceDestroy() {
         scope.cancel()
-        wallet = null
+        repo = null
         db = null
+        wallets.clear()
         preparedSends.clear()
         isInitialized = false
     }

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -798,9 +798,26 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     else -> QuoteState.PAID // Default to PAID for external quotes
                 }
 
+                // ZEUS Pay locks quotes to the wallet's seed-prefix key
+                // (seed[0..32]), which is byte-identical to cdk's "legacy
+                // NpubCash" key. Storing that key on the quote makes cdk's
+                // mint saga scrub it mid-flight (a version bump), and the
+                // saga's post-mint write then dies with ConcurrentUpdate
+                // AFTER the mint has issued the signatures. Instead, store
+                // the quote with no key and write cdk's NpubCash quote-key
+                // marker: at signing time cdk re-derives the identical
+                // seed-prefix key from the marker, with no mid-saga write.
+                if (!secretKey.isNullOrEmpty()) {
+                    db!!.kvWrite(
+                        primaryNamespace = "npubcash",
+                        secondaryNamespace = "quotes",
+                        key = quoteId,
+                        value = "legacy-seed-prefix".toByteArray(Charsets.UTF_8)
+                    )
+                }
+
                 // Create the MintQuote object
                 // For external quotes that are PAID, we set amountPaid = amount
-                // Include secretKey for P2PK-locked quotes
                 val zeroAmount = Amount(0UL)
                 val quote = MintQuote(
                     id = quoteId,
@@ -814,7 +831,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     amountIssued = if (quoteState == QuoteState.ISSUED) amt else zeroAmount,
                     estimatedBlocks = null,
                     paymentMethod = PaymentMethod.Bolt11,
-                    secretKey = secretKey,
+                    secretKey = null,
                     usedByOperation = null,
                     version = 0u
                 )

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitPackage.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitPackage.kt
@@ -19,7 +19,7 @@ class CashuDevKitPackage : ReactPackage {
          */
         fun isAvailable(): Boolean {
             return try {
-                Class.forName("org.cashudevkit.MultiMintWallet")
+                Class.forName("org.cashudevkit.WalletRepository")
                 true
             } catch (e: ClassNotFoundException) {
                 Log.w(TAG, "CashuDevKit library not available: ${e.message}")

--- a/cashu-cdk/CashuDevKit.ts
+++ b/cashu-cdk/CashuDevKit.ts
@@ -316,6 +316,12 @@ class CashuDevKit {
      * @param state - The quote state (UNPAID, PAID, PENDING, ISSUED)
      * @param expiry - The quote expiry timestamp
      * @param secretKey - Optional hex-encoded secret key for P2PK-locked quotes
+     * @param useSeedPrefixMarker - When the secret key equals CDK's seed
+     * prefix (seed[0..32]), store the quote keyless and write cdk's NpubCash
+     * quote-key marker instead, to avoid cdk's legacy npubcash scrub
+     * (https://github.com/cashubtc/cdk/issues/2335). Must be false when the
+     * key differs from the seed prefix (v1 wallets), or cdk would sign with
+     * the wrong key.
      */
     async addExternalMintQuote(
         mintUrl: string,
@@ -324,7 +330,8 @@ class CashuDevKit {
         request: string,
         state: string,
         expiry: number,
-        secretKey?: string
+        secretKey?: string,
+        useSeedPrefixMarker: boolean = false
     ): Promise<boolean> {
         try {
             return await CashuDevKitModule.addExternalMintQuote(
@@ -334,7 +341,8 @@ class CashuDevKit {
                 request,
                 state,
                 expiry,
-                secretKey
+                secretKey,
+                useSeedPrefixMarker
             );
         } catch (error) {
             throw mapCDKError(error);

--- a/cashu-cdk/CashuDevKit.ts
+++ b/cashu-cdk/CashuDevKit.ts
@@ -450,31 +450,6 @@ class CashuDevKit {
     }
 
     /**
-     * Execute MPP melt (pay Lightning invoice using multi-path payments)
-     * Uses the CDK's high-level melt which handles quote creation,
-     * proof selection, and partial payment in one call.
-     * @param bolt11 - BOLT11 invoice to pay
-     * @param options - Melt options including MPP amount
-     * @param maxFee - Maximum fee in sats (0 for no limit)
-     */
-    async meltMpp(
-        bolt11: string,
-        options?: any,
-        maxFee: number = 0
-    ): Promise<CDKMelted> {
-        try {
-            const json = await CashuDevKitModule.meltMpp(
-                bolt11,
-                options ? JSON.stringify(options) : undefined,
-                maxFee
-            );
-            return JSON.parse(json);
-        } catch (error) {
-            throw mapCDKError(error);
-        }
-    }
-
-    /**
      * Execute a partial melt from a specific mint.
      * Creates its own melt quote directly with the mint API
      * to get the actual fee, then sends all proofs.

--- a/cashu-cdk/types.ts
+++ b/cashu-cdk/types.ts
@@ -280,11 +280,6 @@ export interface CashuDevKitNativeModule {
     ): Promise<string>;
     checkMeltQuote(mintUrl: string, quoteId: string): Promise<string>;
     melt(mintUrl: string, quoteId: string): Promise<string>;
-    meltMpp(
-        bolt11: string,
-        optionsJson?: string,
-        maxFee?: number
-    ): Promise<string>;
     meltPartial(
         mintUrl: string,
         bolt11: string,

--- a/cashu-cdk/types.ts
+++ b/cashu-cdk/types.ts
@@ -259,7 +259,8 @@ export interface CashuDevKitNativeModule {
         request: string,
         state: string,
         expiry: number,
-        secretKey?: string
+        secretKey?: string,
+        useSeedPrefixMarker?: boolean
     ): Promise<boolean>;
     mint(
         mintUrl: string,

--- a/fetch-libraries-versions.json
+++ b/fetch-libraries-versions.json
@@ -10,10 +10,11 @@
         "iosSha256": "fe50c9796f91f121ed58bd2aa3970dc2c3048358b750ff5b8fafa3e6a8b50fce"
     },
     "cdk": {
-        "version": "0.14.2",
-        "androidSha256": "e8e9ee354cf21546e49946d351a6c482355f8b3800c60a8a9348c4ae40f529cb",
-        "iosSha256": "5c4a152cdcd6aaa6bbd1aef65c43eaeeb6ebde3f0f365fb2254cefbc49d5ea49",
-        "iosBindingsSha256": "9e3d83af633cd615f50d4c0b71e4cbdcc357e08e12209a2160a5236ef3f9fa28"
+        "version": "0.17.3",
+        "androidSha256": "632e4d593a7ed3abfc142df9cfc9b8ef68cd29db8cd12de260eb568f9828f39a",
+        "androidBindingsSha256": "56d990510fbbfed182e21549168742b007fc736df5184ce6cadf729b47eccc93",
+        "iosSha256": "02a93d7e649069dd8c75b9f14f74606ca23bf081725be57786524c60839395de",
+        "iosBindingsSha256": "2bca7a65eeee1e1ebc45f33287293e31bb473ed3662cb74a3d699444e3c831e8"
     },
     "zeus-cashu-restore": {
         "version": "0.1.0",

--- a/fetch-libraries.sh
+++ b/fetch-libraries.sh
@@ -10,6 +10,7 @@ LDK_NODE_ANDROID_SHA256=$(jq "['ldk-node']['androidSha256']")
 LDK_NODE_IOS_SHA256=$(jq "['ldk-node']['iosSha256']")
 CDK_VERSION=$(jq "['cdk']['version']")
 CDK_ANDROID_SHA256=$(jq "['cdk']['androidSha256']")
+CDK_ANDROID_BINDINGS_SHA256=$(jq "['cdk']['androidBindingsSha256']")
 CDK_IOS_SHA256=$(jq "['cdk']['iosSha256']")
 CDK_IOS_BINDINGS_SHA256=$(jq "['cdk']['iosBindingsSha256']")
 RESTORE_VERSION=$(jq "['zeus-cashu-restore']['version']")
@@ -23,8 +24,8 @@ RESTORE_IOS_BINDINGS_SHA256=$(jq "['zeus-cashu-restore']['iosBindingsSha256']")
 # blank hash would otherwise skip verification silently.
 for HASH in "$EMBEDDED_LND_ANDROID_SHA256" "$EMBEDDED_LND_IOS_SHA256" \
             "$LDK_NODE_ANDROID_SHA256" "$LDK_NODE_IOS_SHA256" \
-            "$CDK_ANDROID_SHA256" "$CDK_IOS_SHA256" \
-            "$CDK_IOS_BINDINGS_SHA256" \
+            "$CDK_ANDROID_SHA256" "$CDK_ANDROID_BINDINGS_SHA256" \
+            "$CDK_IOS_SHA256" "$CDK_IOS_BINDINGS_SHA256" \
             "$RESTORE_ANDROID_SHA256" "$RESTORE_IOS_SHA256" \
             "$RESTORE_ANDROID_BINDINGS_SHA256" "$RESTORE_IOS_BINDINGS_SHA256"; do
     if ! echo "$HASH" | grep -qE '^[0-9a-f]{64}$'; then
@@ -112,16 +113,19 @@ unzip ios/LndMobileLibZipFile/$EMBEDDED_LND_IOS_FILE.zip -d ios/LncMobile
 # CashuDevKit #
 ###############
 
-# Local filename (what we save as)
+# Local filenames (what we save as)
 CDK_ANDROID_FILE=cashudevkit.aar
-CDK_IOS_FILE=cdkFFI.xcframework
-# Remote filename (what's on GitHub releases)
-CDK_ANDROID_REMOTE=cdk-kotlin-$CDK_VERSION.aar
+CDK_ANDROID_BINDINGS_FILE=cdk-jvm.jar
+CDK_IOS_FILE=CashuDevKitFFI.xcframework
 
-CDK_FILE_PATH=https://github.com/cashubtc/cdk-kotlin/releases/download/v$CDK_VERSION/
+# Since 0.17.x, cdk-kotlin is distributed via Maven Central and split in two:
+# cdk-android (only the per-ABI libcdk_ffi.so) + cdk-jvm (the compiled Kotlin
+# bindings). Both are vendored here with pinned hashes; JNA comes via gradle.
+CDK_MAVEN_PATH=https://repo1.maven.org/maven2/org/cashudevkit
 CDK_IOS_PATH=https://github.com/cashubtc/cdk-swift/releases/download/v$CDK_VERSION/
 
-CDK_ANDROID_LINK=$CDK_FILE_PATH$CDK_ANDROID_REMOTE
+CDK_ANDROID_LINK=$CDK_MAVEN_PATH/cdk-android/$CDK_VERSION/cdk-android-$CDK_VERSION.aar
+CDK_ANDROID_BINDINGS_LINK=$CDK_MAVEN_PATH/cdk-jvm/$CDK_VERSION/cdk-jvm-$CDK_VERSION.jar
 CDK_IOS_LINK=$CDK_IOS_PATH$CDK_IOS_FILE.zip
 
 # Android CDK
@@ -135,6 +139,19 @@ if ! echo "$CDK_ANDROID_SHA256 android/cdk/$CDK_ANDROID_FILE" | sha256sum -c -; 
 
     if ! echo "$CDK_ANDROID_SHA256 android/cdk/$CDK_ANDROID_FILE" | sha256sum -c -; then
         echo "CDK Android checksum failed" >&2
+        exit 1
+    fi
+fi
+
+# Android CDK Kotlin bindings (cdk-jvm)
+if ! echo "$CDK_ANDROID_BINDINGS_SHA256 android/cdk/$CDK_ANDROID_BINDINGS_FILE" | sha256sum -c -; then
+    echo "CDK Android bindings jar missing or checksum failed" >&2
+
+    rm -f android/cdk/$CDK_ANDROID_BINDINGS_FILE
+    curl -fL $CDK_ANDROID_BINDINGS_LINK > android/cdk/$CDK_ANDROID_BINDINGS_FILE
+
+    if ! echo "$CDK_ANDROID_BINDINGS_SHA256 android/cdk/$CDK_ANDROID_BINDINGS_FILE" | sha256sum -c -; then
+        echo "CDK Android bindings checksum failed" >&2
         exit 1
     fi
 fi
@@ -155,17 +172,38 @@ if ! echo "$CDK_IOS_SHA256 ios/CashuDevKitLibZipFile/$CDK_IOS_FILE.zip" | sha256
     fi
 fi
 
+# Remove artifacts from the pre-0.17.x layout (framework and zip were named
+# cdkFFI; the Android aar bundled its own bindings so there was no jar)
+rm -rf ios/Cdk/cdkFFI.xcframework
+rm -f ios/CashuDevKitLibZipFile/cdkFFI.xcframework.zip
+
 # Extract to ios/Cdk directory (used by Podfile)
 rm -rf ios/Cdk/$CDK_IOS_FILE
 
 unzip ios/CashuDevKitLibZipFile/$CDK_IOS_FILE.zip -d ios/Cdk
+
+# Strip the macOS slice: upstream ships it as a dynamic library while the
+# iOS slices are static archives, and CocoaPods refuses mixed xcframeworks.
+rm -rf ios/Cdk/$CDK_IOS_FILE/macos-arm64_x86_64
+python3 - <<EOF
+import plistlib
+path = "ios/Cdk/$CDK_IOS_FILE/Info.plist"
+with open(path, "rb") as f:
+    plist = plistlib.load(f)
+plist["AvailableLibraries"] = [
+    lib for lib in plist["AvailableLibraries"]
+    if lib.get("SupportedPlatform") != "macos"
+]
+with open(path, "wb") as f:
+    plistlib.dump(plist, f)
+EOF
 
 echo "CashuDevKit iOS framework installed to ios/Cdk/$CDK_IOS_FILE"
 
 # Download matching Swift bindings from cdk-swift repo. When bumping the CDK
 # version, update iosBindingsSha256 in fetch-libraries-versions.json to the
 # hash of the file at the new tag.
-CDK_SWIFT_BINDINGS_URL="https://raw.githubusercontent.com/cashubtc/cdk-swift/v$CDK_VERSION/Sources/CashuDevKit/CashuDevKit.swift"
+CDK_SWIFT_BINDINGS_URL="https://raw.githubusercontent.com/cashubtc/cdk-swift/v$CDK_VERSION/Sources/Cdk/CashuDevKit.swift"
 mkdir -p ios/CashuDevKit
 
 if ! echo "$CDK_IOS_BINDINGS_SHA256 ios/CashuDevKit/CashuDevKit.swift" | sha256sum -c -; then

--- a/ios/CashuDevKit.podspec
+++ b/ios/CashuDevKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CashuDevKit'
-  s.version          = '0.14.2'
+  s.version          = '0.17.3'
   s.summary          = 'Cashu Development Kit - FFI bindings for iOS'
   s.description      = <<-DESC
     CashuDevKit provides Swift bindings to the Cashu Development Kit (CDK),
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
 
   # Vendored xcframework
-  s.vendored_frameworks = 'Cdk/cdkFFI.xcframework'
+  s.vendored_frameworks = 'Cdk/CashuDevKitFFI.xcframework'
 
   # Source files - Swift bindings
   s.source_files = 'CashuDevKit/CashuDevKit.swift'
@@ -38,5 +38,5 @@ Pod::Spec.new do |s|
   }
 
   # Preserve paths for the framework
-  s.preserve_paths = 'Cdk/cdkFFI.xcframework/**/*'
+  s.preserve_paths = 'Cdk/CashuDevKitFFI.xcframework/**/*'
 end

--- a/ios/CashuDevKit/CashuDevKitModule.m
+++ b/ios/CashuDevKit/CashuDevKitModule.m
@@ -105,12 +105,6 @@ RCT_EXTERN_METHOD(melt:(NSString *)mintUrl
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(meltMpp:(NSString *)bolt11
-                  optionsJson:(NSString * _Nullable)optionsJson
-                  maxFee:(nonnull NSNumber *)maxFee
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(meltPartial:(NSString *)mintUrl
                   bolt11:(NSString *)bolt11
                   mppAmountMsat:(nonnull NSNumber *)mppAmountMsat

--- a/ios/CashuDevKit/CashuDevKitModule.m
+++ b/ios/CashuDevKit/CashuDevKitModule.m
@@ -73,6 +73,7 @@ RCT_EXTERN_METHOD(addExternalMintQuote:(NSString *)mintUrl
                   state:(NSString *)state
                   expiry:(nonnull NSNumber *)expiry
                   secretKey:(NSString * _Nullable)secretKey
+                  useSeedPrefixMarker:(BOOL)useSeedPrefixMarker
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -166,9 +166,11 @@ class CashuDevKitModule: RCTEventEmitter {
 
         let url = MintUrl(url: normalized)
         let unit = walletQueue.sync { walletUnit }
-        if !(await repo.hasMint(mintUrl: url)) {
-            try await repo.createWallet(mintUrl: url, unit: unit, targetProofCount: nil)
-        }
+        // hasMint matches any unit for the URL while getWallet is keyed on
+        // (URL, unit), so a mint loaded only under a non-sat unit would skip
+        // creation here and then miss. createWallet is a no-network map
+        // insert, so create unconditionally instead of guarding
+        try await repo.createWallet(mintUrl: url, unit: unit, targetProofCount: nil)
         let wallet = try await repo.getWallet(mintUrl: url, unit: unit)
         walletQueue.sync { wallets[normalized] = wallet }
         return wallet

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -823,25 +823,39 @@ class CashuDevKitModule: RCTEventEmitter {
                 // Create the MintQuote object
                 // For external quotes that are PAID, we set amountPaid = amount
                 let zeroAmount = Amount(value: 0)
-                let quote = MintQuote(
-                    id: quoteId,
-                    amount: amt,
-                    unit: .sat,
-                    request: request,
-                    state: quoteState,
-                    expiry: UInt64(truncating: expiry),
-                    mintUrl: url,
-                    amountIssued: quoteState == .issued ? amt : zeroAmount,
-                    amountPaid: (quoteState == .paid || quoteState == .issued) ? amt : zeroAmount,
-                    estimatedBlocks: nil,
-                    paymentMethod: .bolt11,
-                    secretKey: useSeedPrefixMarker ? nil : storedSecretKey,
-                    usedByOperation: nil,
-                    version: 0
-                )
+                func makeQuote(version: UInt32) -> MintQuote {
+                    MintQuote(
+                        id: quoteId,
+                        amount: amt,
+                        unit: .sat,
+                        request: request,
+                        state: quoteState,
+                        expiry: UInt64(truncating: expiry),
+                        mintUrl: url,
+                        amountIssued: quoteState == .issued ? amt : zeroAmount,
+                        amountPaid: (quoteState == .paid || quoteState == .issued) ? amt : zeroAmount,
+                        estimatedBlocks: nil,
+                        paymentMethod: .bolt11,
+                        secretKey: useSeedPrefixMarker ? nil : storedSecretKey,
+                        usedByOperation: nil,
+                        version: version
+                    )
+                }
 
-                // Add to database
-                try await db.addMintQuote(quote: quote)
+                // addMintQuote is a CAS upsert: the update only applies while
+                // the stored row still has the version we write, and a failed
+                // mint attempt leaves the row bumped by the saga's claim.
+                // Reuse the stored version (0 for a fresh insert) so retries
+                // do not die with ConcurrentUpdate before minting
+                let storedVersion = try await db.getMintQuote(quoteId: quoteId)?.version ?? 0
+                do {
+                    try await db.addMintQuote(quote: makeQuote(version: storedVersion))
+                } catch {
+                    // Lost the CAS race between read and write; re-read and
+                    // retry once
+                    let retryVersion = try await db.getMintQuote(quoteId: quoteId)?.version ?? 0
+                    try await db.addMintQuote(quote: makeQuote(version: retryVersion))
+                }
 
                 resolve(true)
             } catch let error as FfiError {

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -5,17 +5,25 @@ import ZeusCashuRestore
 
 /// CashuDevKit Native Module for React Native
 /// Provides bridge to CDK FFI bindings
+///
+/// CDK 0.15+ replaced the MultiMintWallet with a WalletRepository plus
+/// per-mint Wallet objects, and one-shot melts with a two-phase
+/// prepare/confirm flow. This module adapts the new API behind the
+/// pre-existing bridge contract: method names, parameters and resolved
+/// JSON shapes are unchanged from the 0.14.x module.
 @objc(CashuDevKitModule)
 class CashuDevKitModule: RCTEventEmitter {
 
     // MARK: - Properties
 
-    private var wallet: MultiMintWallet?
+    private var repo: WalletRepository?
     private var db: WalletSqliteDatabase?
+    private var walletUnit: CurrencyUnit = .sat
+    private var wallets: [String: Wallet] = [:]
     private var preparedSends: [String: PreparedSend] = [:]
     private var isInitialized: Bool = false
 
-    // Serial queue for thread-safe wallet access
+    // Serial queue for thread-safe access to the properties above
     private let walletQueue = DispatchQueue(label: "app.zeusln.cashudevkit.wallet")
 
     // MARK: - Module Setup
@@ -41,21 +49,21 @@ class CashuDevKitModule: RCTEventEmitter {
           !pubkey.isEmpty else {
         return nil
     }
-    
+
       let locktime: UInt64 = {
         if let lt = condData["locktime"] as? NSNumber {
             return lt.uint64Value
         }
         return 0
     }()
-    
+
     let refundKeys: [String] = {
         if let keys = condData["refund_keys"] as? [String] {
             return keys.filter { !$0.isEmpty }
         }
         return []
     }()
-    
+
     let conditions = Conditions(
         locktime: locktime,
         pubkeys: [],
@@ -64,7 +72,7 @@ class CashuDevKitModule: RCTEventEmitter {
         sigFlag: 0,
         numSigsRefund: 0
     )
-    
+
     return .p2pk(pubkey: pubkey, conditions: conditions)
   }
 
@@ -119,12 +127,50 @@ class CashuDevKitModule: RCTEventEmitter {
         return nil
     }
 
-    /// Returns the initialized wallet or rejects with NO_WALLET error
-    private func getInitializedWallet(reject: @escaping RCTPromiseRejectBlock) -> MultiMintWallet? {
-        guard isInitialized, let wallet = wallet else {
+    /// Returns the initialized wallet repository or rejects with NO_WALLET error
+    private func getInitializedRepo(reject: @escaping RCTPromiseRejectBlock) -> WalletRepository? {
+        let repo: WalletRepository? = walletQueue.sync {
+            guard isInitialized else { return nil }
+            return self.repo
+        }
+        guard let repo else {
             reject("NO_WALLET", "Wallet not initialized", nil)
             return nil
         }
+        return repo
+    }
+
+    private func normalizeMintUrl(_ mintUrl: String) -> String {
+        var url = mintUrl
+        while url.hasSuffix("/") {
+            url = String(url.dropLast())
+        }
+        return url
+    }
+
+    /// Get (or lazily create) the per-mint Wallet for a mint URL.
+    ///
+    /// The repository only creates an in-memory Wallet handle here; no
+    /// network request is made until the wallet is used. Creating on
+    /// demand preserves the 0.14.x MultiMintWallet behavior where
+    /// receive/restore operated with allowUntrusted: true.
+    private func getWallet(_ mintUrl: String) async throws -> Wallet {
+        let normalized = normalizeMintUrl(mintUrl)
+        if let cached = walletQueue.sync(execute: { wallets[normalized] }) {
+            return cached
+        }
+
+        guard let repo = walletQueue.sync(execute: { isInitialized ? self.repo : nil }) else {
+            throw FfiError.Internal(errorMessage: "Wallet not initialized")
+        }
+
+        let url = MintUrl(url: normalized)
+        let unit = walletQueue.sync { walletUnit }
+        if !(await repo.hasMint(mintUrl: url)) {
+            try await repo.createWallet(mintUrl: url, unit: unit, targetProofCount: nil)
+        }
+        let wallet = try await repo.getWallet(mintUrl: url, unit: unit)
+        walletQueue.sync { wallets[normalized] = wallet }
         return wallet
     }
 
@@ -203,49 +249,63 @@ class CashuDevKitModule: RCTEventEmitter {
         }
     }
 
+    /// Map the CDK FFI error to the legacy bridge error codes that JS
+    /// consumers were written against. CDK 0.15+ collapsed the previous
+    /// 19 error variants into Cdk(code, message) with Cashu protocol
+    /// error codes, plus Internal(message) for infrastructure errors.
     private func mapFfiError(_ error: FfiError) -> (code: String, message: String) {
         switch error {
-        case .Generic(let message):
-            return ("GENERIC_ERROR", message)
-        case .AmountOverflow(let message):
-            return ("AMOUNT_OVERFLOW", message)
-        case .PaymentFailed(let message):
-            return ("PAYMENT_FAILED", message)
-        case .PaymentPending(let message):
-            return ("PAYMENT_PENDING", message)
-        case .InsufficientFunds(let message):
-            return ("INSUFFICIENT_FUNDS", message)
-        case .Database(let message):
-            return ("DATABASE_ERROR", message)
-        case .Network(let message):
-            return ("NETWORK_ERROR", message)
-        case .InvalidToken(let message):
-            return ("INVALID_TOKEN", message)
-        case .Wallet(let message):
-            return ("WALLET_ERROR", message)
-        case .KeysetUnknown(let message):
-            return ("KEYSET_UNKNOWN", message)
-        case .UnitNotSupported(let message):
-            return ("UNIT_NOT_SUPPORTED", message)
-        case .InvalidMnemonic(let message):
-            return ("INVALID_MNEMONIC", message)
-        case .InvalidUrl(let message):
-            return ("INVALID_URL", message)
-        case .DivisionByZero(let message):
-            return ("DIVISION_BY_ZERO", message)
-        case .Amount(let message):
-            return ("AMOUNT_ERROR", message)
-        case .RuntimeTaskJoin(let message):
-            return ("RUNTIME_ERROR", message)
-        case .InvalidHex(let message):
-            return ("INVALID_HEX", message)
-        case .InvalidCryptographicKey(let message):
-            return ("INVALID_KEY", message)
-        case .Serialization(let message):
-            return ("SERIALIZATION_ERROR", message)
+        case let .Cdk(code, errorMessage):
+            return (legacyErrorCode(protocolCode: code, message: errorMessage), errorMessage)
+        case let .Internal(errorMessage):
+            return (legacyErrorCode(protocolCode: nil, message: errorMessage), errorMessage)
         @unknown default:
             return ("UNKNOWN_ERROR", "Unknown error occurred")
         }
+    }
+
+    private func legacyErrorCode(protocolCode: UInt32?, message: String) -> String {
+        if let code = protocolCode {
+            switch code {
+            case 10003, 11001, 11002, 11007:
+                // Token verification / already spent / unbalanced / duplicate inputs
+                return "INVALID_TOKEN"
+            case 11005:
+                return "UNIT_NOT_SUPPORTED"
+            case 12001, 12002:
+                return "KEYSET_UNKNOWN"
+            case 20005:
+                return "PAYMENT_PENDING"
+            case 20000...20999:
+                return "PAYMENT_FAILED"
+            default:
+                break
+            }
+        }
+
+        let lowered = message.lowercased()
+        if lowered.contains("insufficient funds") {
+            return "INSUFFICIENT_FUNDS"
+        }
+        if lowered.contains("payment failed") {
+            return "PAYMENT_FAILED"
+        }
+        if lowered.contains("payment pending") || lowered.contains("quote pending") {
+            return "PAYMENT_PENDING"
+        }
+        if lowered.contains("network") || lowered.contains("connection") || lowered.contains("transport") {
+            return "NETWORK_ERROR"
+        }
+        if lowered.contains("database") {
+            return "DATABASE_ERROR"
+        }
+        if lowered.contains("mnemonic") {
+            return "INVALID_MNEMONIC"
+        }
+        if lowered.contains("invalid url") {
+            return "INVALID_URL"
+        }
+        return "GENERIC_ERROR"
     }
 
     private func encodeMintQuote(_ quote: MintQuote) -> [String: Any] {
@@ -270,13 +330,15 @@ class CashuDevKitModule: RCTEventEmitter {
             "state": quoteStateToString(quote.state),
             "expiry": quote.expiry
         ]
-        if let preimage = quote.paymentPreimage {
+        // Upstream renamed payment_preimage to payment_proof; the bridge
+        // key is part of the JS contract and keeps the old name
+        if let preimage = quote.paymentProof {
             result["payment_preimage"] = preimage
         }
         return result
     }
 
-    private func encodeMelted(_ melted: Melted) -> [String: Any] {
+    private func encodeMelted(_ melted: FinalizedMelt) -> [String: Any] {
         var result: [String: Any] = [
             "state": quoteStateToString(melted.state),
             "amount": melted.amount.value,
@@ -313,40 +375,20 @@ class CashuDevKitModule: RCTEventEmitter {
         "unit": token.unit().map { currencyUnitToString($0) } ?? "sat"
     ]
     do {
-        if let wallet = self.wallet {
-            let keysets = try await wallet.getMintKeysets(mintUrl: mintUrl)
-            let proofs = try token.proofs(mintKeysets: keysets)
-            result["proofs"] = proofs.map { encodeProof($0) }
+        // Only resolve proofs through a wallet the mint is already part
+        // of; decoding a foreign token must not add its mint or contact it
+        if let repo = walletQueue.sync(execute: { isInitialized ? self.repo : nil }) {
+            if await repo.hasMint(mintUrl: MintUrl(url: normalizeMintUrl(mintUrl.url))) {
+                let wallet = try await getWallet(mintUrl.url)
+                let keysets = try await wallet.getMintKeysets(filter: .all)
+                let proofs = try token.proofs(mintKeysets: keysets)
+                result["proofs"] = proofs.map { encodeProof($0) }
+            }
         }
     } catch {
         result["proofs"] = []
     }
     return result
-    }
-
-    private func encodeMintInfo(_ info: MintInfo) -> [String: Any] {
-        var result: [String: Any] = [:]
-
-        if let name = info.name {
-            result["name"] = name
-        }
-        if let pubkey = info.pubkey {
-            result["pubkey"] = pubkey
-        }
-        if let version = info.version {
-            result["version"] = version
-        }
-        if let description = info.description {
-            result["description"] = description
-        }
-        if let descriptionLong = info.descriptionLong {
-            result["description_long"] = descriptionLong
-        }
-        if let motd = info.motd {
-            result["motd"] = motd
-        }
-
-        return result
     }
 
     private func encodeKeyset(_ keyset: KeySetInfo) -> [String: Any] {
@@ -376,19 +418,22 @@ class CashuDevKitModule: RCTEventEmitter {
                 let dbPath = getDatabasePath(for: mnemonic)
                 self.currentDbPath = dbPath
                 let sqliteDb = try WalletSqliteDatabase(filePath: dbPath)
-                self.db = sqliteDb
 
                 let currencyUnit = parseCurrencyUnit(unit)
 
-                // WalletSqliteDatabase conforms to WalletDatabase protocol, pass directly
-                let newWallet = try MultiMintWallet(
-                    unit: currencyUnit,
+                // WalletSqliteDatabase conforms to WalletDatabase; passing
+                // it via WalletStore.custom keeps the same handle available
+                // for the direct database methods below
+                let newRepo = try WalletRepository(
                     mnemonic: mnemonic,
-                    db: sqliteDb
+                    store: .custom(db: sqliteDb)
                 )
 
                 walletQueue.sync {
-                    self.wallet = newWallet
+                    self.db = sqliteDb
+                    self.repo = newRepo
+                    self.walletUnit = currencyUnit
+                    self.wallets.removeAll()
                     self.isInitialized = true
                 }
 
@@ -406,14 +451,15 @@ class CashuDevKitModule: RCTEventEmitter {
     func addMint(_ mintUrl: String, targetProofCount: NSNumber,
                  resolve: @escaping RCTPromiseResolveBlock,
                  reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard let repo = getInitializedRepo(reject: reject) else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
+                let url = MintUrl(url: normalizeMintUrl(mintUrl))
                 // Use nil if targetProofCount is 0 or negative (sentinel for "use default")
                 let count: UInt32? = targetProofCount.intValue > 0 ? targetProofCount.uint32Value : nil
-                try await wallet.addMint(mintUrl: url, targetProofCount: count)
+                let unit = walletQueue.sync { walletUnit }
+                try await repo.createWallet(mintUrl: url, unit: unit, targetProofCount: count)
                 resolve(nil)
             } catch let error as FfiError {
                 let (code, message) = mapFfiError(error)
@@ -428,13 +474,20 @@ class CashuDevKitModule: RCTEventEmitter {
     func removeMint(_ mintUrl: String,
                     resolve: @escaping RCTPromiseResolveBlock,
                     reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard let repo = getInitializedRepo(reject: reject) else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
-                await wallet.removeMint(mintUrl: url)
-                if let db = self.db {
+                let normalized = normalizeMintUrl(mintUrl)
+                let url = MintUrl(url: normalized)
+                let unit = walletQueue.sync { walletUnit }
+                // removeWallet only drops the in-memory wallet; tolerate a
+                // mint the repository does not know (parity with the
+                // non-throwing 0.14.x removeMint)
+                try? await repo.removeWallet(mintUrl: url, currencyUnit: unit)
+                _ = walletQueue.sync { wallets.removeValue(forKey: normalized) }
+                let dbHandle: WalletSqliteDatabase? = walletQueue.sync { self.db }
+                if let db = dbHandle {
                     try await db.removeMint(mintUrl: url)
                 } else {
                     reject(
@@ -457,10 +510,18 @@ class CashuDevKitModule: RCTEventEmitter {
     @objc(getMintUrls:rejecter:)
     func getMintUrls(resolve: @escaping RCTPromiseResolveBlock,
                      reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard let repo = getInitializedRepo(reject: reject) else { return }
 
         Task {
-            let urls = await wallet.getMintUrls()
+            let wallets = await repo.getWallets()
+            var seen = Set<String>()
+            var urls: [String] = []
+            for wallet in wallets {
+                let url = wallet.mintUrl().url
+                if seen.insert(url).inserted {
+                    urls.append(url)
+                }
+            }
             resolve(urls)
         }
     }
@@ -470,11 +531,11 @@ class CashuDevKitModule: RCTEventEmitter {
     @objc(getTotalBalance:rejecter:)
     func getTotalBalance(resolve: @escaping RCTPromiseResolveBlock,
                          reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard let repo = getInitializedRepo(reject: reject) else { return }
 
         Task {
             do {
-                let balances = try await wallet.getBalances()
+                let balances = try await repo.getBalances()
                 var total: UInt64 = 0
                 for (_, amount) in balances {
                     total += amount.value
@@ -492,14 +553,14 @@ class CashuDevKitModule: RCTEventEmitter {
     @objc(getBalances:rejecter:)
     func getBalances(resolve: @escaping RCTPromiseResolveBlock,
                      reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard let repo = getInitializedRepo(reject: reject) else { return }
 
         Task {
             do {
-                let balances = try await wallet.getBalances()
+                let balances = try await repo.getBalances()
                 var result: [String: UInt64] = [:]
-                for (mintUrl, amount) in balances {
-                    result[mintUrl] = amount.value
+                for (key, amount) in balances {
+                    result[key.mintUrl.url, default: 0] += amount.value
                 }
                 resolve(encodeToJson(result))
             } catch let error as FfiError {
@@ -561,12 +622,12 @@ class CashuDevKitModule: RCTEventEmitter {
     func getMintKeysets(_ mintUrl: String,
                         resolve: @escaping RCTPromiseResolveBlock,
                         reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
-                let keysets = try await wallet.getMintKeysets(mintUrl: url)
+                let wallet = try await getWallet(mintUrl)
+                let keysets = try await wallet.getMintKeysets(filter: .all)
                 let encoded = keysets.map { encodeKeyset($0) }
                 resolve(encodeToJson(encoded))
             } catch let error as FfiError {
@@ -584,13 +645,18 @@ class CashuDevKitModule: RCTEventEmitter {
     func createMintQuote(_ mintUrl: String, amount: NSNumber, description: String?,
                          resolve: @escaping RCTPromiseResolveBlock,
                          reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
                 let amt = Amount(value: amount.uint64Value)
-                let quote = try await wallet.mintQuote(mintUrl: url, amount: amt, description: description)
+                let wallet = try await getWallet(mintUrl)
+                let quote = try await wallet.mintQuote(
+                    paymentMethod: .bolt11,
+                    amount: amt,
+                    description: description,
+                    extra: nil
+                )
                 resolve(encodeToJson(encodeMintQuote(quote)))
             } catch let error as FfiError {
                 let (code, message) = mapFfiError(error)
@@ -605,12 +671,12 @@ class CashuDevKitModule: RCTEventEmitter {
     func checkMintQuote(_ mintUrl: String, quoteId: String,
                         resolve: @escaping RCTPromiseResolveBlock,
                         reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
-                let quote = try await wallet.checkMintQuote(mintUrl: url, quoteId: quoteId)
+                let wallet = try await getWallet(mintUrl)
+                let quote = try await wallet.checkMintQuote(quoteId: quoteId)
                 resolve(encodeToJson(encodeMintQuote(quote)))
             } catch let error as FfiError {
                 let (code, message) = mapFfiError(error)
@@ -690,7 +756,11 @@ class CashuDevKitModule: RCTEventEmitter {
                                secretKey: String?,
                                resolve: @escaping RCTPromiseResolveBlock,
                                reject: @escaping RCTPromiseRejectBlock) {
-        guard isInitialized, let db = db else {
+        let dbHandle: WalletSqliteDatabase? = walletQueue.sync {
+            guard isInitialized else { return nil }
+            return self.db
+        }
+        guard let db = dbHandle else {
             reject("NO_WALLET", "Wallet not initialized", nil)
             return
         }
@@ -729,8 +799,11 @@ class CashuDevKitModule: RCTEventEmitter {
                     mintUrl: url,
                     amountIssued: quoteState == .issued ? amt : zeroAmount,
                     amountPaid: (quoteState == .paid || quoteState == .issued) ? amt : zeroAmount,
+                    estimatedBlocks: nil,
                     paymentMethod: .bolt11,
-                    secretKey: secretKey
+                    secretKey: secretKey,
+                    usedByOperation: nil,
+                    version: 0
                 )
 
                 // Add to database
@@ -752,14 +825,17 @@ class CashuDevKitModule: RCTEventEmitter {
     func mintExternal(_ mintUrl: String, quoteId: String, amount: NSNumber,
                       resolve: @escaping RCTPromiseResolveBlock,
                       reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
-
                 // Mint - quote should be in database now
-                let proofs = try await wallet.mint(mintUrl: url, quoteId: quoteId, spendingConditions: nil)
+                let wallet = try await getWallet(mintUrl)
+                let proofs = try await wallet.mint(
+                    quoteId: quoteId,
+                    amountSplitTarget: .none,
+                    spendingConditions: nil
+                )
                 let encoded = proofs.map { encodeProof($0) }
                 resolve(encodeToJson(encoded))
             } catch let error as FfiError {
@@ -775,12 +851,10 @@ class CashuDevKitModule: RCTEventEmitter {
     func mint(_ mintUrl: String, quoteId: String, conditionsJson: String?,
               resolve: @escaping RCTPromiseResolveBlock,
               reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
-
                 // Parse spending conditions if provided
                 var conditions: SpendingConditions? = nil
                 if let json = conditionsJson,
@@ -789,7 +863,12 @@ class CashuDevKitModule: RCTEventEmitter {
                    conditions = parseP2PKConditions(from: parsed)
                 }
 
-                let proofs = try await wallet.mint(mintUrl: url, quoteId: quoteId, spendingConditions: conditions)
+                let wallet = try await getWallet(mintUrl)
+                let proofs = try await wallet.mint(
+                    quoteId: quoteId,
+                    amountSplitTarget: .none,
+                    spendingConditions: conditions
+                )
                 let encoded = proofs.map { encodeProof($0) }
                 resolve(encodeToJson(encoded))
             } catch let error as FfiError {
@@ -807,16 +886,17 @@ class CashuDevKitModule: RCTEventEmitter {
     func createMeltQuote(_ mintUrl: String, request: String, optionsJson: String?,
                          resolve: @escaping RCTPromiseResolveBlock,
                          reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
                 let options = parseMeltOptions(from: optionsJson)
+                let wallet = try await getWallet(mintUrl)
                 let quote = try await wallet.meltQuote(
-                    mintUrl: url,
+                    method: .bolt11,
                     request: request,
-                    options: options
+                    options: options,
+                    extra: nil
                 )
                 resolve(encodeToJson(encodeMeltQuote(quote)))
             } catch let error as FfiError {
@@ -832,12 +912,12 @@ class CashuDevKitModule: RCTEventEmitter {
     func checkMeltQuote(_ mintUrl: String, quoteId: String,
                         resolve: @escaping RCTPromiseResolveBlock,
                         reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
-                let quote = try await wallet.checkMeltQuote(mintUrl: url, quoteId: quoteId)
+                let wallet = try await getWallet(mintUrl)
+                let quote = try await wallet.checkMeltQuoteStatus(quoteId: quoteId)
                 resolve(encodeToJson(encodeMeltQuote(quote)))
             } catch let error as FfiError {
                 let (code, message) = mapFfiError(error)
@@ -852,12 +932,13 @@ class CashuDevKitModule: RCTEventEmitter {
     func melt(_ mintUrl: String, quoteId: String,
               resolve: @escaping RCTPromiseResolveBlock,
               reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
-                let melted = try await wallet.meltWithMint(mintUrl: url, quoteId: quoteId)
+                let wallet = try await getWallet(mintUrl)
+                let prepared = try await wallet.prepareMelt(quoteId: quoteId)
+                let melted = try await prepared.confirm()
                 resolve(encodeToJson(encodeMelted(melted)))
             } catch let error as FfiError {
                 let (code, message) = mapFfiError(error)
@@ -868,73 +949,58 @@ class CashuDevKitModule: RCTEventEmitter {
         }
     }
 
-    @objc(meltMpp:optionsJson:maxFee:resolver:rejecter:)
-    func meltMpp(_ bolt11: String, optionsJson: String?, maxFee: NSNumber,
-                 resolve: @escaping RCTPromiseResolveBlock,
-                 reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
-
-        Task {
-            do {
-                let options = parseMeltOptions(from: optionsJson)
-                let fee = maxFee.uint64Value > 0 ? Amount(value: maxFee.uint64Value) : nil
-                let melted = try await wallet.melt(bolt11: bolt11, options: options, maxFee: fee)
-                resolve(encodeToJson(encodeMelted(melted)))
-            } catch let error as FfiError {
-                let (code, message) = mapFfiError(error)
-                reject(code, message, error)
-            } catch {
-                reject("MELT_MPP_ERROR", error.localizedDescription, error)
-            }
-        }
-    }
-
     @objc(meltPartial:bolt11:mppAmountMsat:resolver:rejecter:)
     func meltPartial(_ mintUrl: String, bolt11: String, mppAmountMsat: NSNumber,
                      resolve: @escaping RCTPromiseResolveBlock,
                      reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
                 let mppAmount = Amount(value: mppAmountMsat.uint64Value)
+                let wallet = try await getWallet(mintUrl)
 
                 // Step 1: Create melt quote via CDK with MPP options
                 let options = MeltOptions.mpp(amount: mppAmount)
                 let quote = try await wallet.meltQuote(
-                    mintUrl: url,
+                    method: .bolt11,
                     request: bolt11,
-                    options: options
+                    options: options,
+                    extra: nil
                 )
 
-                // Step 2: Select proofs via CDK and execute melt
-                // Try meltProofs with all proofs from this mint —
+                // Step 2: Gather this mint's unspent proofs —
                 // the mint knows the MPP partial amount from the quote
-                let allProofs = try await wallet.listProofs()
-                let normalizedUrl = mintUrl.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-                var mintProofs: [Proof] = []
-                for (key, proofs) in allProofs {
-                    let normalizedKey = key.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-                    if normalizedKey == normalizedUrl {
-                        mintProofs = proofs
-                        break
-                    }
+                let dbHandle: WalletSqliteDatabase? = walletQueue.sync { self.db }
+                guard let db = dbHandle else {
+                    reject("NO_WALLET", "Wallet not initialized", nil)
+                    return
                 }
+                let url = MintUrl(url: normalizeMintUrl(mintUrl))
+                let proofInfos = try await db.getProofs(
+                    mintUrl: url,
+                    unit: .sat,
+                    state: [.unspent],
+                    spendingConditions: nil
+                )
+                let mintProofs = proofInfos.map { $0.proof }
 
                 guard !mintProofs.isEmpty else {
                     reject("NO_PROOFS", "No proofs found for mint \(mintUrl)", nil)
                     return
                 }
 
-                // Step 3: Try CDK's meltProofs first (keeps proof DB in sync)
-                let melted = try await wallet.meltProofs(
-                    mintUrl: url,
+                // Step 3: Two-phase melt with the selected proofs
+                let prepared = try await wallet.prepareMeltProofs(
                     quoteId: quote.id,
                     proofs: mintProofs
                 )
+                let melted = try await prepared.confirm()
 
                 resolve(encodeToJson(encodeMelted(melted)))
+            } catch let error as FfiError {
+                let (code, message) = mapFfiError(error)
+                reject(code, message, error)
             } catch {
                 reject("MELT_PARTIAL_ERROR", error.localizedDescription, error)
             }
@@ -947,11 +1013,10 @@ class CashuDevKitModule: RCTEventEmitter {
     func prepareSend(_ mintUrl: String, amount: NSNumber, optionsJson: String?,
                      resolve: @escaping RCTPromiseResolveBlock,
                      reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
                 let amt = Amount(value: amount.uint64Value)
 
                 // Parse options if provided
@@ -982,25 +1047,22 @@ class CashuDevKitModule: RCTEventEmitter {
                     }
                 }
 
-                let innerSendOptions = SendOptions(
+                let sendOptions = SendOptions(
                     memo: nil,
                     conditions: spendingConditions,
                     amountSplitTarget: .none,
                     sendKind: sendKind,
                     includeFee: includeFee,
+                    useP2bk: false,
                     maxProofs: nil,
-                    metadata: [:]
-                )
-                let sendOptions = MultiMintSendOptions(
-                    allowTransfer: false,
-                    maxTransferAmount: nil,
-                    allowedMints: [],
-                    excludedMints: [],
-                    sendOptions: innerSendOptions
+                    metadata: [:],
+                    p2pkSigningKeys: [],
+                    p2pkLockedProofSendMode: .swap
                 )
 
-                let prepared = try await wallet.prepareSend(mintUrl: url, amount: amt, options: sendOptions)
-                let preparedId = prepared.id()
+                let wallet = try await getWallet(mintUrl)
+                let prepared = try await wallet.prepareSend(amount: amt, options: sendOptions)
+                let preparedId = prepared.operationId()
                 let preparedAmount = prepared.amount().value
                 let preparedFee = prepared.fee().value
 
@@ -1028,7 +1090,8 @@ class CashuDevKitModule: RCTEventEmitter {
     func confirmSend(_ preparedSendId: String, memo: String?,
                      resolve: @escaping RCTPromiseResolveBlock,
                      reject: @escaping RCTPromiseRejectBlock) {
-        guard let prepared = preparedSends[preparedSendId] else {
+        let prepared: PreparedSend? = walletQueue.sync { preparedSends[preparedSendId] }
+        guard let prepared else {
             reject("NO_PREPARED_SEND", "Prepared send not found", nil)
             return
         }
@@ -1058,7 +1121,8 @@ class CashuDevKitModule: RCTEventEmitter {
     func cancelSend(_ preparedSendId: String,
                     resolve: @escaping RCTPromiseResolveBlock,
                     reject: @escaping RCTPromiseRejectBlock) {
-        guard let prepared = preparedSends[preparedSendId] else {
+        let prepared: PreparedSend? = walletQueue.sync { preparedSends[preparedSendId] }
+        guard let prepared else {
             resolve(nil)
             return
         }
@@ -1087,7 +1151,7 @@ class CashuDevKitModule: RCTEventEmitter {
     func receive(_ encodedToken: String, optionsJson: String?,
                  resolve: @escaping RCTPromiseResolveBlock,
                  reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
@@ -1101,7 +1165,7 @@ class CashuDevKitModule: RCTEventEmitter {
                    let data = json.data(using: .utf8),
                    let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                     if let keys = parsed["p2pk_signing_keys"] as? [String] {
-                        p2pkSigningKeys = keys.compactMap {
+                        p2pkSigningKeys = keys.map {
                             SecretKey(hex: $0)
                         }
                     }
@@ -1110,18 +1174,17 @@ class CashuDevKitModule: RCTEventEmitter {
                     }
                 }
 
-                let innerReceiveOptions = ReceiveOptions(
+                let receiveOptions = ReceiveOptions(
                     amountSplitTarget: .none,
                     p2pkSigningKeys: p2pkSigningKeys,
                     preimages: preimages,
                     metadata: [:]
                 )
-                let receiveOptions = MultiMintReceiveOptions(
-                    allowUntrusted: true,
-                    transferToMint: nil,
-                    receiveOptions: innerReceiveOptions
-                )
 
+                // The token's mint is added on demand, matching the 0.14.x
+                // MultiMintWallet behavior of allowUntrusted: true
+                let tokenMintUrl = try token.mintUrl()
+                let wallet = try await getWallet(tokenMintUrl.url)
                 let amount = try await wallet.receive(token: token, options: receiveOptions)
                 resolve(NSNumber(value: amount.value))
             } catch let error as FfiError {
@@ -1171,13 +1234,15 @@ class CashuDevKitModule: RCTEventEmitter {
     func restore(_ mintUrl: String,
                  resolve: @escaping RCTPromiseResolveBlock,
                  reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
-                let amount = try await wallet.restore(mintUrl: url)
-                resolve(NSNumber(value: amount.value))
+                let wallet = try await getWallet(mintUrl)
+                // Restored splits the result into spent/unspent/pending;
+                // the bridge contract is the recovered spendable amount
+                let restored = try await wallet.restore()
+                resolve(NSNumber(value: restored.unspent.value))
             } catch let error as FfiError {
                 let (code, message) = mapFfiError(error)
                 reject(code, message, error)
@@ -1191,7 +1256,7 @@ class CashuDevKitModule: RCTEventEmitter {
     func restoreFromSeed(_ mintUrl: String, seedHex: String,
                          resolve: @escaping RCTPromiseResolveBlock,
                          reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
@@ -1207,18 +1272,14 @@ class CashuDevKitModule: RCTEventEmitter {
                 // Step 2: Feed the token into CDK's receive to import proofs into the wallet
                 let token = try Token.fromString(encodedToken: tokenString)
 
-                let innerReceiveOptions = ReceiveOptions(
+                let receiveOptions = ReceiveOptions(
                     amountSplitTarget: .none,
                     p2pkSigningKeys: [],
                     preimages: [],
                     metadata: [:]
                 )
-                let receiveOptions = MultiMintReceiveOptions(
-                    allowUntrusted: true,
-                    transferToMint: nil,
-                    receiveOptions: innerReceiveOptions
-                )
 
+                let wallet = try await getWallet(mintUrl)
                 let amount = try await wallet.receive(token: token, options: receiveOptions)
                 resolve(NSNumber(value: amount.value))
             } catch let error as ZeusCashuRestore.RestoreError {
@@ -1238,12 +1299,10 @@ class CashuDevKitModule: RCTEventEmitter {
     func checkProofsState(_ mintUrl: String, proofsJson: String,
                           resolve: @escaping RCTPromiseResolveBlock,
                           reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
-
                 // Parse proofs from JSON
                 guard let data = proofsJson.data(using: .utf8),
                       let proofsArray = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
@@ -1266,25 +1325,16 @@ class CashuDevKitModule: RCTEventEmitter {
                         c: c,
                         keysetId: keysetId,
                         witness: nil,
-                        dleq: nil
+                        dleq: nil,
+                        p2pkE: nil
                     )
                     proofs.append(proof)
                 }
 
-                let states = try await wallet.checkProofsState(mintUrl: url, proofs: proofs)
-                let encoded = states.map { state -> [String: Any] in
-                    var stateStr: String
-                    switch state {
-                    case .unspent:
-                        stateStr = "Unspent"
-                    case .pending:
-                        stateStr = "Pending"
-                    case .spent:
-                        stateStr = "Spent"
-                    default:
-                        stateStr = "Unknown"
-                    }
-                    return ["state": stateStr]
+                let wallet = try await getWallet(mintUrl)
+                let spentFlags = try await wallet.checkProofsSpent(proofs: proofs)
+                let encoded = spentFlags.map { spent -> [String: Any] in
+                    return ["state": spent ? "Spent" : "Unspent"]
                 }
                 resolve(encodeToJson(encoded))
             } catch let error as FfiError {
@@ -1302,15 +1352,18 @@ class CashuDevKitModule: RCTEventEmitter {
     func createMintBolt12Quote(_ mintUrl: String, amount: NSNumber, description: String?,
                                resolve: @escaping RCTPromiseResolveBlock,
                                reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
                 let amt = Amount(value: amount.uint64Value)
-
-                // Note: BOLT12 mint quote might need different API - check CDK version
-                let quote = try await wallet.mintQuote(mintUrl: url, amount: amt, description: description)
+                let wallet = try await getWallet(mintUrl)
+                let quote = try await wallet.mintQuote(
+                    paymentMethod: .bolt12,
+                    amount: amt,
+                    description: description,
+                    extra: nil
+                )
                 resolve(encodeToJson(encodeMintQuote(quote)))
             } catch let error as FfiError {
                 let (code, message) = mapFfiError(error)
@@ -1325,16 +1378,17 @@ class CashuDevKitModule: RCTEventEmitter {
     func createMeltBolt12Quote(_ mintUrl: String, request: String, optionsJson: String?,
                                resolve: @escaping RCTPromiseResolveBlock,
                                reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
                 let options = parseMeltOptions(from: optionsJson)
+                let wallet = try await getWallet(mintUrl)
                 let quote = try await wallet.meltQuote(
-                    mintUrl: url,
+                    method: .bolt12,
                     request: request,
-                    options: options
+                    options: options,
+                    extra: nil
                 )
                 resolve(encodeToJson(encodeMeltQuote(quote)))
             } catch let error as FfiError {
@@ -1350,15 +1404,15 @@ class CashuDevKitModule: RCTEventEmitter {
     func createMeltHumanReadableQuote(_ mintUrl: String, address: String, amountMsat: NSNumber,
                                        resolve: @escaping RCTPromiseResolveBlock,
                                        reject: @escaping RCTPromiseRejectBlock) {
-        guard let wallet = getInitializedWallet(reject: reject) else { return }
+        guard getInitializedRepo(reject: reject) != nil else { return }
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
+                let wallet = try await getWallet(mintUrl)
                 let quote = try await wallet.meltHumanReadableQuote(
-                    mintUrl: url,
                     address: address,
-                    amountMsat: amountMsat.uint64Value
+                    amountMsat: Amount(value: amountMsat.uint64Value),
+                    network: .bitcoin
                 )
                 resolve(encodeToJson(encodeMeltQuote(quote)))
             } catch let error as FfiError {
@@ -1376,7 +1430,11 @@ class CashuDevKitModule: RCTEventEmitter {
     func listTransactions(_ direction: String?,
                           resolve: @escaping RCTPromiseResolveBlock,
                           reject: @escaping RCTPromiseRejectBlock) {
-        guard isInitialized, let _ = wallet, let db = db else {
+        let dbHandle: WalletSqliteDatabase? = walletQueue.sync {
+            guard isInitialized else { return nil }
+            return self.db
+        }
+        guard let db = dbHandle else {
             reject("NO_WALLET", "Wallet not initialized", nil)
             return
         }
@@ -1425,7 +1483,8 @@ class CashuDevKitModule: RCTEventEmitter {
     func getUnspentProofs(_ mintUrl: String,
                           resolve: @escaping RCTPromiseResolveBlock,
                           reject: @escaping RCTPromiseRejectBlock) {
-        guard let db = self.db else {
+        let dbHandle: WalletSqliteDatabase? = walletQueue.sync { self.db }
+        guard let db = dbHandle else {
             reject("NO_WALLET", "Wallet not initialized", nil)
             return
         }
@@ -1464,7 +1523,8 @@ class CashuDevKitModule: RCTEventEmitter {
     func removeProofs(_ proofsYJson: String,
                       resolve: @escaping RCTPromiseResolveBlock,
                       reject: @escaping RCTPromiseRejectBlock) {
-        guard let db = self.db else {
+        let dbHandle: WalletSqliteDatabase? = walletQueue.sync { self.db }
+        guard let db = dbHandle else {
             reject("NO_WALLET", "Wallet not initialized", nil)
             return
         }
@@ -1501,8 +1561,9 @@ class CashuDevKitModule: RCTEventEmitter {
 
     override func invalidate() {
         walletQueue.sync {
-            wallet = nil
+            repo = nil
             db = nil
+            wallets.removeAll()
             preparedSends.removeAll()
             isInitialized = false
         }

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -775,7 +775,7 @@ class CashuDevKitModule: RCTEventEmitter {
 
         Task {
             do {
-                let url = MintUrl(url: mintUrl)
+                let url = MintUrl(url: normalizeMintUrl(mintUrl))
                 let amt = Amount(value: UInt64(truncating: amount))
 
                 // Map state string to QuoteState enum

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -750,10 +750,11 @@ class CashuDevKitModule: RCTEventEmitter {
 
     /// Add an external mint quote to CDK's database.
     /// This allows minting from quotes created externally (e.g., by ZeusPay server).
-    @objc(addExternalMintQuote:quoteId:amount:request:state:expiry:secretKey:resolver:rejecter:)
+    @objc(addExternalMintQuote:quoteId:amount:request:state:expiry:secretKey:useSeedPrefixMarker:resolver:rejecter:)
     func addExternalMintQuote(_ mintUrl: String, quoteId: String, amount: NSNumber,
                                request: String, state: String, expiry: NSNumber,
                                secretKey: String?,
+                               useSeedPrefixMarker: Bool,
                                resolve: @escaping RCTPromiseResolveBlock,
                                reject: @escaping RCTPromiseRejectBlock) {
         let dbHandle: WalletSqliteDatabase? = walletQueue.sync {
@@ -785,18 +786,25 @@ class CashuDevKitModule: RCTEventEmitter {
                     quoteState = .paid // Default to PAID for external quotes
                 }
 
-                // ZEUS Pay locks quotes to the wallet's seed-prefix key
-                // (seed[0..32]), which is byte-identical to cdk's "legacy
-                // NpubCash" key. Storing that key on the quote makes cdk's
-                // mint saga scrub it mid-flight (a version bump), and the
-                // saga's post-mint write then dies with ConcurrentUpdate
-                // AFTER the mint has issued the signatures. Instead, store
-                // the quote with no key and write cdk's NpubCash quote-key
-                // marker: at signing time cdk re-derives the identical
-                // seed-prefix key from the marker, with no mid-saga write.
+                // For v2-bip39 wallets, ZEUS Pay locks quotes to the seed-
+                // prefix key (seed[0..32]), which is byte-identical to cdk's
+                // "legacy NpubCash" key. Storing that key on the quote makes
+                // cdk's mint saga scrub it mid-flight (a version bump), and
+                // the saga's post-mint write then dies with ConcurrentUpdate
+                // AFTER the mint has issued the signatures. For those quotes
+                // (useSeedPrefixMarker, decided by JS via byte comparison),
+                // store the quote with no key and write cdk's NpubCash
+                // quote-key marker: at signing time cdk re-derives the
+                // identical seed-prefix key from the marker, with no mid-saga
+                // write. v1 wallets sign with a different key (LND seed
+                // bytes [32:64]), so the marker would derive the wrong key
+                // for them; their key is stored on the quote instead, which
+                // is safe because the scrub only triggers on byte equality
+                // with the seed prefix.
                 // Upstream bug: https://github.com/cashubtc/cdk/issues/2335
                 // Remove when fixed: https://github.com/ZeusLN/zeus/issues/4402
-                if let secretKey, !secretKey.isEmpty {
+                let storedSecretKey = (secretKey?.isEmpty == false) ? secretKey : nil
+                if storedSecretKey != nil && useSeedPrefixMarker {
                     try await db.kvWrite(
                         primaryNamespace: "npubcash",
                         secondaryNamespace: "quotes",
@@ -820,7 +828,7 @@ class CashuDevKitModule: RCTEventEmitter {
                     amountPaid: (quoteState == .paid || quoteState == .issued) ? amt : zeroAmount,
                     estimatedBlocks: nil,
                     paymentMethod: .bolt11,
-                    secretKey: nil,
+                    secretKey: useSeedPrefixMarker ? nil : storedSecretKey,
                     usedByOperation: nil,
                     version: 0
                 )

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -166,12 +166,20 @@ class CashuDevKitModule: RCTEventEmitter {
 
         let url = MintUrl(url: normalized)
         let unit = walletQueue.sync { walletUnit }
-        // hasMint matches any unit for the URL while getWallet is keyed on
-        // (URL, unit), so a mint loaded only under a non-sat unit would skip
-        // creation here and then miss. createWallet is a no-network map
-        // insert, so create unconditionally instead of guarding
-        try await repo.createWallet(mintUrl: url, unit: unit, targetProofCount: nil)
-        let wallet = try await repo.getWallet(mintUrl: url, unit: unit)
+        // Try the (URL, unit)-keyed lookup first and only create on a miss:
+        // creating unconditionally would overwrite a wallet configured by
+        // addMint (e.g. a custom targetProofCount) with a default-config
+        // handle. The FFI does not expose the unit-keyed hasWallet, so a
+        // failed get is the miss signal; createWallet is a no-network map
+        // insert, and a concurrent double-create is a benign same-config
+        // overwrite
+        let wallet: Wallet
+        do {
+            wallet = try await repo.getWallet(mintUrl: url, unit: unit)
+        } catch {
+            try await repo.createWallet(mintUrl: url, unit: unit, targetProofCount: nil)
+            wallet = try await repo.getWallet(mintUrl: url, unit: unit)
+        }
         walletQueue.sync { wallets[normalized] = wallet }
         return wallet
     }

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -785,9 +785,26 @@ class CashuDevKitModule: RCTEventEmitter {
                     quoteState = .paid // Default to PAID for external quotes
                 }
 
+                // ZEUS Pay locks quotes to the wallet's seed-prefix key
+                // (seed[0..32]), which is byte-identical to cdk's "legacy
+                // NpubCash" key. Storing that key on the quote makes cdk's
+                // mint saga scrub it mid-flight (a version bump), and the
+                // saga's post-mint write then dies with ConcurrentUpdate
+                // AFTER the mint has issued the signatures. Instead, store
+                // the quote with no key and write cdk's NpubCash quote-key
+                // marker: at signing time cdk re-derives the identical
+                // seed-prefix key from the marker, with no mid-saga write.
+                if let secretKey, !secretKey.isEmpty {
+                    try await db.kvWrite(
+                        primaryNamespace: "npubcash",
+                        secondaryNamespace: "quotes",
+                        key: quoteId,
+                        value: Data("legacy-seed-prefix".utf8)
+                    )
+                }
+
                 // Create the MintQuote object
                 // For external quotes that are PAID, we set amountPaid = amount
-                // Include secretKey for P2PK-locked quotes
                 let zeroAmount = Amount(value: 0)
                 let quote = MintQuote(
                     id: quoteId,
@@ -801,7 +818,7 @@ class CashuDevKitModule: RCTEventEmitter {
                     amountPaid: (quoteState == .paid || quoteState == .issued) ? amt : zeroAmount,
                     estimatedBlocks: nil,
                     paymentMethod: .bolt11,
-                    secretKey: secretKey,
+                    secretKey: nil,
                     usedByOperation: nil,
                     version: 0
                 )

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -794,6 +794,8 @@ class CashuDevKitModule: RCTEventEmitter {
                 // the quote with no key and write cdk's NpubCash quote-key
                 // marker: at signing time cdk re-derives the identical
                 // seed-prefix key from the marker, with no mid-saga write.
+                // Upstream bug: https://github.com/cashubtc/cdk/issues/2335
+                // Remove when fixed: https://github.com/ZeusLN/zeus/issues/4402
                 if let secretKey, !secretKey.isEmpty {
                     try await db.kvWrite(
                         primaryNamespace: "npubcash",

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -535,9 +535,13 @@ class CashuDevKitModule: RCTEventEmitter {
 
         Task {
             do {
+                // getBalances() is keyed by (mint URL, unit) and load_wallets
+                // creates a wallet per supported unit, so only fold this
+                // wallet's unit; other units must not count toward the total
+                let unit = walletQueue.sync { walletUnit }
                 let balances = try await repo.getBalances()
                 var total: UInt64 = 0
-                for (_, amount) in balances {
+                for (key, amount) in balances where key.unit == unit {
                     total += amount.value
                 }
                 resolve(NSNumber(value: total))
@@ -557,9 +561,10 @@ class CashuDevKitModule: RCTEventEmitter {
 
         Task {
             do {
+                let unit = walletQueue.sync { walletUnit }
                 let balances = try await repo.getBalances()
                 var result: [String: UInt64] = [:]
-                for (key, amount) in balances {
+                for (key, amount) in balances where key.unit == unit {
                     result[key.mintUrl.url, default: 0] += amount.value
                 }
                 resolve(encodeToJson(result))

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -490,11 +490,21 @@ class CashuDevKitModule: RCTEventEmitter {
             do {
                 let normalized = normalizeMintUrl(mintUrl)
                 let url = MintUrl(url: normalized)
-                let unit = walletQueue.sync { walletUnit }
-                // removeWallet only drops the in-memory wallet; tolerate a
-                // mint the repository does not know (parity with the
-                // non-throwing 0.14.x removeMint)
-                try? await repo.removeWallet(mintUrl: url, currencyUnit: unit)
+                // load_wallets creates one wallet per supported unit, so
+                // drop every unit's wallet for this mint, not just the
+                // configured one: a leftover handle keeps the mint in
+                // getMintUrls, and the persisted list then re-adds the
+                // mint at the next boot's reconcile. Compare
+                // case-insensitively since cdk canonicalizes scheme and
+                // host casing. removeWallet failures are tolerated (parity
+                // with the non-throwing 0.14.x removeMint)
+                for wallet in await repo.getWallets()
+                where wallet.mintUrl().url.lowercased() == normalized.lowercased() {
+                    try? await repo.removeWallet(
+                        mintUrl: wallet.mintUrl(),
+                        currencyUnit: wallet.unit()
+                    )
+                }
                 _ = walletQueue.sync { wallets.removeValue(forKey: normalized) }
                 let dbHandle: WalletSqliteDatabase? = walletQueue.sync { self.db }
                 if let db = dbHandle {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -4,7 +4,7 @@ platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
 # CashuDevKit framework path
-cashudevkit_framework_path = File.join(__dir__, 'Cdk', 'cdkFFI.xcframework')
+cashudevkit_framework_path = File.join(__dir__, 'Cdk', 'CashuDevKitFFI.xcframework')
 
 target 'zeus' do
   config = use_native_modules!

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CashuDevKit (0.14.2)
+  - CashuDevKit (0.17.3)
   - CocoaAsyncSocket (7.6.5)
   - FBLazyVector (0.85.3)
   - hermes-engine (250829098.0.10):
@@ -1452,7 +1452,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-document-picker (11.0.3):
+  - react-native-document-picker (12.0.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2857,10 +2857,10 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  CashuDevKit: e1c67c3d60c5bec683f205f922e9894d7df23072
+  CashuDevKit: caaa82e41ee209ead7d9605f330e0b20e8b34345
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: 62676867dde41ae5f64ee61b85459360c95eaf62
+  hermes-engine: c9c1c1a785028d5dec6bbf0f0a97ddd4e2887358
   lottie-ios: 8f959969761e9c45d70353667d00af0e5b9cadb3
   lottie-react-native: ee142214581f3bb68fbda7efcf07b835a189eeda
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
@@ -2871,7 +2871,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: 92dc569ba6cd17b5f682b26e3dcd58662d6c6fed
+  React-Core-prebuilt: 2c0825a731d0162a00acbbfe97d151e29780ae41
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189
@@ -2902,7 +2902,7 @@ SPEC CHECKSUMS:
   React-mutationobservernativemodule: a42d1626651ccd7d0dc02a56e69d4ec77c248893
   react-native-biometrics: 43ed5b828646a7862dbc7945556446be00798e7d
   react-native-blob-util: 13e70f811eb34f14864622c4afa37cc20fe8100e
-  react-native-document-picker: afdb2a4db7b55e184c591af8915ba4d1f3ef6eda
+  react-native-document-picker: c3a7536f3ee52525b4714c3720537f941d0cb094
   react-native-encrypted-storage: 569d114e329b1c2c2d9f8c84bcdbe4478dda2258
   react-native-get-random-values: 419569b6ed3d15bfb9b6781b2f2e058f8e8d2698
   react-native-hce: ad5462e792d84e87924308dda1ee516757f1c0eb
@@ -2955,7 +2955,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: c8f81e6c6f762dcf442a6203a1fb58f7dafc8014
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: 5399daf6260555c80b23ba4077203eeb7d8d0d54
+  ReactNativeDependencies: 71c1fd32a01912780816675fa8f151bf46785eef
   ReactNativeNitroTor: 3a55374c5816550e4b24f65e9380a5e315797899
   RNCAsyncStorage: 2ad919e88b8bc2cd80e8697ce66d04d006743283
   RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
@@ -2977,6 +2977,6 @@ SPEC CHECKSUMS:
   Yoga: 77dfa8673de2874e1855002ae59c68b8be9b007b
   ZeusCashuRestore: 393af11e3fda37ed1948256a2e6d33b7e7267802
 
-PODFILE CHECKSUM: 46cc7c644f445f9ba1009b1cd13b8fc3ce6e7f74
+PODFILE CHECKSUM: 1601156ec4b5ac796dfa3af63e105ba8901c14a2
 
 COCOAPODS: 1.16.2

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -836,7 +836,14 @@ export default class CashuStore {
                                 }
                             }
 
-                            // First, add the external quote to CDK's database with secret key
+                            // First, add the external quote to CDK's database with secret key.
+                            // When the key equals CDK's seed prefix (v2-bip39
+                            // wallets), the native side stores the quote
+                            // keyless with cdk's NpubCash marker instead, to
+                            // dodge cdk's legacy npubcash scrub (cdk#2335).
+                            const useSeedPrefixMarker = secretKey
+                                ? this.secretKeyMatchesCdkSeedPrefix(secretKey)
+                                : false;
                             await CashuDevKit.addExternalMintQuote(
                                 mintUrl,
                                 quoteId,
@@ -844,7 +851,8 @@ export default class CashuStore {
                                 externalQuote.request || '',
                                 externalQuote.state || 'PAID',
                                 externalQuote.expiry || 0,
-                                secretKey || undefined
+                                secretKey || undefined,
+                                useSeedPrefixMarker
                             );
                             if (__DEV__) {
                                 console.log(
@@ -3701,6 +3709,25 @@ export default class CashuStore {
             return null;
         }
         return privkey;
+    };
+
+    /**
+     * Whether the given P2PK secret key is byte-identical to the CDK
+     * wallet's seed prefix (seed[0..32]). cdk's legacy NpubCash heuristic
+     * claims such keys as its own, so quotes carrying them must use the
+     * quote-key marker workaround instead of storing the key. v1 wallets
+     * derive their key from LND seed bytes [32:64] and won't match, so
+     * their key is stored on the quote and signs correctly.
+     * See https://github.com/cashubtc/cdk/issues/2335
+     */
+    private secretKeyMatchesCdkSeedPrefix = (secretKeyHex: string): boolean => {
+        const mnemonic = this.getCDKMnemonic();
+        if (!mnemonic) return false;
+        const seed = bip39scure.mnemonicToSeedSync(mnemonic);
+        return (
+            bytesToHex(seed.slice(0, 32)).toLowerCase() ===
+            secretKeyHex.toLowerCase()
+        );
     };
 
     @action

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -423,8 +423,22 @@ export default class CashuStore {
         try {
             await CashuDevKit.addMint(normalizedUrl);
             this.addedMintsCache.add(normalizedUrl);
+            runInAction(() => {
+                if (this.cashuWallets[normalizedUrl]) {
+                    this.cashuWallets[normalizedUrl].errorConnecting = false;
+                }
+            });
         } catch (e) {
-            // Don't cache failures - allow retries on subsequent calls
+            // Don't cache failures - allow retries on subsequent calls.
+            // Rethrow so callers fail at the first broken step instead of
+            // a later, more confusing one.
+            console.error(`CDK: Failed to add mint ${normalizedUrl}:`, e);
+            runInAction(() => {
+                if (this.cashuWallets[normalizedUrl]) {
+                    this.cashuWallets[normalizedUrl].errorConnecting = true;
+                }
+            });
+            throw e;
         }
     };
 

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -1044,10 +1044,12 @@ export default class CashuStore {
     private classifyMppRejection = (body: string): MultimintSkipReason => {
         const lower = (body || '').toLowerCase();
         // Mints refuse MPP for invoices they themselves issued. Nutshell
-        // returns "internal mpp not allowed"; other implementations may
-        // phrase it as a self-payment.
+        // returns "internal mpp not allowed"; cdk-mintd returns
+        // "Multi-Part Internal Melt Quotes are not supported"; other
+        // implementations may phrase it as a self-payment.
         if (
             lower.includes('internal mpp not allowed') ||
+            lower.includes('internal melt quote') ||
             lower.includes('self payment') ||
             lower.includes('self-payment')
         ) {

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -3322,9 +3322,13 @@ export default class CashuStore {
                     ? JSON.parse(storedMintUrls)
                     : [];
 
-                // If no mints in local storage (e.g. fresh recovery),
-                // try to restore mint list from Nostr backup
-                if (localMintUrls.length === 0) {
+                // If mints have never been stored locally (fresh install
+                // or recovery), try to restore the mint list from Nostr
+                // backup. A stored empty list means the user removed every
+                // mint; treating it as fresh would resurrect the removed
+                // mints from the stale relay backup, since empty lists are
+                // deliberately never published
+                if (!storedMintUrls) {
                     try {
                         const nostrMints = await this.nostrRestoreMints();
                         if (nostrMints && nostrMints.length > 0) {
@@ -3658,7 +3662,11 @@ export default class CashuStore {
             if (
                 initialMintUrls &&
                 initialMintUrls.length > 0 &&
-                this.mintUrls.length === 0
+                this.mintUrls.length === 0 &&
+                // Same fresh-state discriminator as the Nostr restore above:
+                // a stored empty list means the user removed every mint, so
+                // onboarding mints must not come back
+                !storedMintUrls
             ) {
                 console.log(
                     'Adding initial mints from onboarding:',

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -2733,6 +2733,9 @@ export default class CashuStore {
         }
 
         delete this.cashuWallets[mintUrl];
+        // Evict from the ensureMintAdded cache so later flows cannot treat
+        // the removed mint as still present
+        this.addedMintsCache.delete(this.normalizeMintUrl(mintUrl));
         const updatedMintUrls = await CashuDevKit.getMintUrls();
         runInAction(() => {
             this.mintUrls = updatedMintUrls;
@@ -3065,9 +3068,20 @@ export default class CashuStore {
     @action
     public checkPendingItems = async () => {
         InteractionManager.runAfterInteractions(async () => {
+            // Skip items for mints that are no longer configured: polling
+            // them goes through ensureMintAdded, which would re-add a
+            // removed mint on the next boot
+            const knownMints = new Set(
+                this.mintUrls.map((url) => this.normalizeMintUrl(url))
+            );
+
             // Check pending invoices
             const pendingInvoices = this.invoices?.filter(
-                (invoice) => !invoice.isPaid && !invoice.isExpired
+                (invoice) =>
+                    !invoice.isPaid &&
+                    !invoice.isExpired &&
+                    (!invoice.mintUrl ||
+                        knownMints.has(this.normalizeMintUrl(invoice.mintUrl)))
             );
             if (pendingInvoices && pendingInvoices.length > 0) {
                 for (const invoice of pendingInvoices) {
@@ -3087,7 +3101,10 @@ export default class CashuStore {
 
             // Check unspent sent tokens
             const unspentSentTokens = this.sentTokens?.filter(
-                (token) => !token.spent
+                (token) =>
+                    !token.spent &&
+                    (!token.mint ||
+                        knownMints.has(this.normalizeMintUrl(token.mint)))
             );
             let tokensUpdated = false;
             if (unspentSentTokens && unspentSentTokens.length > 0) {
@@ -3119,8 +3136,16 @@ export default class CashuStore {
      */
     @action
     public checkSentTokensSpentStatus = async (): Promise<boolean> => {
+        // Same removed-mint gate as checkPendingItems: checkTokenSpent runs
+        // ensureMintAdded, which would re-add a removed mint
+        const knownMints = new Set(
+            this.mintUrls.map((url) => this.normalizeMintUrl(url))
+        );
         const unspentSentTokens = this.sentTokens?.filter(
-            (token) => !token.spent
+            (token) =>
+                !token.spent &&
+                (!token.mint ||
+                    knownMints.has(this.normalizeMintUrl(token.mint)))
         );
 
         let tokensUpdated = false;

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -59,7 +59,7 @@ import CashuUtils, {
     MultimintProgressCallback,
     MultinutPaymentStep
 } from '../utils/CashuUtils';
-import { errorToUserFriendly } from '../utils/ErrorUtils';
+import { cashuErrorForDisplay, errorToUserFriendly } from '../utils/ErrorUtils';
 import { localeString } from '../utils/LocaleUtils';
 import MigrationsUtils from '../utils/MigrationUtils';
 import { themeColor, getUpgradeBackgroundColor } from '../utils/ThemeUtils';
@@ -3853,7 +3853,7 @@ export default class CashuStore {
             if (__DEV__) {
                 console.log('Cashu createInvoice err', e);
             }
-            const error_msg = e?.message || e?.toString() || 'Unknown error';
+            const error_msg = cashuErrorForDisplay(e) || 'Unknown error';
             runInAction(() => {
                 this.creatingInvoiceError = true;
                 this.creatingInvoice = false;
@@ -4389,7 +4389,7 @@ export default class CashuStore {
 
             return payment;
         } catch (err: any) {
-            const errorMsg = String(err?.message);
+            const errorMsg = cashuErrorForDisplay(err);
             console.error('CDK payLnInvoiceFromEcash error:', err);
             if (!isDonationPayment) {
                 runInAction(() => {
@@ -4655,9 +4655,9 @@ export default class CashuStore {
 
             runInAction(() => {
                 this.paymentError = true;
-                this.paymentErrorMsg =
-                    firstFailure ||
-                    localeString('stores.CashuStore.errorPayingInvoice');
+                this.paymentErrorMsg = firstFailure
+                    ? cashuErrorForDisplay(firstFailure)
+                    : localeString('stores.CashuStore.errorPayingInvoice');
                 this.loading = false;
             });
 
@@ -4795,9 +4795,9 @@ export default class CashuStore {
             console.error('Error checking token spent status:', error);
             runInAction(() => {
                 this.error = true;
-                this.error_msg =
-                    errorMessage ||
-                    localeString('stores.CashuStore.checkSpentError');
+                this.error_msg = errorMessage
+                    ? cashuErrorForDisplay(errorMessage)
+                    : localeString('stores.CashuStore.checkSpentError');
             });
             return false;
         }
@@ -5392,7 +5392,7 @@ export default class CashuStore {
                 this.error = true;
                 this.error_msg = `${localeString(
                     'stores.CashuStore.sweepError'
-                )} (${mintUrl}): ${error.message || error.toString()}`;
+                )} (${mintUrl}): ${cashuErrorForDisplay(error)}`;
             });
             return false;
         }
@@ -5519,7 +5519,7 @@ export default class CashuStore {
             return { token, decoded };
         } catch (e: any) {
             const errorMsg =
-                e?.message ||
+                cashuErrorForDisplay(e) ||
                 localeString('stores.CashuStore.errorMintingToken');
             console.error('CDK mintToken error:', e);
             runInAction(() => {

--- a/utils/ErrorUtils.test.ts
+++ b/utils/ErrorUtils.test.ts
@@ -1,7 +1,8 @@
 import {
     errorToUserFriendly,
     parseLdkNodeError,
-    parseCashuDevKitError
+    parseCashuDevKitError,
+    cashuErrorForDisplay
 } from './ErrorUtils';
 
 jest.mock('./LocaleUtils', () => ({
@@ -457,6 +458,69 @@ describe('ErrorUtils', () => {
                     'CashuDevKit.FfiError.PaymentFailed(message: "no route to recipient")'
                 )
             ).toEqual('no route to recipient');
+        });
+
+        // cdk 0.17.x error shapes: FfiError collapsed to Cdk(code, errorMessage)
+        // and Internal(errorMessage); Kotlin package moved to org.cashudevkit
+
+        it('extracts errorMessage from iOS 0.17.x FfiError.Cdk with code', () => {
+            expect(
+                parseCashuDevKitError(
+                    'CashuDevKit.FfiError.Cdk(code: 20001, errorMessage: "Quote not paid")'
+                )
+            ).toEqual('Quote not paid');
+        });
+
+        it('extracts errorMessage from iOS 0.17.x FfiError.Internal', () => {
+            expect(
+                parseCashuDevKitError(
+                    'CashuDevKit.FfiError.Internal(errorMessage: "Insufficient funds")'
+                )
+            ).toEqual('Insufficient funds');
+        });
+
+        it('extracts errorMessage from Android 0.17.x FfiException.Cdk envelope', () => {
+            expect(
+                parseCashuDevKitError(
+                    'org.cashudevkit.FfiException$Cdk: code=20005, errorMessage=Quote pending'
+                )
+            ).toEqual('Quote pending');
+        });
+
+        it('extracts errorMessage from Android 0.17.x FfiException.Internal envelope', () => {
+            expect(
+                parseCashuDevKitError(
+                    'org.cashudevkit.FfiException$Internal: errorMessage=timed out connecting to mint'
+                )
+            ).toEqual('timed out connecting to mint');
+        });
+
+        it('strips a bare code=/errorMessage= envelope', () => {
+            expect(
+                parseCashuDevKitError(
+                    'code=20001, errorMessage=insufficient inputs provided'
+                )
+            ).toEqual('Insufficient inputs provided');
+        });
+    });
+
+    describe('cashuErrorForDisplay', () => {
+        it('passes short parsed messages through unchanged', () => {
+            expect(
+                cashuErrorForDisplay(
+                    'CashuDevKit.FfiError.Cdk(code: 20001, errorMessage: "Quote not paid")'
+                )
+            ).toEqual('Quote not paid');
+        });
+
+        it('truncates oversized error bodies so raw dumps cannot fill the screen', () => {
+            const jsonDump = `Error creating invoice: ${JSON.stringify({
+                contact: [{ info: 'npub…', method: 'nostr' }],
+                description: 'x'.repeat(400)
+            })}`;
+            const result = cashuErrorForDisplay(jsonDump);
+            expect(result.length).toBeLessThanOrEqual(301);
+            expect(result.endsWith('…')).toBe(true);
         });
     });
 });

--- a/utils/ErrorUtils.ts
+++ b/utils/ErrorUtils.ts
@@ -56,10 +56,16 @@ const parseLdkNodeError = (error: any): string => {
 };
 
 // Parses CashuDevKit FFI error strings from both platforms into clean messages.
-// iOS:     "CashuDevKit.FfiError.Generic(message: \"actual message\")" (UniFFI
-//          generates errorDescription = String(reflecting: self) which leaks the
-//          fully-qualified type whenever the generic catch block fires).
-// Android: "uniffi.cdk_ffi.FfiException$Generic: actual message"
+// cdk 0.17.x collapsed the FFI error into two variants, Cdk(code, errorMessage)
+// and Internal(errorMessage), and the Kotlin bindings moved from the
+// uniffi.cdk_ffi package to org.cashudevkit. The native modules normally
+// unwrap these before rejecting, but raw shapes can still leak via generic
+// catch paths:
+// iOS:     "CashuDevKit.FfiError.Cdk(code: 20001, errorMessage: \"actual message\")"
+//          (UniFFI generates errorDescription = String(reflecting: self))
+// Android: "org.cashudevkit.FfiException$Cdk: code=20001, errorMessage=actual message"
+// Pre-0.17 shapes ("...FfiError.Generic(message: ...)",
+// "uniffi.cdk_ffi.FfiException$Generic: ...") are kept for robustness.
 const parseCashuDevKitError = (error: any): string => {
     const str =
         typeof error === 'string'
@@ -68,7 +74,7 @@ const parseCashuDevKitError = (error: any): string => {
     if (!str) return str;
 
     const iosWithAssoc = str.match(
-        /CashuDevKit\.FfiError\.\w+\(message:\s*"([\s\S]+?)"\)/
+        /CashuDevKit\.FfiError\.\w+\((?:code:\s*\d+,\s*)?(?:message|errorMessage):\s*"([\s\S]+?)"\)/
     );
     if (iosWithAssoc) return extractMintDetail(iosWithAssoc[1].trim());
 
@@ -76,16 +82,30 @@ const parseCashuDevKitError = (error: any): string => {
     if (iosBare) return humanizeVariantName(iosBare[1]);
 
     const androidMatch = str.match(
-        /uniffi\.cdk_ffi\.FfiException[.$](\w+)(?::\s*([\s\S]+))?/
+        /(?:uniffi\.cdk_ffi|org\.cashudevkit)\.FfiException[.$](\w+)(?::\s*([\s\S]+))?/
     );
     if (androidMatch) {
-        const inner = androidMatch[2]?.trim();
+        // Kotlin's Internal variant formats its message as
+        // "errorMessage=<text>" with no code prefix; strip the envelope
+        const inner = androidMatch[2]?.trim().replace(/^errorMessage=\s*/, '');
         return inner
             ? extractMintDetail(inner)
             : humanizeVariantName(androidMatch[1]);
     }
 
     return extractMintDetail(str);
+};
+
+// Hard cap on Cashu error text bound for direct display. Mint failures can
+// carry entire JSON documents in the error detail (e.g. an unparseable
+// /v1/info body); the parsed message is truncated so a raw dump can never
+// fill the screen.
+const CASHU_ERROR_DISPLAY_LIMIT = 300;
+
+const cashuErrorForDisplay = (error: any): string => {
+    const parsed = parseCashuDevKitError(error);
+    if (parsed.length <= CASHU_ERROR_DISPLAY_LIMIT) return parsed;
+    return `${parsed.slice(0, CASHU_ERROR_DISPLAY_LIMIT).trimEnd()}…`;
 };
 
 // "InsufficientFunds" -> "Insufficient funds"
@@ -102,7 +122,7 @@ const humanizeVariantName = (variant: string): string => {
 // to just the detail, capitalized.
 const extractMintDetail = (msg: string): string => {
     const detailMatch = msg.match(
-        /code:\s*\d+,\s*(?:detail|error):\s*([\s\S]+)$/i
+        /code[:=]\s*\d+,\s*(?:detail|error|errorMessage)[:=]\s*([\s\S]+)$/i
     );
     if (!detailMatch) return msg;
 
@@ -168,4 +188,9 @@ const errorToUserFriendly = (error: Error, errorContext?: string[]) => {
     return baseError;
 };
 
-export { errorToUserFriendly, parseLdkNodeError, parseCashuDevKitError };
+export {
+    errorToUserFriendly,
+    parseLdkNodeError,
+    parseCashuDevKitError,
+    cashuErrorForDisplay
+};


### PR DESCRIPTION
# Description

Fixes ecash operations against Minibits and any other mint running an onchain-enabled cdk-mintd 0.17.x, by bumping the bundled Cashu Dev Kit from 0.14.2 to 0.17.3.

## Root cause

Minibits migrated its mint to cdk-mintd 0.17.2 (`motd: "migrated"`), which advertises NUT-30 onchain support in `/v1/info`. cdk 0.14.2 cannot deserialize that document. Two fields fail (verified with a Rust test parsing the live Minibits JSON against the pinned `cashu` crate versions):

- NUT-17: the closed `WsCommand` enum rejects `onchain_mint_quote` / `onchain_melt_quote`
- NUT-4: the `MintMethodOptions` untagged enum rejects the onchain entry's `options: {confirmations: 1}`

`Wallet::mint_quote` loads mint info as its first step, so every mint quote and melt against such a mint fails, and cdk's `ErrorResponse::from_value` fallback stuffs the entire raw info JSON into the error message, producing an unreadable full-screen banner. The tolerant parsing landed upstream in cdk 0.15.0 with no 0.14.x backport, and 0.15.0 is also the release that removed the `MultiMintWallet` API, so there is no fix version without this migration. cashu 0.15.0 and 0.17.3 both parse the Minibits document cleanly.

## What changed

**Artifact plumbing** (distribution changed upstream at 0.17.x):
- Android moved to Maven Central and is split in two: `cdk-android` (per-ABI `libcdk_ffi.so` only) plus `cdk-jvm` (compiled Kotlin bindings). Both are vendored with pinned sha256 hashes; JNA was already a gradle dependency. Both new hashes are wired into the fail-closed hash format check in `fetch-libraries.sh`.
- iOS framework zip renamed to `CashuDevKitFFI.xcframework.zip` (sha256 matches the binaryTarget checksum in cdk-swift's own `Package.swift`); Swift bindings moved to `Sources/Cdk/`. The upstream xcframework ships a macOS slice as a dynamic library while the iOS slices are static, which CocoaPods refuses; `fetch-libraries.sh` strips the macOS slice after extraction.

**Native module ports** (iOS and Android in lockstep). The JS bridge contract is unchanged: method names, parameters, resolved JSON keys, omit-when-nil behavior, and state string casing are all preserved, so `CashuStore.ts` logic is untouched. Internally:
- `MultiMintWallet` becomes a `WalletRepository` over the same `WalletSqliteDatabase` handle plus per-mint `Wallet` objects created on demand
- melts use the new two-phase `prepareMelt` / `prepareMeltProofs` + `confirm()` flow inline within a single bridge call; `FinalizedMelt` is encoded into the legacy `Melted` JSON shape
- the upstream `payment_preimage` to `payment_proof` rename stays `payment_preimage` in bridge JSON
- `receive` / `restoreFromSeed` add the token's mint on demand, preserving the previous hardcoded `allowUntrusted: true` behavior; decoding a foreign token still does not add or contact its mint
- `checkProofsState` maps `checkProofsSpent` booleans to the same `Spent` / `Unspent` strings, which also removes an old iOS/Android divergence (`Unknown` vs `Reserved` for exotic states; JS treats anything not `Unspent` as spent)
- `restore` resolves `Restored.unspent` (the recovered spendable amount)
- the FFI error enum collapsed from 19 variants to `Cdk(code, message)` / `Internal(message)`; both `mapFfiError` implementations derive the legacy bridge error code strings from protocol codes and pass the message through for JS-side classification
- `meltMpp` is removed (zero app call sites; its global mint selection has no 0.17 equivalent)
- iOS `meltPartial` gains the `FfiError` catch arm it was missing (previously the main source of raw FFI dumps in the UI)
- `addExternalMintQuote` (ZEUS Pay) stores the quote without its P2PK secret key and writes cdk's NpubCash quote-key marker instead. The ZEUS Pay key is the wallet's seed prefix (seed[0..32]), byte-identical to what cdk's npubcash feature treats as a legacy NpubCash key; storing it made the mint saga scrub the quote mid-flight (an optimistic-lock version bump) and the saga's post-mint write then failed with "Concurrent update detected" after the mint had already issued signatures, stranding the funds until restore. With the marker, cdk re-derives the identical key at signing time and no mid-saga write occurs. Verified deterministic on every lightning address redemption before the fix. This knowingly couples to cdk's npubcash kv layout; to be removed when upstream fixes the scrub/saga interaction (filed as cashubtc/cdk#2335). A related follow-up worth considering: calling `recoverIncompleteSagas` at wallet init to self-heal any interrupted operation.

**Error display hardening:**
- `parseCashuDevKitError` handles the 0.17.x error shapes on both platforms (including the Kotlin package move from `uniffi.cdk_ffi` to `org.cashudevkit`), with test vectors
- new `cashuErrorForDisplay` truncates parsed error text at 300 chars at display time, applied at every `CashuStore` `error_msg` / `paymentErrorMsg` assignment fed by raw exception text, so a raw JSON body can never fill the screen again; `mapCDKError` classification still sees the full message
- `ensureMintAdded` no longer swallows `addMint` failures: it logs, records `errorConnecting`, and rethrows so failures surface at the first broken step

## Wallet database migration

The cdk wallet sqlite migrations from 0.14.2 to 0.17.3 are additive and auto-applied on first open; no manual steps. **The upgrade is one-way**: a `payment_preimage` column rename means a wallet db opened by 0.17.3 cannot roll back to a 0.14.2 build.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS (simulator; on-device passes in progress, see device checklist below)

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [x] Contributors will need to run `yarn` after this PR is merged in
- [x] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated (unchanged: the CDK is vendored via `fetch-libraries.sh`, pinned in `fetch-libraries-versions.json`)
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

## Device test checklist

- [x] iOS: fresh ecash wallet init
- [x] iOS: create ecash invoice from Minibits (the original bug): mint quote now succeeds
- [x] iOS: pay that invoice and confirm payment detection + balance credit
- [x] Android: fresh ecash wallet init
- [x] Existing 0.14.2 wallet db auto-migration (throwaway wallet first; migration is one-way)
- [x] Mint / melt / send / receive round-trip on a second mint
- [x] Multimint payment (melt planner) across two mints
- [x] ZEUS Pay external quote redemption
- [x] Restore from seed (v1 legacy and v2)
- [x] Offline send (prepareSend / confirmSend) and reclaim
- [x] Token from a not-yet-added mint still auto-adds on receive
- [x] Forced mint error shows a humanized, truncated message (no raw JSON banner) — tested on iOS against a mock mint serving a 1.9 KB unparseable info document (same failure class as the original incident); banner truncates at ~300 chars with ellipsis
- [ ] v1-wallet ZEUS Pay redemption (v1 seed, key persisted on quote rather than marker)
- [ ] Retry after a failed external mint: a quote left claimed by a dead saga mints on the next poll (quote version CAS fix)
- [ ] Init timing: `initializeWallet` with 4+ mints, one unreachable host, timed against a 0.14.2 build (see #4413)
- [ ] Remove a multi-unit mint (e.g. testnut, advertises usd), restart, confirm it stays removed (see review video)
- [ ] Remove a mint that still has a pending unexpired invoice, restart, confirm it stays removed (pending-poll re-add fix)
- [ ] Remove the LAST remaining mint, restart, confirm it stays removed (Nostr fresh-recovery discriminator fix)


