### PR TITLE
fix: show errors on Zeus Pay Plus screen

### DIFF
--- a/views/LightningAddress/ZeusPayPlus.tsx
+++ b/views/LightningAddress/ZeusPayPlus.tsx
@@ -27,6 +27,7 @@ import ZeusPayIcon from '../../assets/images/SVG/zeus-pay.svg';
 
 import ZeusPayPlusSettings from './ZeusPayPlusSettings';
 import ZeusPayPlusPerksList from './ZeusPayPlusPerksList';
+import { ErrorMessage } from '../../components/SuccessErrorMessage';
 
 interface ZeusPayPlusProps {
     navigation: NativeStackNavigationProp<any, any>;
@@ -45,7 +46,9 @@ export default class ZeusPayPlus extends React.Component<ZeusPayPlusProps, {}> {
             lightningAddressType,
             zeusPlusExpiresAt,
             zeusPlusAnnualFeeSats,
-            loading
+            loading,
+            error,
+            error_msg
         } = LightningAddressStore;
 
         const zeusPayPlus = !!zeusPlusExpiresAt;
@@ -88,6 +91,7 @@ export default class ZeusPayPlus extends React.Component<ZeusPayPlusProps, {}> {
                         navigation={navigation}
                     />
                     <View style={{ flex: 1, margin: 5 }}>
+                        {error && <ErrorMessage message={error_msg} />}
                         <Row style={{ alignSelf: 'center', marginTop: 10 }}>
                             <Text
                                 style={{


### PR DESCRIPTION
# Description

Fix error handling on the Zeus Pay Plus screen by displaying the error message returned from LightningAddressStore.
This makes payment/order creation failures visible to users instead of failing silently.
 
Example Screenshot : 

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-17 at 17 10 53" src="https://github.com/user-attachments/assets/e8e838fc-f424-453b-8005-e7e2c5d4dbd4" />


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
