### PR TITLE
fix: release fetchLock on every fetchData exit (stale balance until reconnect)

### DIFF
--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -59,10 +59,18 @@ export default class LND {
                     // Clearnet-over-Tor: keep strict TLS because exit
                     // nodes can MITM.
                     isOnionHttpsUrl(url)
-                ).then((response: any) => {
-                    calls.delete(id);
-                    return response;
-                })
+                )
+                    .then((response: any) => {
+                        calls.delete(id);
+                        return response;
+                    })
+                    .catch((error: any) => {
+                        // evict rejected requests too, otherwise every
+                        // subsequent identical call gets the same cached
+                        // rejection until the next reconnect clears the map
+                        calls.delete(id);
+                        throw error;
+                    })
             );
         } else {
             const timeoutPromise = new Promise((_, reject) => {

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1638,6 +1638,9 @@ export default class SettingsStore {
     @observable public triggerSettingsRefresh: boolean = false;
     @observable public connecting = true;
     @observable public fetchLock = false;
+    // Monotonic token identifying the fetchData invocation that currently
+    // owns fetchLock; releaseFetchLock is a no-op for stale owners
+    private fetchLockSeq = 0;
     @observable public lurkerExposed = false;
     private lurkerTimeout: ReturnType<typeof setTimeout> | null = null;
     // LNDHub
@@ -2214,6 +2217,26 @@ export default class SettingsStore {
         this.settings.supportedBiometryType !== undefined;
 
     public setLoginStatus = (status = false) => (this.loggedIn = status);
+
+    // Single-flight guard for Wallet.fetchData. Returns an ownership token,
+    // or null if another invocation already holds the lock.
+    @action
+    public acquireFetchLock = (): number | null => {
+        if (this.fetchLock) return null;
+        this.fetchLock = true;
+        return ++this.fetchLockSeq;
+    };
+
+    // Release is a no-op unless the caller still owns the lock:
+    // setConnectingStatus(true) (wallet switch, restart) clears the lock
+    // mid-flight and a newer invocation may have re-acquired it; a stale
+    // invocation must never free the current owner's lock.
+    @action
+    public releaseFetchLock = (seq: number) => {
+        if (this.fetchLockSeq === seq) {
+            this.fetchLock = false;
+        }
+    };
 
     @action
     public setConnectingStatus = (status = false) => {

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -191,6 +191,9 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
     private linkingSubscription: EmitterSubscription | undefined;
     private startupTimeoutId?: ReturnType<typeof setTimeout>;
     private _navigating = false;
+    // Monotonic token identifying the fetchData invocation that currently
+    // owns SettingsStore.fetchLock; see the release logic in fetchData
+    private fetchDataSeq = 0;
     // Set once this instance replaces itself with the startup wallet
     // selection screen; late focus/AppState triggers must not connect to
     // the previously selected wallet or consume the initial deep link
@@ -525,6 +528,30 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
     }
 
     async fetchData(transientRetryCount = 0) {
+        const { SettingsStore } = this.props;
+
+        // ensure we don't run this twice in parallel
+        if (SettingsStore.fetchLock) return;
+        SettingsStore.fetchLock = true;
+        const seq = ++this.fetchDataSeq;
+
+        try {
+            await this.fetchDataCore(transientRetryCount);
+        } finally {
+            // Single release point: every exit from fetchDataCore (success,
+            // early return, or throw) must free the lock, otherwise
+            // pull-to-refresh and app-resume refreshes silently no-op until
+            // the next full reconnect. Skip the release if this invocation
+            // no longer owns the lock: setConnectingStatus(true) (wallet
+            // switch, restart) clears it mid-flight and a newer fetchData
+            // may have re-acquired it.
+            if (this.fetchDataSeq === seq) {
+                SettingsStore.fetchLock = false;
+            }
+        }
+    }
+
+    private async fetchDataCore(transientRetryCount = 0) {
         const {
             AlertStore,
             NodeInfoStore,
@@ -570,8 +597,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             ldkRgsServer,
             ldkScorerUrl,
             ldkVssServer,
-            updateSettings,
-            fetchLock
+            updateSettings
         } = SettingsStore;
         const { isSyncing } = SyncStore;
         const {
@@ -586,10 +612,6 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         } = settings;
         const expressGraphSyncEnabled =
             settings.expressGraphSync && embeddedLndNetwork === 'Mainnet';
-
-        // ensure we don't run this twice in parallel
-        if (fetchLock) return;
-        SettingsStore.fetchLock = true;
 
         let start;
         if (connecting) {
@@ -710,7 +732,6 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                         : errMsg;
                     SettingsStore.ldkNodeSyncing = false;
                     SettingsStore.setConnectingStatus(false);
-                    SettingsStore.fetchLock = false;
                     return;
                 }
 
@@ -1347,8 +1368,6 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 LinkingUtils.handleInitialUrl(this.props.navigation);
             }
         }
-
-        SettingsStore.fetchLock = false;
 
         // Process any deep link that was deferred while login was required
         LinkingUtils.processPendingDeepLink(this.props.navigation);

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -191,9 +191,6 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
     private linkingSubscription: EmitterSubscription | undefined;
     private startupTimeoutId?: ReturnType<typeof setTimeout>;
     private _navigating = false;
-    // Monotonic token identifying the fetchData invocation that currently
-    // owns SettingsStore.fetchLock; see the release logic in fetchData
-    private fetchDataSeq = 0;
     // Set once this instance replaces itself with the startup wallet
     // selection screen; late focus/AppState triggers must not connect to
     // the previously selected wallet or consume the initial deep link
@@ -531,9 +528,8 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         const { SettingsStore } = this.props;
 
         // ensure we don't run this twice in parallel
-        if (SettingsStore.fetchLock) return;
-        SettingsStore.fetchLock = true;
-        const seq = ++this.fetchDataSeq;
+        const seq = SettingsStore.acquireFetchLock();
+        if (seq === null) return;
 
         try {
             await this.fetchDataCore(transientRetryCount);
@@ -541,13 +537,9 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             // Single release point: every exit from fetchDataCore (success,
             // early return, or throw) must free the lock, otherwise
             // pull-to-refresh and app-resume refreshes silently no-op until
-            // the next full reconnect. Skip the release if this invocation
-            // no longer owns the lock: setConnectingStatus(true) (wallet
-            // switch, restart) clears it mid-flight and a newer fetchData
-            // may have re-acquired it.
-            if (this.fetchDataSeq === seq) {
-                SettingsStore.fetchLock = false;
-            }
+            // the next full reconnect. The store ignores the release if this
+            // invocation no longer owns the lock.
+            SettingsStore.releaseFetchLock(seq);
         }
     }
 
@@ -925,6 +917,12 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                             isLndError(error, LndErrorCode.LND_START_FAILED) ||
                             isLndError(error, LndErrorCode.LND_READY_TIMEOUT)
                         ) {
+                            // Leave connecting mode before showing the restart
+                            // alert: with the fetch lock now released on exit,
+                            // a background/foreground would otherwise re-run
+                            // the full stop/init/start cycle and stack a
+                            // second restart alert on top of this one
+                            setConnectingStatus(false);
                             restartNeeded(true);
                             return;
                         }

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1586,6 +1586,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                             <LayerBalances
                                 navigation={navigation}
                                 onRefresh={() => this.getSettingsAndNavigate()}
+                                refreshing={this.state.loading}
                                 consolidated
                             />
 


### PR DESCRIPTION
# Description

Fixes the recurring user report: "I received a payment, it shows on the Activity screen, but the home screen balance doesn't update. Pull-to-refresh does nothing. It eventually corrects itself but it can take hours."

## Root cause

`fetchData()` acquires `SettingsStore.fetchLock` on entry and released it only on the happy-path final line. Every error exit left the lock held, and `setConnectingStatus(false)` does not clear it (only `setConnectingStatus(true)` does). So a single failed or interrupted refresh (one flaky request on mobile data, a Tor timeout, a briefly dead LNC tunnel) permanently wedged the lock. From then on:

- every pull-to-refresh and app-resume refresh hit `if (fetchLock) return;` and silently did nothing
- the Activity screen kept updating, because it fetches through `ActivityStore` directly and is not gated by the lock, which is exactly the reported asymmetry
- the balance only recovered when something ran `setConnectingStatus(true)` (wallet switch, wallet config save) or the OS killed the app, hence "it may take hours"

Several of the wedge paths are completely silent (no error pane): the LNDHub, LNC, and NWC refresh catches just log and return, and embedded-lnd fatal throws land in `getSettingsAndNavigate`'s catch which only calls `setConnectingStatus(false)`.

## Exit-path audit (lock outcome before vs after)

| Exit from fetchData | Before | After |
|---|---|---|
| Natural end (success) | released | released (finally) |
| ldk-node startup throw (VSS hard-fail catch) | released (hand-added) | released (finally, hand release removed) |
| embedded-lnd channel-migration lock mode return | LEAKED | released |
| embedded-lnd folder-missing alert returns (2 sites) | LEAKED | released |
| embedded-lnd fatal init/start/post-creation throw | LEAKED | released |
| embedded-lnd LND_START_FAILED / READY_TIMEOUT restartNeeded return | LEAKED | released, and now drops connecting mode first, so an app resume behind the restart alert does not re-run the full stop/init/start cycle and stack a second alert |
| transient retry (not exhausted) | cleared by setConnectingStatus(true) inside retryOnTransientError, re-acquired by the recursive fetchData | unchanged, outer finally skips release via ownership token |
| transient retry exhausted (throw) | LEAKED | released |
| embedded-lnd refresh RPC fatal throw | LEAKED | released |
| lndhub connect/refresh catch return | LEAKED (silent, no error pane) | released |
| LNC catch return | LEAKED (silent) | released |
| NWC catch return | LEAKED (silent) | released |
| ldk-node refresh catch return | LEAKED | released |
| default LND / CLNRest catch return | LEAKED | released |
| throw from unguarded post-connect calls (e.g. LSPStore.getLSPInfo) | LEAKED | released |

## What is deliberately unchanged

- **Single-flight semantics**: the lock is acquired before `fetchDataCore` and held for the invocation's entire awaited duration. Concurrent entries (double focus, pull-to-refresh during connect) still no-op at the guard. `fetchDataCore` is the previous method body, unchanged except for removing the three manual lock writes.
- **The `setConnectingStatus(true)` contract**: it still clears the lock, so the error-screen Restart button, wallet switch, and the transient-retry loop recover exactly as before. They are just no longer the only recovery.
- **Interleaving this fixes beyond the wedge**: the old unconditional end-of-body release could free a lock it no longer owned. If invocation A is in flight, a wallet switch runs `setConnectingStatus(true)` (clears the lock) and invocation B acquires it, then A finishing (or now, failing) would release B's lock and let a third entry run a second full connect concurrently with B. The new release is gated on an ownership token (`SettingsStore.acquireFetchLock()` / `releaseFetchLock(seq)`), so a stale invocation never frees the current owner's lock. The token lives in the store next to the lock itself (not on the Wallet instance), so ownership stays correct even if a stale invocation outlives a Wallet remount, and both lock writes go through MobX actions.

## Second fix: Tor request cache pinning stale rejections

`LND.restReq` caches in-flight requests by url+body; the Tor branch deleted the cache entry only on success. A rejected `doTorRequest` stayed cached indefinitely, so every subsequent identical call (balance and node info fetches are byte-identical) got the same cached rejection until reconnect ran `clearCachedCalls()`. This is the long-standing "the same error repeats on every retry over Tor" behavior, and for Tor users it independently pinned balance queries stale for a whole session. Now rejected entries are evicted and the error rethrown, mirroring the clearnet branch.

## Third fix: pull-to-refresh feedback

Wallet never passed `refreshing` to `LayerBalances`, so the spinner cleared instantly whether or not a refresh ran. It now reflects the existing `loading` state, so the user can see the refresh happening (and finishing).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A (stores/views/backends have no jest harness; manual matrix below is the evidence)

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android (pending)
- [ ] iOS (pending)

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node (pending)
- [ ] Embedded LND (pending)

Remote
- [ ] LND (REST) (pending)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Planned manual matrix (per the lifecycle validation protocol): cold start per backend, 20x rapid wallet switch, 20x background/foreground storm, plus the repro for this bug: force a refresh failure (airplane mode during pull-to-refresh), restore network, verify the next pull-to-refresh recovers the balance without a wallet switch or app restart.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

