### PR TITLE
components: sync accessibilityState of wallet rows

### DIFF
--- a/components/LayerBalances/EcashSwipeableRow.tsx
+++ b/components/LayerBalances/EcashSwipeableRow.tsx
@@ -43,8 +43,10 @@ interface EcashSwipeableRowProps {
 @observer
 export default class EcashSwipeableRow extends Component<
     EcashSwipeableRowProps,
-    {}
+    { expanded: boolean }
 > {
+    state = { expanded: false };
+
     private renderAction = (
         text: string,
         x: number,
@@ -249,6 +251,7 @@ export default class EcashSwipeableRow extends Component<
             needsConfig,
             navigation
         } = this.props;
+        const { expanded } = this.state;
 
         if (locked && lightning) {
             return (
@@ -277,6 +280,8 @@ export default class EcashSwipeableRow extends Component<
                 rightThreshold={40}
                 renderLeftActions={this.renderActions}
                 containerStyle={{ width: '100%' }}
+                onSwipeableWillOpen={() => this.setState({ expanded: true })}
+                onSwipeableWillClose={() => this.setState({ expanded: false })}
             >
                 <TouchableOpacity
                     onPress={() =>
@@ -288,6 +293,8 @@ export default class EcashSwipeableRow extends Component<
                     }
                     activeOpacity={1}
                     style={{ opacity: needsConfig ? 0.4 : 1 }}
+                    accessibilityRole="button"
+                    accessibilityState={{ expanded }}
                 >
                     {children}
                 </TouchableOpacity>

--- a/components/LayerBalances/EcashSwipeableRow.tsx
+++ b/components/LayerBalances/EcashSwipeableRow.tsx
@@ -259,6 +259,7 @@ export default class EcashSwipeableRow extends Component<
                     onPress={() => (disabled ? null : this.fetchLnInvoice())}
                     activeOpacity={1}
                     style={{ width: '100%' }}
+                    accessibilityRole="button"
                 >
                     {children}
                 </TouchableOpacity>

--- a/components/LayerBalances/EcashSwipeableRow.tsx
+++ b/components/LayerBalances/EcashSwipeableRow.tsx
@@ -296,6 +296,16 @@ export default class EcashSwipeableRow extends Component<
                     style={{ opacity: needsConfig ? 0.4 : 1 }}
                     accessibilityRole="button"
                     accessibilityState={{ expanded }}
+                    accessibilityActions={[
+                        { name: 'expand' },
+                        { name: 'collapse' }
+                    ]}
+                    onAccessibilityAction={({
+                        nativeEvent: { actionName }
+                    }) => {
+                        if (actionName === 'expand') this.open();
+                        else if (actionName === 'collapse') this.close();
+                    }}
                 >
                     {children}
                 </TouchableOpacity>

--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -378,6 +378,7 @@ export default class LightningSwipeableRow extends Component<
                             text: localeString('views.Wallet.waitForSync')
                         })
                     }
+                    accessibilityRole="button"
                 >
                     <View style={{ opacity: 0.25 }}>{children}</View>
                 </TouchableOpacity>
@@ -395,6 +396,7 @@ export default class LightningSwipeableRow extends Component<
                 <TouchableOpacity
                     onPress={() => (disabled ? null : this.fetchLnInvoice())}
                     activeOpacity={1}
+                    accessibilityRole="button"
                 >
                     {children}
                 </TouchableOpacity>

--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -49,8 +49,10 @@ interface LightningSwipeableRowProps {
 @observer
 export default class LightningSwipeableRow extends Component<
     LightningSwipeableRowProps,
-    {}
+    { expanded: boolean }
 > {
+    state = { expanded: false };
+
     private renderAction = (
         text: string,
         x: number,
@@ -366,6 +368,7 @@ export default class LightningSwipeableRow extends Component<
             lnurlParams,
             SyncStore
         } = this.props;
+        const { expanded } = this.state;
         const { isSyncing } = SyncStore!;
         if (isSyncing) {
             return (
@@ -406,6 +409,8 @@ export default class LightningSwipeableRow extends Component<
                 leftThreshold={30}
                 rightThreshold={40}
                 renderLeftActions={this.renderActions}
+                onSwipeableWillOpen={() => this.setState({ expanded: true })}
+                onSwipeableWillClose={() => this.setState({ expanded: false })}
             >
                 <TouchableOpacity
                     onPress={() =>
@@ -414,6 +419,8 @@ export default class LightningSwipeableRow extends Component<
                             : this.open()
                     }
                     activeOpacity={1}
+                    accessibilityRole="button"
+                    accessibilityState={{ expanded }}
                 >
                     {children}
                 </TouchableOpacity>

--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -423,6 +423,16 @@ export default class LightningSwipeableRow extends Component<
                     activeOpacity={1}
                     accessibilityRole="button"
                     accessibilityState={{ expanded }}
+                    accessibilityActions={[
+                        { name: 'expand' },
+                        { name: 'collapse' }
+                    ]}
+                    onAccessibilityAction={({
+                        nativeEvent: { actionName }
+                    }) => {
+                        if (actionName === 'expand') this.open();
+                        else if (actionName === 'collapse') this.close();
+                    }}
                 >
                     {children}
                 </TouchableOpacity>

--- a/components/LayerBalances/OnchainSwipeableRow.tsx
+++ b/components/LayerBalances/OnchainSwipeableRow.tsx
@@ -194,6 +194,7 @@ export default class OnchainSwipeableRow extends Component<
                         })
                     }
                     style={{ width: '100%' }}
+                    accessibilityRole="button"
                 >
                     <View style={{ opacity: 0.25 }}>{children}</View>
                 </TouchableOpacity>
@@ -205,6 +206,7 @@ export default class OnchainSwipeableRow extends Component<
                     onPress={() => (disabled ? null : this.sendToAddress())}
                     activeOpacity={1}
                     style={{ width: '100%' }}
+                    accessibilityRole="button"
                 >
                     {children}
                 </TouchableOpacity>

--- a/components/LayerBalances/OnchainSwipeableRow.tsx
+++ b/components/LayerBalances/OnchainSwipeableRow.tsx
@@ -235,6 +235,16 @@ export default class OnchainSwipeableRow extends Component<
                     activeOpacity={1}
                     accessibilityRole="button"
                     accessibilityState={{ expanded }}
+                    accessibilityActions={[
+                        { name: 'expand' },
+                        { name: 'collapse' }
+                    ]}
+                    onAccessibilityAction={({
+                        nativeEvent: { actionName }
+                    }) => {
+                        if (actionName === 'expand') this.open();
+                        else if (actionName === 'collapse') this.close();
+                    }}
                 >
                     {children}
                 </TouchableOpacity>

--- a/components/LayerBalances/OnchainSwipeableRow.tsx
+++ b/components/LayerBalances/OnchainSwipeableRow.tsx
@@ -39,8 +39,10 @@ interface OnchainSwipeableRowProps {
 @observer
 export default class OnchainSwipeableRow extends Component<
     OnchainSwipeableRowProps,
-    {}
+    { expanded: boolean }
 > {
+    state = { expanded: false };
+
     private renderAction = (
         text: string,
         x: number,
@@ -181,6 +183,7 @@ export default class OnchainSwipeableRow extends Component<
     render() {
         const { children, value, locked, hidden, disabled, SyncStore } =
             this.props;
+        const { expanded } = this.state;
         const { isSyncing } = SyncStore!;
         if (isSyncing) {
             return (
@@ -222,10 +225,14 @@ export default class OnchainSwipeableRow extends Component<
                 rightThreshold={40}
                 renderLeftActions={this.renderActions}
                 containerStyle={{ width: '100%' }}
+                onSwipeableWillOpen={() => this.setState({ expanded: true })}
+                onSwipeableWillClose={() => this.setState({ expanded: false })}
             >
                 <TouchableOpacity
                     onPress={() => (value ? this.sendToAddress() : this.open())}
                     activeOpacity={1}
+                    accessibilityRole="button"
+                    accessibilityState={{ expanded }}
                 >
                     {children}
                 </TouchableOpacity>


### PR DESCRIPTION
# Description

Relates to issue: **#1752**

The swipeable wallet rows in `LayerBalances` did not expose `accessibilityState`. A screen reader could not tell if a row was open or closed.

Each row component now keeps an `expanded` flag in component state and passes it to the row as `accessibilityState={{ expanded }}`, together with `accessibilityRole="button"`. `Accordion` already uses the same pair, so this follows a pattern that is in the repo.

The flag is driven by `onSwipeableWillOpen` and `onSwipeableWillClose`, not by `onSwipeableOpen` and `onSwipeableClose`. In `react-native-gesture-handler` 2.31.2 the second pair runs inside the spring animation callback, and only when the animation reports `finished`. If the user interrupts a swipe, that callback does not run and the state stays wrong. The `Will` callbacks always run, and they also cover the programmatic `open()` and `close()` calls used by row taps and by the action buttons.

The rows also declare `accessibilityActions` for `expand` and `collapse` and handle them. Without that, setting `expanded` makes `ReactAccessibilityDelegate` add `ACTION_EXPAND` or `ACTION_COLLAPSE` to the node, so TalkBack offers the action, but performing it only flips a view tag and dispatches nothing to JS, because `accessibilityActionsMap` is filled from declared actions only. The announced action did nothing, and the flipped tag disagreed with component state until the next swipe. This matters most for rows with a payment value, where a double tap starts the pay flow instead of opening the row.

`PaymentMethodList` passes `locked={true}` to every row, so those rows take the early-return branches and are not covered by the `expanded` work. Those branches are still tappable — they open an invoice, send to an address, or show the sync info modal — so they now carry `accessibilityRole="button"`. No `expanded` state is added there, because a locked row does not open. Branches that only return `children` or a plain `View` are left alone: they have no press handler, so a button role would be wrong.

### How this was checked

On the emulator the row is one node with `class="android.widget.Button"` and the label `Lightning, 250,000, sats`. Opening by swipe and by tap gives `expanded: true`, closing gives `expanded: false` — confirmed with a temporary log, removed before the commit. Swipe-to-open, swipe-to-close and tap-to-open still behave the same after the action wiring.

I could not perform the Expand action through TalkBack on the emulator. TalkBack was active (`dumpsys accessibility` shows the bound service, `touchExplorationEnabled=true`, `TouchExplorer` and `KeyboardInterceptor` enabled), but events injected with `adb shell input` go in below touch exploration — an injected swipe reached the app and opened the row instead of being consumed for navigation, and TalkBack's keyboard shortcuts did not open its menu either. So the inert-action claim above is from the `ReactAccessibilityDelegate` source, not from a device run.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android — Android 16 (API 36), Pixel 9 Pro AVD, x86_64 emulator
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [x] LndHub — local stub server, only to bring the wallet screen up; the change itself does not touch any backend

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
