### PR TITLE
ui: disable pay on zero balance, grey out disabled button icons

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -75,14 +75,18 @@ function Button(props: ButtonProps) {
                     ? React.isValidElement(icon)
                         ? icon
                         : {
-                              color: icon.color
+                              ...icon,
+                              // match @rneui's disabled title color:
+                              // color(theme.colors.disabled).darken(0.3)
+                              color: disabled
+                                  ? 'hsl(208, 8%, 63%)'
+                                  : icon.color
                                   ? icon.color
                                   : iconOnly
                                   ? textColor
                                   : secondary
                                   ? themeColor('highlight')
-                                  : themeColor('background'),
-                              ...icon
+                                  : themeColor('background')
                           }
                     : null
             }

--- a/views/Cashu/CashuPaymentRequest.tsx
+++ b/views/Cashu/CashuPaymentRequest.tsx
@@ -1028,7 +1028,8 @@ export default class CashuPaymentRequest extends React.Component<
                             {requestAmount &&
                             requestAmount >= slideToPayThreshold &&
                             !SettingsStore.settingsUpdateInProgress &&
-                            !hasPayReqError ? (
+                            !hasPayReqError &&
+                            !noBalance ? (
                                 <SwipeButton
                                     key={this.state.swipeButtonKey}
                                     onSwipeSuccess={this.triggerPayment}
@@ -1067,7 +1068,8 @@ export default class CashuPaymentRequest extends React.Component<
                                         onPress={this.triggerPayment}
                                         disabled={
                                             SettingsStore.settingsUpdateInProgress ||
-                                            hasPayReqError
+                                            hasPayReqError ||
+                                            noBalance
                                         }
                                     />
                                 </View>

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -1605,7 +1605,10 @@ export default class PaymentRequest extends React.Component<
                                 <SwipeButton
                                     key={this.state.swipeButtonKey}
                                     onSwipeSuccess={this.triggerPayment}
-                                    disabled={TransactionsStore.paymentInFlight}
+                                    disabled={
+                                        TransactionsStore.paymentInFlight ||
+                                        noBalance
+                                    }
                                     instructionText={localeString(
                                         'views.PaymentRequest.slideToPay'
                                     )}
@@ -1623,18 +1626,15 @@ export default class PaymentRequest extends React.Component<
                                         title={localeString(
                                             'views.PaymentRequest.payInvoice'
                                         )}
-                                        icon={
-                                            lightningReadyToSend
-                                                ? {
-                                                      name: 'send',
-                                                      size: 25
-                                                  }
-                                                : undefined
-                                        }
+                                        icon={{
+                                            name: 'send',
+                                            size: 25
+                                        }}
                                         onPress={this.triggerPayment}
                                         disabled={
                                             !lightningReadyToSend ||
-                                            TransactionsStore.paymentInFlight
+                                            TransactionsStore.paymentInFlight ||
+                                            noBalance
                                         }
                                     />
                                 </View>


### PR DESCRIPTION
# Description

Cleans up the disabled states of the pay buttons on the Lightning and Cashu payment request views.

**`components/Button.tsx`**
- When a `Button` is disabled, its icon is now rendered in the same grey `@rneui/themed` uses for the disabled title text (`hsl(208, 8%, 63%)`, i.e. `color(theme.colors.disabled).darken(0.3)`). Previously the icon kept its full-color styling while the label and background greyed out. Applies to every disabled `Button` with an icon app-wide.

**`views/PaymentRequest.tsx`**
- The "Pay this invoice" button and the slide-to-pay variant are now disabled when the Lightning balance is 0. Previously the zero-balance case only kept the button disabled on embedded-lnd (via `checkIfLndReady` never marking Lightning ready); every other backend enabled the button immediately, even while the "no Lightning balance" warning was showing above it.
- The send icon is now always passed to the button, so it shows greyed out while disabled instead of disappearing while Lightning is not ready to send.

**`views/Cashu/CashuPaymentRequest.tsx`**
- Same zero-balance gating for consistency: with a total mint balance of 0, the SwipeButton is replaced by the greyed static button (above the slide-to-pay threshold) and the "Pay this invoice" button is disabled (below it). Previously the view showed the no-balance warning but still allowed triggering the payment.

No new strings, no dependency changes, no storage changes.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
