### PR TITLE
ui: NeutrinoPeers: move loading indicator into header

### DIFF
--- a/views/Settings/EmbeddedNode/Peers/NeutrinoPeers.tsx
+++ b/views/Settings/EmbeddedNode/Peers/NeutrinoPeers.tsx
@@ -123,10 +123,12 @@ export default class NeutrinoPeers extends React.Component<
                                 fontFamily: 'PPNeueMontreal-Book'
                             }
                         }}
+                        rightComponent={
+                            loading ? <LoadingIndicator size={30} /> : undefined
+                        }
                         navigation={navigation}
                     />
                     <View style={{ flex: 1 }}>
-                        {loading && <LoadingIndicator />}
                         {!pingTimeout &&
                             !pingUnreachable &&
                             !loading &&

--- a/views/Settings/EmbeddedNode/Peers/NeutrinoPeers.tsx
+++ b/views/Settings/EmbeddedNode/Peers/NeutrinoPeers.tsx
@@ -124,7 +124,11 @@ export default class NeutrinoPeers extends React.Component<
                             }
                         }}
                         rightComponent={
-                            loading ? <LoadingIndicator size={30} /> : undefined
+                            loading ? (
+                                <View>
+                                    <LoadingIndicator size={30} />
+                                </View>
+                            ) : undefined
                         }
                         navigation={navigation}
                     />


### PR DESCRIPTION
# Description

On the Neutrino peers settings page, the loading indicator (shown while pinging a peer or optimizing peers) rendered full-width at the top of the content area, pushing the page content around while active. This moves it into the top right corner of the header as a small (size 30) `LoadingIndicator` passed via the `Header` `rightComponent` prop, matching the pattern used in views like `Invoice` and `OnChainAddresses`.

No logic changes: the ping result messages already gated on `!loading`, so their behavior is unchanged.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
