### PR TITLE
fix(nwc): cap pay_invoice requests per connection

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1768,6 +1768,7 @@
     "stores.NostrWalletConnectStore.error.connectionNameExists": "Connection name already exists",
     "stores.NostrWalletConnectStore.error.connectionNotFound": "Connection not found",
     "stores.NostrWalletConnectStore.error.paymentQueueWaitExceeded": "Another payment was in progress and this request waited too long; it was not executed. Please try again.",
+    "stores.NostrWalletConnectStore.error.paymentQueueConnectionBusy": "A payment is already in progress for this connection; it was not executed. Please try again.",
     "stores.NostrWalletConnectStore.error.makeInvoiceRateLimited": "Too many invoice requests from this connection. Please wait before trying again.",
     "stores.NostrWalletConnectStore.error.failedToConnectRelay": "Failed to Connect {{relayUrl}}",
     "stores.NostrWalletConnectStore.error.failedToLoadConnections": "Failed to load connections",

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1318,6 +1318,111 @@ describe('NostrWalletConnectStore activity prune', () => {
     });
 });
 
+describe('NostrWalletConnectStore payment queue fairness', () => {
+    function deferred<T>() {
+        let resolve!: (value: T) => void;
+        const promise = new Promise<T>((res) => {
+            resolve = res;
+        });
+        return { promise, resolve };
+    }
+
+    it('rejects a second pay from the same connection while one is outstanding', async () => {
+        const store = buildPayInvoiceTestStore();
+        const first = deferred<string>();
+        const p1 = (store as any).enqueuePayment(
+            'conn-a',
+            () => first.promise,
+            () => 'stale',
+            () => 'busy'
+        );
+        const p2 = (store as any).enqueuePayment(
+            'conn-a',
+            () => Promise.resolve('second'),
+            () => 'stale',
+            () => 'busy'
+        );
+
+        await expect(p2).resolves.toBe('busy');
+        first.resolve('first');
+        await expect(p1).resolves.toBe('first');
+    });
+
+    it('lets another connection enqueue behind an in-flight pay', async () => {
+        const store = buildPayInvoiceTestStore();
+        const first = deferred<string>();
+        const p1 = (store as any).enqueuePayment(
+            'conn-a',
+            () => first.promise,
+            () => 'stale',
+            () => 'busy'
+        );
+        const p2 = (store as any).enqueuePayment(
+            'conn-b',
+            () => Promise.resolve('victim'),
+            () => 'stale',
+            () => 'busy'
+        );
+
+        first.resolve('attacker');
+        await expect(p1).resolves.toBe('attacker');
+        await expect(p2).resolves.toBe('victim');
+    });
+
+    it('releases the per-connection slot after the outstanding pay finishes', async () => {
+        const store = buildPayInvoiceTestStore();
+        const first = deferred<string>();
+        const p1 = (store as any).enqueuePayment(
+            'conn-a',
+            () => first.promise,
+            () => 'stale',
+            () => 'busy'
+        );
+        first.resolve('first');
+        await expect(p1).resolves.toBe('first');
+
+        const p2 = (store as any).enqueuePayment(
+            'conn-a',
+            () => Promise.resolve('again'),
+            () => 'stale',
+            () => 'busy'
+        );
+        await expect(p2).resolves.toBe('again');
+    });
+
+    it('does not starve a second connection when the first floods the queue', async () => {
+        const store = buildPayInvoiceTestStore();
+        const first = deferred<string>();
+        const attackerFirst = (store as any).enqueuePayment(
+            'conn-a',
+            () => first.promise,
+            () => 'stale',
+            () => 'busy'
+        );
+        const attackerFlood = await Promise.all(
+            Array.from({ length: 6 }, () =>
+                (store as any).enqueuePayment(
+                    'conn-a',
+                    () => Promise.resolve('extra'),
+                    () => 'stale',
+                    () => 'busy'
+                )
+            )
+        );
+        const victim = (store as any).enqueuePayment(
+            'conn-b',
+            () => Promise.resolve('victim'),
+            () => 'stale',
+            () => 'busy'
+        );
+
+        expect(attackerFlood.every((result) => result === 'busy')).toBe(true);
+        first.resolve('attacker');
+        await expect(attackerFirst).resolves.toBe('attacker');
+        await expect(victim).resolves.toBe('victim');
+    });
+});
+
 describe('NostrWalletConnectStore sign_message', () => {
     afterEach(() => {
         (BackendUtils.supportsMessageSigning as jest.Mock).mockReturnValue(

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -88,6 +88,14 @@ const PAYMENT_PROCESSING_DELAY_MS = 100;
  * already given up on the request.
  */
 const MAX_PAYMENT_QUEUE_WAIT_MS = 30_000;
+/**
+ * Outstanding pay_invoice slots per connection on the global queue
+ * (in-flight + waiting). The backend still runs one pay at a time
+ * (shared TransactionsStore / CashuStore), but a flood from one
+ * connection cannot occupy every slot and starve the others into
+ * RATE_LIMITED.
+ */
+const MAX_QUEUED_PAYMENTS_PER_CONNECTION = 1;
 const SAVE_CONNECTIONS_DEBOUNCE_MS = 500;
 /** Min time a pay_invoice must stay pending before getActivities polls the node */
 const PENDING_PAYMENT_STATUS_MIN_AGE_MS = 5_000;
@@ -161,6 +169,7 @@ export default class NostrWalletConnectStore {
     @observable public iosAudioKeepAliveDisconnects: number = 0;
     // Tail of the payment-handler queue; see enqueuePayment
     private paymentQueue: Promise<unknown> = Promise.resolve();
+    private paymentQueueDepthByConnection = new Map<string, number>();
     private iosAudioUptimeInterval: ReturnType<typeof setInterval> | null =
         null;
     private iosAudioInterruptedUnsub: (() => void) | null = null;
@@ -646,6 +655,7 @@ export default class NostrWalletConnectStore {
             this.lastPendingPaymentStatusFetchByConnection.delete(connectionId);
             this.lastPendingInvoiceStatusFetchByConnection.delete(connectionId);
             this.makeInvoiceTimestampsByConnection.delete(connectionId);
+            this.paymentQueueDepthByConnection.delete(connectionId);
             runInAction(() => {
                 this.connections.splice(index, 1);
             });
@@ -1353,11 +1363,19 @@ export default class NostrWalletConnectStore {
                 handler.payInvoice = (request: Nip47PayInvoiceRequest) =>
                     this.withGlobalHandler(connection.id, () =>
                         this.enqueuePayment(
+                            connection.id,
                             () => payHandler(request),
                             () =>
                                 NostrConnectUtils.createNip47Error(
                                     localeString(
                                         'stores.NostrWalletConnectStore.error.paymentQueueWaitExceeded'
+                                    ),
+                                    Nip47ErrorCode.RATE_LIMITED
+                                ),
+                            () =>
+                                NostrConnectUtils.createNip47Error(
+                                    localeString(
+                                        'stores.NostrWalletConnectStore.error.paymentQueueConnectionBusy'
                                     ),
                                     Nip47ErrorCode.RATE_LIMITED
                                 )
@@ -1636,16 +1654,41 @@ export default class NostrWalletConnectStore {
     // its client has likely timed out already, and paying late would spend
     // sats against a request the client reported as failed. `onStale`
     // supplies the response for that case (RATE_LIMITED).
+    // Per-connection depth is capped so one client cannot fill the FIFO
+    // and starve every other connection into that same stale reject.
     private enqueuePayment<T>(
+        connectionId: string,
         task: () => Promise<T>,
-        onStale: () => T
+        onStale: () => T,
+        onBusy: () => T = onStale
     ): Promise<T> {
+        const depth = this.paymentQueueDepthByConnection.get(connectionId) ?? 0;
+        if (depth >= MAX_QUEUED_PAYMENTS_PER_CONNECTION) {
+            return Promise.resolve(onBusy());
+        }
+
+        this.paymentQueueDepthByConnection.set(connectionId, depth + 1);
         const enqueuedAt = Date.now();
-        const result = this.paymentQueue.then(() =>
-            Date.now() - enqueuedAt > MAX_PAYMENT_QUEUE_WAIT_MS
-                ? onStale()
-                : task()
-        );
+        const result = this.paymentQueue.then(async () => {
+            try {
+                if (Date.now() - enqueuedAt > MAX_PAYMENT_QUEUE_WAIT_MS) {
+                    return onStale();
+                }
+                return await task();
+            } finally {
+                const remaining =
+                    (this.paymentQueueDepthByConnection.get(connectionId) ??
+                        1) - 1;
+                if (remaining <= 0) {
+                    this.paymentQueueDepthByConnection.delete(connectionId);
+                } else {
+                    this.paymentQueueDepthByConnection.set(
+                        connectionId,
+                        remaining
+                    );
+                }
+            }
+        });
         this.paymentQueue = result.then(
             () => undefined,
             () => undefined


### PR DESCRIPTION
# Description

NWC `pay_invoice` is serialized on a process-wide queue so concurrent payments cannot clobber shared `TransactionsStore` / `CashuStore` state. A request that waits more than 30s is rejected with `RATE_LIMITED` instead of being paid after the client has already given up.

The queue previously had no per-connection admission cap. A single client could enqueue many `pay_invoice` requests, keeping the queue occupied for multiple seconds per payment. This could cause other connections' payments to wait beyond the 30s limit and fail with `RATE_LIMITED` — effectively a cross-connection DoS using only otherwise-granted payment authority. No funds theft is possible.

## This PR

- Allows at most **one outstanding `pay_invoice` per connection** (in-flight or waiting).
- Rejects additional requests from the same connection immediately with `RATE_LIMITED`.
- Allows other connections to enqueue behind the current in-flight payment.
- Keeps global one-at-a-time payment execution unchanged.
- Keeps the existing 30s stale-request cap unchanged.

A single long-running payment (~120s) can still cause a waiting request from another connection to exceed the 30s cap. This is an inherent limitation of having one occupied payment backend, rather than a queue that can be filled by a single connection.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
