### PR TITLE
ui: KeyValue: add copy icon and make tap copy values

### DIFF
--- a/components/FeeBreakdown.tsx
+++ b/components/FeeBreakdown.tsx
@@ -454,6 +454,7 @@ export default class FeeBreakdown extends React.Component<
                                 value={channelId}
                                 color={themeColor('chain')}
                                 sensitive
+                                showCopyIcon
                                 mempoolLink={() =>
                                     UrlUtils.goToBlockExplorerChannelId(
                                         channelId,
@@ -470,6 +471,7 @@ export default class FeeBreakdown extends React.Component<
                                 value={channelPoint}
                                 color={themeColor('highlight')}
                                 sensitive
+                                showCopyIcon
                                 mempoolLink={() =>
                                     UrlUtils.goToBlockExplorerTXID(
                                         channelPoint,

--- a/components/KeyValue.tsx
+++ b/components/KeyValue.tsx
@@ -90,17 +90,23 @@ export default class KeyValue extends React.Component<KeyValueProps> {
         const lurkerMode: boolean =
             SettingsStore?.settings?.privacy?.lurkerMode || false;
 
-        // lurker mode only redacts sensitive values; copying or opening a
-        // link on a redacted value would expose the real value
+        // lurker mode only redacts sensitive values; copying a redacted
+        // value would put the real value on the clipboard, so copy actions
+        // are disabled for redacted values. mempoolLink stays active:
+        // navigation is an explicit act and remains available elsewhere in
+        // lurker mode (e.g. the note edit button, custom explorer links)
         const valueHidden = lurkerMode && sensitive;
 
         {
             /* TODO: rig up RTL */
         }
+        // long press copies any copyable value; the icon and tap-to-copy
+        // are opt-in per call site
         const isCopyable =
             !disableCopy &&
-            !!showCopyIcon &&
+            !valueHidden &&
             (typeof value === 'string' || typeof value === 'number');
+        const showIcon = isCopyable && !!showCopyIcon;
         const rtl = false;
         const KeyBase = (
             <Body>
@@ -183,7 +189,7 @@ export default class KeyValue extends React.Component<KeyValueProps> {
                         ? PrivacyUtils.sensitiveValue({ input: value })
                         : value}
                 </Text>
-                {isCopyable && !valueHidden && (
+                {showIcon && (
                     <Pressable
                         onPress={() => this.copyText()}
                         onPressIn={() => this.setValueOpacity(0.2)}
@@ -209,15 +215,17 @@ export default class KeyValue extends React.Component<KeyValueProps> {
         );
 
         let Value: any;
-        if (!valueHidden && (isCopyable || mempoolLink)) {
+        if (isCopyable || mempoolLink) {
             Value = (
                 <Pressable
-                    onPress={mempoolLink ? mempoolLink : () => this.copyText()}
-                    onLongPress={
-                        mempoolLink && isCopyable
+                    onPress={
+                        mempoolLink
+                            ? mempoolLink
+                            : showIcon
                             ? () => this.copyText()
                             : undefined
                     }
+                    onLongPress={isCopyable ? () => this.copyText() : undefined}
                     onPressIn={() => this.setValueOpacity(0.2)}
                     onPressOut={() => this.setValueOpacity(1)}
                 >

--- a/components/KeyValue.tsx
+++ b/components/KeyValue.tsx
@@ -90,6 +90,10 @@ export default class KeyValue extends React.Component<KeyValueProps> {
         const lurkerMode: boolean =
             SettingsStore?.settings?.privacy?.lurkerMode || false;
 
+        // lurker mode only redacts sensitive values; copying or opening a
+        // link on a redacted value would expose the real value
+        const valueHidden = lurkerMode && sensitive;
+
         {
             /* TODO: rig up RTL */
         }
@@ -179,7 +183,7 @@ export default class KeyValue extends React.Component<KeyValueProps> {
                         ? PrivacyUtils.sensitiveValue({ input: value })
                         : value}
                 </Text>
-                {isCopyable && !lurkerMode && (
+                {isCopyable && !valueHidden && (
                     <Pressable
                         onPress={() => this.copyText()}
                         onPressIn={() => this.setValueOpacity(0.2)}
@@ -205,7 +209,7 @@ export default class KeyValue extends React.Component<KeyValueProps> {
         );
 
         let Value: any;
-        if (!lurkerMode && (isCopyable || mempoolLink)) {
+        if (!valueHidden && (isCopyable || mempoolLink)) {
             Value = (
                 <Pressable
                     onPress={mempoolLink ? mempoolLink : () => this.copyText()}

--- a/components/KeyValue.tsx
+++ b/components/KeyValue.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import {
+    Animated,
+    Pressable,
     StyleProp,
     StyleSheet,
     Text,
@@ -16,7 +18,10 @@ import { showCopiedToast } from './CopiedToast';
 import { Row } from './layout/Row';
 
 import { themeColor } from '../utils/ThemeUtils';
+import { localeString } from '../utils/LocaleUtils';
 import PrivacyUtils from '../utils/PrivacyUtils';
+
+import Copy from '../assets/images/SVG/Copy.svg';
 
 import ModalStore from '../stores/ModalStore';
 import SettingsStore from '../stores/SettingsStore';
@@ -36,6 +41,7 @@ interface KeyValueProps {
     }>;
     mempoolLink?: () => void;
     disableCopy?: boolean;
+    showCopyIcon?: boolean;
     containerStyle?: StyleProp<ViewStyle>;
     ModalStore?: ModalStore;
     SettingsStore?: SettingsStore;
@@ -44,11 +50,21 @@ interface KeyValueProps {
 @inject('ModalStore', 'SettingsStore')
 @observer
 export default class KeyValue extends React.Component<KeyValueProps> {
+    valueOpacity = new Animated.Value(1);
+
     copyText = () => {
         const { value } = this.props;
         Clipboard.setString(value.toString());
         Vibration.vibrate(50);
         showCopiedToast();
+    };
+
+    setValueOpacity = (toValue: number) => {
+        Animated.timing(this.valueOpacity, {
+            toValue,
+            duration: toValue === 1 ? 150 : 50,
+            useNativeDriver: true
+        }).start();
     };
 
     render() {
@@ -64,6 +80,7 @@ export default class KeyValue extends React.Component<KeyValueProps> {
             infoModalAdditionalButtons,
             mempoolLink,
             disableCopy,
+            showCopyIcon,
             containerStyle,
             ModalStore,
             SettingsStore
@@ -76,9 +93,10 @@ export default class KeyValue extends React.Component<KeyValueProps> {
         {
             /* TODO: rig up RTL */
         }
-        const isCopyable = disableCopy
-            ? false
-            : typeof value === 'string' || typeof value === 'number';
+        const isCopyable =
+            !disableCopy &&
+            !!showCopyIcon &&
+            (typeof value === 'string' || typeof value === 'number');
         const rtl = false;
         const KeyBase = (
             <Body>
@@ -153,25 +171,56 @@ export default class KeyValue extends React.Component<KeyValueProps> {
                 <Text
                     style={{
                         color: color || themeColor('text'),
-                        fontFamily: 'PPNeueMontreal-Book'
+                        fontFamily: 'PPNeueMontreal-Book',
+                        flexShrink: 1
                     }}
                 >
                     {sensitive
                         ? PrivacyUtils.sensitiveValue({ input: value })
                         : value}
                 </Text>
+                {isCopyable && !lurkerMode && (
+                    <Pressable
+                        onPress={() => this.copyText()}
+                        onPressIn={() => this.setValueOpacity(0.2)}
+                        onPressOut={() => this.setValueOpacity(1)}
+                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                        accessibilityLabel={localeString(
+                            'components.CopyButton.copy'
+                        )}
+                        style={{ marginLeft: 6 }}
+                    >
+                        {/* viewBox crops the whitespace baked into
+                            Copy.svg so the icon's layout box matches
+                            its visible artwork */}
+                        <Copy
+                            viewBox="6 4 12 16"
+                            height={15}
+                            width={11.25}
+                            stroke={themeColor('secondaryText')}
+                        />
+                    </Pressable>
+                )}
             </View>
         );
 
         let Value: any;
-        if (!lurkerMode && isCopyable) {
+        if (!lurkerMode && (isCopyable || mempoolLink)) {
             Value = (
-                <TouchableOpacity
-                    onLongPress={() => this.copyText()}
-                    onPress={mempoolLink}
+                <Pressable
+                    onPress={mempoolLink ? mempoolLink : () => this.copyText()}
+                    onLongPress={
+                        mempoolLink && isCopyable
+                            ? () => this.copyText()
+                            : undefined
+                    }
+                    onPressIn={() => this.setValueOpacity(0.2)}
+                    onPressOut={() => this.setValueOpacity(1)}
                 >
-                    {ValueBase}
-                </TouchableOpacity>
+                    <Animated.View style={{ opacity: this.valueOpacity }}>
+                        {ValueBase}
+                    </Animated.View>
+                </Pressable>
             );
         } else {
             Value = typeof value === 'object' ? value : ValueBase;

--- a/components/PaymentDetailsSheet.tsx
+++ b/components/PaymentDetailsSheet.tsx
@@ -418,6 +418,7 @@ export default class PaymentDetailsSheet extends React.Component<PaymentDetailsS
                                                 )}
                                                 value={paymentHash}
                                                 sensitive
+                                                showCopyIcon
                                             />
                                         ) : null}
 
@@ -428,6 +429,7 @@ export default class PaymentDetailsSheet extends React.Component<PaymentDetailsS
                                                 )}
                                                 value={paymentPreimage}
                                                 sensitive
+                                                showCopyIcon
                                             />
                                         ) : null}
 

--- a/views/Cashu/CashuInvoice.tsx
+++ b/views/Cashu/CashuInvoice.tsx
@@ -203,6 +203,7 @@ export default class CashuInvoiceView extends React.Component<
                                 keyValue={localeString('cashu.mintUrl')}
                                 value={mintUrl}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -259,6 +260,7 @@ export default class CashuInvoiceView extends React.Component<
                                 keyValue={localeString('general.note')}
                                 value={getNote}
                                 sensitive
+                                showCopyIcon
                                 mempoolLink={() =>
                                     navigation.navigate('AddNotes', {
                                         noteKey: getNoteKey

--- a/views/Cashu/CashuPayment.tsx
+++ b/views/Cashu/CashuPayment.tsx
@@ -240,6 +240,7 @@ export default class CashuPayment extends React.Component<
                                 keyValue={localeString('cashu.mintUrl')}
                                 value={getMintUrl}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -267,6 +268,7 @@ export default class CashuPayment extends React.Component<
                                 value={getDestination}
                                 sensitive
                                 color={themeColor('highlight')}
+                                showCopyIcon
                                 mempoolLink={() =>
                                     UrlUtils.goToBlockExplorerPubkey(
                                         getDestination,
@@ -283,6 +285,7 @@ export default class CashuPayment extends React.Component<
                                 )}
                                 value={paymentHash}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -293,6 +296,7 @@ export default class CashuPayment extends React.Component<
                                 )}
                                 value={getPreimage}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -357,6 +361,7 @@ export default class CashuPayment extends React.Component<
                                 keyValue={localeString('general.note')}
                                 value={storedNote}
                                 sensitive
+                                showCopyIcon
                                 mempoolLink={() =>
                                     navigation.navigate('AddNotes', {
                                         noteKey: getNoteKey

--- a/views/Cashu/CashuPaymentRequest.tsx
+++ b/views/Cashu/CashuPaymentRequest.tsx
@@ -711,6 +711,7 @@ export default class CashuPaymentRequest extends React.Component<
                                             )}
                                             value={zaplockerNpub}
                                             sensitive
+                                            showCopyIcon
                                         />
 
                                         <View style={styles.button}>
@@ -771,6 +772,7 @@ export default class CashuPaymentRequest extends React.Component<
                                             'general.destination'
                                         )}
                                         value={destination}
+                                        showCopyIcon
                                     />
                                 )}
 
@@ -780,6 +782,7 @@ export default class CashuPaymentRequest extends React.Component<
                                             'views.PaymentRequest.paymentHash'
                                         )}
                                         value={payment_hash}
+                                        showCopyIcon
                                     />
                                 )}
 

--- a/views/Cashu/CashuToken.tsx
+++ b/views/Cashu/CashuToken.tsx
@@ -345,6 +345,7 @@ export default class CashuTokenView extends React.Component<
                                     keyValue={localeString('cashu.mintUrl')}
                                     value={mint}
                                     sensitive
+                                    showCopyIcon
                                 />
                             )}
 
@@ -388,6 +389,7 @@ export default class CashuTokenView extends React.Component<
                                         decoded.getLockPubkey
                                     }
                                     sensitive
+                                    showCopyIcon
                                 />
                             )}
 

--- a/views/Cashu/Mint.tsx
+++ b/views/Cashu/Mint.tsx
@@ -820,6 +820,7 @@ export default class Mint extends React.Component<MintProps, MintState> {
                         <KeyValue
                             keyValue={localeString('cashu.mintUrl')}
                             value={mint?.mintUrl}
+                            showCopyIcon
                         />
                     )}
 
@@ -834,6 +835,7 @@ export default class Mint extends React.Component<MintProps, MintState> {
                         <KeyValue
                             keyValue={localeString('views.NodeInfo.pubkey')}
                             value={mintInfo?.pubkey}
+                            showCopyIcon
                         />
                     )}
 

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -683,12 +683,14 @@ export default class ChannelView extends React.Component<
                         <KeyValue
                             keyValue={localeString('views.Channel.channelId')}
                             value={channelId}
+                            showCopyIcon
                         />
                     )}
                     {shortChannelId && (
                         <KeyValue
                             keyValue={localeString('views.Channel.scid')}
                             value={shortChannelId}
+                            showCopyIcon
                         />
                     )}
 
@@ -745,6 +747,7 @@ export default class ChannelView extends React.Component<
                                     value={PrivacyUtils.sensitiveValue({
                                         input: aliasScids.join(', ')
                                     })}
+                                    showCopyIcon
                                 />
                             )}
                             {showPeerAliasScid && (
@@ -755,6 +758,7 @@ export default class ChannelView extends React.Component<
                                     value={PrivacyUtils.sensitiveValue({
                                         input: peerScidAlias
                                     })}
+                                    showCopyIcon
                                 />
                             )}
                             {showZeroConfConfirmedScid && (
@@ -765,6 +769,7 @@ export default class ChannelView extends React.Component<
                                     value={PrivacyUtils.sensitiveValue({
                                         input: zeroConfConfirmedScid
                                     })}
+                                    showCopyIcon
                                 />
                             )}
                         </>
@@ -799,6 +804,7 @@ export default class ChannelView extends React.Component<
                             keyValue={localeString('views.Channel.chainHash')}
                             value={chain_hash}
                             sensitive
+                            showCopyIcon
                         />
                     )}
                     {!!closeHeight && (
@@ -807,6 +813,7 @@ export default class ChannelView extends React.Component<
                             value={closeHeight}
                             color={themeColor('highlight')}
                             sensitive
+                            showCopyIcon
                             mempoolLink={() =>
                                 UrlUtils.goToBlockExplorerBlockHeight(
                                     closeHeight,
@@ -846,6 +853,7 @@ export default class ChannelView extends React.Component<
                             value={closing_txid}
                             sensitive
                             color={themeColor('highlight')}
+                            showCopyIcon
                             mempoolLink={() =>
                                 UrlUtils.goToBlockExplorerTXID(
                                     closing_txid,
@@ -862,6 +870,7 @@ export default class ChannelView extends React.Component<
                             value={closing_tx_hash}
                             sensitive
                             color={themeColor('highlight')}
+                            showCopyIcon
                             mempoolLink={() =>
                                 UrlUtils.goToBlockExplorerTXID(
                                     closing_tx_hash,
@@ -882,6 +891,7 @@ export default class ChannelView extends React.Component<
                                 value={channel_point}
                                 sensitive
                                 color={themeColor('highlight')}
+                                showCopyIcon
                                 mempoolLink={() =>
                                     UrlUtils.goToBlockExplorerTXID(
                                         channel_point,

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -744,9 +744,8 @@ export default class ChannelView extends React.Component<
                                                   'views.Channel.aliasScid'
                                               )
                                     }
-                                    value={PrivacyUtils.sensitiveValue({
-                                        input: aliasScids.join(', ')
-                                    })}
+                                    value={aliasScids.join(', ')}
+                                    sensitive
                                     showCopyIcon
                                 />
                             )}
@@ -755,9 +754,8 @@ export default class ChannelView extends React.Component<
                                     keyValue={localeString(
                                         'views.Channel.peerAliasScid'
                                     )}
-                                    value={PrivacyUtils.sensitiveValue({
-                                        input: peerScidAlias
-                                    })}
+                                    value={peerScidAlias}
+                                    sensitive
                                     showCopyIcon
                                 />
                             )}
@@ -766,9 +764,8 @@ export default class ChannelView extends React.Component<
                                     keyValue={localeString(
                                         'views.Channel.zeroConfConfirmedScid'
                                     )}
-                                    value={PrivacyUtils.sensitiveValue({
-                                        input: zeroConfConfirmedScid
-                                    })}
+                                    value={zeroConfConfirmedScid}
+                                    sensitive
                                     showCopyIcon
                                 />
                             )}

--- a/views/Invoice.tsx
+++ b/views/Invoice.tsx
@@ -410,6 +410,7 @@ export default class InvoiceView extends React.Component<
                                 )}
                                 value={fallback_addr}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -429,6 +430,7 @@ export default class InvoiceView extends React.Component<
                                 keyValue={localeString('views.Invoice.rHash')}
                                 value={getRHash}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -439,6 +441,7 @@ export default class InvoiceView extends React.Component<
                                 )}
                                 value={getRPreimage}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -449,6 +452,7 @@ export default class InvoiceView extends React.Component<
                                 )}
                                 value={getDescriptionHash}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -459,6 +463,7 @@ export default class InvoiceView extends React.Component<
                                 )}
                                 value={payment_hash}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -469,6 +474,7 @@ export default class InvoiceView extends React.Component<
                                 )}
                                 value={payment_preimage}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -477,6 +483,7 @@ export default class InvoiceView extends React.Component<
                                 keyValue={localeString('views.PayCode.bolt12')}
                                 value={bolt12}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -485,6 +492,7 @@ export default class InvoiceView extends React.Component<
                                 keyValue={localeString('general.note')}
                                 value={storedNote}
                                 sensitive
+                                showCopyIcon
                                 mempoolLink={() =>
                                     navigation.navigate('AddNotes', {
                                         noteKey: getNoteKey

--- a/views/LSPS1/OrderResponse.tsx
+++ b/views/LSPS1/OrderResponse.tsx
@@ -63,6 +63,7 @@ export default class LSPS1OrderResponse extends React.Component<
                     <KeyValue
                         keyValue={localeString('views.LSPS1.orderId')}
                         value={orderResponse?.order_id}
+                        showCopyIcon
                     />
                 )}
                 {orderResponse?.lsp_balance_sat &&
@@ -203,6 +204,7 @@ export default class LSPS1OrderResponse extends React.Component<
                                     payment?.lightning_invoice ||
                                     payment?.bolt11_invoice
                                 }
+                                showCopyIcon
                             />
                         )}
                         {payment?.min_fee_for_0conf && (
@@ -229,6 +231,7 @@ export default class LSPS1OrderResponse extends React.Component<
                                     'views.Settings.AddContact.onchainAddress'
                                 )}
                                 value={payment?.onchain_address}
+                                showCopyIcon
                             />
                         )}
                         {payment?.onchain_payment && (
@@ -297,6 +300,7 @@ export default class LSPS1OrderResponse extends React.Component<
                             <KeyValue
                                 keyValue={localeString('views.Invoice.title')}
                                 value={payment?.bolt11.invoice}
+                                showCopyIcon
                             />
                         )}
                     </>
@@ -349,6 +353,7 @@ export default class LSPS1OrderResponse extends React.Component<
                             <KeyValue
                                 keyValue={localeString('general.address')}
                                 value={payment?.onchain.address}
+                                showCopyIcon
                             />
                         )}
                         {payment?.onchain.min_fee_for_0conf && (
@@ -383,6 +388,7 @@ export default class LSPS1OrderResponse extends React.Component<
                             )}
                             value={channel?.funding_outpoint}
                             sensitive
+                            showCopyIcon
                             color={themeColor('highlight')}
                             mempoolLink={() =>
                                 UrlUtils.goToBlockExplorerTXID(

--- a/views/LSPS1/index.tsx
+++ b/views/LSPS1/index.tsx
@@ -623,6 +623,7 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
                                                                 value={
                                                                     lspDisplay
                                                                 }
+                                                                showCopyIcon
                                                             />
 
                                                             {info?.max_channel_balance_sat &&

--- a/views/LSPS7/OrderResponse.tsx
+++ b/views/LSPS7/OrderResponse.tsx
@@ -44,6 +44,7 @@ export default class LSPS7OrderResponse extends React.Component<
                     <KeyValue
                         keyValue={localeString('views.LSPS1.orderId')}
                         value={orderResponse?.order_id}
+                        showCopyIcon
                     />
                 )}
 
@@ -101,6 +102,7 @@ export default class LSPS7OrderResponse extends React.Component<
                         <KeyValue
                             keyValue={localeString('views.Channel.scid')}
                             value={channel.short_channel_id}
+                            showCopyIcon
                         />
                         <KeyValue
                             keyValue={localeString(
@@ -127,6 +129,7 @@ export default class LSPS7OrderResponse extends React.Component<
                                         'views.LSPS7.originalOrderId'
                                     )}
                                     value={channel.original_order.id}
+                                    showCopyIcon
                                 />
                                 <KeyValue
                                     keyValue={localeString(
@@ -145,6 +148,7 @@ export default class LSPS7OrderResponse extends React.Component<
                                     value={channel.extension_order_ids.join(
                                         ', '
                                     )}
+                                    showCopyIcon
                                 />
                             )}
                     </>
@@ -209,6 +213,7 @@ export default class LSPS7OrderResponse extends React.Component<
                             <KeyValue
                                 keyValue={localeString('views.Invoice.title')}
                                 value={payment?.bolt11.invoice}
+                                showCopyIcon
                             />
                         )}
                     </>
@@ -263,6 +268,7 @@ export default class LSPS7OrderResponse extends React.Component<
                             <KeyValue
                                 keyValue={localeString('general.address')}
                                 value={payment?.onchain.address}
+                                showCopyIcon
                             />
                         )}
                         {payment?.onchain.min_fee_for_0conf && (

--- a/views/LSPS7/index.tsx
+++ b/views/LSPS7/index.tsx
@@ -450,6 +450,7 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
                                             <KeyValue
                                                 keyValue="LSP"
                                                 value={lspDisplay}
+                                                showCopyIcon
                                             />
 
                                             <KeyValue
@@ -471,6 +472,7 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
                                                 'views.Channel.scid'
                                             )}
                                             value={chanId}
+                                            showCopyIcon
                                         />
 
                                         <KeyValue

--- a/views/LightningAddress/Attestation.tsx
+++ b/views/LightningAddress/Attestation.tsx
@@ -117,6 +117,7 @@ export default function Attestation(props: AttestationProps) {
                             <KeyValue
                                 keyValue={localeString('general.id')}
                                 value={item.id}
+                                showCopyIcon
                             />
                         )}
 
@@ -147,12 +148,14 @@ export default function Attestation(props: AttestationProps) {
                             <KeyValue
                                 keyValue={localeString('nostr.pubkey')}
                                 value={item.pubkey}
+                                showCopyIcon
                             />
                         )}
 
                         <KeyValue
                             keyValue={localeString('nostr.npub')}
                             value={nip19.npubEncode(item.pubkey)}
+                            showCopyIcon
                         />
                     </ScrollView>
                     <View style={{ bottom: 15 }}>

--- a/views/LightningAddress/CreateZaplockerLightningAddress.tsx
+++ b/views/LightningAddress/CreateZaplockerLightningAddress.tsx
@@ -178,6 +178,7 @@ export default class CreateZaplockerLightningAddress extends React.Component<
                                                         'nostr.npub'
                                                     )}
                                                     value={nostrNpub}
+                                                    showCopyIcon
                                                 />
                                             )}
                                         </View>

--- a/views/LightningAddress/NostrKeys.tsx
+++ b/views/LightningAddress/NostrKeys.tsx
@@ -293,6 +293,8 @@ export default class NostrKey extends React.Component<
                                             : '*'.repeat(64)
                                     }
                                     sensitive
+                                    showCopyIcon
+                                    disableCopy={!revealSensitive}
                                 />
                             )}
 
@@ -301,6 +303,7 @@ export default class NostrKey extends React.Component<
                                     keyValue={localeString('nostr.pubkey')}
                                     value={nostrPublicKey}
                                     sensitive
+                                    showCopyIcon
                                 />
                             )}
 
@@ -313,6 +316,8 @@ export default class NostrKey extends React.Component<
                                             : '*'.repeat(63)
                                     }
                                     sensitive
+                                    showCopyIcon
+                                    disableCopy={!revealSensitive}
                                 />
                             )}
 
@@ -321,6 +326,7 @@ export default class NostrKey extends React.Component<
                                     keyValue={localeString('nostr.npub')}
                                     value={nostrNpub}
                                     sensitive
+                                    showCopyIcon
                                 />
                             )}
                         </View>

--- a/views/NodeInfo.tsx
+++ b/views/NodeInfo.tsx
@@ -126,6 +126,7 @@ export default class NodeInfo extends React.Component<
                         keyValue={localeString('views.NodeInfo.pubkey')}
                         value={nodeInfo.nodeId}
                         sensitive
+                        showCopyIcon
                     />
                 )}
 
@@ -136,6 +137,7 @@ export default class NodeInfo extends React.Component<
                         )}
                         value={selectedMintPubkey}
                         sensitive
+                        showCopyIcon
                     />
                 )}
                 {nodeInfo.version && (
@@ -200,6 +202,7 @@ export default class NodeInfo extends React.Component<
                     <KeyValue
                         keyValue={localeString('views.NodeInfo.blockHash')}
                         value={nodeInfo.block_hash}
+                        showCopyIcon
                     />
                 )}
 

--- a/views/OpenChannel.tsx
+++ b/views/OpenChannel.tsx
@@ -431,6 +431,7 @@ export default class OpenChannel extends React.Component<
                                                 'views.OpenChannel.nodePubkey'
                                             )}
                                             value={channel.node_pubkey_string}
+                                            showCopyIcon
                                         />
                                         {/* Host is intentionally not shown: Lightning backends treat the entered
                                             address as a hint only and may connect via a gossip-discovered address
@@ -529,6 +530,7 @@ export default class OpenChannel extends React.Component<
                                     'views.OpenChannel.nodePubkey'
                                 )}
                                 value={node_pubkey_string}
+                                showCopyIcon
                             />
                             {/* Host is intentionally not shown: Lightning backends treat the entered
                                 address as a hint only and may connect via a gossip-discovered address

--- a/views/Order.tsx
+++ b/views/Order.tsx
@@ -1227,6 +1227,7 @@ export default class OrderView extends React.Component<OrderProps, OrderState> {
                                           )
                                 }
                                 value={order.payment.tx}
+                                showCopyIcon
                             />
                         </>
                     )}

--- a/views/PSBT.tsx
+++ b/views/PSBT.tsx
@@ -351,6 +351,7 @@ export default class PSBT extends React.Component<PSBTProps, PSBTState> {
                                                                                 value={Base64Utils.bytesToHex(
                                                                                     derivation.masterFingerprint
                                                                                 ).toUpperCase()}
+                                                                                showCopyIcon
                                                                             />
                                                                         )}
                                                                         {derivation.pubkey && (
@@ -361,6 +362,7 @@ export default class PSBT extends React.Component<PSBTProps, PSBTState> {
                                                                                 value={Base64Utils.bytesToHex(
                                                                                     derivation.pubkey
                                                                                 ).toUpperCase()}
+                                                                                showCopyIcon
                                                                             />
                                                                         )}
                                                                         {derivation.path && (
@@ -446,6 +448,7 @@ export default class PSBT extends React.Component<PSBTProps, PSBTState> {
                                                                                 value={Base64Utils.bytesToHex(
                                                                                     derivation.masterFingerprint
                                                                                 ).toUpperCase()}
+                                                                                showCopyIcon
                                                                             />
                                                                         )}
                                                                         {derivation.pubkey && (
@@ -456,6 +459,7 @@ export default class PSBT extends React.Component<PSBTProps, PSBTState> {
                                                                                 value={Base64Utils.bytesToHex(
                                                                                     derivation.pubkey
                                                                                 ).toUpperCase()}
+                                                                                showCopyIcon
                                                                             />
                                                                         )}
                                                                         {derivation.path && (

--- a/views/PayCode.tsx
+++ b/views/PayCode.tsx
@@ -189,6 +189,7 @@ export default class PayCodeView extends React.Component<
                             <KeyValue
                                 keyValue={localeString('views.PayCode.offerId')}
                                 value={offer_id}
+                                showCopyIcon
                             />
 
                             {bolt12 && (
@@ -197,6 +198,7 @@ export default class PayCodeView extends React.Component<
                                         'views.PayCode.bolt12'
                                     )}
                                     value={bolt12}
+                                    showCopyIcon
                                 />
                             )}
                         </View>

--- a/views/Payment.tsx
+++ b/views/Payment.tsx
@@ -254,6 +254,7 @@ export default class PaymentView extends React.Component<
                                 value={getDestination}
                                 sensitive
                                 color={themeColor('highlight')}
+                                showCopyIcon
                                 mempoolLink={() =>
                                     UrlUtils.goToBlockExplorerPubkey(
                                         getDestination,
@@ -270,6 +271,7 @@ export default class PaymentView extends React.Component<
                                 )}
                                 value={paymentHash}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -280,6 +282,7 @@ export default class PaymentView extends React.Component<
                                 )}
                                 value={getPreimage}
                                 sensitive
+                                showCopyIcon
                             />
                         )}
 
@@ -347,6 +350,7 @@ export default class PaymentView extends React.Component<
                                 keyValue={localeString('general.note')}
                                 value={storedNote}
                                 sensitive
+                                showCopyIcon
                                 mempoolLink={() =>
                                     navigation.navigate('AddNotes', {
                                         noteKey: getNoteKey

--- a/views/PaymentRequest.tsx
+++ b/views/PaymentRequest.tsx
@@ -823,6 +823,7 @@ export default class PaymentRequest extends React.Component<
                                             )}
                                             value={zaplockerNpub}
                                             sensitive
+                                            showCopyIcon
                                         />
 
                                         <View style={styles.button}>
@@ -894,6 +895,7 @@ export default class PaymentRequest extends React.Component<
                                             'general.destination'
                                         )}
                                         value={destination}
+                                        showCopyIcon
                                     />
                                 )}
 
@@ -903,6 +905,7 @@ export default class PaymentRequest extends React.Component<
                                             'views.PaymentRequest.paymentHash'
                                         )}
                                         value={payment_hash}
+                                        showCopyIcon
                                     />
                                 )}
 

--- a/views/Routing/RoutingEvent.tsx
+++ b/views/Routing/RoutingEvent.tsx
@@ -163,6 +163,7 @@ export default class RoutingEvent extends React.Component<
                             channel.chan_id || channel.channelId || channelId
                         }
                         sensitive
+                        showCopyIcon
                     />
                 </>
             )}

--- a/views/Routing/RoutingEvent.tsx
+++ b/views/Routing/RoutingEvent.tsx
@@ -162,7 +162,6 @@ export default class RoutingEvent extends React.Component<
                         value={
                             channel.chan_id || channel.channelId || channelId
                         }
-                        sensitive
                         showCopyIcon
                     />
                 </>
@@ -352,9 +351,9 @@ export default class RoutingEvent extends React.Component<
                                                           { channel: chanIn }
                                                       )
                                               )
-                                            : chanInLabel
+                                            : inChannelId
                                     }
-                                    sensitive
+                                    showCopyIcon
                                 />
                             )}
 
@@ -373,9 +372,9 @@ export default class RoutingEvent extends React.Component<
                                                           { channel: chanOut }
                                                       )
                                               )
-                                            : chanOutLabel
+                                            : outChannelId
                                     }
-                                    sensitive
+                                    showCopyIcon
                                 />
                             )}
 

--- a/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
@@ -564,6 +564,7 @@ export default class NWCConnectionDetails extends React.Component<
                                             'views.Settings.NostrWalletConnect.connectionId'
                                         )}
                                         value={connection.id}
+                                        showCopyIcon
                                     />
 
                                     <KeyValue
@@ -571,12 +572,14 @@ export default class NWCConnectionDetails extends React.Component<
                                             'views.Settings.NostrWalletConnect.publicKey'
                                         )}
                                         value={connection.pubkey}
+                                        showCopyIcon
                                     />
                                     <KeyValue
                                         keyValue={localeString(
                                             'nostr.relayUrl'
                                         )}
                                         value={connection.relayUrl}
+                                        showCopyIcon
                                     />
 
                                     {connection.description && (

--- a/views/Swaps/Refund.tsx
+++ b/views/Swaps/Refund.tsx
@@ -351,6 +351,7 @@ export default class RefundSwap extends React.Component<
                                         key={key}
                                         keyValue={pascalToHumanReadable(key)}
                                         value={value.toString()}
+                                        showCopyIcon
                                     />
                                 );
                             })}

--- a/views/Swaps/SwapDetails.tsx
+++ b/views/Swaps/SwapDetails.tsx
@@ -900,6 +900,7 @@ export default class SwapDetails extends React.Component<
                     <KeyValue
                         keyValue={localeString('views.SwapDetails.swapId')}
                         value={swapData.id}
+                        showCopyIcon
                     />
 
                     {swapData.isSubmarineSwap && (
@@ -922,12 +923,14 @@ export default class SwapDetails extends React.Component<
                         <KeyValue
                             keyValue={localeString('general.address')}
                             value={swapData.effectiveLockupAddress}
+                            showCopyIcon
                         />
                     )}
                     {swapData?.txid && (
                         <KeyValue
                             keyValue={localeString('views.SendingOnChain.txid')}
                             value={swapData.txid}
+                            showCopyIcon
                             mempoolLink={() =>
                                 UrlUtils.goToBlockExplorerTXID(
                                     swapData?.txid!,
@@ -945,6 +948,7 @@ export default class SwapDetails extends React.Component<
                                         'views.Invoice.title'
                                     )}
                                     value={swapData.invoice}
+                                    showCopyIcon
                                 />
                             )}
                             <KeyValue
@@ -972,6 +976,7 @@ export default class SwapDetails extends React.Component<
                                 'views.SwapDetails.lockupAddress'
                             )}
                             value={swapData.lockupAddress}
+                            showCopyIcon
                         />
                     )}
 
@@ -992,6 +997,7 @@ export default class SwapDetails extends React.Component<
                                 'views.SwapDetails.claimPublicKey'
                             )}
                             value={swapData?.servicePubKey}
+                            showCopyIcon
                         />
                     )}
                     {swapData.isReverseSwap && swapData.refundPubKey && (
@@ -1000,6 +1006,7 @@ export default class SwapDetails extends React.Component<
                                 'views.SwapDetails.refundPublicKey'
                             )}
                             value={swapData.refundPubKey}
+                            showCopyIcon
                         />
                     )}
                     {swapData.isReverseSwap && swapData?.preimageHash && (
@@ -1008,6 +1015,7 @@ export default class SwapDetails extends React.Component<
                                 'views.SwapDetails.preimageHash'
                             )}
                             value={swapData?.preimageHash}
+                            showCopyIcon
                         />
                     )}
 

--- a/views/Tools/Accounts/ImportingAccount.tsx
+++ b/views/Tools/Accounts/ImportingAccount.tsx
@@ -130,6 +130,7 @@ export default class ImportingAccount extends React.Component<
                             'views.ImportAccount.extendedPubKey'
                         )}
                         value={extended_public_key}
+                        showCopyIcon
                     />
 
                     {!!master_key_fingerprint && (
@@ -140,6 +141,7 @@ export default class ImportingAccount extends React.Component<
                             value={Base64Utils.reverseMfpBytes(
                                 Base64Utils.base64ToHex(master_key_fingerprint)
                             ).toUpperCase()}
+                            showCopyIcon
                         />
                     )}
 
@@ -155,6 +157,7 @@ export default class ImportingAccount extends React.Component<
                             'views.ImportAccount.derivationPath'
                         )}
                         value={derivation_path}
+                        showCopyIcon
                     />
 
                     <KeyValue

--- a/views/Tools/NostrKeys/index.tsx
+++ b/views/Tools/NostrKeys/index.tsx
@@ -120,6 +120,7 @@ export default class NostrKeys extends React.Component<
                                     keyValue={localeString('nostr.npub')}
                                     value={npub}
                                     sensitive
+                                    showCopyIcon
                                 />
 
                                 <KeyValue
@@ -128,6 +129,8 @@ export default class NostrKeys extends React.Component<
                                         revealSensitive ? nsec : '*'.repeat(63)
                                     }
                                     sensitive
+                                    showCopyIcon
+                                    disableCopy={!revealSensitive}
                                 />
 
                                 <View style={styles.navItem}>

--- a/views/Tools/Watchtowers/WatchtowerDetails.tsx
+++ b/views/Tools/Watchtowers/WatchtowerDetails.tsx
@@ -225,6 +225,7 @@ export default class WatchtowerDetails extends React.Component<
                                     displayData.pubkey
                                 )}
                                 sensitive
+                                showCopyIcon
                             />
 
                             <KeyValue
@@ -245,6 +246,7 @@ export default class WatchtowerDetails extends React.Component<
                                 )}
                                 value={displayData.addresses.join('\n')}
                                 sensitive
+                                showCopyIcon
                             />
 
                             <KeyValue

--- a/views/Transaction.tsx
+++ b/views/Transaction.tsx
@@ -390,19 +390,17 @@ export default class TransactionView extends React.Component<
                     )}
 
                     {storedNote && (
-                        <TouchableOpacity
-                            onPress={() =>
+                        <KeyValue
+                            keyValue={localeString('general.note')}
+                            value={storedNote}
+                            sensitive
+                            showCopyIcon
+                            mempoolLink={() =>
                                 navigation.navigate('AddNotes', {
                                     noteKey: getNoteKey
                                 })
                             }
-                        >
-                            <KeyValue
-                                keyValue={localeString('general.note')}
-                                value={storedNote}
-                                sensitive
-                            />
-                        </TouchableOpacity>
+                        />
                     )}
                 </ScrollView>
                 <View style={{ bottom: 15 }}>

--- a/views/UTXOs/UTXO.tsx
+++ b/views/UTXOs/UTXO.tsx
@@ -175,20 +175,18 @@ export default class UTXO extends React.Component<UTXOProps, UTXOState> {
                         )}
 
                         {this.state.storedLabel && (
-                            <TouchableOpacity
-                                onPress={() =>
+                            <KeyValue
+                                keyValue={localeString('views.UTXOs.label')}
+                                value={this.state.storedLabel}
+                                sensitive
+                                showCopyIcon
+                                mempoolLink={() =>
                                     navigation.navigate('AddNotes', {
                                         noteKey: utxo.getOutpoint,
                                         context: 'label'
                                     })
                                 }
-                            >
-                                <KeyValue
-                                    keyValue={localeString('views.UTXOs.label')}
-                                    value={this.state.storedLabel}
-                                    sensitive
-                                />
-                            </TouchableOpacity>
+                            />
                         )}
                     </ScrollView>
 

--- a/views/UTXOs/UTXO.tsx
+++ b/views/UTXOs/UTXO.tsx
@@ -94,6 +94,7 @@ export default class UTXO extends React.Component<UTXOProps, UTXOState> {
                         <KeyValue
                             keyValue={localeString('general.outpoint')}
                             value={getOutpoint}
+                            showCopyIcon
                         />
 
                         {!!address && (

--- a/views/VerifyOnChain.tsx
+++ b/views/VerifyOnChain.tsx
@@ -200,7 +200,7 @@ export default class VerifyOnChain extends React.Component<VerifyOnChainProps> {
                                 : localeString('general.destination')
                         }
                         value={destination}
-                        disableCopy={false}
+                        showCopyIcon
                     />
                     {hasAdditional && (
                         <TouchableOpacity onPress={this.toggleBitcoinUnits}>
@@ -232,7 +232,7 @@ export default class VerifyOnChain extends React.Component<VerifyOnChainProps> {
                                     'general.destination'
                                 )} #${idx + 2}`}
                                 value={o?.address}
-                                disableCopy={false}
+                                showCopyIcon
                             />
                             <TouchableOpacity onPress={this.toggleBitcoinUnits}>
                                 <KeyValue
@@ -284,7 +284,7 @@ export default class VerifyOnChain extends React.Component<VerifyOnChainProps> {
                             idx + 1
                         }`}
                         value={u}
-                        disableCopy={false}
+                        showCopyIcon
                     />
                 ))}
             </View>

--- a/views/WithdrawalRequestInfo.tsx
+++ b/views/WithdrawalRequestInfo.tsx
@@ -158,6 +158,7 @@ export default class WithdrawalRequestInfo extends React.Component<
                                     keyValue={localeString('general.signature')}
                                     value={withdrawalReqResult?.signature}
                                     sensitive
+                                    showCopyIcon
                                     color={themeColor('text')}
                                 />
                             </View>
@@ -169,6 +170,7 @@ export default class WithdrawalRequestInfo extends React.Component<
                                     )}
                                     value={bolt12}
                                     sensitive
+                                    showCopyIcon
                                     color={themeColor('text')}
                                 />
                             </View>


### PR DESCRIPTION
# Description

|-|-|-|
|-|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-12 at 22 02 53" src="https://github.com/user-attachments/assets/0c098cc8-cf59-4f4e-aee3-67026383bd42" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-12 at 22 02 45" src="https://github.com/user-attachments/assets/f398d59b-70b3-429b-a336-94f48c980af8" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-12 at 22 02 40" src="https://github.com/user-attachments/assets/3fd7cb55-aca5-4be1-ab87-2623661af466" />|


Copying a value from a detail screen (payment hash, preimage, address, pubkey, etc.) currently requires a long press on the value, which is an invisible gesture most users never discover, and any string value is silently copyable. This PR makes copyability explicit and visible:

- `KeyValue` gets a `showCopyIcon` prop that renders the existing `Copy.svg` next to the value (16px, `secondaryText` stroke), with its own touch target, `hitSlop`, and an accessibility label reusing the existing `components.CopyButton.copy` locale key
- The icon is now the copyability contract: rows with `showCopyIcon` copy on a regular press (existing "Copied!" toast + vibration feedback); rows without it are not copyable at all, and long press is removed
- Rows with a `mempoolLink` keep press = open block explorer; the copy icon is the copy affordance there, and long-press copy is retained as a fallback
- `showCopyIcon` is applied across the detail views to identifier-type fields: payment hashes, preimages, payment requests, tx ids, block hashes, addresses, pubkeys, node URIs, channel ids/points, order/swap IDs, nostr keys, and mint/relay/watchtower URLs. Amounts, fees, dates, statuses, and other display-only fields are no longer copyable
- The masked nsec/privkey rows in the NostrKeys views pass `disableCopy` while hidden, so the icon only appears (and copy only works) once revealed
- `flexShrink` added to the value text so long values do not push the icon off-screen

Lurker mode behavior is unchanged: no copying, and the icon does not render.

Screenshots to follow with device testing.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Device and backend testing pending; will check off before marking ready for review.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

No new locale strings; the icon's accessibility label reuses `components.CopyButton.copy`.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
