### PR TITLE
fix: avoid spurious node refetch after unlocking

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1988,7 +1988,16 @@ export default class SettingsStore {
         }
 
         await this.setSettings(newSettings);
-        this.triggerSettingsRefresh = true;
+
+        // Only ask the Wallet screen for a full node refetch when the write
+        // actually changed something. Bookkeeping writes that re-persist an
+        // identical value (authenticationAttempts: 0 after a successful
+        // login, supportedBiometryType on every app start) would otherwise
+        // arm the flag and cost the user a visible reconnect on the next
+        // focus event.
+        if (!isEqual(existingSettings, newSettings)) {
+            this.triggerSettingsRefresh = true;
+        }
 
         // Update store's node properties from latest settings
         this.updateNodeProperties(newSettings);

--- a/views/Lockscreen.tsx
+++ b/views/Lockscreen.tsx
@@ -188,7 +188,7 @@ export default class Lockscreen extends React.Component<
 
             if (isVerified) {
                 SettingsStore.setPosStatus('inactive');
-                this.resetAuthenticationAttempts();
+                await this.resetAuthenticationAttempts();
                 SettingsStore.setLoginStatus(true);
                 this.proceed(
                     pendingNavigation?.screen,
@@ -295,7 +295,7 @@ export default class Lockscreen extends React.Component<
 
             // Check if we're modifying security settings first
             if (modifySecurityScreen) {
-                this.resetAuthenticationAttempts();
+                await this.resetAuthenticationAttempts();
                 navigation.popTo(modifySecurityScreen);
                 return;
             } else if (deletePassword) {
@@ -312,7 +312,7 @@ export default class Lockscreen extends React.Component<
                 return;
             } else if (SettingsStore.settings.selectNodeOnStartup) {
                 // Only handle wallet selection when NOT modifying security
-                this.resetAuthenticationAttempts();
+                await this.resetAuthenticationAttempts();
 
                 const shareIntentData = route.params?.shareIntentData;
 
@@ -333,7 +333,7 @@ export default class Lockscreen extends React.Component<
                 ) {
                     setPosStatus('inactive');
                 }
-                this.resetAuthenticationAttempts();
+                await this.resetAuthenticationAttempts();
                 const pendingNavigation = route.params?.pendingNavigation;
                 this.proceed(
                     pendingNavigation?.screen,
@@ -476,11 +476,16 @@ export default class Lockscreen extends React.Component<
         }
     };
 
-    resetAuthenticationAttempts = () => {
+    // Must be awaited before navigating away: updateSettings() persists to
+    // storage before it sets SettingsStore.triggerSettingsRefresh, so a
+    // fire-and-forget call lands that flag *after* the Wallet screen has
+    // regained focus and cleared it. The flag then survives until the next
+    // focus event and forces a needless full node refetch there.
+    resetAuthenticationAttempts = async () => {
         const { SettingsStore } = this.props;
         const { updateSettings } = SettingsStore;
 
-        updateSettings({ authenticationAttempts: 0 });
+        await updateSettings({ authenticationAttempts: 0 });
     };
 
     generateErrorMessage = (): string => {

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -280,6 +280,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             // focus event can fire multiple times before the first async
             // call completes, causing duplicate node builds.
             if (this._navigating) {
+                // Leave the flags armed: a settings change that arrived
+                // while this refresh was already in flight is not covered
+                // by it, and clearing here would drop it silently. The next
+                // focus event picks it up instead.
                 console.log(
                     '[Wallet] handleFocus: skipping — getSettingsAndNavigate already in flight'
                 );
@@ -291,13 +295,13 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 console.log(
                     `[Wallet] handleFocus: triggering getSettingsAndNavigate (initialLoad=${this.state.initialLoad}, posWasEnabled=${SettingsStore.posWasEnabled}, triggerSettingsRefresh=${SettingsStore.triggerSettingsRefresh}, connecting=${SettingsStore.connecting})`
                 );
+                SettingsStore.posWasEnabled = false;
+                SettingsStore.triggerSettingsRefresh = false;
                 this._navigating = true;
                 this.getSettingsAndNavigate(shareIntentData).finally(() => {
                     this._navigating = false;
                 });
             }
-            SettingsStore.posWasEnabled = false;
-            SettingsStore.triggerSettingsRefresh = false;
         }
 
         if (


### PR DESCRIPTION
# Description

I noticed this minor issue:
Opening and closing the menu once after app start triggered a full node refetch, with a visible loading indicator, although nothing had been changed. A second open/close was clean. Only reproducible with a lock configured (PIN, password or biometrics).

Tracing it turned up two further problems in the same mechanism, fixed in the follow-up commits.

1.
`resetAuthenticationAttempts()` was fire-and-forget. `updateSettings()` persists to storage *before* it sets `triggerSettingsRefresh`, so on a successful login the flag landed after `proceed()` had already returned to the Wallet screen and its `handleFocus()` had cleared it. The flag then survived until the next focus event (first menu close) and forced the refetch there.
-> Now awaited at all four call sites.

2.
`updateSettings()` armed `triggerSettingsRefresh` unconditionally, so writes re-persisting an identical value cost a full refetch too. Two happen on every normal app start: `supportedBiometryType` and `authenticationAttempts: 0`. Now guarded by an `isEqual()` check against the settings read at the start of the call.

3.
Mostly theoretical, because probably not reproducible in practice, but fixed anyway since it is a simple fix:
`handleFocus()` also cleared the flags in the branch where the `_navigating` guard skipped the call. A settings change arriving while a refresh was in flight was therefore consumed without ever being applied. Clearing now happens only in the branch that actually starts `getSettingsAndNavigate()`.

### Testing
Verified on Android with PIN and with biometrics: no refetch on the first menu open/close. Settings changes that do require a reconnect still trigger one.
Please test on iOS.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [x] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
