### PR TITLE
stores: clear stale ZEUS Pay auth cache on node switch

### DIFF
--- a/stores/LightningAddressStore.ts
+++ b/stores/LightningAddressStore.ts
@@ -98,7 +98,7 @@ export default class LightningAddressStore {
     @observable public readyToAutomaticallyAccept: boolean = false;
     @observable public prepareToAutomaticallyAcceptStart: boolean = false;
     // Auth
-    auth: Auth;
+    auth?: Auth;
     authDate?: Date;
 
     cashuStore: CashuStore;
@@ -118,7 +118,7 @@ export default class LightningAddressStore {
     private getAuthData = async () => {
         const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);
 
-        if (this.authDate && this.authDate > tenMinutesAgo) {
+        if (this.auth && this.authDate && this.authDate > tenMinutesAgo) {
             return this.auth;
         } else {
             const authResponse = await ReactNativeBlobUtil.fetch(
@@ -1389,6 +1389,12 @@ export default class LightningAddressStore {
         this.localHashes = 0;
         this.paid = [];
         this.preimageMap = {};
+        // the cached auth signature is tied to the previous node's
+        // pubkey; reusing it after a node switch makes the server
+        // reject calls with 'invalid signature'
+        this.auth = undefined;
+        this.authDate = undefined;
+        if (this.socket) this.socket.disconnect();
         this.socket = undefined;
         this.lightningAddress = '';
         this.lightningAddressHandle = '';


### PR DESCRIPTION
# Description

Relates to issue: **#4279**

`LightningAddressStore.getAuthData` caches the ZEUS Pay auth pair (`verification` challenge + node signature) for 10 minutes in plain instance fields. `reset()`, which runs on every node switch, never cleared them. After switching between two nodes, every ZEUS Pay call sent the new node's pubkey alongside the previous node's cached signature, so the server rejected everything with "invalid signature" until the app was force closed (wiping the in-memory cache) or the 10-minute window lapsed.

This PR:
- clears `auth` / `authDate` in `reset()` so the first call after a node switch fetches and signs a fresh challenge with the new node's key
- disconnects the old socket.io connection (authenticated as the previous node) instead of just dropping the reference, so its `paid` handler can't fire redeems against the newly active node

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I've run `yarn run tsc` and made sure my code compiles correctly
- [ ] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [ ] I've run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

### Suggested test plan

1. On a device with two embedded nodes that both have ZEUS Pay addresses, connect to node A and open the Lightning Address screen (works).
2. Switch to node B within 10 minutes and open the Lightning Address screen.
3. Before this fix: "invalid signature" error until force close. After: loads normally.
4. Verify Zaplocker/Cashu auto-accept still works after a switch (socket reconnects as the new node).