### PR TITLE
ui: Sweepremoteclosed: fix fee fetch, loading and button states

### DIFF
--- a/views/Settings/EmbeddedNode/Chantools/Sweepremoteclosed.tsx
+++ b/views/Settings/EmbeddedNode/Chantools/Sweepremoteclosed.tsx
@@ -90,7 +90,7 @@ export default class Sweepremoteclosed extends React.Component<
         sweepAddr: '',
         apiUrl: 'https://api.node-recovery.com',
         customApiUrl: '',
-        feeRate: '21',
+        feeRate: '',
         recoveryWindow: '200',
         sleepSeconds: '0',
         loading: false,
@@ -135,10 +135,16 @@ export default class Sweepremoteclosed extends React.Component<
                                     fontFamily: 'PPNeueMontreal-Book'
                                 }
                             }}
+                            rightComponent={
+                                loading ? (
+                                    <View>
+                                        <LoadingIndicator size={30} />
+                                    </View>
+                                ) : undefined
+                            }
                             navigation={navigation}
                         />
                         {error && <ErrorMessage message={error} dismissable />}
-                        {loading && <LoadingIndicator />}
                         <ScrollView style={{ margin: 10 }}>
                             {isLdkNode && (
                                 <Text
@@ -371,7 +377,7 @@ export default class Sweepremoteclosed extends React.Component<
                                     title={localeString(
                                         'views.Settings.EmbeddedNode.Chantools.Sweepremoteclosed.start'
                                     )}
-                                    disabled={!sweepAddr}
+                                    disabled={!sweepAddr || loading}
                                     onPress={async () => {
                                         this.setState({
                                             error: '',
@@ -395,6 +401,9 @@ export default class Sweepremoteclosed extends React.Component<
                                                                 )
                                                         }
                                                     );
+                                                this.setState({
+                                                    loading: false
+                                                });
                                                 navigation.navigate('TxHex', {
                                                     txHex: response,
                                                     hideWarning: true
@@ -430,6 +439,9 @@ export default class Sweepremoteclosed extends React.Component<
                                                                 ?.nodeInfo
                                                                 ?.isTestNet
                                                     });
+                                                this.setState({
+                                                    loading: false
+                                                });
                                                 navigation.navigate('TxHex', {
                                                     txHex: response,
                                                     hideWarning: true

--- a/views/Settings/EmbeddedNode/Chantools/Sweepremoteclosed.tsx
+++ b/views/Settings/EmbeddedNode/Chantools/Sweepremoteclosed.tsx
@@ -75,6 +75,7 @@ interface SweepremoteclosedState {
     sleepSeconds: string;
     recoveryWindow: string;
     loading: boolean;
+    feeLoadingError: boolean;
     error: string;
 }
 
@@ -94,6 +95,7 @@ export default class Sweepremoteclosed extends React.Component<
         recoveryWindow: '200',
         sleepSeconds: '0',
         loading: false,
+        feeLoadingError: false,
         error: ''
     };
 
@@ -109,6 +111,7 @@ export default class Sweepremoteclosed extends React.Component<
             recoveryWindow,
             sleepSeconds,
             loading,
+            feeLoadingError,
             error
         } = this.state;
 
@@ -241,7 +244,13 @@ export default class Sweepremoteclosed extends React.Component<
                                     fee={feeRate}
                                     onChangeFee={(text: string) => {
                                         this.setState({
-                                            feeRate: text
+                                            feeRate: text,
+                                            feeLoadingError: false
+                                        });
+                                    }}
+                                    onFeeError={(error: boolean) => {
+                                        this.setState({
+                                            feeLoadingError: error
                                         });
                                     }}
                                     navigation={navigation}
@@ -377,7 +386,12 @@ export default class Sweepremoteclosed extends React.Component<
                                     title={localeString(
                                         'views.Settings.EmbeddedNode.Chantools.Sweepremoteclosed.start'
                                     )}
-                                    disabled={!sweepAddr || loading}
+                                    disabled={
+                                        !sweepAddr ||
+                                        loading ||
+                                        feeLoadingError ||
+                                        !(Number(feeRate) > 0)
+                                    }
                                     onPress={async () => {
                                         this.setState({
                                             error: '',
@@ -392,8 +406,8 @@ export default class Sweepremoteclosed extends React.Component<
                                                                 sweepAddr,
                                                             feeRateSatsPerVbyte:
                                                                 Number(
-                                                                    feeRate || 2
-                                                                ),
+                                                                    feeRate
+                                                                ) || 2,
                                                             sleepSeconds:
                                                                 Number(
                                                                     sleepSeconds ||
@@ -427,9 +441,9 @@ export default class Sweepremoteclosed extends React.Component<
                                                             recoveryWindow ||
                                                                 200
                                                         ),
-                                                        feeRate: Number(
-                                                            feeRate || 2
-                                                        ),
+                                                        feeRate:
+                                                            Number(feeRate) ||
+                                                            2,
                                                         sleepSeconds: Number(
                                                             sleepSeconds || 0
                                                         ),


### PR DESCRIPTION
# Description

Fixes three issues on the sweep remote closed view (Settings > Embedded node > Chantools > Sweep remote closed), most noticeable when running it against LDK Node:

1. **Recommended fee rate is now fetched by default.** The view initialized the fee field with a hardcoded `21` sat/vB. `OnchainFeeInput` skips the mempool recommended-rate fetch whenever it is handed an already-valid fee, so the fetch never ran. The fee state now starts empty, which triggers the fetch of the user's preferred mempool rate on mount. With mempool rates disabled, the plain numeric input behaves as before.
2. **Loading indicator moved to the top right of the header.** Replaces the indicator that rendered below the header, using the same `rightComponent` pattern as `NeutrinoPeers`.
3. **Start button is disabled while a sweep is processing.** `disabled` is now `!sweepAddr || loading`. While wiring this up, found that `loading` was never reset on the success path (only in the catch), so after a successful sweep the spinner (and now the disabled button) would persist when navigating back from the TxHex view. Both success branches (LDK Node and chantools) now reset `loading` before navigating.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
