### PR TITLE
views: ZeusPayPlus: route settings gear to NWC address settings

### DIFF
--- a/views/LightningAddress/ZeusPayPlus.tsx
+++ b/views/LightningAddress/ZeusPayPlus.tsx
@@ -57,6 +57,8 @@ export default class ZeusPayPlus extends React.Component<ZeusPayPlusProps, {}> {
                         navigation.navigate('LightningAddressSettings');
                     } else if (lightningAddressType === 'cashu') {
                         navigation.navigate('CashuLightningAddressSettings');
+                    } else if (lightningAddressType === 'nwc') {
+                        navigation.navigate('NWCAddressSettings');
                     }
                 }}
             >


### PR DESCRIPTION
# Description

Fixes the dead settings gear on the ZEUS Pay+ view for NWC lightning addresses, as reported by @ajaysehwal on #4419 (video repro: remote LND node with an NWC address).

The gear's press handler in `views/LightningAddress/ZeusPayPlus.tsx` predates the NWC address type: it only handles `zaplocker` and `cashu`, so for an `nwc` address the tap silently does nothing. The ZEUS Pay hub's gear (`views/LightningAddress/index.tsx`) already routes `nwc` to `NWCAddressSettings`; this adds the same branch here.

Pre-existing on master, not introduced by the #4419 stack, so filed separately. Audited the other Gear buttons in `views/`: this was the only handler missing the `nwc` branch.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding