### PR TITLE
fix: harden node config export with scrypt + AES-256-GCM

### DIFF
--- a/utils/NodeConfigUtils.test.ts
+++ b/utils/NodeConfigUtils.test.ts
@@ -1,12 +1,15 @@
 import RNFS from 'react-native-fs';
+import * as CryptoJS from 'crypto-js';
 
 import {
     saveNodeConfigs,
     createExportFileContent,
     saveNodeConfigExportFile,
-    decryptExportData
+    decryptExportData,
+    EXPORT_FORMAT_VERSION,
+    NodeConfigExport
 } from './NodeConfigUtils';
-import SettingsStore, { Settings } from '../stores/SettingsStore';
+import SettingsStore, { Node, Settings } from '../stores/SettingsStore';
 
 // Mock for RNFS
 jest.mock('react-native-fs', () => ({
@@ -21,6 +24,37 @@ const createMockSettingsStore = (nodes?: any[]): Partial<SettingsStore> => ({
     settings: { nodes } as any as Settings,
     updateSettings: mockUpdateSettings
 });
+
+// scrypt at N=16384 is deliberately slow; give the suite room for it.
+jest.setTimeout(30000);
+
+const NODES: Node[] = [
+    {
+        host: 'node.example.com',
+        port: '8080',
+        macaroonHex: 'deadbeefcafe',
+        implementation: 'lnd',
+        certVerification: true,
+        dismissCustodialWarning: false,
+        nickname: 'primary'
+    },
+    {
+        implementation: 'lightning-node-connect',
+        pairingPhrase: 'abandon abandon abandon',
+        certVerification: false,
+        dismissCustodialWarning: false
+    }
+];
+
+const PASSWORD = 'correct horse battery staple';
+
+const parse = (content: string): NodeConfigExport =>
+    JSON.parse(content) as NodeConfigExport;
+
+type EncryptedV2 = Extract<NodeConfigExport, { version: 2 }>;
+
+const exportEncrypted = async (): Promise<EncryptedV2> =>
+    parse(await createExportFileContent(NODES, true, PASSWORD)) as EncryptedV2;
 
 describe('NodeConfigUtils', () => {
     beforeEach(() => {
@@ -97,43 +131,6 @@ describe('NodeConfigUtils', () => {
         });
     });
 
-    describe('createExportFileContent', () => {
-        const testNodes = [
-            {
-                id: 'test-node',
-                name: 'Test Node',
-                implementation: 'lnd',
-                dismissCustodialWarning: true
-            } as any
-        ];
-
-        it('should create unencrypted export data when useEncryption is false', () => {
-            const result = createExportFileContent(testNodes, false);
-            const parsedResult = JSON.parse(result);
-
-            expect(parsedResult).toEqual({
-                version: 1,
-                encrypted: false,
-                data: {
-                    nodes: testNodes
-                }
-            });
-        });
-
-        it('should create encrypted export data when useEncryption is true', () => {
-            const result = createExportFileContent(
-                testNodes,
-                true,
-                'test-password'
-            );
-            const parsedResult = JSON.parse(result);
-
-            expect(parsedResult.version).toBe(1);
-            expect(parsedResult.encrypted).toBe(true);
-            expect(typeof parsedResult.data).toBe('string'); // Encrypted data is a string
-        });
-    });
-
     describe('saveNodeConfigExportFile', () => {
         it('should save file successfully and return the path', async () => {
             const mockWriteFile = jest.spyOn(RNFS, 'writeFile');
@@ -154,28 +151,207 @@ describe('NodeConfigUtils', () => {
         });
     });
 
-    describe('decryptExportData', () => {
-        it('should decrypt encrypted export data correctly', () => {
-            const testNodes = [
-                {
-                    id: 'test-node',
-                    name: 'Test Node',
-                    implementation: 'lnd',
-                    dismissCustodialWarning: true
-                } as any
-            ];
-            const testPassword = 'test-password';
-            const encryptedExport = createExportFileContent(
-                testNodes,
+    describe('createExportFileContent', () => {
+        it('writes an unencrypted envelope at the current format version', async () => {
+            const parsed = parse(await createExportFileContent(NODES, false));
+
+            expect(parsed).toEqual({
+                version: EXPORT_FORMAT_VERSION,
+                encrypted: false,
+                data: { nodes: NODES }
+            });
+        });
+
+        it('writes a v2 scrypt + AES-256-GCM envelope when encrypting', async () => {
+            const parsed = await exportEncrypted();
+
+            expect(parsed.version).toBe(2);
+            expect(parsed.encrypted).toBe(true);
+            expect(parsed.cipher).toBe('aes-256-gcm');
+            expect(parsed.kdf.name).toBe('scrypt');
+            expect(parsed.kdf.N).toBe(16384);
+            expect(parsed.kdf.dkLen).toBe(32);
+            expect(Buffer.from(parsed.kdf.salt, 'base64')).toHaveLength(16);
+            expect(Buffer.from(parsed.iv, 'base64')).toHaveLength(12);
+            expect(Buffer.from(parsed.tag, 'base64')).toHaveLength(16);
+        });
+
+        it('never leaves credentials recoverable from the ciphertext', async () => {
+            const content = await createExportFileContent(
+                NODES,
                 true,
-                testPassword
+                PASSWORD
             );
-            const exportData = JSON.parse(encryptedExport);
-            const decryptedNodes = decryptExportData(
-                exportData.data,
-                testPassword
+
+            expect(content).not.toContain('deadbeefcafe');
+            expect(content).not.toContain('node.example.com');
+            expect(content).not.toContain('abandon abandon abandon');
+            expect(content).not.toContain(PASSWORD);
+        });
+
+        it('uses a fresh salt and IV on every export', async () => {
+            const a = await exportEncrypted();
+            const b = await exportEncrypted();
+
+            expect(a.kdf.salt).not.toBe(b.kdf.salt);
+            expect(a.iv).not.toBe(b.iv);
+            expect(a.data).not.toBe(b.data);
+        });
+
+        it('reports progress and yields to the event loop while deriving', async () => {
+            const progress: number[] = [];
+            let ticks = 0;
+            const interval = setInterval(() => {
+                ticks += 1;
+            }, 5);
+
+            try {
+                await createExportFileContent(NODES, true, PASSWORD, (p) =>
+                    progress.push(p)
+                );
+            } finally {
+                clearInterval(interval);
+            }
+
+            expect(progress.length).toBeGreaterThan(1);
+            expect(Math.min(...progress)).toBeGreaterThanOrEqual(0);
+            expect(Math.max(...progress)).toBeLessThanOrEqual(1);
+            // A blocking derivation would starve the timer entirely.
+            expect(ticks).toBeGreaterThan(0);
+        });
+
+        it('refuses to encrypt without a password rather than silently exporting plaintext', async () => {
+            await expect(
+                createExportFileContent(NODES, true, '')
+            ).rejects.toThrow();
+            await expect(
+                createExportFileContent(NODES, true, undefined)
+            ).rejects.toThrow();
+        });
+    });
+
+    describe('decryptExportData - v2', () => {
+        it('round-trips the node list', async () => {
+            await expect(
+                decryptExportData(await exportEncrypted(), PASSWORD)
+            ).resolves.toEqual(NODES);
+        });
+
+        it('rejects a wrong password', async () => {
+            await expect(
+                decryptExportData(await exportEncrypted(), 'wrong password')
+            ).rejects.toThrow(/wrong password or altered file/);
+        });
+
+        it('rejects a tampered ciphertext', async () => {
+            const parsed = await exportEncrypted();
+
+            const bytes = Buffer.from(parsed.data, 'base64');
+            bytes[0] ^= 0xff;
+            parsed.data = bytes.toString('base64');
+
+            await expect(decryptExportData(parsed, PASSWORD)).rejects.toThrow(
+                /wrong password or altered file/
             );
-            expect(decryptedNodes).toEqual(testNodes);
+        });
+
+        it('rejects a tampered authentication tag', async () => {
+            const parsed = await exportEncrypted();
+
+            const tag = Buffer.from(parsed.tag, 'base64');
+            tag[0] ^= 0xff;
+            parsed.tag = tag.toString('base64');
+
+            await expect(decryptExportData(parsed, PASSWORD)).rejects.toThrow(
+                /wrong password or altered file/
+            );
+        });
+
+        it('rejects KDF parameters altered after export', async () => {
+            const parsed = await exportEncrypted();
+
+            parsed.kdf.r = 4;
+
+            await expect(decryptExportData(parsed, PASSWORD)).rejects.toThrow();
+        });
+
+        it('rejects an out-of-range scrypt cost before deriving a key', async () => {
+            const parsed = await exportEncrypted();
+
+            parsed.kdf.N = 1 << 24;
+
+            await expect(decryptExportData(parsed, PASSWORD)).rejects.toThrow(
+                /Invalid key derivation parameters/
+            );
+        });
+
+        it('rejects a non-power-of-two scrypt cost', async () => {
+            const parsed = await exportEncrypted();
+
+            parsed.kdf.N = 16383;
+
+            await expect(decryptExportData(parsed, PASSWORD)).rejects.toThrow(
+                /Invalid key derivation parameters/
+            );
+        });
+
+        it('rejects an unknown KDF', async () => {
+            const parsed = await exportEncrypted();
+
+            parsed.kdf.name = 'pbkdf2';
+
+            await expect(decryptExportData(parsed, PASSWORD)).rejects.toThrow(
+                /Unsupported key derivation function/
+            );
+        });
+
+        it('rejects an unknown cipher', async () => {
+            const parsed = await exportEncrypted();
+
+            parsed.cipher = 'aes-256-cbc';
+
+            await expect(decryptExportData(parsed, PASSWORD)).rejects.toThrow(
+                /Unsupported cipher/
+            );
+        });
+    });
+
+    describe('decryptExportData - v1 backward compatibility', () => {
+        // Reproduces exactly what shipped v1 wrote: CryptoJS.AES.encrypt in
+        // string-password mode over the { nodes } payload.
+        const makeV1File = (
+            nodes: Node[],
+            password: string
+        ): NodeConfigExport =>
+            ({
+                version: 1,
+                encrypted: true,
+                data: CryptoJS.AES.encrypt(
+                    JSON.stringify({ nodes }),
+                    password
+                ).toString()
+            } as NodeConfigExport);
+
+        it('still imports a legacy v1 backup', async () => {
+            await expect(
+                decryptExportData(makeV1File(NODES, PASSWORD), PASSWORD)
+            ).resolves.toEqual(NODES);
+        });
+
+        it('rejects a v1 backup with the wrong password', async () => {
+            await expect(
+                decryptExportData(makeV1File(NODES, PASSWORD), 'wrong password')
+            ).rejects.toThrow();
+        });
+    });
+
+    describe('decryptExportData - envelope guards', () => {
+        it('refuses an unencrypted envelope', async () => {
+            const parsed = parse(await createExportFileContent(NODES, false));
+
+            await expect(decryptExportData(parsed, PASSWORD)).rejects.toThrow(
+                /not encrypted/
+            );
         });
     });
 });

--- a/utils/NodeConfigUtils.ts
+++ b/utils/NodeConfigUtils.ts
@@ -1,17 +1,71 @@
 import RNFS from 'react-native-fs';
 import { Platform } from 'react-native';
 import * as CryptoJS from 'crypto-js';
+import crypto from 'crypto';
+import { scrypt } from 'scrypt-js';
 import SettingsStore, { Node } from '../stores/SettingsStore';
 
-interface NodeConfigExport {
-    version: number;
-    encrypted: boolean;
-    data:
-        | {
-              nodes: Node[];
-          }
-        | string;
+export const EXPORT_FORMAT_VERSION = 2;
+
+const KDF_NAME = 'scrypt';
+const CIPHER_NAME = 'aes-256-gcm';
+
+const SALT_BYTES = 16;
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const KEY_BYTES = 32;
+
+const SCRYPT_N = 16384;
+const SCRYPT_R = 8;
+const SCRYPT_P = 1;
+
+// An imported file is untrusted input and scrypt allocates roughly 128 * N * r
+// bytes, so unbounded parameters would let a malicious backup exhaust memory
+// during import. These ceilings stay well above the cost we write ourselves so
+// that the parameters remain tunable without invalidating existing files.
+const MAX_SCRYPT_N = 1 << 20;
+const MAX_SCRYPT_R = 16;
+const MAX_SCRYPT_P = 4;
+
+interface ScryptParams {
+    name: string;
+    N: number;
+    r: number;
+    p: number;
+    dkLen: number;
+    salt: string;
 }
+
+interface NodeConfigPayload {
+    nodes: Node[];
+}
+
+interface UnencryptedExport {
+    version: number;
+    encrypted: false;
+    data: NodeConfigPayload;
+}
+
+interface EncryptedExportV1 {
+    version: 1;
+    encrypted: true;
+    data: string;
+}
+
+interface EncryptedExportV2 {
+    version: 2;
+    encrypted: true;
+    kdf: ScryptParams;
+    cipher: string;
+    iv: string;
+    tag: string;
+    data: string;
+}
+
+export type NodeConfigExport =
+    | UnencryptedExport
+    | EncryptedExportV1
+    | EncryptedExportV2;
 
 export const saveNodeConfigs = async (
     nodes: Node[],
@@ -25,33 +79,155 @@ export const saveNodeConfigs = async (
     });
 };
 
-export const createExportFileContent = (
-    nodes: Node[],
-    useEncryption: boolean,
-    password?: string
-): string => {
-    const nodeConfigExport: NodeConfigExport = {
-        version: 1,
-        encrypted: useEncryption && !!password,
-        data: {
-            nodes
+// NFKC keeps visually identical passwords byte-identical across platforms whose
+// input methods emit different Unicode compositions. Hermes does not guarantee
+// String.prototype.normalize, so fall back to the raw string rather than fail.
+const passwordBytes = (password: string): Buffer => {
+    const normalized =
+        typeof password.normalize === 'function'
+            ? password.normalize('NFKC')
+            : password;
+    return Buffer.from(normalized, 'utf8');
+};
+
+// Bound the KDF parameters and cipher name into the GCM tag so neither can be
+// altered without the authentication check failing.
+const additionalData = (kdf: ScryptParams): Buffer =>
+    Buffer.from(
+        `zeus-node-config|v${EXPORT_FORMAT_VERSION}|${kdf.name}|${kdf.N}|${kdf.r}|${kdf.p}|${kdf.dkLen}|${CIPHER_NAME}`,
+        'utf8'
+    );
+
+const isPositiveInteger = (value: unknown): value is number =>
+    typeof value === 'number' && Number.isInteger(value) && value > 0;
+
+const assertValidScryptParams = (kdf: ScryptParams | undefined) => {
+    if (!kdf || kdf.name !== KDF_NAME) {
+        throw new Error('Unsupported key derivation function');
+    }
+    if (
+        !isPositiveInteger(kdf.N) ||
+        !isPositiveInteger(kdf.r) ||
+        !isPositiveInteger(kdf.p) ||
+        !isPositiveInteger(kdf.dkLen)
+    ) {
+        throw new Error('Invalid key derivation parameters');
+    }
+    // scrypt requires N to be a power of two greater than one.
+    if (kdf.N < 2 || (kdf.N & (kdf.N - 1)) !== 0 || kdf.N > MAX_SCRYPT_N) {
+        throw new Error('Invalid key derivation parameters');
+    }
+    if (kdf.r > MAX_SCRYPT_R || kdf.p > MAX_SCRYPT_P) {
+        throw new Error('Invalid key derivation parameters');
+    }
+    if (kdf.dkLen !== KEY_BYTES) {
+        throw new Error('Invalid key derivation parameters');
+    }
+    if (typeof kdf.salt !== 'string' || !kdf.salt) {
+        throw new Error('Invalid key derivation parameters');
+    }
+};
+
+export type ProgressHandler = (progress: number) => void;
+
+// scrypt-js only breaks its work into chunks and returns to the event loop when
+// a progress callback is supplied; without one it runs the whole derivation in
+// a single synchronous block and freezes the UI thread. The callback is
+// therefore always passed, even when no caller is listening.
+const deriveKey = async (
+    password: string,
+    kdf: ScryptParams,
+    onProgress?: ProgressHandler
+): Promise<Buffer> => {
+    const derived = await scrypt(
+        passwordBytes(password),
+        Buffer.from(kdf.salt, 'base64'),
+        kdf.N,
+        kdf.r,
+        kdf.p,
+        kdf.dkLen,
+        (progress: number) => {
+            onProgress?.(progress);
         }
-    };
+    );
+    return Buffer.from(derived);
+};
 
-    if (useEncryption && password) {
-        const encryptedData = CryptoJS.AES.encrypt(
-            JSON.stringify(nodeConfigExport.data),
-            password
-        ).toString();
+const parseNodes = (decryptedString: string): Node[] => {
+    const decoded = JSON.parse(decryptedString);
 
-        return JSON.stringify({
-            version: 1,
-            encrypted: true,
-            data: encryptedData
-        });
+    if (
+        !decoded ||
+        typeof decoded !== 'object' ||
+        !Array.isArray(decoded.nodes)
+    ) {
+        throw new Error('Invalid data structure');
     }
 
-    return JSON.stringify(nodeConfigExport);
+    return decoded.nodes;
+};
+
+const encryptPayload = async (
+    payload: NodeConfigPayload,
+    password: string,
+    onProgress?: ProgressHandler
+): Promise<EncryptedExportV2> => {
+    const salt = crypto.randomBytes(SALT_BYTES);
+    const iv = crypto.randomBytes(IV_BYTES);
+
+    const kdf: ScryptParams = {
+        name: KDF_NAME,
+        N: SCRYPT_N,
+        r: SCRYPT_R,
+        p: SCRYPT_P,
+        dkLen: KEY_BYTES,
+        salt: salt.toString('base64')
+    };
+
+    const key = await deriveKey(password, kdf, onProgress);
+    const cipher = crypto.createCipheriv(CIPHER_NAME, key, iv);
+    cipher.setAAD(additionalData(kdf));
+
+    const ciphertext = Buffer.concat([
+        cipher.update(Buffer.from(JSON.stringify(payload), 'utf8')),
+        cipher.final()
+    ]);
+
+    return {
+        version: 2,
+        encrypted: true,
+        kdf,
+        cipher: CIPHER_NAME,
+        iv: iv.toString('base64'),
+        tag: cipher.getAuthTag().toString('base64'),
+        data: ciphertext.toString('base64')
+    };
+};
+
+export const createExportFileContent = async (
+    nodes: Node[],
+    useEncryption: boolean,
+    password?: string,
+    onProgress?: ProgressHandler
+): Promise<string> => {
+    const payload: NodeConfigPayload = { nodes };
+
+    if (!useEncryption) {
+        const unencrypted: UnencryptedExport = {
+            version: EXPORT_FORMAT_VERSION,
+            encrypted: false,
+            data: payload
+        };
+        return JSON.stringify(unencrypted);
+    }
+
+    // Returning an unencrypted file here would silently contradict the user's
+    // choice to encrypt, so treat a missing password as a hard failure.
+    if (!password) {
+        throw new Error('A password is required to encrypt the export');
+    }
+
+    return JSON.stringify(await encryptPayload(payload, password, onProgress));
 };
 
 export const saveNodeConfigExportFile = async (
@@ -64,7 +240,6 @@ export const saveNodeConfigExportFile = async (
                 ? `${RNFS.DownloadDirectoryPath}/${fileName}`
                 : `${RNFS.DocumentDirectoryPath}/${fileName}`;
 
-        console.log(`Saving node config to: ${filePath}`);
         await RNFS.writeFile(filePath, fileContent, 'utf8');
 
         return filePath;
@@ -74,34 +249,72 @@ export const saveNodeConfigExportFile = async (
     }
 };
 
-export const decryptExportData = (
-    encryptedData: string,
-    password: string
-): Node[] => {
-    try {
-        const decryptedString = CryptoJS.AES.decrypt(
-            encryptedData,
-            password
-        ).toString(CryptoJS.enc.Utf8);
+// Version 1 used CryptoJS.AES.encrypt in string-password mode, which derives
+// the key with a single MD5 pass (EVP_BytesToKey) and authenticates nothing.
+// It is retained for import only so that existing backups stay readable.
+const decryptV1 = (encryptedData: string, password: string): Node[] => {
+    const decryptedString = CryptoJS.AES.decrypt(
+        encryptedData,
+        password
+    ).toString(CryptoJS.enc.Utf8);
 
-        if (!decryptedString) {
-            throw new Error('Decryption failed - wrong password?');
-        }
-
-        const decryptedData: NodeConfigExport['data'] =
-            JSON.parse(decryptedString);
-
-        if (
-            typeof decryptedData === 'string' ||
-            !decryptedData ||
-            !Array.isArray(decryptedData.nodes)
-        ) {
-            throw new Error('Invalid data structure');
-        }
-
-        return decryptedData.nodes;
-    } catch (error) {
-        console.error('Decryption error:', error);
-        throw error;
+    if (!decryptedString) {
+        throw new Error('Decryption failed - wrong password?');
     }
+
+    return parseNodes(decryptedString);
+};
+
+const decryptV2 = async (
+    exportData: EncryptedExportV2,
+    password: string,
+    onProgress?: ProgressHandler
+): Promise<Node[]> => {
+    assertValidScryptParams(exportData.kdf);
+
+    if (exportData.cipher !== CIPHER_NAME) {
+        throw new Error('Unsupported cipher');
+    }
+
+    const iv = Buffer.from(exportData.iv, 'base64');
+    const tag = Buffer.from(exportData.tag, 'base64');
+
+    if (iv.length !== IV_BYTES || tag.length !== TAG_BYTES) {
+        throw new Error('Invalid encryption envelope');
+    }
+
+    const key = await deriveKey(password, exportData.kdf, onProgress);
+    const decipher = crypto.createDecipheriv(CIPHER_NAME, key, iv);
+    decipher.setAAD(additionalData(exportData.kdf));
+    decipher.setAuthTag(tag);
+
+    let plaintext: Buffer;
+    try {
+        // final() verifies the tag, so a wrong password and a modified file are
+        // both rejected here rather than surfacing as malformed JSON later.
+        plaintext = Buffer.concat([
+            decipher.update(Buffer.from(exportData.data, 'base64')),
+            decipher.final()
+        ]);
+    } catch (error) {
+        throw new Error('Decryption failed - wrong password or altered file');
+    }
+
+    return parseNodes(plaintext.toString('utf8'));
+};
+
+export const decryptExportData = async (
+    exportData: NodeConfigExport,
+    password: string,
+    onProgress?: ProgressHandler
+): Promise<Node[]> => {
+    if (!exportData.encrypted) {
+        throw new Error('Export is not encrypted');
+    }
+
+    // Callers surface and log the failure; re-logging it here would duplicate
+    // every wrong-password attempt in the device logs.
+    return exportData.version === 1
+        ? decryptV1(exportData.data, password)
+        : decryptV2(exportData, password, onProgress);
 };

--- a/views/Tools/NodeConfigExportImport.tsx
+++ b/views/Tools/NodeConfigExportImport.tsx
@@ -35,9 +35,11 @@ import { themeColor, isLightTheme } from '../../utils/ThemeUtils';
 import { getPhoto } from '../../utils/PhotoUtils';
 import {
     saveNodeConfigs,
-    createExportFileContent as createExportFileContent,
+    createExportFileContent,
     saveNodeConfigExportFile,
-    decryptExportData
+    decryptExportData,
+    EXPORT_FORMAT_VERSION,
+    NodeConfigExport
 } from '../../utils/NodeConfigUtils';
 import KeychainRecoveryUtils, {
     RecoveryResult,
@@ -94,16 +96,6 @@ interface NodeConfigExportImportState {
     selectedRecoveryResult: RecoveryResult | null;
     recoveryNodes: Node[];
     selectedRecoveryNodes: Array<number>;
-}
-
-interface NodeConfigExport {
-    version: number;
-    encrypted: boolean;
-    data:
-        | {
-              nodes: Node[];
-          }
-        | string;
 }
 
 @inject('SettingsStore')
@@ -530,6 +522,7 @@ export default class NodeConfigExportImport extends React.Component<
             useEncryption,
             exportPassword
         } = this.state;
+
         const { SettingsStore } = this.props;
         const { settings } = SettingsStore;
 
@@ -539,7 +532,7 @@ export default class NodeConfigExportImport extends React.Component<
             const selectedNodeConfigs = selectedNodeIndices.map(
                 (index) => nodes[index]
             );
-            const exportFileContent = createExportFileContent(
+            const exportFileContent = await createExportFileContent(
                 selectedNodeConfigs,
                 useEncryption,
                 exportPassword
@@ -604,7 +597,10 @@ export default class NodeConfigExportImport extends React.Component<
             const content = await RNFS.readFile(filePath, 'utf8');
             const importData: NodeConfigExport = JSON.parse(content);
 
-            if (!importData.version || importData.version > 1) {
+            if (
+                !importData.version ||
+                importData.version > EXPORT_FORMAT_VERSION
+            ) {
                 this.handleError(
                     undefined,
                     'views.Tools.nodeConfigExportImport.importError'
@@ -621,7 +617,16 @@ export default class NodeConfigExportImport extends React.Component<
                 });
             } else {
                 // Show node selection modal for unencrypted imports
-                const nodes = (importData.data as { nodes: Node[] }).nodes;
+                const nodes = (importData.data as { nodes: Node[] })?.nodes;
+
+                if (!Array.isArray(nodes)) {
+                    this.handleError(
+                        undefined,
+                        'views.Tools.nodeConfigExportImport.importError'
+                    );
+                    return;
+                }
+
                 this.setState({
                     isLoading: false,
                     importNodes: nodes,
@@ -875,10 +880,7 @@ export default class NodeConfigExportImport extends React.Component<
         try {
             this.setState({ isLoading: true });
 
-            const nodes = decryptExportData(
-                importData!.data as string,
-                password
-            );
+            const nodes = await decryptExportData(importData!, password);
 
             // Show node selection modal for encrypted imports
             this.setState({


### PR DESCRIPTION
This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
