### PR TITLE
Move pull-to-refresh indicator out of the balances list

### DIFF
--- a/components/LayerBalances/index.tsx
+++ b/components/LayerBalances/index.tsx
@@ -57,7 +57,6 @@ interface LayerBalancesProps {
     consolidated?: boolean;
     editMode?: boolean;
     needsConfig?: boolean;
-    refreshing?: boolean;
 }
 
 //  To toggle LTR/RTL change to `true`
@@ -435,8 +434,7 @@ export default class LayerBalances extends Component<LayerBalancesProps, {}> {
             onRefresh,
             locked,
             consolidated,
-            editMode,
-            refreshing
+            editMode
         } = this.props;
 
         const { settings } = SettingsStore!;
@@ -556,7 +554,7 @@ export default class LayerBalances extends Component<LayerBalancesProps, {}> {
                     keyExtractor={(_item, index) => `message ${index}`}
                     style={{ marginTop: 20 }}
                     onRefresh={() => onRefresh()}
-                    refreshing={refreshing ? refreshing : false}
+                    refreshing={false}
                 />
             </View>
         );

--- a/views/Tools/Accounts/Accounts.tsx
+++ b/views/Tools/Accounts/Accounts.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TouchableOpacity } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { Route } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -46,6 +46,7 @@ interface AccountsState {
     offer: string;
     locked: boolean;
     editMode: boolean;
+    refreshing: boolean;
 }
 
 @inject('BalanceStore', 'UTXOsStore', 'UnitsStore')
@@ -60,7 +61,8 @@ export default class Accounts extends React.Component<
         lightning: '',
         offer: '',
         locked: false,
-        editMode: false
+        editMode: false,
+        refreshing: false
     };
 
     componentDidMount() {
@@ -92,10 +94,38 @@ export default class Accounts extends React.Component<
         }
     }
 
+    handleRefresh = async () => {
+        const { BalanceStore, UTXOsStore } = this.props;
+        this.setState({ refreshing: true });
+        try {
+            await Promise.all(
+                BackendUtils.supportsAccounts()
+                    ? [
+                          BalanceStore.getBlockchainBalance(true, false),
+                          BalanceStore.getLightningBalance(true),
+                          UTXOsStore.listAccounts()
+                      ]
+                    : [
+                          BalanceStore.getBlockchainBalance(true, false),
+                          BalanceStore.getLightningBalance(true)
+                      ]
+            );
+        } finally {
+            this.setState({ refreshing: false });
+        }
+    };
+
     render() {
         const { BalanceStore, UnitsStore, UTXOsStore, navigation } = this.props;
-        const { value, satAmount, lightning, offer, locked, editMode } =
-            this.state;
+        const {
+            value,
+            satAmount,
+            lightning,
+            offer,
+            locked,
+            editMode,
+            refreshing
+        } = this.state;
         const { loadingAccounts, accounts } = UTXOsStore;
 
         const FilterButton = () => (
@@ -138,50 +168,29 @@ export default class Accounts extends React.Component<
                         style: { color: themeColor('text') }
                     }}
                     rightComponent={
-                        value ? (
-                            <></>
-                        ) : (
-                            <Row>
-                                {accounts.length > 0 && <FilterButton />}
-                                <AddButton />
-                            </Row>
-                        )
+                        <Row>
+                            {refreshing && (
+                                <View style={{ marginRight: 10 }}>
+                                    <LoadingIndicator size={30} />
+                                </View>
+                            )}
+                            {!value && (
+                                <>
+                                    {accounts.length > 0 && <FilterButton />}
+                                    <AddButton />
+                                </>
+                            )}
+                        </Row>
                     }
                     navigation={navigation}
                 />
-                {loadingAccounts && <LoadingIndicator />}
-                {!loadingAccounts && (
+                {loadingAccounts && !refreshing && <LoadingIndicator />}
+                {(!loadingAccounts || refreshing) && (
                     <LayerBalances
                         navigation={navigation}
                         BalanceStore={BalanceStore}
                         UnitsStore={UnitsStore}
-                        onRefresh={async () =>
-                            await Promise.all(
-                                BackendUtils.supportsAccounts()
-                                    ? [
-                                          BalanceStore.getBlockchainBalance(
-                                              true,
-                                              false
-                                          ),
-                                          BalanceStore.getLightningBalance(
-                                              true
-                                          ),
-                                          UTXOsStore.listAccounts()
-                                      ]
-                                    : [
-                                          BalanceStore.getBlockchainBalance(
-                                              true,
-                                              false
-                                          ),
-                                          BalanceStore.getLightningBalance(true)
-                                      ]
-                            )
-                        }
-                        refreshing={
-                            BalanceStore?.loadingLightningBalance ||
-                            BalanceStore?.loadingBlockchainBalance ||
-                            UTXOsStore?.loadingAccounts
-                        }
+                        onRefresh={this.handleRefresh}
                         // for payment method selection
                         value={value}
                         satAmount={satAmount}
@@ -191,7 +200,7 @@ export default class Accounts extends React.Component<
                         editMode={editMode}
                     />
                 )}
-                {!loadingAccounts && !!value && !!lightning && (
+                {(!loadingAccounts || refreshing) && !!value && !!lightning && (
                     <Button
                         title={localeString('views.Accounts.fetchTxFees')}
                         containerStyle={{

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1584,7 +1584,6 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                             <LayerBalances
                                 navigation={navigation}
                                 onRefresh={() => this.getSettingsAndNavigate()}
-                                refreshing={this.state.loading}
                                 consolidated
                             />
 


### PR DESCRIPTION
# Description

On iOS, the balances list rows shift down to make room for the FlatList RefreshControl spinner whenever `refreshing` is true. On the Wallet screen this indicator is redundant since loading state is already shown in the top right corner of the header, and it also fired on background connect cycles the user never initiated (`Wallet.tsx` fed it `this.state.loading`, which `getSettingsAndNavigate()` sets on every boot/reconnect pass).

Changes:

- `components/LayerBalances`: remove the `refreshing` prop. The FlatList keeps `refreshing={false}` because VirtualizedList requires the prop whenever `onRefresh` is set. Pull-to-refresh still works; the spinner just no longer persists and shifts the rows.
- `views/Wallet/Wallet.tsx`: stop passing `refreshing={this.state.loading}`.
- `views/Tools/Accounts`: since this screen has no header loading state of its own, give it one: track pull-to-refresh in component state and show a small `LoadingIndicator` in the header `rightComponent`, matching the pattern in Receive and Invoice. The balances list now stays mounted during refresh instead of being swapped for the full-screen indicator mid-gesture (the full-screen indicator still covers the initial account load).

Screenshots: pending device testing (draft).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
