### PR TITLE
chore: bump CDK to 0.17.4; drop npubcash quote-key marker workaround

### DIFF
--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -802,7 +802,6 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         state: String,
         expiry: Double,
         secretKey: String?,
-        useSeedPrefixMarker: Boolean,
         promise: Promise
     ) {
         if (!isInitialized || db == null) {
@@ -824,32 +823,11 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     else -> QuoteState.PAID // Default to PAID for external quotes
                 }
 
-                // For v2-bip39 wallets, ZEUS Pay locks quotes to the seed-
-                // prefix key (seed[0..32]), which is byte-identical to cdk's
-                // "legacy NpubCash" key. Storing that key on the quote makes
-                // cdk's mint saga scrub it mid-flight (a version bump), and
-                // the saga's post-mint write then dies with ConcurrentUpdate
-                // AFTER the mint has issued the signatures. For those quotes
-                // (useSeedPrefixMarker, decided by JS via byte comparison),
-                // store the quote with no key and write cdk's NpubCash
-                // quote-key marker: at signing time cdk re-derives the
-                // identical seed-prefix key from the marker, with no mid-saga
-                // write. v1 wallets sign with a different key (LND seed
-                // bytes [32:64]), so the marker would derive the wrong key
-                // for them; their key is stored on the quote instead, which
-                // is safe because the scrub only triggers on byte equality
-                // with the seed prefix.
-                // Upstream bug: https://github.com/cashubtc/cdk/issues/2335
-                // Remove when fixed: https://github.com/ZeusLN/zeus/issues/4402
+                // Storing a key equal to cdk's seed prefix on the quote
+                // requires cdk >= 0.17.4: earlier versions claim it as a
+                // legacy NpubCash key and scrub it mid-mint-saga, stranding
+                // the minted funds (cashubtc/cdk#2335).
                 val storedSecretKey = secretKey?.takeIf { it.isNotEmpty() }
-                if (storedSecretKey != null && useSeedPrefixMarker) {
-                    db!!.kvWrite(
-                        primaryNamespace = "npubcash",
-                        secondaryNamespace = "quotes",
-                        key = quoteId,
-                        value = "legacy-seed-prefix".toByteArray(Charsets.UTF_8)
-                    )
-                }
 
                 // Create the MintQuote object
                 // For external quotes that are PAID, we set amountPaid = amount
@@ -866,7 +844,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     amountIssued = if (quoteState == QuoteState.ISSUED) amt else zeroAmount,
                     estimatedBlocks = null,
                     paymentMethod = PaymentMethod.Bolt11,
-                    secretKey = if (useSeedPrefixMarker) null else storedSecretKey,
+                    secretKey = storedSecretKey,
                     usedByOperation = null,
                     version = version
                 )

--- a/cashu-cdk/CashuDevKit.ts
+++ b/cashu-cdk/CashuDevKit.ts
@@ -316,12 +316,6 @@ class CashuDevKit {
      * @param state - The quote state (UNPAID, PAID, PENDING, ISSUED)
      * @param expiry - The quote expiry timestamp
      * @param secretKey - Optional hex-encoded secret key for P2PK-locked quotes
-     * @param useSeedPrefixMarker - When the secret key equals CDK's seed
-     * prefix (seed[0..32]), store the quote keyless and write cdk's NpubCash
-     * quote-key marker instead, to avoid cdk's legacy npubcash scrub
-     * (https://github.com/cashubtc/cdk/issues/2335). Must be false when the
-     * key differs from the seed prefix (v1 wallets), or cdk would sign with
-     * the wrong key.
      */
     async addExternalMintQuote(
         mintUrl: string,
@@ -330,8 +324,7 @@ class CashuDevKit {
         request: string,
         state: string,
         expiry: number,
-        secretKey?: string,
-        useSeedPrefixMarker: boolean = false
+        secretKey?: string
     ): Promise<boolean> {
         try {
             return await CashuDevKitModule.addExternalMintQuote(
@@ -341,8 +334,7 @@ class CashuDevKit {
                 request,
                 state,
                 expiry,
-                secretKey,
-                useSeedPrefixMarker
+                secretKey
             );
         } catch (error) {
             throw mapCDKError(error);

--- a/cashu-cdk/types.ts
+++ b/cashu-cdk/types.ts
@@ -259,8 +259,7 @@ export interface CashuDevKitNativeModule {
         request: string,
         state: string,
         expiry: number,
-        secretKey?: string,
-        useSeedPrefixMarker?: boolean
+        secretKey?: string
     ): Promise<boolean>;
     mint(
         mintUrl: string,

--- a/fetch-libraries-versions.json
+++ b/fetch-libraries-versions.json
@@ -10,11 +10,11 @@
         "iosSha256": "fe50c9796f91f121ed58bd2aa3970dc2c3048358b750ff5b8fafa3e6a8b50fce"
     },
     "cdk": {
-        "version": "0.17.3",
-        "androidSha256": "632e4d593a7ed3abfc142df9cfc9b8ef68cd29db8cd12de260eb568f9828f39a",
-        "androidBindingsSha256": "56d990510fbbfed182e21549168742b007fc736df5184ce6cadf729b47eccc93",
-        "iosSha256": "02a93d7e649069dd8c75b9f14f74606ca23bf081725be57786524c60839395de",
-        "iosBindingsSha256": "2bca7a65eeee1e1ebc45f33287293e31bb473ed3662cb74a3d699444e3c831e8"
+        "version": "0.17.4",
+        "androidSha256": "9717f92f62ae9c9e044b5f40f5831a2bd0d9fc3bb9dd63739468500bfe70f4cd",
+        "androidBindingsSha256": "520bdd3ff49d7f0b5376b4313720665d7208634a1c463620d3959437484d8260",
+        "iosSha256": "0908c519ee72a0d80713dbb96d787fd5a3bd8ee1fb38074cc2e562b417911c96",
+        "iosBindingsSha256": "7ebcce2363c346daaae4c01c090d34a6d73bf168ddef0395a5eae9aab36bf53f"
     },
     "zeus-cashu-restore": {
         "version": "0.1.0",

--- a/ios/CashuDevKit.podspec
+++ b/ios/CashuDevKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CashuDevKit'
-  s.version          = '0.17.3'
+  s.version          = '0.17.4'
   s.summary          = 'Cashu Development Kit - FFI bindings for iOS'
   s.description      = <<-DESC
     CashuDevKit provides Swift bindings to the Cashu Development Kit (CDK),

--- a/ios/CashuDevKit/CashuDevKitModule.m
+++ b/ios/CashuDevKit/CashuDevKitModule.m
@@ -73,7 +73,6 @@ RCT_EXTERN_METHOD(addExternalMintQuote:(NSString *)mintUrl
                   state:(NSString *)state
                   expiry:(nonnull NSNumber *)expiry
                   secretKey:(NSString * _Nullable)secretKey
-                  useSeedPrefixMarker:(BOOL)useSeedPrefixMarker
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -775,11 +775,10 @@ class CashuDevKitModule: RCTEventEmitter {
 
     /// Add an external mint quote to CDK's database.
     /// This allows minting from quotes created externally (e.g., by ZeusPay server).
-    @objc(addExternalMintQuote:quoteId:amount:request:state:expiry:secretKey:useSeedPrefixMarker:resolver:rejecter:)
+    @objc(addExternalMintQuote:quoteId:amount:request:state:expiry:secretKey:resolver:rejecter:)
     func addExternalMintQuote(_ mintUrl: String, quoteId: String, amount: NSNumber,
                                request: String, state: String, expiry: NSNumber,
                                secretKey: String?,
-                               useSeedPrefixMarker: Bool,
                                resolve: @escaping RCTPromiseResolveBlock,
                                reject: @escaping RCTPromiseRejectBlock) {
         let dbHandle: WalletSqliteDatabase? = walletQueue.sync {
@@ -811,32 +810,11 @@ class CashuDevKitModule: RCTEventEmitter {
                     quoteState = .paid // Default to PAID for external quotes
                 }
 
-                // For v2-bip39 wallets, ZEUS Pay locks quotes to the seed-
-                // prefix key (seed[0..32]), which is byte-identical to cdk's
-                // "legacy NpubCash" key. Storing that key on the quote makes
-                // cdk's mint saga scrub it mid-flight (a version bump), and
-                // the saga's post-mint write then dies with ConcurrentUpdate
-                // AFTER the mint has issued the signatures. For those quotes
-                // (useSeedPrefixMarker, decided by JS via byte comparison),
-                // store the quote with no key and write cdk's NpubCash
-                // quote-key marker: at signing time cdk re-derives the
-                // identical seed-prefix key from the marker, with no mid-saga
-                // write. v1 wallets sign with a different key (LND seed
-                // bytes [32:64]), so the marker would derive the wrong key
-                // for them; their key is stored on the quote instead, which
-                // is safe because the scrub only triggers on byte equality
-                // with the seed prefix.
-                // Upstream bug: https://github.com/cashubtc/cdk/issues/2335
-                // Remove when fixed: https://github.com/ZeusLN/zeus/issues/4402
+                // Storing a key equal to cdk's seed prefix on the quote
+                // requires cdk >= 0.17.4: earlier versions claim it as a
+                // legacy NpubCash key and scrub it mid-mint-saga, stranding
+                // the minted funds (cashubtc/cdk#2335).
                 let storedSecretKey = (secretKey?.isEmpty == false) ? secretKey : nil
-                if storedSecretKey != nil && useSeedPrefixMarker {
-                    try await db.kvWrite(
-                        primaryNamespace: "npubcash",
-                        secondaryNamespace: "quotes",
-                        key: quoteId,
-                        value: Data("legacy-seed-prefix".utf8)
-                    )
-                }
 
                 // Create the MintQuote object
                 // For external quotes that are PAID, we set amountPaid = amount
@@ -854,7 +832,7 @@ class CashuDevKitModule: RCTEventEmitter {
                         amountPaid: (quoteState == .paid || quoteState == .issued) ? amt : zeroAmount,
                         estimatedBlocks: nil,
                         paymentMethod: .bolt11,
-                        secretKey: useSeedPrefixMarker ? nil : storedSecretKey,
+                        secretKey: storedSecretKey,
                         usedByOperation: nil,
                         version: version
                     )

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CashuDevKit (0.17.3)
+  - CashuDevKit (0.17.4)
   - CocoaAsyncSocket (7.6.5)
   - FBLazyVector (0.85.3)
   - hermes-engine (250829098.0.10):
@@ -2857,7 +2857,7 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  CashuDevKit: caaa82e41ee209ead7d9605f330e0b20e8b34345
+  CashuDevKit: aca7feab2317e80d84a980f3f5ab5f174f18e8ee
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   hermes-engine: c9c1c1a785028d5dec6bbf0f0a97ddd4e2887358

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -836,14 +836,8 @@ export default class CashuStore {
                                 }
                             }
 
-                            // First, add the external quote to CDK's database with secret key.
-                            // When the key equals CDK's seed prefix (v2-bip39
-                            // wallets), the native side stores the quote
-                            // keyless with cdk's NpubCash marker instead, to
-                            // dodge cdk's legacy npubcash scrub (cdk#2335).
-                            const useSeedPrefixMarker = secretKey
-                                ? this.secretKeyMatchesCdkSeedPrefix(secretKey)
-                                : false;
+                            // First, add the external quote to CDK's database
+                            // with the secret key
                             await CashuDevKit.addExternalMintQuote(
                                 mintUrl,
                                 quoteId,
@@ -851,8 +845,7 @@ export default class CashuStore {
                                 externalQuote.request || '',
                                 externalQuote.state || 'PAID',
                                 externalQuote.expiry || 0,
-                                secretKey || undefined,
-                                useSeedPrefixMarker
+                                secretKey || undefined
                             );
                             if (__DEV__) {
                                 console.log(
@@ -3742,25 +3735,6 @@ export default class CashuStore {
             return null;
         }
         return privkey;
-    };
-
-    /**
-     * Whether the given P2PK secret key is byte-identical to the CDK
-     * wallet's seed prefix (seed[0..32]). cdk's legacy NpubCash heuristic
-     * claims such keys as its own, so quotes carrying them must use the
-     * quote-key marker workaround instead of storing the key. v1 wallets
-     * derive their key from LND seed bytes [32:64] and won't match, so
-     * their key is stored on the quote and signs correctly.
-     * See https://github.com/cashubtc/cdk/issues/2335
-     */
-    private secretKeyMatchesCdkSeedPrefix = (secretKeyHex: string): boolean => {
-        const mnemonic = this.getCDKMnemonic();
-        if (!mnemonic) return false;
-        const seed = bip39scure.mnemonicToSeedSync(mnemonic);
-        return (
-            bytesToHex(seed.slice(0, 32)).toLowerCase() ===
-            secretKeyHex.toLowerCase()
-        );
     };
 
     @action


### PR DESCRIPTION
# Description

Relates to issue: #4413, #4402

Follow-up to #4397. cdk shipped [v0.17.4](https://github.com/cashubtc/cdk/releases/tag/v0.17.4) today in response to the two issues we filed during that review, so this bumps to it and removes the workaround the old behavior forced on us.

**Commit 1: bump Cashu Dev Kit to 0.17.4.** `WalletRepository` construction is offline-first again ([cashubtc/cdk#2351](https://github.com/cashubtc/cdk/issues/2351)): `load_wallets` restores wallet units from the mint info already persisted in the wallet db instead of issuing a sequential `GET /v1/info` per stored mint (on a client with no request timeout) before the constructor returns. Wallet init no longer scales with mint count or blocks on unreachable mints, which fixes #4413 with no ZEUS-side changes. Upstream added regression coverage asserting zero network connections during startup.

Artifact integrity: the iOS `CashuDevKitFFI.xcframework.zip` SHA256 pinned here matches the checksum in cdk-swift v0.17.4's own `Package.swift`. The uniffi contract version is unchanged at 30, and the bindings diff over 0.17.3 is doc comments plus the two `WalletRepository` constructor checksums. The 0.17.4 xcframework still ships the mixed macOS slice, so the existing strip step in `fetch-libraries.sh` stays.

**Commit 2: drop the npubcash marker workaround in `addExternalMintQuote`.** cdk 0.17.4 also fixes [cashubtc/cdk#2335](https://github.com/cashubtc/cdk/issues/2335): signing-key resolution now consults the kv marker only and otherwise returns the quote's stored key without touching wallet state, the legacy scrub only runs on quotes that provably came from an NpubCash account, and the mint saga reloads quote snapshots after key resolution. Upstream's `external_seed_prefix_key_is_not_claimed_by_npubcash` test covers our exact case. So the P2PK secret key is stored on external quotes again for both v1 and v2 wallets, and the keyless-quote-plus-marker path, the `useSeedPrefixMarker` bridge parameter, and the JS seed-prefix byte comparison are removed. Closes #4402.

Notes:
- In-flight quotes stored keyless with the marker by earlier builds still sign correctly; 0.17.4 retains the marker resolution path.
- The stored-version CAS handling in `addExternalMintQuote` stays; it addresses a separate failure mode (retrying after a dead saga claim bumped the row version).
- The db migration from 0.17.3 is additive (`legacy_quotes_migrated_v2` kv key); no ZEUS data migration is needed.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Device test checklist (both platforms):
- [ ] ZEUS Pay lightning address redemption on a v2-bip39 wallet (key now stored on the quote)
- [ ] ZEUS Pay lightning address redemption on a v1 wallet, if a v1 seed is available
- [ ] ZEUS Pay redemption of a quote created by a pre-0.17.4 build (keyless with marker) after upgrading
- [ ] Fresh wallet init with 4+ mints configured, one of them unreachable: cashu balances render without delay
- [ ] Retry a redemption after a failed mint attempt (dead saga claim, CAS version fix from #4397 still applies)
- [ ] Minibits invoice create/pay, multimint melt, restore, offline send (regression sweep from the #4397 checklist)

Build verification so far: `yarn verify` green (1149 tests), Android `compileDebugKotlin` clean against the 0.17.4 jar, iOS simulator `xcodebuild` BUILD SUCCEEDED against the 0.17.4 xcframework.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [x] Contributors will need to run `yarn` after this PR is merged in
- [x] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

_`package.json`/`yarn.lock` are untouched; the dependency change is the native CDK artifact pins in `fetch-libraries-versions.json` (plus the podspec version and `Podfile.lock`). Re-running `yarn` covers it: postinstall runs `fetch-libraries` and `pod-install`._

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
