### PR TITLE
fix(nwc): hold NWC budget for late-settling pays

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1797,6 +1797,7 @@
     "stores.NostrWalletConnectStore.error.noCashuMintSelected": "No Cashu mint selected. Please select a mint first.",
     "stores.NostrWalletConnectStore.error.failedToDecodeInvoice": "Failed to decode invoice - payReq is undefined",
     "stores.NostrWalletConnectStore.error.invoiceAlreadyPaid": "Invoice already paid",
+    "stores.NostrWalletConnectStore.error.invoicePaymentInProgress": "A payment for this invoice is still in progress",
     "stores.NostrWalletConnectStore.error.invalidPaymentRequest": "Invalid payment request",
     "stores.NostrWalletConnectStore.error.invalidAmount": "Invalid amount",
     "stores.NostrWalletConnectStore.error.invalidSignMessage": "Message must be a non-empty string",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1797,7 +1797,6 @@
     "stores.NostrWalletConnectStore.error.noCashuMintSelected": "No Cashu mint selected. Please select a mint first.",
     "stores.NostrWalletConnectStore.error.failedToDecodeInvoice": "Failed to decode invoice - payReq is undefined",
     "stores.NostrWalletConnectStore.error.invoiceAlreadyPaid": "Invoice already paid",
-    "stores.NostrWalletConnectStore.error.invoicePaymentInProgress": "A payment for this invoice is still in progress",
     "stores.NostrWalletConnectStore.error.invalidPaymentRequest": "Invalid payment request",
     "stores.NostrWalletConnectStore.error.invalidAmount": "Invalid amount",
     "stores.NostrWalletConnectStore.error.invalidSignMessage": "Message must be a non-empty string",

--- a/models/NWCConnection.test.ts
+++ b/models/NWCConnection.test.ts
@@ -6,7 +6,16 @@ jest.mock('../utils/NostrConnectUtils', () => ({
     __esModule: true,
     default: {
         getReadOnlyPermissions: () => [],
-        hasPaymentPermissions: () => false
+        hasPaymentPermissions: () => false,
+        isPaymentTimedOutMessage: (message?: string | null) => {
+            if (!message) return false;
+            const normalized = message.toLowerCase();
+            return (
+                normalized.includes('timed out') ||
+                message === 'views.SendingLightning.paymentTimedOut' ||
+                message === 'error.paymentTimedOut'
+            );
+        }
     }
 }));
 
@@ -308,5 +317,41 @@ describe('NWCConnection pay_invoice activity lookup', () => {
         expect(
             connection.findPayInvoiceActivity('lnbc1normalized', paymentHash)
         ).toBeUndefined();
+    });
+
+    it('isUnresolvedPayInvoiceActivity matches pending and timeout-failed holds', () => {
+        const connection = baseConnection();
+        const pending = {
+            id: 'lnbc1pending',
+            type: 'pay_invoice' as const,
+            payment_source: 'lightning' as const,
+            status: 'pending' as const,
+            satAmount: 100
+        };
+        const timeoutFailed = {
+            id: 'lnbc1timeout',
+            type: 'pay_invoice' as const,
+            payment_source: 'lightning' as const,
+            status: 'failed' as const,
+            satAmount: 100,
+            error: 'views.SendingLightning.paymentTimedOut'
+        };
+
+        expect(connection.isUnresolvedPayInvoiceActivity(pending)).toBe(true);
+        expect(connection.isUnresolvedPayInvoiceActivity(timeoutFailed)).toBe(
+            true
+        );
+        expect(
+            connection.isUnresolvedPayInvoiceActivity({
+                ...timeoutFailed,
+                error: 'FAILURE_REASON_NO_ROUTE'
+            })
+        ).toBe(false);
+        expect(
+            connection.isUnresolvedPayInvoiceActivity({
+                ...pending,
+                isBudgetDebited: true
+            })
+        ).toBe(false);
     });
 });

--- a/models/NWCConnection.ts
+++ b/models/NWCConnection.ts
@@ -264,6 +264,24 @@ export default class NWCConnection extends BaseModel {
         return index !== -1 ? this.activity[index] : undefined;
     }
 
+    /** Pending hold or timeout-failed row still awaiting node reconciliation. */
+    public isUnresolvedPayInvoiceActivity(
+        activity: ConnectionActivity
+    ): boolean {
+        if (
+            activity.type !== 'pay_invoice' ||
+            activity.payment_source === 'cashu' ||
+            activity.isBudgetDebited
+        ) {
+            return false;
+        }
+        return (
+            activity.status === 'pending' ||
+            (activity.status === 'failed' &&
+                NostrConnectUtils.isPaymentTimedOutMessage(activity.error))
+        );
+    }
+
     @computed public get remainingBudget(): number {
         if (!this.hasBudgetLimit) return Infinity;
         return Math.max(0, this.maxAmountSats! - this.effectiveSpendSats);

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1453,6 +1453,45 @@ describe('NostrWalletConnectStore timeout-failed pay_invoice reconcile', () => {
         expect(connection.canSpend(1)).toBe(false);
     });
 
+    it('does not promote a CLN-shaped failed sendpay to pending', async () => {
+        const store = buildPayInvoiceTestStore();
+        const invoice = 'lnbc1cln-failed-shape';
+        const paymentHash = hex64('8');
+        const failedCln = new Payment({
+            payment_request: invoice,
+            payment_hash: paymentHash,
+            status: 'failed',
+            payment_preimage:
+                '0000000000000000000000000000000000000000000000000000000000000000'
+        });
+        (store as any).paymentsStore = {
+            payments: [failedCln],
+            getPayments: jest.fn(async () => [failedCln])
+        };
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'failed',
+                    satAmount: 10000,
+                    paymentHash,
+                    error: 'views.SendingLightning.paymentTimedOut',
+                    createdAt: new Date(Date.now() - 60_000)
+                }
+            ]
+        });
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(connection.activity[0].status).toBe('failed');
+        expect(connection.pendingSpendSats).toBe(0);
+        expect(connection.canSpend(10000)).toBe(true);
+    });
+
     it('does not debit a genuine route failure that never settled', async () => {
         const store = buildPayInvoiceTestStore();
         const invoice = 'lnbc1genuine-fail';
@@ -1518,7 +1557,7 @@ describe('NostrWalletConnectStore timeout-failed pay_invoice reconcile', () => {
         await (store as any).reconcilePendingPayInvoiceActivities(connection);
 
         expect(connection.activity[0].status).toBe('failed');
-        expect(connection.activity[0].error).toBe('FAILURE_REASON_NO_ROUTE');
+        expect(connection.activity[0].error).toBe('error.failureReasonNoRoute');
         expect(
             NostrConnectUtils.isPaymentTimedOutMessage(
                 connection.activity[0].error
@@ -1695,10 +1734,8 @@ describe('NostrWalletConnectStore handleLightningPayInvoice replay guard', () =>
         );
 
         expect(transactionsStore.sendPayment).not.toHaveBeenCalled();
-        expect(response.error?.code).toBe(Nip47ErrorCode.FAILED_TO_PAY_INVOICE);
-        expect(response.error?.message).toBe(
-            'stores.NostrWalletConnectStore.error.invoicePaymentInProgress'
-        );
+        expect(response.error).toBeUndefined();
+        expect(response.result?.preimage).toBe('');
         expect(connection.activity[0].status).toBe('pending');
         expect(connection.pendingSpendSats).toBe(5000);
     });
@@ -1715,6 +1752,7 @@ describe('NostrWalletConnectStore handleLightningPayInvoice replay guard', () =>
         });
         paymentsStore.payments = [settled];
         paymentsStore.getPayments = jest.fn().mockResolvedValue([settled]);
+        transactionsStore.payment_hash = paymentHash;
         transactionsStore.payment_error =
             'views.SendingLightning.paymentTimedOut';
         transactionsStore.loading = false;

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -645,6 +645,35 @@ describe('NostrWalletConnectStore pay_invoice activity upsert', () => {
         ).not.toHaveBeenCalled();
         expect(connection.activity[0].status).toBe('success');
     });
+
+    it('upsertPayInvoiceActivity never demotes pending to failed', () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store, {
+            activity: [
+                {
+                    id: normalizedInvoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'pending',
+                    satAmount: 100,
+                    paymentHash
+                }
+            ]
+        });
+
+        const applied = (store as any).upsertPayInvoiceActivity(connection, {
+            id: normalizedInvoice,
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'failed',
+            satAmount: 100,
+            error: 'payment is in transition'
+        });
+
+        expect(applied).toBe(false);
+        expect(connection.activity[0].status).toBe('pending');
+        expect(connection.pendingSpendSats).toBe(100);
+    });
 });
 
 describe('NostrWalletConnectStore connection data scoping', () => {
@@ -1435,6 +1464,262 @@ describe('NostrWalletConnectStore timeout-failed pay_invoice reconcile', () => {
         expect(connection.activity[0].status).toBe('failed');
         expect(connection.totalSpendSats).toBe(0);
         expect(connection.canSpend(10000)).toBe(true);
+    });
+
+    it('overwrites the timeout error once the node confirms failure', async () => {
+        const store = buildPayInvoiceTestStore();
+        const invoice = 'lnbc1timeout-confirmed-fail';
+        const paymentHash = hex64('a');
+        const failed = new Payment({
+            payment_request: invoice,
+            payment_hash: paymentHash,
+            status: 'FAILED',
+            failure_reason: 'FAILURE_REASON_NO_ROUTE',
+            value_sat: 10000
+        });
+        (store as any).paymentsStore = {
+            payments: [failed],
+            getPayments: jest.fn(async () => [failed])
+        };
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'failed',
+                    satAmount: 10000,
+                    paymentHash,
+                    error: 'views.SendingLightning.paymentTimedOut',
+                    createdAt: new Date(Date.now() - 60_000)
+                }
+            ]
+        });
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(connection.activity[0].status).toBe('failed');
+        expect(connection.activity[0].error).toBe('FAILURE_REASON_NO_ROUTE');
+        expect(
+            NostrConnectUtils.isPaymentTimedOutMessage(
+                connection.activity[0].error
+            )
+        ).toBe(false);
+    });
+
+    it('does not churn on idempotent reconcile of node-confirmed failure', async () => {
+        const store = buildPayInvoiceTestStore();
+        const invoice = 'lnbc1timeout-churn';
+        const paymentHash = hex64('b');
+        const failed = new Payment({
+            payment_request: invoice,
+            payment_hash: paymentHash,
+            status: 'FAILED',
+            failure_reason: 'FAILURE_REASON_NO_ROUTE',
+            value_sat: 10000
+        });
+        (store as any).paymentsStore = {
+            payments: [failed],
+            getPayments: jest.fn(async () => [failed])
+        };
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'failed',
+                    satAmount: 10000,
+                    paymentHash,
+                    error: 'views.SendingLightning.paymentTimedOut',
+                    createdAt: new Date(Date.now() - 60_000)
+                }
+            ]
+        });
+        const findAndUpdateConnection = jest.spyOn(
+            store as any,
+            'findAndUpdateConnection'
+        );
+        const scheduleMaxBudgetRefresh = jest.spyOn(
+            store as any,
+            'scheduleMaxBudgetRefresh'
+        );
+
+        const first = await (store as any).reconcilePendingPayInvoiceActivities(
+            connection
+        );
+        const second = await (
+            store as any
+        ).reconcilePendingPayInvoiceActivities(connection);
+        const third = await (store as any).reconcilePendingPayInvoiceActivities(
+            connection
+        );
+
+        expect(first).toBe(true);
+        expect(second).toBe(false);
+        expect(third).toBe(false);
+        expect(findAndUpdateConnection).toHaveBeenCalledTimes(1);
+        expect(scheduleMaxBudgetRefresh).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('NostrWalletConnectStore handleLightningPayInvoice replay guard', () => {
+    const invoice = 'lnbc1replay-guard';
+    const paymentHash = hex64('c');
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (BackendUtils as any).decodePaymentRequest = jest
+            .fn()
+            .mockResolvedValue({
+                timestamp: String(Math.floor(Date.now() / 1000) - 60),
+                expiry: '3600'
+            });
+        jest.spyOn(NostrConnectUtils, 'decodeInvoiceTags').mockResolvedValue({
+            paymentRequest: invoice,
+            paymentHash,
+            descriptionHash: '',
+            description: '',
+            amount: 5000,
+            expiryTime: 0,
+            createdAt: 0,
+            isExpired: false,
+            network: 'bitcoin'
+        });
+        jest.spyOn(
+            NostrConnectUtils,
+            'getPayInvoiceAmountSats'
+        ).mockResolvedValue(5000);
+    });
+
+    function buildHandlerStore() {
+        const transactionsStore: any = {
+            reset: jest.fn(),
+            sendPayment: jest.fn(),
+            payment_hash: null,
+            payment_preimage: null,
+            payment_fee: 0,
+            status: null,
+            isIncomplete: null,
+            error: false,
+            payment_error: null,
+            loading: false
+        };
+        const balanceStore = {
+            getLightningBalance: jest
+                .fn()
+                .mockResolvedValue({ lightningBalance: 100000 })
+        };
+        const paymentsStore: any = {
+            payments: [],
+            getPayments: jest.fn().mockResolvedValue([])
+        };
+        const settingsStore: any = {
+            connecting: false,
+            implementation: 'lnd',
+            settings: {
+                locale: 'en',
+                ecash: { enableCashu: false },
+                lightningAddress: { enabled: false }
+            }
+        };
+        const store = new NostrWalletConnectStore(
+            settingsStore,
+            balanceStore as any,
+            {
+                nodeInfo: { nodeId: NODE_PUBKEY },
+                getNodeInfo: jest.fn()
+            } as any,
+            transactionsStore as any,
+            {} as any,
+            { invoices: [] } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            paymentsStore as any
+        );
+        jest.spyOn(store as any, 'findAndUpdateConnection').mockImplementation(
+            () => undefined
+        );
+        jest.spyOn(store as any, 'scheduleMaxBudgetRefresh').mockImplementation(
+            () => undefined
+        );
+        jest.spyOn(store as any, 'waitForPaymentCompletion').mockResolvedValue(
+            undefined
+        );
+        return { store, transactionsStore, paymentsStore };
+    }
+
+    it('refuses to replay pay_invoice while a pending hold exists', async () => {
+        const { store, transactionsStore } = buildHandlerStore();
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 100000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'pending',
+                    satAmount: 5000,
+                    paymentHash,
+                    createdAt: new Date(Date.now() - 60_000)
+                }
+            ]
+        });
+
+        const response = await (store as any).handleLightningPayInvoice(
+            connection,
+            { invoice }
+        );
+
+        expect(transactionsStore.sendPayment).not.toHaveBeenCalled();
+        expect(response.error?.code).toBe(Nip47ErrorCode.FAILED_TO_PAY_INVOICE);
+        expect(response.error?.message).toBe(
+            'stores.NostrWalletConnectStore.error.invoicePaymentInProgress'
+        );
+        expect(connection.activity[0].status).toBe('pending');
+        expect(connection.pendingSpendSats).toBe(5000);
+    });
+
+    it('finalizes and debits when the store errors but the node lists settlement', async () => {
+        const { store, transactionsStore, paymentsStore } = buildHandlerStore();
+        const settled = new Payment({
+            payment_request: invoice,
+            payment_hash: paymentHash,
+            status: 'SUCCEEDED',
+            value_sat: 5000,
+            fee_sat: '10',
+            payment_preimage: hex64('d')
+        });
+        paymentsStore.payments = [settled];
+        paymentsStore.getPayments = jest.fn().mockResolvedValue([settled]);
+        transactionsStore.payment_error =
+            'views.SendingLightning.paymentTimedOut';
+        transactionsStore.loading = false;
+        transactionsStore.status = 'FAILED';
+        transactionsStore.isIncomplete = true;
+
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 100000,
+            totalSpendSats: 0
+        });
+
+        const response = await (store as any).handleLightningPayInvoice(
+            connection,
+            { invoice }
+        );
+
+        expect(transactionsStore.sendPayment).toHaveBeenCalled();
+        expect(response.error).toBeUndefined();
+        expect(response.result?.preimage).toBe(hex64('d'));
+        expect(connection.activity[0].status).toBe('success');
+        expect(connection.activity[0].isBudgetDebited).toBe(true);
+        expect(connection.totalSpendSats).toBe(5010);
     });
 });
 

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -674,6 +674,23 @@ describe('NostrWalletConnectStore pay_invoice activity upsert', () => {
         expect(connection.activity[0].status).toBe('pending');
         expect(connection.pendingSpendSats).toBe(100);
     });
+
+    it('recordFailedPayment stores timeout errors as locale keys', async () => {
+        const store = buildPayInvoiceTestStore();
+        const connection = seedPayInvoiceConnection(store);
+
+        await (store as any).recordFailedPayment({
+            rawInvoice: normalizedInvoice,
+            connection,
+            amountSats: 100,
+            payment_source: 'lightning',
+            errorMessage: 'payment timed out waiting for preimage'
+        });
+
+        expect(connection.activity[0].error).toBe(
+            'views.SendingLightning.paymentTimedOut'
+        );
+    });
 });
 
 describe('NostrWalletConnectStore connection data scoping', () => {

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -60,6 +60,7 @@ import Storage from '../storage';
 import BackendUtils from '../utils/BackendUtils';
 import NWCConnection, { BudgetRenewalType } from '../models/NWCConnection';
 import Invoice from '../models/Invoice';
+import Payment from '../models/Payment';
 import Base64Utils from '../utils/Base64Utils';
 import NostrConnectUtils, { Nip47ErrorCode } from '../utils/NostrConnectUtils';
 import NostrWalletConnectStore, {
@@ -1315,6 +1316,125 @@ describe('NostrWalletConnectStore activity prune', () => {
         expect((store as any).checkMakeInvoiceLimits(connection)).toBeNull();
         (store as any).pruneConnectionActivity(connection);
         expect(connection.activity.length).toBeLessThanOrEqual(100);
+    });
+});
+
+describe('NostrWalletConnectStore timeout-failed pay_invoice reconcile', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('debits a timeout-failed pay_invoice once the node later shows settlement', async () => {
+        const store = buildPayInvoiceTestStore();
+        const invoice = 'lnbc1timeout-missed-debit';
+        const paymentHash = hex64('e');
+        const settled = new Payment({
+            payment_request: invoice,
+            payment_hash: paymentHash,
+            status: 'SUCCEEDED',
+            value_sat: 10000,
+            fee_sat: '50',
+            payment_preimage: hex64('9')
+        });
+        (store as any).paymentsStore = {
+            payments: [settled],
+            getPayments: jest.fn(async () => [settled])
+        };
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'failed',
+                    satAmount: 10000,
+                    paymentHash,
+                    error: 'views.SendingLightning.paymentTimedOut',
+                    createdAt: new Date(Date.now() - 60_000)
+                }
+            ]
+        });
+
+        expect(connection.canSpend(10000)).toBe(true);
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(connection.activity[0].status).toBe('success');
+        expect(connection.activity[0].isBudgetDebited).toBe(true);
+        expect(connection.totalSpendSats).toBe(10050);
+        expect(connection.canSpend(1)).toBe(false);
+    });
+
+    it('promotes a timeout-failed pay_invoice to pending when the node still shows in-flight', async () => {
+        const store = buildPayInvoiceTestStore();
+        const invoice = 'lnbc1timeout-still-inflight';
+        const paymentHash = hex64('f');
+        const inFlight = new Payment({
+            payment_request: invoice,
+            payment_hash: paymentHash,
+            status: 'IN_FLIGHT',
+            payment_preimage:
+                '0000000000000000000000000000000000000000000000000000000000000000'
+        });
+        (store as any).paymentsStore = {
+            payments: [inFlight],
+            getPayments: jest.fn(async () => [inFlight])
+        };
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'failed',
+                    satAmount: 10000,
+                    paymentHash,
+                    error: 'views.SendingLightning.paymentTimedOut',
+                    createdAt: new Date(Date.now() - 60_000)
+                }
+            ]
+        });
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(connection.activity[0].status).toBe('pending');
+        expect(connection.pendingSpendSats).toBe(10000);
+        expect(connection.totalSpendSats).toBe(0);
+        expect(connection.canSpend(1)).toBe(false);
+    });
+
+    it('does not debit a genuine route failure that never settled', async () => {
+        const store = buildPayInvoiceTestStore();
+        const invoice = 'lnbc1genuine-fail';
+        (store as any).paymentsStore = {
+            payments: [],
+            getPayments: jest.fn(async () => [])
+        };
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'failed',
+                    satAmount: 10000,
+                    error: 'route not found',
+                    createdAt: new Date(Date.now() - 60_000)
+                }
+            ]
+        });
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(connection.activity[0].status).toBe('failed');
+        expect(connection.totalSpendSats).toBe(0);
+        expect(connection.canSpend(10000)).toBe(true);
     });
 });
 

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1660,6 +1660,100 @@ describe('NostrWalletConnectStore timeout-failed pay_invoice reconcile', () => {
         expect(scheduleMaxBudgetRefresh).toHaveBeenCalledTimes(1);
     });
 
+    it('debits a stale hold when the node lists settlement instead of abandoning', async () => {
+        const store = buildPayInvoiceTestStore();
+        const invoice = 'lnbc1stale-settled-probe';
+        const paymentHash = hex64('1');
+        const staleCreatedAt = new Date(
+            Date.now() -
+                NostrConnectUtils.UNRESOLVED_PAY_INVOICE_MAX_AGE_MS -
+                1000
+        );
+        const settled = new Payment({
+            payment_request: invoice,
+            payment_hash: paymentHash,
+            status: 'SUCCEEDED',
+            value_sat: 10000,
+            fee_sat: '50',
+            payment_preimage: hex64('2')
+        });
+        (store as any).paymentsStore = {
+            payments: [settled],
+            getPayments: jest.fn(async () => [settled])
+        };
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'failed',
+                    satAmount: 10000,
+                    paymentHash,
+                    error: 'views.SendingLightning.paymentTimedOut',
+                    createdAt: staleCreatedAt
+                }
+            ]
+        });
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(connection.activity[0].status).toBe('success');
+        expect(connection.activity[0].isBudgetDebited).toBe(true);
+        expect(connection.totalSpendSats).toBe(10050);
+        expect(connection.activity[0].error).toBeUndefined();
+    });
+
+    it('keeps a stale hold when the node still lists the payment in-flight', async () => {
+        const store = buildPayInvoiceTestStore();
+        const invoice = 'lnbc1stale-inflight-probe';
+        const paymentHash = hex64('3');
+        const staleCreatedAt = new Date(
+            Date.now() -
+                NostrConnectUtils.UNRESOLVED_PAY_INVOICE_MAX_AGE_MS -
+                1000
+        );
+        const inFlight = new Payment({
+            payment_request: invoice,
+            payment_hash: paymentHash,
+            status: 'IN_FLIGHT',
+            payment_preimage:
+                '0000000000000000000000000000000000000000000000000000000000000000'
+        });
+        (store as any).paymentsStore = {
+            payments: [inFlight],
+            getPayments: jest.fn(async () => [inFlight])
+        };
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'failed',
+                    satAmount: 10000,
+                    paymentHash,
+                    error: 'views.SendingLightning.paymentTimedOut',
+                    createdAt: staleCreatedAt
+                }
+            ]
+        });
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(connection.activity[0].status).toBe('pending');
+        expect(
+            connection.isUnresolvedPayInvoiceActivity(connection.activity[0])
+        ).toBe(true);
+        expect(connection.activity[0].error).toBeUndefined();
+        expect(connection.pendingSpendSats).toBe(10000);
+        expect(connection.totalSpendSats).toBe(0);
+    });
+
     it('abandons a permanent pending hold when the node never lists the payment', async () => {
         const store = buildPayInvoiceTestStore();
         const invoice = 'lnbc1permanent-pending-hold';

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1288,7 +1288,7 @@ describe('NostrWalletConnectStore activity prune', () => {
         jest.clearAllMocks();
     });
 
-    it('never prunes pending pay_invoice entries when trimming the activity log', () => {
+    it('never prunes unresolved pay_invoice entries when trimming the activity log', () => {
         const store = buildPayInvoiceTestStore();
         const oldest = new Date('2024-01-01T00:00:00Z');
         const activity = [
@@ -1327,6 +1327,44 @@ describe('NostrWalletConnectStore activity prune', () => {
             connection.activity.find((a) => a.id === 'lnbc-make-0')
         ).toBeUndefined();
         expect(connection.pendingSpendSats).toBe(1000);
+    });
+
+    it('never prunes timeout-failed pay_invoice entries awaiting reconcile', () => {
+        const store = buildPayInvoiceTestStore();
+        const oldest = new Date('2024-01-01T00:00:00Z');
+        const activity = [
+            {
+                id: 'lnbc-timeout-failed-pay',
+                type: 'pay_invoice' as const,
+                payment_source: 'lightning' as const,
+                status: 'failed' as const,
+                satAmount: 1000,
+                error: 'views.SendingLightning.paymentTimedOut',
+                createdAt: oldest
+            },
+            ...Array.from({ length: 99 }, (_, i) => ({
+                id: `lnbc-make-${i}`,
+                type: 'make_invoice' as const,
+                payment_source: 'lightning' as const,
+                status: 'success' as const,
+                createdAt: new Date(oldest.getTime() + (i + 1) * 1000)
+            }))
+        ];
+        const connection = seedPayInvoiceConnection(store, { activity });
+        connection.activity.push({
+            id: 'lnbc-make-new',
+            type: 'make_invoice',
+            payment_source: 'lightning',
+            status: 'success',
+            createdAt: new Date('2024-06-01T00:00:00Z')
+        });
+
+        (store as any).pruneConnectionActivity(connection);
+
+        expect(connection.activity).toHaveLength(100);
+        expect(
+            connection.activity.find((a) => a.id === 'lnbc-timeout-failed-pay')
+        ).toBeDefined();
     });
 
     it('stops pruning when every activity entry is still pending', () => {

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1659,6 +1659,118 @@ describe('NostrWalletConnectStore timeout-failed pay_invoice reconcile', () => {
         expect(findAndUpdateConnection).toHaveBeenCalledTimes(1);
         expect(scheduleMaxBudgetRefresh).toHaveBeenCalledTimes(1);
     });
+
+    it('abandons a permanent pending hold when the node never lists the payment', async () => {
+        const store = buildPayInvoiceTestStore();
+        const invoice = 'lnbc1permanent-pending-hold';
+        const staleCreatedAt = new Date(
+            Date.now() -
+                NostrConnectUtils.UNRESOLVED_PAY_INVOICE_MAX_AGE_MS -
+                1000
+        );
+        (store as any).paymentsStore = {
+            payments: [],
+            getPayments: jest.fn(async () => [])
+        };
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'pending',
+                    satAmount: 10000,
+                    createdAt: staleCreatedAt
+                }
+            ]
+        });
+
+        expect(connection.pendingSpendSats).toBe(10000);
+        expect(
+            connection.isUnresolvedPayInvoiceActivity(connection.activity[0])
+        ).toBe(true);
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(connection.activity[0].status).toBe('failed');
+        expect(connection.activity[0].error).toBe('error.paymentFailed');
+        expect(
+            connection.isUnresolvedPayInvoiceActivity(connection.activity[0])
+        ).toBe(false);
+        expect(connection.pendingSpendSats).toBe(0);
+        expect(connection.canSpend(10000)).toBe(true);
+    });
+
+    it('abandons a permanent timeout-failed hold when the node never lists the payment', async () => {
+        const store = buildPayInvoiceTestStore();
+        const invoice = 'lnbc1permanent-timeout-hold';
+        const staleCreatedAt = new Date(
+            Date.now() -
+                NostrConnectUtils.UNRESOLVED_PAY_INVOICE_MAX_AGE_MS -
+                1000
+        );
+        (store as any).paymentsStore = {
+            payments: [],
+            getPayments: jest.fn(async () => [])
+        };
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'failed',
+                    satAmount: 10000,
+                    error: 'views.SendingLightning.paymentTimedOut',
+                    createdAt: staleCreatedAt
+                }
+            ]
+        });
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(connection.activity[0].status).toBe('failed');
+        expect(connection.activity[0].error).toBe('error.paymentFailed');
+        expect(
+            connection.isUnresolvedPayInvoiceActivity(connection.activity[0])
+        ).toBe(false);
+        expect(connection.canSpend(10000)).toBe(true);
+    });
+
+    it('does not abandon a recent unresolved hold with no node listing', async () => {
+        const store = buildPayInvoiceTestStore();
+        const invoice = 'lnbc1recent-hold';
+        (store as any).paymentsStore = {
+            payments: [],
+            getPayments: jest.fn(async () => [])
+        };
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'pending',
+                    satAmount: 10000,
+                    createdAt: new Date(Date.now() - 60_000)
+                }
+            ]
+        });
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(connection.activity[0].status).toBe('pending');
+        expect(
+            connection.isUnresolvedPayInvoiceActivity(connection.activity[0])
+        ).toBe(true);
+        expect(connection.pendingSpendSats).toBe(10000);
+    });
 });
 
 describe('NostrWalletConnectStore handleLightningPayInvoice replay guard', () => {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2382,6 +2382,9 @@ export default class NostrWalletConnectStore {
                 paymentHash
             );
 
+        // Deliberate: debit when the node shows this invoice settled even if
+        // Zeus did not initiate the pay via this NWC connection. Without that,
+        // a wallet-paid invoice retried over NWC would escape the budget cap.
         const settledEvidence =
             !!preimage ||
             (!!payment && NostrConnectUtils.isSettledPayment(payment));
@@ -2730,26 +2733,48 @@ export default class NostrWalletConnectStore {
     private async reconcilePendingPayInvoiceActivities(
         connection: NWCConnection
     ): Promise<boolean> {
+        let changed = false;
+
         const pending = connection.activity.filter((a) =>
             connection.isUnresolvedPayInvoiceActivity(a)
         );
         if (pending.length === 0) return false;
 
+        for (const activity of pending) {
+            if (this.abandonStaleUnresolvedPayInvoiceHold(activity)) {
+                changed = true;
+            }
+        }
+
+        const stillUnresolved = connection.activity.filter((a) =>
+            connection.isUnresolvedPayInvoiceActivity(a)
+        );
+        if (stillUnresolved.length === 0) {
+            if (changed) {
+                this.scheduleMaxBudgetRefresh();
+                this.findAndUpdateConnection(connection);
+            }
+            return changed;
+        }
+
         const payments = await this.getPaymentsForPendingPayInvoiceRefresh(
             connection.id,
-            pending
+            stillUnresolved
         );
 
-        let changed = false;
-
-        for (const activity of pending) {
+        for (const activity of stillUnresolved) {
             const payment = payments.find(
                 (p) =>
                     p.getPaymentRequest === activity.id ||
                     (!!activity.paymentHash &&
                         p.paymentHash === activity.paymentHash)
             );
-            if (!payment) continue;
+            if (!payment) {
+                if (this.abandonStaleUnresolvedPayInvoiceHold(activity)) {
+                    changed = true;
+                }
+                continue;
+            }
 
             runInAction(() => {
                 if (
@@ -2765,6 +2790,25 @@ export default class NostrWalletConnectStore {
             this.findAndUpdateConnection(connection);
         }
         return changed;
+    }
+
+    /**
+     * Release a hold the node will never list. Non-timeout error exits reconcile
+     * and prune protection so budget and replay recover without deleting the
+     * connection.
+     */
+    private abandonStaleUnresolvedPayInvoiceHold(
+        activity: ConnectionActivity
+    ): boolean {
+        if (!NostrConnectUtils.isPayInvoiceHoldAbandoned(activity)) {
+            return false;
+        }
+
+        runInAction(() => {
+            activity.status = 'failed';
+            activity.error = 'error.paymentFailed';
+        });
+        return true;
     }
 
     private applyPayInvoiceReconcile(

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1806,16 +1806,20 @@ export default class NostrWalletConnectStore {
             let oldestTime = Infinity;
             for (let i = 0; i < connection.activity.length; i++) {
                 const activity = connection.activity[i];
-                // Pending pay_invoice holds budget via pendingSpendSats until
-                // reconcilePendingPayInvoiceActivities settles it. Active pending
-                // make_invoice must stay for the outstanding cap. Expired or
-                // already-paid pending make_invoice is prunable: those entries are
-                // only reconciled from user-driven paths, so a make_invoice-only
-                // client would otherwise grow activity without bound.
+                // Unresolved pay_invoice (pending or timeout-failed) must survive
+                // until reconcilePendingPayInvoiceActivities can debit. Active
+                // pending make_invoice must stay for the outstanding cap.
+                if (
+                    activity.type === 'pay_invoice' &&
+                    activity.payment_source !== 'cashu' &&
+                    connection.isUnresolvedPayInvoiceActivity(activity)
+                ) {
+                    continue;
+                }
                 if (
                     activity.status === 'pending' &&
-                    (activity.type !== 'make_invoice' ||
-                        this.isActivePendingMakeInvoice(activity))
+                    activity.type === 'make_invoice' &&
+                    this.isActivePendingMakeInvoice(activity)
                 ) {
                     continue;
                 }
@@ -2066,8 +2070,8 @@ export default class NostrWalletConnectStore {
     ): Promise<boolean> {
         if (
             activity.type === 'pay_invoice' &&
-            activity.status === 'pending' &&
-            activity.payment_source !== 'cashu'
+            activity.payment_source !== 'cashu' &&
+            connection.isUnresolvedPayInvoiceActivity(activity)
         ) {
             return this.reconcilePendingPayInvoiceActivities(connection);
         }
@@ -2380,9 +2384,7 @@ export default class NostrWalletConnectStore {
 
         const settledEvidence =
             !!preimage ||
-            (!!payment &&
-                NostrConnectUtils.isSettledPayment(payment) &&
-                !!paymentHash);
+            (!!payment && NostrConnectUtils.isSettledPayment(payment));
 
         if (!settledEvidence) {
             const paymentError = this.checkPaymentErrors(

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2270,7 +2270,11 @@ export default class NostrWalletConnectStore {
         // Late-settling pays can be recorded failed when the 125s wait
         // expires; debit them before enforcing budget so a replay cannot
         // spend the same sats twice.
-        await this.reconcilePendingPayInvoiceActivities(connection);
+        try {
+            await this.reconcilePendingPayInvoiceActivities(connection);
+        } catch (error) {
+            console.error('NWC: pay_invoice reconcile failed:', error);
+        }
 
         const { paymentRequest, paymentHash: decodedPaymentHash } =
             await NostrConnectUtils.decodeInvoiceTags(request.invoice);
@@ -2279,12 +2283,16 @@ export default class NostrWalletConnectStore {
             decodedPaymentHash
         );
         if (existing && connection.isUnresolvedPayInvoiceActivity(existing)) {
-            return NostrConnectUtils.createNip47Error(
-                localeString(
-                    'stores.NostrWalletConnectStore.error.invoicePaymentInProgress'
-                ),
-                Nip47ErrorCode.FAILED_TO_PAY_INVOICE
-            );
+            const fees_paid =
+                existing.fees_paid || existing.payment?.getFee || 0;
+
+            return {
+                result: {
+                    preimage: '',
+                    fees_paid: satsToMillisats(Number(fees_paid) || 0)
+                },
+                error: undefined
+            };
         }
 
         const budgetCheck = this.validateBudgetBeforePayment(
@@ -2372,7 +2380,9 @@ export default class NostrWalletConnectStore {
 
         const settledEvidence =
             !!preimage ||
-            (!!payment && NostrConnectUtils.isSettledPayment(payment));
+            (!!payment &&
+                NostrConnectUtils.isSettledPayment(payment) &&
+                !!paymentHash);
 
         if (!settledEvidence) {
             const paymentError = this.checkPaymentErrors(
@@ -2778,20 +2788,15 @@ export default class NostrWalletConnectStore {
             paymentStatus: activity.payment?.status
         };
 
-        if (raw.isFailed) {
-            // CLN listpays does not populate failure_reason/htlcs, so
-            // Payment.isFailed may stay false for genuine CLN failures;
-            // those rows remain in the reconcile filter until expiry.
+        if (NostrConnectUtils.isListedPaymentFailed(raw)) {
             activity.status = 'failed';
-            activity.error =
-                listed.failure_reason &&
-                String(listed.failure_reason) !== 'FAILURE_REASON_NONE'
-                    ? String(listed.failure_reason)
-                    : localeString('error.paymentFailed');
-        } else if (raw.isIncomplete) {
+            activity.error = NostrConnectUtils.paymentFailureReasonLocaleKey(
+                listed.failure_reason
+            );
+        } else if (NostrConnectUtils.isListedPaymentInTransit(raw)) {
             activity.status = 'pending';
             activity.error = undefined;
-        } else {
+        } else if (!raw.isIncomplete) {
             activity.status = 'success';
             activity.error = undefined;
             const amountSats =
@@ -2805,6 +2810,8 @@ export default class NostrWalletConnectStore {
                 connection.trackSpending(spendSats, this.maxBudgetLimit);
                 activity.isBudgetDebited = true;
             }
+        } else {
+            return false;
         }
 
         activity.payment = listed;

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1809,6 +1809,8 @@ export default class NostrWalletConnectStore {
                 // Unresolved pay_invoice (pending or timeout-failed) must survive
                 // until reconcilePendingPayInvoiceActivities can debit. Active
                 // pending make_invoice must stay for the outstanding cap.
+                // Cashu pay_invoice is excluded: melt never records pending today;
+                // extend this guard if that changes (pendingSpendSats counts it too).
                 if (
                     activity.type === 'pay_invoice' &&
                     activity.payment_source !== 'cashu' &&

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2267,6 +2267,11 @@ export default class NostrWalletConnectStore {
             }
         }
 
+        // Late-settling pays can be recorded failed when the 125s wait
+        // expires; debit them before enforcing budget so a replay cannot
+        // spend the same sats twice.
+        await this.reconcilePendingPayInvoiceActivities(connection);
+
         const budgetCheck = this.validateBudgetBeforePayment(
             connection,
             amountSats,
@@ -2339,28 +2344,6 @@ export default class NostrWalletConnectStore {
             };
         }
 
-        const paymentError = this.checkPaymentErrors(
-            Nip47ErrorCode.FAILED_TO_PAY_INVOICE,
-            localeString('views.SendingLightning.paymentTimedOut'),
-            localeString(
-                'stores.NostrWalletConnectStore.error.noPreimageReceived'
-            )
-        );
-        if (
-            paymentError &&
-            paymentError.error &&
-            paymentError.error.code === Nip47ErrorCode.FAILED_TO_PAY_INVOICE
-        ) {
-            await this.recordFailedPayment({
-                rawInvoice: request.invoice,
-                connection,
-                amountSats,
-                payment_source: 'lightning',
-                errorMessage: paymentError.error?.message
-            });
-            return paymentError;
-        }
-
         const preimage = this.transactionsStore.payment_preimage;
         const fees_paid = this.transactionsStore.payment_fee;
 
@@ -2371,6 +2354,34 @@ export default class NostrWalletConnectStore {
                 payments,
                 paymentHash
             );
+
+        const settledEvidence =
+            !!preimage ||
+            (!!payment && NostrConnectUtils.isSettledPayment(payment));
+
+        if (!settledEvidence) {
+            const paymentError = this.checkPaymentErrors(
+                Nip47ErrorCode.FAILED_TO_PAY_INVOICE,
+                localeString('views.SendingLightning.paymentTimedOut'),
+                localeString(
+                    'stores.NostrWalletConnectStore.error.noPreimageReceived'
+                )
+            );
+            if (
+                paymentError &&
+                paymentError.error &&
+                paymentError.error.code === Nip47ErrorCode.FAILED_TO_PAY_INVOICE
+            ) {
+                await this.recordFailedPayment({
+                    rawInvoice: request.invoice,
+                    connection,
+                    amountSats,
+                    payment_source: 'lightning',
+                    errorMessage: paymentError.error?.message
+                });
+                return paymentError;
+            }
+        }
 
         const feeSats = Number(payment?.getFee) || Number(fees_paid) || 0;
 
@@ -2683,10 +2694,11 @@ export default class NostrWalletConnectStore {
     }
 
     /**
-     * Promotes pending pay_invoice activities that have since settled or failed.
-     * Used by the activity screen and by list_transactions — without the latter,
-     * an NWC client sees a settled payment as pending until someone opens the
-     * screen. Node fetches are rate limited by the helper below.
+     * Promotes pending (and timeout-failed) pay_invoice activities that have
+     * since settled or failed. Used by the activity screen, list_transactions,
+     * and pay_invoice budget checks. A payment recorded failed after the store
+     * wait can still settle; without this, that spend never hits the budget.
+     * Node fetches are rate limited by the helper below.
      */
     private async reconcilePendingPayInvoiceActivities(
         connection: NWCConnection
@@ -2694,8 +2706,11 @@ export default class NostrWalletConnectStore {
         const pending = connection.activity.filter(
             (a) =>
                 a.type === 'pay_invoice' &&
-                a.status === 'pending' &&
-                a.payment_source !== 'cashu'
+                a.payment_source !== 'cashu' &&
+                !a.isBudgetDebited &&
+                (a.status === 'pending' ||
+                    (a.status === 'failed' &&
+                        NostrConnectUtils.isPaymentTimedOutMessage(a.error)))
         );
         if (pending.length === 0) return false;
 
@@ -2716,7 +2731,13 @@ export default class NostrWalletConnectStore {
             if (!payment) continue;
 
             runInAction(() => {
-                if (activity.status !== 'pending') return;
+                if (activity.isBudgetDebited) return;
+                if (
+                    activity.status !== 'pending' &&
+                    activity.status !== 'failed'
+                ) {
+                    return;
+                }
 
                 activity.payment = new Payment(payment);
                 changed = true;
@@ -2725,9 +2746,14 @@ export default class NostrWalletConnectStore {
                     activity.status = 'failed';
                     return;
                 }
-                if (payment.isIncomplete) return;
+                if (payment.isIncomplete) {
+                    activity.status = 'pending';
+                    activity.error = undefined;
+                    return;
+                }
 
                 activity.status = 'success';
+                activity.error = undefined;
                 const amountSats =
                     Math.floor(Number(activity.satAmount)) ||
                     Math.floor(Number(payment.getAmount) || 0);

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2742,29 +2742,12 @@ export default class NostrWalletConnectStore {
         );
         if (pending.length === 0) return false;
 
-        for (const activity of pending) {
-            if (this.abandonStaleUnresolvedPayInvoiceHold(activity)) {
-                changed = true;
-            }
-        }
-
-        const stillUnresolved = connection.activity.filter((a) =>
-            connection.isUnresolvedPayInvoiceActivity(a)
-        );
-        if (stillUnresolved.length === 0) {
-            if (changed) {
-                this.scheduleMaxBudgetRefresh();
-                this.findAndUpdateConnection(connection);
-            }
-            return changed;
-        }
-
         const payments = await this.getPaymentsForPendingPayInvoiceRefresh(
             connection.id,
-            stillUnresolved
+            pending
         );
 
-        for (const activity of stillUnresolved) {
+        for (const activity of pending) {
             const payment = payments.find(
                 (p) =>
                     p.getPaymentRequest === activity.id ||

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -3201,7 +3201,9 @@ export default class NostrWalletConnectStore {
                 satAmount: amountSats,
                 status: 'failed',
                 payment_source,
-                error: errorMessage,
+                error: NostrConnectUtils.isPaymentTimedOutMessage(errorMessage)
+                    ? 'views.SendingLightning.paymentTimedOut'
+                    : errorMessage,
                 createdAt: new Date(),
                 ...(paymentHash ? { paymentHash } : {})
             });

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2272,6 +2272,21 @@ export default class NostrWalletConnectStore {
         // spend the same sats twice.
         await this.reconcilePendingPayInvoiceActivities(connection);
 
+        const { paymentRequest, paymentHash: decodedPaymentHash } =
+            await NostrConnectUtils.decodeInvoiceTags(request.invoice);
+        const existing = connection.findPayInvoiceActivity(
+            paymentRequest || request.invoice,
+            decodedPaymentHash
+        );
+        if (existing && connection.isUnresolvedPayInvoiceActivity(existing)) {
+            return NostrConnectUtils.createNip47Error(
+                localeString(
+                    'stores.NostrWalletConnectStore.error.invoicePaymentInProgress'
+                ),
+                Nip47ErrorCode.FAILED_TO_PAY_INVOICE
+            );
+        }
+
         const budgetCheck = this.validateBudgetBeforePayment(
             connection,
             amountSats,
@@ -2703,14 +2718,8 @@ export default class NostrWalletConnectStore {
     private async reconcilePendingPayInvoiceActivities(
         connection: NWCConnection
     ): Promise<boolean> {
-        const pending = connection.activity.filter(
-            (a) =>
-                a.type === 'pay_invoice' &&
-                a.payment_source !== 'cashu' &&
-                !a.isBudgetDebited &&
-                (a.status === 'pending' ||
-                    (a.status === 'failed' &&
-                        NostrConnectUtils.isPaymentTimedOutMessage(a.error)))
+        const pending = connection.activity.filter((a) =>
+            connection.isUnresolvedPayInvoiceActivity(a)
         );
         if (pending.length === 0) return false;
 
@@ -2731,40 +2740,10 @@ export default class NostrWalletConnectStore {
             if (!payment) continue;
 
             runInAction(() => {
-                if (activity.isBudgetDebited) return;
                 if (
-                    activity.status !== 'pending' &&
-                    activity.status !== 'failed'
+                    this.applyPayInvoiceReconcile(activity, connection, payment)
                 ) {
-                    return;
-                }
-
-                activity.payment = new Payment(payment);
-                changed = true;
-
-                if (payment.isFailed) {
-                    activity.status = 'failed';
-                    return;
-                }
-                if (payment.isIncomplete) {
-                    activity.status = 'pending';
-                    activity.error = undefined;
-                    return;
-                }
-
-                activity.status = 'success';
-                activity.error = undefined;
-                const amountSats =
-                    Math.floor(Number(activity.satAmount)) ||
-                    Math.floor(Number(payment.getAmount) || 0);
-                const feeSats = Number(payment.getFee) || 0;
-                activity.fees_paid = feeSats;
-
-                const spendSats =
-                    amountSats + NostrConnectUtils.resolveFeeSats(feeSats);
-                if (spendSats > 0 && !activity.isBudgetDebited) {
-                    connection.trackSpending(spendSats, this.maxBudgetLimit);
-                    activity.isBudgetDebited = true;
+                    changed = true;
                 }
             });
         }
@@ -2774,6 +2753,70 @@ export default class NostrWalletConnectStore {
             this.findAndUpdateConnection(connection);
         }
         return changed;
+    }
+
+    private applyPayInvoiceReconcile(
+        activity: ConnectionActivity,
+        connection: NWCConnection,
+        raw: Payment
+    ): boolean {
+        if (activity.isBudgetDebited) return false;
+        if (activity.status !== 'pending' && activity.status !== 'failed') {
+            return false;
+        }
+
+        const listed = new Payment(raw);
+        const before = {
+            status: activity.status,
+            error: activity.error,
+            fees_paid: activity.fees_paid,
+            isBudgetDebited: !!activity.isBudgetDebited,
+            paymentHash:
+                activity.payment instanceof Payment
+                    ? activity.payment.paymentHash
+                    : undefined,
+            paymentStatus: activity.payment?.status
+        };
+
+        if (raw.isFailed) {
+            // CLN listpays does not populate failure_reason/htlcs, so
+            // Payment.isFailed may stay false for genuine CLN failures;
+            // those rows remain in the reconcile filter until expiry.
+            activity.status = 'failed';
+            activity.error =
+                listed.failure_reason &&
+                String(listed.failure_reason) !== 'FAILURE_REASON_NONE'
+                    ? String(listed.failure_reason)
+                    : localeString('error.paymentFailed');
+        } else if (raw.isIncomplete) {
+            activity.status = 'pending';
+            activity.error = undefined;
+        } else {
+            activity.status = 'success';
+            activity.error = undefined;
+            const amountSats =
+                Math.floor(Number(activity.satAmount)) ||
+                Math.floor(Number(raw.getAmount) || 0);
+            const feeSats = Number(raw.getFee) || 0;
+            activity.fees_paid = feeSats;
+            const spendSats =
+                amountSats + NostrConnectUtils.resolveFeeSats(feeSats);
+            if (spendSats > 0) {
+                connection.trackSpending(spendSats, this.maxBudgetLimit);
+                activity.isBudgetDebited = true;
+            }
+        }
+
+        activity.payment = listed;
+
+        return (
+            before.status !== activity.status ||
+            before.error !== activity.error ||
+            before.fees_paid !== activity.fees_paid ||
+            before.isBudgetDebited !== !!activity.isBudgetDebited ||
+            before.paymentHash !== listed.paymentHash ||
+            before.paymentStatus !== listed.status
+        );
     }
 
     private async getPaymentsForPendingPayInvoiceRefresh(
@@ -3188,7 +3231,11 @@ export default class NostrWalletConnectStore {
         );
         const existing = index !== -1 ? connection.activity[index] : undefined;
 
-        if (existing?.status === 'success' && record.status !== 'success') {
+        if (
+            existing &&
+            ((existing.status === 'success' && record.status !== 'success') ||
+                (existing.status === 'pending' && record.status === 'failed'))
+        ) {
             return false;
         }
 

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -112,6 +112,14 @@ const paymentFixtures = {
             htlcs: [{ status: 'FAILED' }]
         }),
 
+    failedCln: () =>
+        new Payment({
+            payment_request: INVOICE_A,
+            payment_hash: HASH_A,
+            status: 'failed',
+            payment_preimage: ZERO_PREIMAGE
+        }),
+
     /** Another invoice — used to verify lookup does not cross-match */
     otherInvoiceInFlight: () =>
         new Payment({
@@ -788,6 +796,17 @@ describe('NostrConnectUtils', () => {
 
                 it('returns not inTransit when timeout fired and the listed payment failed', () => {
                     const failed = paymentFixtures.failed();
+                    const result = resolve({
+                        payments: [failed],
+                        paymentState: storeState.timedOut()
+                    });
+
+                    expect(result.inTransit).toBe(false);
+                    expect(result.payment).toBe(failed);
+                });
+
+                it('returns not inTransit when CLN lists a failed sendpay', () => {
+                    const failed = paymentFixtures.failedCln();
                     const result = resolve({
                         payments: [failed],
                         paymentState: storeState.timedOut()

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -1312,4 +1312,44 @@ describe('NostrConnectUtils', () => {
             );
         });
     });
+
+    describe('isPayInvoiceHoldAbandoned', () => {
+        const now = Date.parse('2024-06-15T12:00:00Z');
+        const baseActivity = (): ConnectionActivity => ({
+            id: 'lnbc1hold',
+            type: 'pay_invoice',
+            payment_source: 'lightning',
+            status: 'pending',
+            satAmount: 1000,
+            createdAt: new Date(now - 60_000)
+        });
+
+        it('abandons after max age with no node listing', () => {
+            const activity = baseActivity();
+            activity.createdAt = new Date(
+                now - NostrConnectUtils.UNRESOLVED_PAY_INVOICE_MAX_AGE_MS - 1000
+            );
+            expect(
+                NostrConnectUtils.isPayInvoiceHoldAbandoned(activity, now)
+            ).toBe(true);
+        });
+
+        it('abandons after invoice expiry plus grace', () => {
+            const activity = baseActivity();
+            activity.expiresAt = new Date(
+                now -
+                    NostrConnectUtils.UNRESOLVED_PAY_INVOICE_INVOICE_GRACE_MS -
+                    1000
+            );
+            expect(
+                NostrConnectUtils.isPayInvoiceHoldAbandoned(activity, now)
+            ).toBe(true);
+        });
+
+        it('keeps a recent unresolved hold', () => {
+            expect(
+                NostrConnectUtils.isPayInvoiceHoldAbandoned(baseActivity(), now)
+            ).toBe(false);
+        });
+    });
 });

--- a/utils/NostrConnectUtils.test.ts
+++ b/utils/NostrConnectUtils.test.ts
@@ -748,24 +748,66 @@ describe('NostrConnectUtils', () => {
                     });
                 });
 
-                it('returns not inTransit when timeout fired but nothing is in flight', () => {
+                it('returns settled payment when timeout fired after the list already shows success', () => {
+                    const settled = paymentFixtures.settled();
                     const result = resolve({
-                        payments: [paymentFixtures.settled()],
+                        payments: [settled],
                         paymentState: storeState.timedOut()
                     });
 
-                    expect(result).toEqual({ inTransit: false });
+                    expect(result.inTransit).toBe(false);
+                    expect(result.payment).toBe(settled);
+                });
+
+                it('holds budget when timeout fired and the payment is not listed yet', () => {
+                    const result = resolve({
+                        payments: [],
+                        paymentState: storeState.timedOut()
+                    });
+
+                    expect(result).toEqual({ inTransit: true });
+                });
+
+                it('holds budget when send is still loading and the payment is not listed yet', () => {
+                    const result = resolve({
+                        payments: [],
+                        paymentState: storeState.stillLoading()
+                    });
+
+                    expect(result).toEqual({ inTransit: true });
+                });
+
+                it('does not treat an unrelated in-flight payment as this invoice', () => {
+                    const result = resolve({
+                        payments: [paymentFixtures.otherInvoiceInFlight()],
+                        paymentState: storeState.timedOut()
+                    });
+
+                    expect(result).toEqual({ inTransit: true });
+                });
+
+                it('returns not inTransit when timeout fired and the listed payment failed', () => {
+                    const failed = paymentFixtures.failed();
+                    const result = resolve({
+                        payments: [failed],
+                        paymentState: storeState.timedOut()
+                    });
+
+                    expect(result.inTransit).toBe(false);
+                    expect(result.payment).toBe(failed);
                 });
             });
 
             describe('when store shows settled failure (no false positive)', () => {
                 it('does not treat a genuine failure as in-transit', () => {
+                    const failed = paymentFixtures.failed();
                     const result = resolve({
-                        payments: [paymentFixtures.failed()],
+                        payments: [failed],
                         paymentState: storeState.failed()
                     });
 
-                    expect(result).toEqual({ inTransit: false });
+                    expect(result.inTransit).toBe(false);
+                    expect(result.payment).toBe(failed);
                 });
             });
         });

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -20,6 +20,7 @@ import Invoice from '../models/Invoice';
 import Payment from '../models/Payment';
 import CashuPayment from '../models/CashuPayment';
 import CashuInvoice from '../models/CashuInvoice';
+import { lnrpc } from '../proto/lightning';
 
 import Base64Utils from './Base64Utils';
 import { localeString } from './LocaleUtils';
@@ -1027,6 +1028,40 @@ export default class NostrConnectUtils {
         return hasInFlightStatus && payment.isIncomplete && !payment.isFailed;
     }
 
+    /** CLN listpays marks failures with status only — no htlcs/failure_reason. */
+    static isListedPaymentFailed(payment: Payment): boolean {
+        if (payment.isFailed) return true;
+        const status = payment.status;
+        return status === 'failed' || status === 'FAILED';
+    }
+
+    static paymentFailureReasonLocaleKey(
+        reason: string | number | null | undefined
+    ): string {
+        if (
+            reason == null ||
+            reason === '' ||
+            reason === 'FAILURE_REASON_NONE' ||
+            reason === lnrpc.PaymentFailureReason.FAILURE_REASON_NONE
+        ) {
+            return 'error.paymentFailed';
+        }
+        const name =
+            typeof reason === 'number'
+                ? lnrpc.PaymentFailureReason[reason]
+                : String(reason);
+        const keys: Record<string, string> = {
+            FAILURE_REASON_TIMEOUT: 'error.failureReasonTimeout',
+            FAILURE_REASON_NO_ROUTE: 'error.failureReasonNoRoute',
+            FAILURE_REASON_ERROR: 'error.failureReasonError',
+            FAILURE_REASON_INCORRECT_PAYMENT_DETAILS:
+                'error.failureReasonIncorrectPaymentDetails',
+            FAILURE_REASON_INSUFFICIENT_BALANCE:
+                'error.failureReasonInsufficientBalance'
+        };
+        return keys[name] || 'error.paymentFailed';
+    }
+
     static findPaymentForInvoice<T extends Payment>(
         invoice: string,
         payments: T[],
@@ -1180,13 +1215,16 @@ export default class NostrConnectUtils {
             if (listed && NostrConnectUtils.isSettledPayment(listed)) {
                 return { inTransit: false, payment: listed };
             }
-            if (listed && listed.isFailed) {
+            if (listed && NostrConnectUtils.isListedPaymentFailed(listed)) {
                 return { inTransit: false, payment: listed };
             }
             // Timeout / still-loading with no listed outcome: the HTLC may
             // still settle. Treat as in-flight so budget is held via
             // pendingSpendSats instead of recording a terminal failure.
-            if (timedOutOrStillLoading) {
+            if (
+                timedOutOrStillLoading &&
+                (!listed || NostrConnectUtils.isListedPaymentInTransit(listed))
+            ) {
                 return { inTransit: true, payment: listed };
             }
             if (listed && NostrConnectUtils.isListedPaymentInTransit(listed)) {

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -1170,13 +1170,25 @@ export default class NostrConnectUtils {
             ) || paymentState.loading;
 
         if (timedOutOrStillLoading || paymentState.isIncomplete) {
-            const payment = NostrConnectUtils.findInTransitPaymentForInvoice(
+            const listed = NostrConnectUtils.findPaymentForInvoice(
                 invoice,
                 payments,
                 paymentHash
             );
-            if (payment) {
-                return { inTransit: true, payment };
+            if (listed && NostrConnectUtils.isSettledPayment(listed)) {
+                return { inTransit: false, payment: listed };
+            }
+            if (listed && listed.isFailed) {
+                return { inTransit: false, payment: listed };
+            }
+            // Timeout / still-loading with no listed outcome: the HTLC may
+            // still settle. Treat as in-flight so budget is held via
+            // pendingSpendSats instead of recording a terminal failure.
+            if (timedOutOrStillLoading) {
+                return { inTransit: true, payment: listed };
+            }
+            if (listed && NostrConnectUtils.isListedPaymentInTransit(listed)) {
+                return { inTransit: true, payment: listed };
             }
         }
 

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -1001,9 +1001,11 @@ export default class NostrConnectUtils {
     static isPaymentTimedOutMessage(message?: string | null): boolean {
         if (!message) return false;
         const normalized = message.toLowerCase();
-        // English substring catches raw backend/LND strings; localized paths use localeString equality below.
+        // English substring catches raw backend/LND strings; keys are locale-stable.
         return (
             normalized.includes('timed out') ||
+            message === 'views.SendingLightning.paymentTimedOut' ||
+            message === 'error.paymentTimedOut' ||
             message ===
                 localeString('views.SendingLightning.paymentTimedOut') ||
             message === localeString('error.paymentTimedOut')

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -1013,6 +1013,62 @@ export default class NostrConnectUtils {
         );
     }
 
+    /** Max hold when the node never lists the payment (LndHub, paginated history). */
+    static readonly UNRESOLVED_PAY_INVOICE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+    /** Grace after bolt11 expiry before abandoning an unresolved hold. */
+    static readonly UNRESOLVED_PAY_INVOICE_INVOICE_GRACE_MS =
+        24 * 60 * 60 * 1000;
+
+    static resolveBolt11ExpiryTimeMs(invoice: string): number | undefined {
+        try {
+            const decoded = Bolt11Utils.decode(invoice);
+            const expiry = decoded.timeExpireDate;
+            if (expiry == null || expiry <= 0) return undefined;
+            return expiry * 1000;
+        } catch {
+            return undefined;
+        }
+    }
+
+    /** True when an unresolved pay_invoice hold should be released. */
+    static isPayInvoiceHoldAbandoned(
+        activity: ConnectionActivity,
+        nowMs: number = Date.now()
+    ): boolean {
+        if (
+            activity.type !== 'pay_invoice' ||
+            activity.payment_source === 'cashu' ||
+            activity.isBudgetDebited
+        ) {
+            return false;
+        }
+
+        const createdAt = activity.createdAt?.getTime();
+        if (!createdAt) return false;
+
+        if (
+            nowMs >=
+            createdAt + NostrConnectUtils.UNRESOLVED_PAY_INVOICE_MAX_AGE_MS
+        ) {
+            return true;
+        }
+
+        const expiryMs =
+            activity.expiresAt?.getTime() ??
+            NostrConnectUtils.resolveBolt11ExpiryTimeMs(activity.id);
+        if (
+            expiryMs &&
+            nowMs >=
+                expiryMs +
+                    NostrConnectUtils.UNRESOLVED_PAY_INVOICE_INVOICE_GRACE_MS
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
     static isSettledPayment(payment: Payment): boolean {
         return !payment.isIncomplete && !payment.isFailed;
     }

--- a/views/Settings/NostrWalletConnect/NWCConnectionActivity.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionActivity.tsx
@@ -223,7 +223,7 @@ export default class NWCConnectionActivity extends React.Component<
         ModalStore.toggleInfoModal({
             title: localeString('views.Payment.failedPayment'),
             text: item.error
-                ? [item.error]
+                ? [localeString(item.error) || item.error]
                 : [localeString('error.paymentFailed')]
         });
     };


### PR DESCRIPTION
# Description

Fixes NWC `pay_invoice` budget accounting when a payment settles after the store's ~125s wait.

A payment that was still unknown at timeout was recorded as `failed`. Since `failed` is terminal for the budget and `reconcile` only looked at `pending`, `totalSpendSats` stayed at `0`.

After a restart, a replayed request could then pass the budget check and pay the same invoice again on backends that re-pay the same invoice, resulting in bounded overspend (~2× in the reproduced case).

The concurrent burst / check-then-act race is **not** this bug. That path is already closed by the payment queue, `pendingSpendSats`, and the preimage fallback.

## This PR

- Treats timeout / still-loading payments with no listed outcome as **in-flight**, so `pendingSpendSats` continues to hold the budget.
- If the payments list already shows success, **debits** the spend instead of classifying the payment as failed.
- Reconciles **timeout-failed** activity that later settles or is still in-flight, covering already-persisted bad records.
- Runs reconciliation **before** the next budget check so a restart + replay cannot spend twice.

## Scope

This PR does **not** add a processed-event ledger. That belongs to the separate NWC replay finding.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
