### PR TITLE
fix(nwc): skip replayed request events by id before handlers

### DIFF
--- a/models/NWCConnection.ts
+++ b/models/NWCConnection.ts
@@ -76,6 +76,7 @@ export interface NWCConnectionData {
     nodePubkey: string;
     implementation: string;
     activity?: ConnectionActivity[];
+    processedEventIds?: string[];
     metadata?: any;
 }
 export interface ConnectionWarning {
@@ -130,6 +131,7 @@ export default class NWCConnection extends BaseModel {
     @observable implementation: Implementations;
     @observable metadata?: any;
     @observable activity: ConnectionActivity[] = [];
+    @observable processedEventIds: string[] = [];
     @observable private _warningTypes: ConnectionWarningType[] = [];
 
     constructor(data?: NWCConnectionData) {
@@ -186,6 +188,10 @@ export default class NWCConnection extends BaseModel {
             });
         } else if (!this.activity) {
             this.activity = [];
+        }
+
+        if (!this.processedEventIds) {
+            this.processedEventIds = [];
         }
     }
     @computed public get isExpired(): boolean {

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -728,6 +728,94 @@ describe('NostrWalletConnectStore pay_invoice activity upsert', () => {
     });
 });
 
+describe('NostrWalletConnectStore NWC request event replay guard', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('claims unseen event ids and skips already-seen ones', async () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store);
+        jest.spyOn(store as any, 'scheduleSave').mockImplementation(
+            () => undefined
+        );
+        jest.spyOn(store as any, 'flushScheduledSave').mockResolvedValue(
+            undefined
+        );
+
+        const first = await (store as any).shouldProcessNwcRequestEvent(
+            connection,
+            { id: 'event-1' }
+        );
+        const replay = await (store as any).shouldProcessNwcRequestEvent(
+            connection,
+            { id: 'event-1' }
+        );
+
+        expect(first).toBe(true);
+        expect(replay).toBe(false);
+        expect(connection.processedEventIds).toEqual(['event-1']);
+        expect((store as any).flushScheduledSave).toHaveBeenCalled();
+    });
+
+    it('skips SDK handlers for already-seen request events', async () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store, {
+            processedEventIds: ['seen-event']
+        });
+        jest.spyOn(store as any, 'scheduleSave').mockImplementation(
+            () => undefined
+        );
+        jest.spyOn(store as any, 'flushScheduledSave').mockResolvedValue(
+            undefined
+        );
+
+        const sdkOnEvent = jest.fn();
+        const pool = {
+            subscribe: jest.fn(
+                async (
+                    _relays: string[],
+                    _filter: Record<string, unknown>,
+                    params: {
+                        onevent: (event: {
+                            id: string;
+                        }) => void | Promise<void>;
+                    }
+                ) => {
+                    await params.onevent({ id: 'seen-event' });
+                    await params.onevent({ id: 'new-event' });
+                    return { close: jest.fn() };
+                }
+            )
+        };
+        const nwcWalletService = {
+            pool,
+            subscribe: async (_keypair: unknown, _handler: unknown) => {
+                await pool.subscribe(
+                    ['wss://relay'],
+                    {},
+                    { onevent: sdkOnEvent }
+                );
+                return () => undefined;
+            }
+        };
+
+        await (store as any).subscribeWithSeenEventGuard(
+            connection,
+            nwcWalletService,
+            {},
+            {}
+        );
+
+        expect(sdkOnEvent).toHaveBeenCalledTimes(1);
+        expect(sdkOnEvent).toHaveBeenCalledWith({ id: 'new-event' });
+        expect(connection.processedEventIds).toEqual([
+            'seen-event',
+            'new-event'
+        ]);
+    });
+});
+
 describe('NostrWalletConnectStore connection data scoping', () => {
     const WALLET_ONLY_HASH = hex64('f');
     const CONNECTION_HASH = hex64('e');

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -642,6 +642,90 @@ describe('NostrWalletConnectStore pay_invoice activity upsert', () => {
         ).not.toHaveBeenCalled();
         expect(connection.activity[0].status).toBe('success');
     });
+
+    it('getCachedPayInvoiceResponse returns success preimage without re-paying', async () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store, {
+            activity: [
+                {
+                    id: normalizedInvoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'success',
+                    satAmount: 100,
+                    fees_paid: 21,
+                    preimage: 'cached-preimage',
+                    paymentHash
+                }
+            ]
+        });
+
+        const cached = await (store as any).getCachedPayInvoiceResponse(
+            connection,
+            uppercaseInvoice
+        );
+
+        expect(cached).toEqual({
+            result: {
+                preimage: 'cached-preimage',
+                fees_paid: 21_000
+            },
+            error: undefined
+        });
+    });
+
+    it('getCachedPayInvoiceResponse returns in-flight response for pending pays', async () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store, {
+            activity: [
+                {
+                    id: normalizedInvoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'pending',
+                    satAmount: 100,
+                    fees_paid: 5,
+                    paymentHash
+                }
+            ]
+        });
+
+        const cached = await (store as any).getCachedPayInvoiceResponse(
+            connection,
+            normalizedInvoice
+        );
+
+        expect(cached).toEqual({
+            result: {
+                preimage: '',
+                fees_paid: 5_000
+            },
+            error: undefined
+        });
+    });
+
+    it('getCachedPayInvoiceResponse allows retry after failed payment', async () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store, {
+            activity: [
+                {
+                    id: normalizedInvoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'failed',
+                    satAmount: 100,
+                    paymentHash
+                }
+            ]
+        });
+
+        const cached = await (store as any).getCachedPayInvoiceResponse(
+            connection,
+            normalizedInvoice
+        );
+
+        expect(cached).toBeUndefined();
+    });
 });
 
 describe('NostrWalletConnectStore connection data scoping', () => {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1351,8 +1351,16 @@ export default class NostrWalletConnectStore {
                     ? this.handleCashuPayInvoice.bind(this, connection)
                     : this.handleLightningPayInvoice.bind(this, connection);
                 handler.payInvoice = (request: Nip47PayInvoiceRequest) =>
-                    this.withGlobalHandler(connection.id, () =>
-                        this.enqueuePayment(
+                    this.withGlobalHandler(connection.id, async () => {
+                        const cached = await this.getCachedPayInvoiceResponse(
+                            connection,
+                            request.invoice
+                        );
+                        if (cached) {
+                            return cached;
+                        }
+
+                        return this.enqueuePayment(
                             () => payHandler(request),
                             () =>
                                 NostrConnectUtils.createNip47Error(
@@ -1361,8 +1369,8 @@ export default class NostrWalletConnectStore {
                                     ),
                                     Nip47ErrorCode.RATE_LIMITED
                                 )
-                        )
-                    );
+                        );
+                    });
             }
 
             if (connection.hasPermission('make_invoice')) {
@@ -2227,6 +2235,52 @@ export default class NostrWalletConnectStore {
     }
 
     // PAYMENT PROCESSING METHODS
+
+    /**
+     * Idempotency guard for pay_invoice. connection.activity is persisted per
+     * connection and survives restarts. If this invoice was already paid or is
+     * in-flight, return the cached NIP-47 response instead of sendPayment.
+     */
+    private async getCachedPayInvoiceResponse(
+        connection: NWCConnection,
+        rawInvoice: string
+    ): Promise<{ result: Nip47PayResponse; error: undefined } | undefined> {
+        const { paymentRequest, paymentHash } =
+            await NostrConnectUtils.decodeInvoiceTags(rawInvoice);
+        const id = paymentRequest || rawInvoice;
+        const existing = connection.findPayInvoiceActivity(id, paymentHash);
+        if (!existing) {
+            return undefined;
+        }
+
+        const fees_paid = satsToMillisats(Number(existing.fees_paid) || 0);
+
+        if (existing.status === 'success') {
+            return {
+                result: {
+                    preimage:
+                        existing.preimage ||
+                        existing.payment?.getPreimage ||
+                        '',
+                    fees_paid
+                },
+                error: undefined
+            };
+        }
+
+        if (existing.status === 'pending') {
+            return {
+                result: {
+                    preimage: '',
+                    fees_paid
+                },
+                error: undefined
+            };
+        }
+
+        // failed — allow a genuine client retry, not a replay of a settled pay
+        return undefined;
+    }
 
     private async handleLightningPayInvoice(
         connection: NWCConnection,

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -98,6 +98,8 @@ const MAKE_INVOICE_RATE_WINDOW_MS = 60_000;
 const MAX_MAKE_INVOICE_PER_WINDOW = 5;
 const MAX_PENDING_MAKE_INVOICES_PER_CONNECTION = 10;
 const MAX_CONNECTION_ACTIVITY_ENTRIES = 100;
+/** Cap persisted NWC request event ids per connection (replay protection). */
+const MAX_PROCESSED_NWC_EVENT_IDS = 2000;
 
 export const DEFAULT_NOSTR_RELAYS = [
     'wss://relay.getalby.com/v1',
@@ -1417,9 +1419,13 @@ export default class NostrWalletConnectStore {
                 );
             }
             const unsubscribe = await retry({
-                fn: async () => {
-                    return await nwcWalletService.subscribe(keypair, handler);
-                },
+                fn: async () =>
+                    this.subscribeWithSeenEventGuard(
+                        connection,
+                        nwcWalletService,
+                        keypair,
+                        handler
+                    ),
                 maxRetries: MAX_RELAY_ATTEMPTS,
                 exponentialBackoff: true
             });
@@ -1433,6 +1439,93 @@ export default class NostrWalletConnectStore {
                 error?.message || String(error)
             );
         }
+    }
+
+    /**
+     * Subscribe through the SDK, but claim each request event id first.
+     * Already-seen ids never reach method handlers (pay_invoice, make_invoice, …).
+     * The SDK does not expose event metadata to handlers, so we wrap pool.subscribe
+     * for this call only — decrypt/dispatch/publish stay in @getalby/sdk.
+     */
+    private async subscribeWithSeenEventGuard(
+        connection: NWCConnection,
+        nwcWalletService: NWCWalletService,
+        keypair: NWCWalletServiceKeyPair,
+        handler: NWCWalletServiceRequestHandler
+    ): Promise<() => void> {
+        const service = nwcWalletService as NWCWalletService & {
+            pool: {
+                subscribe: (...args: any[]) => { close: () => void };
+            };
+        };
+        const originalSubscribe = service.pool.subscribe.bind(service.pool);
+
+        service.pool.subscribe = (
+            relays: string[],
+            filter: Record<string, unknown>,
+            params: {
+                onevent?: (event: {
+                    id: string;
+                    created_at: number;
+                    content: string;
+                    tags: string[][];
+                    [key: string]: unknown;
+                }) => void | Promise<void>;
+                [key: string]: unknown;
+            }
+        ) => {
+            const sdkOnEvent = params.onevent;
+            params.onevent = async (event) => {
+                const isNew = await this.shouldProcessNwcRequestEvent(
+                    connection,
+                    event
+                );
+                if (!isNew || !sdkOnEvent) {
+                    return;
+                }
+                return sdkOnEvent(event);
+            };
+            return originalSubscribe(relays, filter, params);
+        };
+
+        try {
+            return await nwcWalletService.subscribe(keypair, handler);
+        } finally {
+            service.pool.subscribe = originalSubscribe;
+        }
+    }
+
+    /**
+     * Returns true if this request event has not been processed yet.
+     * Persists the id before handlers run so a restart cannot re-execute it.
+     */
+    private async shouldProcessNwcRequestEvent(
+        connection: NWCConnection,
+        event: { id?: string }
+    ): Promise<boolean> {
+        const eventId = event?.id;
+        if (!eventId) {
+            return false;
+        }
+        if (connection.processedEventIds.includes(eventId)) {
+            return false;
+        }
+
+        runInAction(() => {
+            const next = connection.processedEventIds.filter(
+                (id) => id !== eventId
+            );
+            next.push(eventId);
+            connection.processedEventIds =
+                next.length > MAX_PROCESSED_NWC_EVENT_IDS
+                    ? next.slice(next.length - MAX_PROCESSED_NWC_EVENT_IDS)
+                    : next;
+            this.findAndUpdateConnection(connection);
+        });
+
+        this.scheduleSave();
+        await this.flushScheduledSave();
+        return true;
     }
 
     private async subscribeToAllConnections(): Promise<void> {

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -520,6 +520,15 @@ export default class NostrConnectUtils {
      * @throws Error if invoice decoding fails
      */
 
+    /** Decode without logging; lookup paths treat malformed invoices as a miss. */
+    private static tryDecodeBolt11(invoice: string) {
+        try {
+            return Bolt11Utils.decode(invoice);
+        } catch {
+            return undefined;
+        }
+    }
+
     static async decodeInvoiceTags(
         invoice: string,
         checkForPaidStatus: boolean = false
@@ -635,12 +644,8 @@ export default class NostrConnectUtils {
         const invoice = request.invoice || paymentRequest;
         if (!invoice) return undefined;
 
-        try {
-            const decoded = await NostrConnectUtils.decodeInvoiceTags(invoice);
-            return decoded.paymentHash || undefined;
-        } catch {
-            return undefined;
-        }
+        const decoded = NostrConnectUtils.tryDecodeBolt11(invoice);
+        return decoded?.payment_hash || undefined;
     }
 
     /** Whether a BOLT11 string matches a NIP-47 lookup request (invoice or hash). */
@@ -659,14 +664,8 @@ export default class NostrConnectUtils {
             normalizedHash ??
             NostrConnectUtils.normalizePaymentHash(request.payment_hash);
         if (!hash) return false;
-        try {
-            const decoded = await NostrConnectUtils.decodeInvoiceTags(
-                paymentRequest
-            );
-            return decoded.paymentHash === hash;
-        } catch {
-            return false;
-        }
+        const decoded = NostrConnectUtils.tryDecodeBolt11(paymentRequest);
+        return !!decoded?.payment_hash && decoded.payment_hash === hash;
     }
 
     static lightningInvoiceExpiresAt(


### PR DESCRIPTION
# Description

NWC wallet service re-executed replayed NIP-47 request events (kind 23194) after restart/re-subscription. `@getalby/sdk` only dedupes event ids in memory per `subscribe()` call, so a storing relay (or anyone republishing captured ciphertext) could redeliver `pay_invoice` / `make_invoice` / `sign_message` with no live client and no connection secret.
This PR claims each request **event id** before SDK handlers run, and persists the id on the connection so a restart cannot re-execute the same event.
## Approach
The SDK does not pass Nostr event metadata into method handlers. Zeus wraps `pool.subscribe` for that one call only; decrypt, dispatch, and response publish stay in `@getalby/sdk`.
1. `shouldProcessNwcRequestEvent` receives the full event (`id`, `content`, `tags`, …).
2. If `event.id` is already in `connection.processedEventIds`, return false — the SDK never calls handlers.
3. Otherwise persist the id (capped at 2000 per connection) **before** handlers run (fail closed).
`getCachedPayInvoiceResponse` remains as a second layer: a **new** event id that repeats the same invoice (lost-response client retry) returns the cached success/pending NIP-47 result instead of `sendPayment`. Failed pays are not cached so genuine retries still work.
No `created_at` / `since` freshness window — those can still be abused.

Related to https://github.com/getAlby/js-sdk/pull/578 


This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
