### PR TITLE
fix: Contacts: clear stale prefillContact on every AddContact exit

### DIFF
--- a/stores/ContactStore.test.ts
+++ b/stores/ContactStore.test.ts
@@ -1,0 +1,132 @@
+jest.mock('../storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn()
+    }
+}));
+
+import Storage from '../storage';
+import ContactStore, { CONTACTS_KEY } from './ContactStore';
+
+const getItemMock = Storage.getItem as jest.Mock;
+const setItemMock = Storage.setItem as jest.Mock;
+
+const savedContacts = () => setItemMock.mock.calls[0][1];
+
+describe('ContactStore', () => {
+    let store: ContactStore;
+    let navigation: { popTo: jest.Mock };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        store = new ContactStore();
+        navigation = { popTo: jest.fn() };
+    });
+
+    describe('saveContact (new contact)', () => {
+        it('assigns a fresh contactId even if contactDetails carries a stale one', async () => {
+            // Regression for #4387: a stale prefillContact leaking its
+            // contactId into a new contact created two contacts sharing
+            // one ID, so deleting or editing one affected both
+            const existing = [{ contactId: 'stale-id', name: 'Alice' }];
+            getItemMock.mockResolvedValue(JSON.stringify(existing));
+
+            await store.saveContact(
+                { name: 'Bob', contactId: 'stale-id' },
+                false,
+                false,
+                navigation
+            );
+
+            expect(setItemMock).toHaveBeenCalledWith(
+                CONTACTS_KEY,
+                expect.any(Array)
+            );
+            const contacts = savedContacts();
+            expect(contacts).toHaveLength(2);
+            const bob = contacts.find((c: any) => c.name === 'Bob');
+            expect(bob.contactId).toBeDefined();
+            expect(bob.contactId).not.toBe('stale-id');
+            expect(navigation.popTo).toHaveBeenCalledWith('Contacts');
+        });
+
+        it('clears prefillContact after saving', async () => {
+            getItemMock.mockResolvedValue(null);
+            store.setPrefillContact({
+                contactId: 'old-id',
+                name: 'Alice'
+            } as any);
+
+            await store.saveContact({ name: 'Bob' }, false, false, navigation);
+
+            expect(store.prefillContact).toBeNull();
+        });
+    });
+
+    describe('saveContact (edit)', () => {
+        it('updates only the contact matching prefillContact.contactId and preserves its ID', async () => {
+            const existing = [
+                { contactId: 'id-a', name: 'Alice', description: '' },
+                { contactId: 'id-b', name: 'Bob', description: '' }
+            ];
+            getItemMock.mockResolvedValue(JSON.stringify(existing));
+            store.setPrefillContact({
+                contactId: 'id-a',
+                name: 'Alice'
+            } as any);
+
+            await store.saveContact(
+                { name: 'Alicia', description: 'renamed' },
+                true,
+                false,
+                navigation
+            );
+
+            const contacts = savedContacts();
+            expect(contacts).toHaveLength(2);
+            const alicia = contacts.find((c: any) => c.contactId === 'id-a');
+            expect(alicia.name).toBe('Alicia');
+            expect(alicia.description).toBe('renamed');
+            const bob = contacts.find((c: any) => c.contactId === 'id-b');
+            expect(bob.name).toBe('Bob');
+            expect(store.prefillContact).toBeNull();
+        });
+    });
+
+    describe('deleteContact', () => {
+        it('removes only the contact matching prefillContact.contactId', async () => {
+            const existing = [
+                { contactId: 'id-a', name: 'Alice' },
+                { contactId: 'id-b', name: 'Bob' }
+            ];
+            getItemMock.mockResolvedValue(JSON.stringify(existing));
+            store.setPrefillContact({
+                contactId: 'id-a',
+                name: 'Alice'
+            } as any);
+
+            await store.deleteContact(navigation);
+
+            const contacts = savedContacts();
+            expect(contacts).toHaveLength(1);
+            expect(contacts[0].contactId).toBe('id-b');
+            expect(store.prefillContact).toBeNull();
+        });
+    });
+
+    describe('clearPrefillContact', () => {
+        it('nulls out prefillContact', () => {
+            store.setPrefillContact({
+                contactId: 'id-a',
+                name: 'Alice'
+            } as any);
+            expect(store.prefillContact).not.toBeNull();
+
+            store.clearPrefillContact();
+
+            expect(store.prefillContact).toBeNull();
+        });
+    });
+});

--- a/stores/ContactStore.ts
+++ b/stores/ContactStore.ts
@@ -66,9 +66,12 @@ export default class ContactStore {
                 // Creating a new contact
                 const contactId = uuidv4();
 
+                // contactId spread last so a leaked ID in contactDetails
+                // can never override the fresh one; duplicate IDs make
+                // delete/edit act on multiple contacts at once
                 const newContact: Contact = {
-                    contactId,
-                    ...compactedContactDetails
+                    ...compactedContactDetails,
+                    contactId
                 };
 
                 const updatedContacts = [...existingContacts, newContact].sort(

--- a/views/Settings/AddContact.tsx
+++ b/views/Settings/AddContact.tsx
@@ -249,7 +249,40 @@ export default class AddContact extends React.Component<
     saveContact = async () => {
         const { navigation, route, ContactStore } = this.props;
         const { isEdit, isNostrContact } = route.params ?? {};
-        const contactDetails = { ...this.state };
+        const {
+            lnAddress,
+            bolt12Address,
+            bolt12Offer,
+            noffer,
+            onchainAddress,
+            nip05,
+            nostrNpub,
+            pubkey,
+            cashuPubkey,
+            name,
+            description,
+            photo,
+            isFavourite
+        } = this.state;
+        // Only pass actual contact fields; UI state (validation arrays,
+        // modal flags) and any prefilled contactId must not be persisted.
+        // The store matches edits via prefillContact.contactId and assigns
+        // fresh IDs to new contacts
+        const contactDetails = {
+            lnAddress,
+            bolt12Address,
+            bolt12Offer,
+            noffer,
+            onchainAddress,
+            nip05,
+            nostrNpub,
+            pubkey,
+            cashuPubkey,
+            name,
+            description,
+            photo,
+            isFavourite
+        };
         await ContactStore.saveContact(
             contactDetails,
             isEdit,
@@ -438,6 +471,14 @@ export default class AddContact extends React.Component<
         this.handlePrefillContact();
     }
 
+    componentWillUnmount() {
+        // The header back arrow, the Android hardware back button and the
+        // iOS swipe-back gesture all pop this screen; only clearing here
+        // covers every exit path, so stale prefill data can never seed a
+        // later Add Contact form
+        this.props.ContactStore.clearPrefillContact();
+    }
+
     componentDidUpdate(prevProps: AddContactProps) {
         const { ContactStore } = this.props;
         if (
@@ -449,7 +490,12 @@ export default class AddContact extends React.Component<
     }
 
     handlePrefillContact = () => {
-        const { ContactStore } = this.props;
+        const { ContactStore, route } = this.props;
+        const { isEdit, isNostrContact } = route.params ?? {};
+
+        // A fresh Add Contact form must never be seeded by prefill data
+        // left over from a previous edit or import flow
+        if (!isEdit && !isNostrContact) return;
 
         if (ContactStore.prefillContact) {
             // Since invalid data cannot be saved, we know all existing fields are valid.
@@ -871,9 +917,6 @@ export default class AddContact extends React.Component<
                                 <ScanBadge navigation={navigation} />
                             </Row>
                         }
-                        onBack={() => {
-                            ContactStore?.clearPrefillContact();
-                        }}
                         containerStyle={{
                             borderBottomWidth: 0
                         }}


### PR DESCRIPTION
# Description

Relates to issue: **#4387**

Leaving `AddContact` with the Android hardware back button or the iOS swipe-back gesture never cleared `ContactStore.prefillContact`: the clear was wired only to the header back arrow's `onPress`, and native-stack pops bypass that handler entirely.

The stale prefill then seeded the next fresh Add Contact form. Worse, the stale `contactId` was spread into component state, passed to `ContactStore.saveContact` via `{ ...this.state }`, and spread *after* the freshly generated uuid in the new-contact branch, silently overriding it. Result: two contacts sharing one ID, so deleting one deleted both and editing one edited both, exactly as reported.

Fix is layered so ID collisions become structurally impossible:

1. **Clear on unmount** (`AddContact.componentWillUnmount`): covers every exit path (header arrow, hardware back, swipe-back gesture). The now-redundant header `onBack` clear is removed. (`blur` deliberately not used: it never fires on native-stack pop.)
2. **Gate prefill consumption**: `handlePrefillContact` now returns early unless the route is an edit or nostr import, so a fresh form can never be seeded by leftover state even if clearing were ever missed.
3. **Explicit save payload**: `saveContact` passes only actual contact fields instead of `{ ...this.state }`, so `contactId`, validation arrays, and modal flags no longer leak into the persisted contact record.
4. **Store hardening**: the new-contact branch spreads `contactId` last, so a leaked ID can never override the fresh uuid. This also aligns the nostr "edit and save" import path with `importToContacts`, which already assigns a fresh local ID.

Adds `stores/ContactStore.test.ts` with a regression test for the duplicate-ID corruption (verified to fail against the unfixed store), plus coverage for edit, delete, and prefill-clearing behavior.

Note: wallets already corrupted (two contacts sharing an ID from before this fix) are not repaired by this PR; a one-time dedupe on load could be a follow-up if deemed worthwhile.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
