### PR TITLE
LSPS1: refetch service info on focus after stacked instance wipes store

### DIFF
--- a/views/LSPS1/index.tsx
+++ b/views/LSPS1/index.tsx
@@ -33,6 +33,7 @@ import BackendUtils from '../../utils/BackendUtils';
 import {
     buildPaymentAwaitParams,
     isOrderFree,
+    LSPOrderState,
     LSPService
 } from '../../models/LSP';
 import { themeColor } from '../../utils/ThemeUtils';
@@ -88,25 +89,60 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
     async componentDidMount() {
         const { LSPStore, SettingsStore, navigation } = this.props;
         LSPStore.resetLSPS1Data();
+        if (
+            !BackendUtils.supportsLSPS1native() &&
+            !BackendUtils.supportsLSPS1rest() &&
+            BackendUtils.supportsLSPScustomMessage()
+        ) {
+            console.log('connecting');
+            await this.connectPeer();
+            console.log('connected');
+            await this.subscribeToCustomMessages();
+        }
+        this.fetchGetInfo();
+
+        navigation.addListener('focus', () => {
+            this.setState({
+                token: SettingsStore.settings?.lsps1Token || ''
+            });
+            // a stacked duplicate of this screen wipes the shared store
+            // when it unmounts; refetch if the service info is gone
+            if (
+                !LSPStore.loadingLSPS1 &&
+                Object.keys(LSPStore.getInfoData).length === 0
+            ) {
+                this.fetchGetInfo();
+            }
+            this.resumeFreeOrderPollingIfNeeded();
+        });
+    }
+
+    private fetchGetInfo = () => {
+        const { LSPStore } = this.props;
         if (BackendUtils.supportsLSPS1native()) {
             // Native LSPS1 - LSP is configured at node initialization
             LSPStore.lsps1GetInfoNative();
         } else if (BackendUtils.supportsLSPS1rest()) {
             LSPStore.lsps1GetInfoREST();
         } else if (BackendUtils.supportsLSPScustomMessage()) {
-            console.log('connecting');
-            await this.connectPeer();
-            console.log('connected');
-            await this.subscribeToCustomMessages();
             LSPStore.lsps1GetInfoCustomMessage();
         }
+    };
 
-        navigation.addListener('focus', () => {
-            this.setState({
-                token: SettingsStore.settings?.lsps1Token || ''
-            });
-        });
-    }
+    private resumeFreeOrderPollingIfNeeded = () => {
+        const { LSPStore } = this.props;
+        const { createOrderResponse } = LSPStore;
+        const result = createOrderResponse?.result || createOrderResponse;
+        const orderId = result?.order_id;
+        if (
+            orderId &&
+            isOrderFree(result?.payment) &&
+            result?.order_state !== LSPOrderState.COMPLETED &&
+            result?.order_state !== LSPOrderState.FAILED
+        ) {
+            LSPStore.startFreeOrderStatusPolling(orderId, LSPService.LSPS1);
+        }
+    };
     componentWillUnmount() {
         if (this.listener) {
             this.listener.remove();

--- a/views/LSPS7/index.tsx
+++ b/views/LSPS7/index.tsx
@@ -26,6 +26,7 @@ import BackendUtils from '../../utils/BackendUtils';
 import {
     buildPaymentAwaitParams,
     isOrderFree,
+    LSPOrderState,
     LSPService
 } from '../../models/LSP';
 import { themeColor } from '../../utils/ThemeUtils';
@@ -105,8 +106,28 @@ export default class LSPS7 extends React.Component<LSPS7Props, LSPS7State> {
             this.setState({
                 token: SettingsStore.settings?.lsps1Token || ''
             });
+            this.resumeFreeOrderPollingIfNeeded();
         });
     }
+
+    // visiting the LSPS1 screen (reachable via LSPS1 Settings) stops the
+    // shared free-order polling; resume it for a pending free order
+    private resumeFreeOrderPollingIfNeeded = () => {
+        const { LSPStore } = this.props;
+        const { createExtensionOrderResponse } = LSPStore;
+        const result =
+            createExtensionOrderResponse?.result ||
+            createExtensionOrderResponse;
+        const orderId = result?.order_id;
+        if (
+            orderId &&
+            isOrderFree(result?.payment) &&
+            result?.order_state !== LSPOrderState.COMPLETED &&
+            result?.order_state !== LSPOrderState.FAILED
+        ) {
+            LSPStore.startFreeOrderStatusPolling(orderId, LSPService.LSPS7);
+        }
+    };
 
     componentWillUnmount() {
         this.props.LSPStore.stopFreeOrderStatusPolling();


### PR DESCRIPTION
# Description

Fixes #4417

The LSPS1 create-order screen loses its service info after navigating LSPS1 -> Settings -> "Purchase inbound channel" (a second LSPS1 copy under react-navigation 7's push-only `navigate`) and returning. The popped duplicate's `componentWillUnmount` calls `LSPStore.resetLSPS1Data()`, wiping `getInfoData` and `createOrderResponse` out from under the original instance, which only fetched in `componentDidMount`. The Service info accordion, LSP balance slider, and Advanced settings disappear and the slider min/max labels render as `0` / `0`. Demo in the issue (found by @ajaysehwal during review of #4396; reproduces on master, predates that PR).

This implements the "refetch on focus" fix recommended in the issue:

- `views/LSPS1/index.tsx`: the getInfo dispatch (native / REST / custom message) is extracted into `fetchGetInfo()`. The existing `focus` listener now re-runs it whenever `getInfoData` is empty and no fetch is in flight. This heals the stacked-duplicate sequence and any other path that clears the store while the screen is mounted below. The custom-message transport setup (`connectPeer` + `subscribeToCustomMessages`) still happens only on mount, under the exact same conditions as before; on the heal path the original instance's peer connection and subscription are still live, so only the getInfo request needs to be re-sent.
- The unmount reset also stops the shared free-order status polling (`stopFreeOrderStatusPolling` is one slot shared by LSPS1 and LSPS7, and `resetLSPS1Data` / `clearLSPS7Order` each kill it). Per the issue's note to check LSPS7 alongside: both screens now resume polling on focus when the store holds a pending (non-terminal) free order. LSPS7 itself cannot be duplicated via the settings screen (Settings only links to LSPS1) and renders from route params, so the polling kill is its only exposure; `startFreeOrderStatusPolling` is a no-op if polling for that order is already active.

The mount-time reset and unmount reset are intentionally left in place: the unmount reset is what stops polling and clears state when the user actually leaves the flow.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I've run `yarn run tsc` and made sure my code compiles correctly
- [ ] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [ ] I've run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
