### PR TITLE
tests: fix PhotoUtils path fragility and stop jest sweeping embedded worktrees

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     ],
     "testPathIgnorePatterns": [
       "check-styles.test.ts",
-      "zeus_modules"
+      "zeus_modules",
+      "/.claude/"
     ]
   },
   "scripts": {

--- a/utils/PhotoUtils.test.ts
+++ b/utils/PhotoUtils.test.ts
@@ -25,11 +25,14 @@ describe('PhotoUtils', () => {
         });
 
         it('groks out preset:// values', () => {
-            expect(getPhoto('preset://lnd')).toEqual(
-                '../../../assets/images/lnd.jpg'
+            // jest's asset transform returns the asset path relative to
+            // node_modules/react-native/jest, so only assert on the
+            // checkout-independent suffix
+            expect(getPhoto('preset://lnd')).toMatch(
+                /assets\/images\/lnd\.jpg$/
             );
-            expect(getPhoto('preset://zeusillustration1a')).toEqual(
-                '../../../assets/images/zeus_illustration_1a.jpg'
+            expect(getPhoto('preset://zeusillustration1a')).toMatch(
+                /assets\/images\/zeus_illustration_1a\.jpg$/
             );
         });
 


### PR DESCRIPTION
# Description

Relates to issue: **N/A**

Fixes spurious local failures of `utils/PhotoUtils.test.ts` when copies of the repo live inside the main checkout (e.g. git worktrees under `.claude/worktrees/`).

**Root cause:** jest's asset transform (`@react-native/jest-preset`) emits `testUri` as the asset path relative to `node_modules/react-native/jest`. The test hardcoded `'../../../assets/images/lnd.jpg'`, which only holds when the repo copy sits at the node_modules root; a copy checked out anywhere else resolves to a different relative path and fails even though `getPhoto` returns the correct asset. The fragile expectation dates back to `46e1d15c8` on master, so it could not be fixed by amending an open branch.

Two commits:

1. **`tests: make PhotoUtils preset URI assertions checkout-independent`** - assert on the path suffix (`assets/images/lnd.jpg`) instead of the full transformer-relative path.
2. **`tests: exclude .claude worktrees from jest runs`** - jest was sweeping test files in worktrees checked out under `.claude/worktrees/`, running stale copies of every suite against the main checkout's config and node_modules (tripling suite counts and producing these path-sensitive failures). Ignore the `.claude` directory like `zeus_modules`.

No runtime code changes; test and jest config only.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [x] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

N/A: test and jest configuration changes only, no app code touched.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

N/A: no backend code paths affected.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

`package.json` changed (jest `testPathIgnorePatterns` only); no dependencies added or bumped, `yarn.lock` untouched.

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
