### PR TITLE
Swaps: retire ZEUS swap server, default to Boltz, fetch rates only in Swaps view

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -320,12 +320,6 @@ export const FEE_ESTIMATOR_KEYS = [
 
 export const SWAP_HOST_KEYS_MAINNET = [
     {
-        key: 'ZEUS',
-        value: 'https://swaps.zeuslsp.com/api/v2',
-        pro: false,
-        supportsRescue: true
-    },
-    {
         key: 'Boltz',
         value: 'https://api.boltz.exchange/v2',
         pro: true,
@@ -353,12 +347,6 @@ export const SWAP_HOST_KEYS_MAINNET = [
 ];
 
 export const SWAP_HOST_KEYS_TESTNET = [
-    {
-        key: 'ZEUS',
-        value: 'https://testnet-swaps.zeuslsp.com/api/v2',
-        pro: false,
-        supportsRescue: true
-    },
     {
         key: 'Boltz',
         value: 'https://api.testnet.boltz.exchange/v2',
@@ -1373,8 +1361,12 @@ export function getLspConfigForNetwork(
 }
 
 // Swaps
-export const DEFAULT_SWAP_HOST_MAINNET = 'https://swaps.zeuslsp.com/api/v2';
+export const DEFAULT_SWAP_HOST_MAINNET = 'https://api.boltz.exchange/v2';
 export const DEFAULT_SWAP_HOST_TESTNET =
+    'https://api.testnet.boltz.exchange/v2';
+// Retired ZEUS swap server hosts, migrated to Boltz
+export const LEGACY_ZEUS_SWAP_HOST_MAINNET = 'https://swaps.zeuslsp.com/api/v2';
+export const LEGACY_ZEUS_SWAP_HOST_TESTNET =
     'https://testnet-swaps.zeuslsp.com/api/v2';
 
 export const DEFAULT_NOSTR_RELAYS_2023 = [
@@ -1930,6 +1922,7 @@ export default class SettingsStore {
                 const parsedSettings = JSON.parse(modernSettings);
                 this.settings = parsedSettings;
                 await MigrationsUtils.migrateRgsDefaultToZeus(parsedSettings);
+                await MigrationsUtils.migrateSwapHostsToBoltz(parsedSettings);
                 await MigrationsUtils.migrateInvoiceExpiryDisplay(
                     parsedSettings
                 );

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -269,11 +269,12 @@ export default class SwapStore {
     };
 
     @action
-    public getLockupTransaction = async (id: string) => {
+    public getLockupTransaction = async (id: string, endpoint?: string) => {
         try {
+            const host = endpoint || this.getHost;
             const response = await ReactNativeBlobUtil.fetch(
                 'GET',
-                `${this.getHost}/swap/submarine/${id}/transaction`,
+                `${host}/swap/submarine/${id}/transaction`,
                 this.getHeaders
             );
 
@@ -606,10 +607,15 @@ export default class SwapStore {
 
                 if (shouldSkip) continue;
 
+                // poll the server the swap was created on; the currently
+                // selected provider may differ (e.g. after the ZEUS ->
+                // Boltz host migration) and won't know this swap's ID
+                const host = swap.endpoint || this.getHost;
+
                 try {
                     const response = await ReactNativeBlobUtil.fetch(
                         'GET',
-                        `${this.getHost}/swap/${swap.id}`,
+                        `${host}/swap/${swap.id}`,
                         this.getHeaders
                     );
 

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -1,4 +1,4 @@
-import { action, observable, computed, runInAction } from 'mobx';
+import { action, observable, computed, runInAction, reaction } from 'mobx';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 import { ECPairAPI, ECPairFactory } from 'ecpair';
 import ecc from '@bitcoinerlab/secp256k1';
@@ -75,6 +75,19 @@ export default class SwapStore {
         this.settingsStore = settingsStore;
         initEccLib(ecc);
         this.ECPair = ECPairFactory(ecc);
+
+        reaction(
+            () => this.getHost,
+            (host) => {
+                // only refetch when rates were already fetched this
+                // session; getHost also changes on startup as settings
+                // load and node info resolves, and rates must not be
+                // fetched on startup
+                if (this.fetchedRatesHost && this.fetchedRatesHost !== host) {
+                    this.getSwapFees();
+                }
+            }
+        );
     }
 
     @computed get claimMinerFee(): number {
@@ -186,12 +199,12 @@ export default class SwapStore {
     public getSwapFees = async () => {
         this.loading = true;
         this.apiError = '';
-        this.fetchedRatesHost = this.getHost;
-        console.log(`Fetching fees from: ${this.getHost}`);
+        const host = this.getHost;
+        console.log(`Fetching fees from: ${host}`);
         try {
             const response = await ReactNativeBlobUtil.fetch(
                 'GET',
-                `${this.getHost}/swap/submarine`,
+                `${host}/swap/submarine`,
                 this.getHeaders
             );
             const status = response.info().status;
@@ -222,7 +235,7 @@ export default class SwapStore {
         try {
             const response = await ReactNativeBlobUtil.fetch(
                 'GET',
-                `${this.getHost}/swap/reverse`,
+                `${host}/swap/reverse`,
                 this.getHeaders
             );
             const status = response.info().status;
@@ -249,6 +262,9 @@ export default class SwapStore {
             console.error('Error fetching reverse swap fees:', e);
             this.apiError = localeString('views.Swaps.fetchFeesFailed');
         }
+        // only record the host once both fetches succeed, so a failed
+        // fetch is retried the next time the Swaps view gains focus
+        if (!this.apiError) this.fetchedRatesHost = host;
         this.loading = false;
     };
 

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -1,4 +1,4 @@
-import { action, observable, computed, runInAction, reaction } from 'mobx';
+import { action, observable, computed, runInAction } from 'mobx';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 import { ECPairAPI, ECPairFactory } from 'ecpair';
 import ecc from '@bitcoinerlab/secp256k1';
@@ -63,6 +63,9 @@ export default class SwapStore {
     @observable public swapsLoading = false;
     @observable public DERIVATION_PATH = 'm/44/0/0/0';
     @observable ECPair: ECPairAPI;
+    // host the swap rates were last fetched from; rates are only
+    // fetched from the Swaps view, never on startup
+    @observable public fetchedRatesHost: string | undefined;
 
     nodeInfoStore: NodeInfoStore;
     settingsStore: SettingsStore;
@@ -72,11 +75,6 @@ export default class SwapStore {
         this.settingsStore = settingsStore;
         initEccLib(ecc);
         this.ECPair = ECPairFactory(ecc);
-
-        reaction(
-            () => this.getHost,
-            () => this.getSwapFees()
-        );
     }
 
     @computed get claimMinerFee(): number {
@@ -188,6 +186,7 @@ export default class SwapStore {
     public getSwapFees = async () => {
         this.loading = true;
         this.apiError = '';
+        this.fetchedRatesHost = this.getHost;
         console.log(`Fetching fees from: ${this.getHost}`);
         try {
             const response = await ReactNativeBlobUtil.fetch(

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -53,6 +53,10 @@ jest.mock('../stores/SettingsStore', () => ({
     DEFAULT_LSPS1_REST_TESTNET: 'https://lsps1.testnet.zeuslsp.com',
     DEFAULT_LSPS1_REST_MUTINYNET: 'https://lsps1.mutinynet.zeuslsp.com',
     DEFAULT_SPEEDLOADER: 'https://egs.lnze.us/',
+    DEFAULT_SWAP_HOST_MAINNET: 'https://api.boltz.exchange/v2',
+    DEFAULT_SWAP_HOST_TESTNET: 'https://api.testnet.boltz.exchange/v2',
+    LEGACY_ZEUS_SWAP_HOST_MAINNET: 'https://swaps.zeuslsp.com/api/v2',
+    LEGACY_ZEUS_SWAP_HOST_TESTNET: 'https://testnet-swaps.zeuslsp.com/api/v2',
     DEFAULT_NOSTR_RELAYS_2023: [
         'wss://nostr.mutinywallet.com',
         'wss://relay.damus.io',
@@ -337,6 +341,99 @@ describe('MigrationUtils', () => {
                     expirySeconds: '7200'
                 }
             });
+        });
+    });
+
+    describe('migrateSwapHostsToBoltz', () => {
+        const EncryptedStorage = require('react-native-encrypted-storage');
+        const { settingsStore } = require('../stores/Stores');
+
+        beforeEach(() => {
+            EncryptedStorage.getItem.mockReset();
+            EncryptedStorage.setItem.mockReset();
+            settingsStore.setSettings.mockReset();
+        });
+
+        it('migrates retired ZEUS swap hosts to the Boltz defaults', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                swaps: {
+                    hostMainnet: 'https://swaps.zeuslsp.com/api/v2',
+                    hostTestnet: 'https://testnet-swaps.zeuslsp.com/api/v2',
+                    customHost: '',
+                    proEnabled: false
+                }
+            };
+
+            await MigrationUtils.migrateSwapHostsToBoltz(settings);
+
+            expect(settings.swaps.hostMainnet).toBe(
+                'https://api.boltz.exchange/v2'
+            );
+            expect(settings.swaps.hostTestnet).toBe(
+                'https://api.testnet.boltz.exchange/v2'
+            );
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+            expect(settingsStore.setSettings.mock.calls[0][0]).toBe(settings);
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'swap-hosts-boltz',
+                'true'
+            );
+        });
+
+        it('leaves non-ZEUS hosts untouched and does not rewrite storage', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                swaps: {
+                    hostMainnet: 'https://api.middle-way.space/v2',
+                    hostTestnet: 'Custom',
+                    customHost: 'https://my-boltz.local/v2',
+                    proEnabled: false
+                }
+            };
+
+            await MigrationUtils.migrateSwapHostsToBoltz(settings);
+
+            expect(settings.swaps.hostMainnet).toBe(
+                'https://api.middle-way.space/v2'
+            );
+            expect(settings.swaps.hostTestnet).toBe('Custom');
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'swap-hosts-boltz',
+                'true'
+            );
+        });
+
+        it('only sets the flag when settings have no swaps block', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {};
+
+            await MigrationUtils.migrateSwapHostsToBoltz(settings);
+
+            expect(settings).toEqual({});
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'swap-hosts-boltz',
+                'true'
+            );
+        });
+
+        it('is a no-op when the migration flag is already set', async () => {
+            EncryptedStorage.getItem.mockResolvedValue('true');
+            const settings: any = {
+                swaps: {
+                    hostMainnet: 'https://swaps.zeuslsp.com/api/v2'
+                }
+            };
+
+            await MigrationUtils.migrateSwapHostsToBoltz(settings);
+
+            expect(settings.swaps.hostMainnet).toBe(
+                'https://swaps.zeuslsp.com/api/v2'
+            );
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
         });
     });
 

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -22,6 +22,10 @@ import {
     DEFAULT_LSP_MUTINYNET,
     DEFAULT_LSPS1_REST_MUTINYNET,
     DEFAULT_SPEEDLOADER,
+    DEFAULT_SWAP_HOST_MAINNET,
+    DEFAULT_SWAP_HOST_TESTNET,
+    LEGACY_ZEUS_SWAP_HOST_MAINNET,
+    LEGACY_ZEUS_SWAP_HOST_TESTNET,
     DEFAULT_NOSTR_RELAYS_2023,
     PosEnabled,
     DEFAULT_SLIDE_TO_PAY_THRESHOLD,
@@ -462,6 +466,9 @@ class MigrationsUtils {
         // migrate old default Olympus LSP hosts to new zeuslsp.com hosts
         await this.migrateOlympusHostsToZeusLsp(newSettings);
 
+        // migrate retired ZEUS swap server hosts to Boltz
+        await this.migrateSwapHostsToBoltz(newSettings);
+
         return newSettings;
     }
 
@@ -550,6 +557,30 @@ class MigrationsUtils {
             await settingsStore.setSettings(settings);
         }
         await EncryptedStorage.setItem(MOD_KEY_ZEUSLSP, 'true');
+        return settings;
+    }
+
+    // migrate users pointed at the retired ZEUS swap server to Boltz.
+    // Must run on both the legacy and modern (zeus-settings-v2) paths.
+    public async migrateSwapHostsToBoltz(settings: any) {
+        const MOD_KEY_SWAP_HOSTS = 'swap-hosts-boltz';
+        const modSwapHosts = await EncryptedStorage.getItem(MOD_KEY_SWAP_HOSTS);
+        if (modSwapHosts) return settings;
+
+        let changed = false;
+        if (settings?.swaps) {
+            if (settings.swaps.hostMainnet === LEGACY_ZEUS_SWAP_HOST_MAINNET) {
+                settings.swaps.hostMainnet = DEFAULT_SWAP_HOST_MAINNET;
+                changed = true;
+            }
+            if (settings.swaps.hostTestnet === LEGACY_ZEUS_SWAP_HOST_TESTNET) {
+                settings.swaps.hostTestnet = DEFAULT_SWAP_HOST_TESTNET;
+                changed = true;
+            }
+        }
+
+        if (changed) await settingsStore.setSettings(settings);
+        await EncryptedStorage.setItem(MOD_KEY_SWAP_HOSTS, 'true');
         return settings;
     }
 

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -38,7 +38,6 @@ import {
 import BalanceStore from '../stores/BalanceStore';
 import ChannelsStore from '../stores/ChannelsStore';
 import InvoicesStore from '../stores/InvoicesStore';
-import SwapStore from '../stores/SwapStore';
 import TransactionsStore, { SendPaymentReq } from '../stores/TransactionsStore';
 import UnitsStore from '../stores/UnitsStore';
 import NodeInfoStore from '../stores/NodeInfoStore';
@@ -61,8 +60,6 @@ import { clearPendingPaymentData } from '../utils/GraphSyncUtils';
 import CaretDown from '../assets/images/SVG/Caret Down.svg';
 import CaretRight from '../assets/images/SVG/Caret Right.svg';
 import QR from '../assets/images/SVG/QR.svg';
-import SwapIcon from '../assets/images/SVG/Swap.svg';
-import BigNumber from 'bignumber.js';
 
 const zaplockerDestinations = [
     // OLYMPUS
@@ -76,7 +73,6 @@ interface InvoiceProps {
     route: Route<'PaymentRequest', { fromGraphSync?: boolean }>;
     BalanceStore: BalanceStore;
     InvoicesStore: InvoicesStore;
-    SwapStore: SwapStore;
     TransactionsStore: TransactionsStore;
     UnitsStore: UnitsStore;
     ChannelsStore: ChannelsStore;
@@ -101,7 +97,6 @@ interface InvoiceState {
     zaplockerToggle: boolean;
     lightningReadyToSend: boolean;
     slideToPayThreshold: number;
-    validAmountToSwap: boolean;
     donationsToggle: boolean;
     donationPercentage: any;
     donationAmount: any;
@@ -117,8 +112,7 @@ interface InvoiceState {
     'ChannelsStore',
     'NodeInfoStore',
     'LnurlPayStore',
-    'SettingsStore',
-    'SwapStore'
+    'SettingsStore'
 )
 @observer
 export default class PaymentRequest extends React.Component<
@@ -145,7 +139,6 @@ export default class PaymentRequest extends React.Component<
         zaplockerToggle: false,
         lightningReadyToSend: false,
         slideToPayThreshold: 10000,
-        validAmountToSwap: false,
         donationsToggle: false,
         donationPercentage: 0,
         donationAmount: 0,
@@ -180,7 +173,6 @@ export default class PaymentRequest extends React.Component<
             }
         }
 
-        const validAmountToSwap = this.isAmountValidToSwap();
         const donationPercentageOptions = [5, 10, 20];
 
         const donationAmount = calculateDonationAmount(
@@ -198,7 +190,6 @@ export default class PaymentRequest extends React.Component<
             maxFeePercent: settings?.payments?.defaultFeePercentage || '5.0',
             timeoutSeconds: settings?.payments?.timeoutSeconds || '60',
             slideToPayThreshold: settings?.payments?.slideToPayThreshold,
-            validAmountToSwap,
             donationPercentage:
                 settings?.payments?.defaultDonationPercentage || 0,
             donationAmount,
@@ -221,68 +212,6 @@ export default class PaymentRequest extends React.Component<
             });
         });
     }
-
-    isAmountValidToSwap(): boolean {
-        const { SwapStore, InvoicesStore } = this.props;
-
-        const subInfo: any = SwapStore.subInfo;
-        const { pay_req } = InvoicesStore;
-        const requestAmount = pay_req && pay_req.getRequestAmount;
-
-        if (!subInfo) {
-            return false;
-        }
-
-        const min = this.calculateLimit(
-            subInfo?.limits?.minimal || 0
-        ).toNumber();
-        const max = this.calculateLimit(
-            subInfo?.limits?.maximal || 0
-        ).toNumber();
-        const minBN = new BigNumber(min);
-        const maxBN = new BigNumber(max);
-
-        const input = this.calculateLimit(requestAmount || 0);
-
-        return input.gte(minBN) && input.lte(maxBN);
-    }
-
-    bigCeil = (big: BigNumber): BigNumber => {
-        return big.integerValue(BigNumber.ROUND_CEIL);
-    };
-
-    calculateSendAmount = (
-        receiveAmount: BigNumber,
-        serviceFee: number,
-        minerFee: number
-    ): BigNumber => {
-        if (receiveAmount.isNaN() || receiveAmount.isLessThanOrEqualTo(0)) {
-            return new BigNumber(0);
-        }
-        return this.bigCeil(
-            receiveAmount
-                .plus(
-                    this.bigCeil(
-                        receiveAmount.times(new BigNumber(serviceFee).div(100))
-                    )
-                )
-                .plus(minerFee)
-        );
-    };
-
-    calculateLimit = (limit: number): any => {
-        const { subInfo } = this.props.SwapStore;
-        const info: any = subInfo;
-        const serviceFeePct = info?.fees?.percentage || 0;
-        const networkFeeBigNum = new BigNumber(info?.fees?.minerFees || 0);
-        const networkFee = networkFeeBigNum.toNumber();
-
-        return this.calculateSendAmount(
-            new BigNumber(limit),
-            serviceFeePct,
-            networkFee
-        );
-    };
 
     componentWillUnmount(): void {
         this.isComponentMounted = false;
@@ -670,40 +599,6 @@ export default class PaymentRequest extends React.Component<
             </TouchableOpacity>
         );
 
-        const SwapButton = () => {
-            const { validAmountToSwap } = this.state;
-
-            if (!validAmountToSwap) return null;
-
-            return (
-                <TouchableOpacity
-                    onPress={() => {
-                        const amountToSwap = isNoAmountInvoice
-                            ? this.state.satAmount
-                            : requestAmount;
-                        if (paymentRequest && amountToSwap) {
-                            navigation.navigate('Swaps', {
-                                initialInvoice: paymentRequest,
-                                initialAmountSats: amountToSwap.toString(),
-                                initialReverse: false // OnChain -> LN for paying a LN invoice
-                            });
-                        }
-                    }}
-                    disabled={
-                        !paymentRequest ||
-                        (!isNoAmountInvoice && !requestAmount)
-                    }
-                >
-                    <SwapIcon
-                        fill={themeColor('text')}
-                        width="36"
-                        height="26"
-                        style={{ marginRight: 10 }}
-                    />
-                </TouchableOpacity>
-            );
-        };
-
         return (
             <Screen>
                 <Header
@@ -720,7 +615,6 @@ export default class PaymentRequest extends React.Component<
                     }}
                     rightComponent={
                         <Row>
-                            {!isPayReqExpired && <SwapButton />}
                             <QRButton />
                         </Row>
                     }

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -28,7 +28,6 @@ import InvoicesStore from '../stores/InvoicesStore';
 import ModalStore from '../stores/ModalStore';
 import NodeInfoStore from '../stores/NodeInfoStore';
 import SettingsStore from '../stores/SettingsStore';
-import SwapStore from '../stores/SwapStore';
 import TransactionsStore from '../stores/TransactionsStore';
 import UTXOsStore from '../stores/UTXOsStore';
 
@@ -58,11 +57,9 @@ import { clearPendingPaymentData } from '../utils/GraphSyncUtils';
 import NFC from '../assets/images/SVG/NFC-alt.svg';
 import ContactIcon from '../assets/images/SVG/PeersContact.svg';
 import Scan from '../assets/images/SVG/Scan.svg';
-import SwapIcon from '../assets/images/SVG/Swap.svg';
 
 import Contact from '../models/Contact';
 import { AdditionalOutput } from '../models/TransactionRequest';
-import BigNumber from 'bignumber.js';
 
 interface SendProps {
     exitSetup: any;
@@ -75,7 +72,6 @@ interface SendProps {
     SettingsStore: SettingsStore;
     TransactionsStore: TransactionsStore;
     UTXOsStore: UTXOsStore;
-    SwapStore: SwapStore;
     route: Route<
         'Send',
         {
@@ -118,7 +114,6 @@ interface SendState {
     account: string;
     additionalOutputs: Array<AdditionalOutput>;
     fundMax: boolean;
-    validAmountToSwap: boolean;
     nfcSupported: boolean;
 }
 
@@ -130,8 +125,7 @@ interface SendState {
     'NodeInfoStore',
     'SettingsStore',
     'TransactionsStore',
-    'UTXOsStore',
-    'SwapStore'
+    'UTXOsStore'
 )
 @observer
 export default class Send extends React.Component<SendProps, SendState> {
@@ -193,12 +187,11 @@ export default class Send extends React.Component<SendProps, SendState> {
             account: 'default',
             additionalOutputs: [],
             fundMax: false,
-            validAmountToSwap: false,
             nfcSupported: false
         };
     }
 
-    async componentDidUpdate(prevProps: SendProps, prevState: SendState) {
+    async componentDidUpdate(prevProps: SendProps) {
         const { route, InvoicesStore } = this.props;
         const { route: prevRoute } = prevProps;
 
@@ -234,76 +227,7 @@ export default class Send extends React.Component<SendProps, SendState> {
             }
             this.setState(stateUpdate as SendState);
         }
-
-        const { SwapStore } = this.props;
-
-        if (
-            this.state.satAmount !== prevState.satAmount &&
-            this.state.satAmount !== '0'
-        ) {
-            const reverseInfo: any = SwapStore.reverseInfo;
-
-            const validAmountToSwap = this.isAmountValidToSwap(
-                reverseInfo,
-                this.state.satAmount
-            );
-
-            if (validAmountToSwap !== this.state.validAmountToSwap) {
-                this.setState({
-                    validAmountToSwap
-                });
-            }
-        }
     }
-
-    isAmountValidToSwap(
-        reverseInfo: any,
-        requestAmount: number | string | null
-    ): boolean {
-        if (!reverseInfo) {
-            return false;
-        }
-        const serviceFeePct = reverseInfo?.fees?.percentage || 0;
-        const networkFeeBigNum = new BigNumber(
-            reverseInfo?.fees?.minerFees?.claim || 0
-        ).plus(reverseInfo?.fees?.minerFees?.lockup || 0);
-        const networkFee = networkFeeBigNum.toNumber();
-
-        const min = reverseInfo?.limits?.minimal || 0;
-        const max = reverseInfo?.limits?.maximal || 0;
-        const minBN = new BigNumber(min);
-        const maxBN = new BigNumber(max);
-
-        const satAmountNew = new BigNumber(requestAmount || 0);
-
-        let input: any;
-        input = this.calculateSendAmount(
-            satAmountNew,
-            serviceFeePct,
-            networkFee
-        );
-
-        return input.gte(minBN) && input.lte(maxBN);
-    }
-
-    bigCeil = (big: BigNumber): BigNumber => {
-        return big.integerValue(BigNumber.ROUND_CEIL);
-    };
-
-    calculateSendAmount = (
-        receiveAmount: BigNumber,
-        serviceFee: number,
-        minerFee: number
-    ): BigNumber => {
-        if (receiveAmount.isNaN() || receiveAmount.isLessThanOrEqualTo(0)) {
-            return new BigNumber(0);
-        }
-        return this.bigCeil(
-            receiveAmount
-                .plus(minerFee)
-                .div(new BigNumber(1).minus(new BigNumber(serviceFee).div(100)))
-        );
-    };
 
     async componentDidMount() {
         const { SettingsStore, route } = this.props;
@@ -736,7 +660,6 @@ export default class Send extends React.Component<SendProps, SendState> {
             additionalOutputs,
             fundMax,
             account,
-            validAmountToSwap,
             utxos,
             nfcSupported,
             timeoutSeconds
@@ -804,42 +727,6 @@ export default class Send extends React.Component<SendProps, SendState> {
                                     <LoadingIndicator size={30} />
                                 </View>
                             )}
-                            {transactionType === 'On-chain' &&
-                                BackendUtils.supportsOnchainSends() &&
-                                validAmountToSwap && (
-                                    <View
-                                        style={{
-                                            marginRight: 15
-                                        }}
-                                    >
-                                        <TouchableOpacity
-                                            onPress={() => {
-                                                // For "all", actual satAmount might be resolved later or be 0 initially.
-                                                // Swaps might need a concrete amount.
-                                                // For now, send what we have. If "all", it might be 0 or a balance.
-                                                const amountForSwap =
-                                                    fundMax &&
-                                                    implementation ===
-                                                        'cln-rest' &&
-                                                    amount === 'all'
-                                                        ? '0' // CLN 'all' is symbolic, swap needs a number or let user input
-                                                        : satAmount || '0';
-                                                navigation.navigate('Swaps', {
-                                                    initialInvoice: destination,
-                                                    initialAmountSats:
-                                                        amountForSwap.toString(),
-                                                    initialReverse: true // LN -> OnChain for sending to an OnChain address
-                                                });
-                                            }}
-                                        >
-                                            <SwapIcon
-                                                fill={themeColor('text')}
-                                                width="36"
-                                                height="26"
-                                            />
-                                        </TouchableOpacity>
-                                    </View>
-                                )}
                             {nfcSupported && (
                                 <View style={{ marginRight: 15 }}>
                                     <TouchableOpacity

--- a/views/Swaps/Refund.tsx
+++ b/views/Swaps/Refund.tsx
@@ -371,7 +371,8 @@ export default class RefundSwap extends React.Component<
                             if (!swapData.lockupTransaction) {
                                 swapData.lockupTransaction =
                                     await SwapStore?.getLockupTransaction(
-                                        swapData.id
+                                        swapData.id,
+                                        swapData.endpoint
                                     );
                             }
 

--- a/views/Swaps/SwapDetails.tsx
+++ b/views/Swaps/SwapDetails.tsx
@@ -373,7 +373,8 @@ export default class SwapDetails extends React.Component<
                         !this.state.swapData?.lockupTransaction?.hex
                     ) {
                         const lockupTx = await SwapStore?.getLockupTransaction(
-                            createdResponse.id
+                            createdResponse.id,
+                            endpoint
                         );
                         this.setState((prevState) => ({
                             swapData: new Swap({

--- a/views/Swaps/SwapDetails.tsx
+++ b/views/Swaps/SwapDetails.tsx
@@ -142,6 +142,16 @@ export default class SwapDetails extends React.Component<
                 return;
             }
 
+            // legacy swaps predate claimMinerFee being stored at
+            // creation; fetch rates so the claim fee does not fall
+            // back to zero
+            if (
+                swapData.claimMinerFee == null &&
+                !this.props.SwapStore?.claimMinerFee
+            ) {
+                this.props.SwapStore?.getSwapFees();
+            }
+
             this.getReverseSwapUpdates(swapData, swapData.isSubmarineSwap);
         }
     }
@@ -659,7 +669,10 @@ export default class SwapDetails extends React.Component<
                 endpoint,
                 transactionHex,
                 feeRate: Number(fee || 2),
-                minerFee: this.props.SwapStore?.claimMinerFee || 0,
+                minerFee:
+                    this.state.swapData?.claimMinerFee ??
+                    this.props.SwapStore?.claimMinerFee ??
+                    0,
                 isTestnet: !!this.props.NodeInfoStore!.nodeInfo.isTestNet
             });
             if (!claim) return false;

--- a/views/Swaps/SwapDetails.tsx
+++ b/views/Swaps/SwapDetails.tsx
@@ -659,6 +659,25 @@ export default class SwapDetails extends React.Component<
         fee: string
     ): Promise<boolean> => {
         try {
+            const { SwapStore } = this.props;
+
+            // legacy swaps predate claimMinerFee being stored at
+            // creation; the mount-time rates prefetch may not have
+            // resolved yet, so wait for it here rather than building
+            // the claim with a zero miner fee
+            let minerFee =
+                this.state.swapData?.claimMinerFee ??
+                SwapStore?.claimMinerFee ??
+                0;
+            if (!minerFee) {
+                try {
+                    await SwapStore?.getSwapFees();
+                    minerFee = SwapStore?.claimMinerFee ?? 0;
+                } catch (e) {
+                    console.log('Error fetching rates for claim fee', e);
+                }
+            }
+
             const claim = ReverseClaimTransaction.build({
                 swap: new Swap({
                     ...createdResponse,
@@ -670,10 +689,7 @@ export default class SwapDetails extends React.Component<
                 endpoint,
                 transactionHex,
                 feeRate: Number(fee || 2),
-                minerFee:
-                    this.state.swapData?.claimMinerFee ??
-                    this.props.SwapStore?.claimMinerFee ??
-                    0,
+                minerFee,
                 isTestnet: !!this.props.NodeInfoStore!.nodeInfo.isTestNet
             });
             if (!claim) return false;

--- a/views/Swaps/index.tsx
+++ b/views/Swaps/index.tsx
@@ -279,6 +279,12 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
         const unsubFocus = this.props.navigation.addListener(
             'focus',
             async () => {
+                // re-fetch rates if the swap host changed since the
+                // last fetch (e.g. returning from Swap Settings)
+                if (SwapStore.fetchedRatesHost !== SwapStore.getHost) {
+                    SwapStore.getSwapFees();
+                }
+
                 const mnemonic = await Storage.getItem(SWAPS_RESCUE_KEY);
 
                 if (mnemonic) {

--- a/views/Swaps/index.tsx
+++ b/views/Swaps/index.tsx
@@ -280,8 +280,12 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
             'focus',
             async () => {
                 // re-fetch rates if the swap host changed since the
-                // last fetch (e.g. returning from Swap Settings)
-                if (SwapStore.fetchedRatesHost !== SwapStore.getHost) {
+                // last fetch (e.g. returning from Swap Settings) or
+                // the last fetch failed (fetchedRatesHost stays unset)
+                if (
+                    !SwapStore.loading &&
+                    SwapStore.fetchedRatesHost !== SwapStore.getHost
+                ) {
                     SwapStore.getSwapFees();
                 }
 

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1309,8 +1309,8 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         }
 
         // check for swaps after node info is fetched
+        // NOTE: swap rates are only fetched from the Swaps view
         if (connecting) {
-            SwapStore.getSwapFees();
             SwapStore.fetchAndUpdateSwaps();
         }
 


### PR DESCRIPTION
# Description

Relates to issue: **N/A**

Three changes to the swaps stack:

**1. Retire the ZEUS swap server, make Boltz the default**

- Removes `swaps.zeuslsp.com` / `testnet-swaps.zeuslsp.com` from the mainnet and testnet swap host lists.
- `DEFAULT_SWAP_HOST_MAINNET` / `DEFAULT_SWAP_HOST_TESTNET` now point at Boltz (`https://api.boltz.exchange/v2`, `https://api.testnet.boltz.exchange/v2`).
- New one-shot `swap-hosts-boltz` migration moves users whose persisted settings still point at the retired hosts to the Boltz defaults. It runs on both the legacy and modern (`zeus-settings-v2`) settings paths, only rewrites hosts that exactly match the retired defaults (SwapMarket, Eldamar, and custom hosts are untouched), and only persists when something actually changed.

**2. Only fetch swap rates when the user enters the Swaps view**

Previously swap rates were fetched on startup: once from `Wallet.tsx` after connect, and again via a `SwapStore` reaction that fired whenever the resolved swap host changed (settings load, node info resolving testnet vs mainnet). Both are removed. `getSwapFees` is now only called from the Swaps view.

- The store tracks which host rates were last fetched from (`fetchedRatesHost`); the Swaps view re-fetches on focus if the provider changed since the last fetch (e.g. returning from Swap Settings).
- Swap status polling for existing swaps (`fetchAndUpdateSwaps`) is unchanged.

**3. Remove the swap shortcuts from Send and PaymentRequest**

The swap shortcut icons in Send (on-chain reverse swap) and PaymentRequest (submarine swap) were gated on cached rate data that no longer loads at startup, so they would have appeared only after visiting the Swaps view. The shortcuts and their supporting fee/limit math are removed; swaps remain available from the Swaps view.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

New unit tests cover the `swap-hosts-boltz` migration (ZEUS hosts rewritten, other hosts untouched, no-op on flag, no rewrite when nothing changed).

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Device tests pending: fresh install (Boltz default), upgrade with persisted ZEUS host (migration), swaps view rate fetch, provider change in Swap Settings followed by return to the Swaps view, confirming no requests to the swap host on startup, and confirming Send / PaymentRequest headers render correctly without the swap shortcut.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
