### PR TITLE
components: prevent crash rendering oversized QR payloads

### DIFF
--- a/components/AnimatedQRDisplay.tsx
+++ b/components/AnimatedQRDisplay.tsx
@@ -9,6 +9,7 @@ import {
     QREncoderType,
     BBQrFileType
 } from '../hooks/useQRAnimation';
+import { SINGLE_FRAME_QR_MAX_LEN } from '../utils/QRAnimationUtils';
 
 interface AnimatedQRDisplayProps {
     data: string;
@@ -31,6 +32,10 @@ const AnimatedQRDisplay: React.FC<AnimatedQRDisplayProps> = ({
 }) => {
     const [selectedIndex, setSelectedIndex] = React.useState(0);
 
+    // Payloads beyond single-QR capacity can only be shown as animated frames;
+    // rendering them as one QR throws in react-native-qrcode-svg
+    const hideSingle = hideSingleFrame || data.length > SINGLE_FRAME_QR_MAX_LEN;
+
     const {
         frameIndex,
         bbqrParts,
@@ -44,10 +49,10 @@ const AnimatedQRDisplay: React.FC<AnimatedQRDisplayProps> = ({
         fileType
     });
 
-    const bcurIndex = hideSingleFrame ? 0 : 1;
-    const bbqrIndex = hideSingleFrame ? 1 : 2;
+    const bcurIndex = hideSingle ? 0 : 1;
+    const bbqrIndex = hideSingle ? 1 : 2;
 
-    const isSingleFrameSelected = !hideSingleFrame && selectedIndex === 0;
+    const isSingleFrameSelected = !hideSingle && selectedIndex === 0;
     const isBcurSelected = selectedIndex === bcurIndex;
     const isBbqrSelected = selectedIndex === bbqrIndex;
 
@@ -71,7 +76,7 @@ const AnimatedQRDisplay: React.FC<AnimatedQRDisplayProps> = ({
             <QRFormatSelector
                 selectedIndex={selectedIndex}
                 onSelect={setSelectedIndex}
-                hideSingleFrame={hideSingleFrame}
+                hideSingleFrame={hideSingle}
             />
             <View style={{ margin: 10 }}>
                 <CollapsedQR

--- a/components/CollapsedQR.tsx
+++ b/components/CollapsedQR.tsx
@@ -138,6 +138,7 @@ interface CollapsedQRState {
     tempQRRef: React.RefObject<QRCodeElement | null> | null;
     qrReady: boolean;
     showSpeedOptions: boolean;
+    qrError: boolean;
 }
 
 export default class CollapsedQR extends React.Component<
@@ -152,7 +153,31 @@ export default class CollapsedQR extends React.Component<
         tempQRRef: null,
         qrReady: false,
         qrAnimationSpeed: this.props.qrAnimationSpeed,
-        showSpeedOptions: false
+        showSpeedOptions: false,
+        qrError: false
+    };
+
+    private unmounted = false;
+
+    componentDidUpdate(prevProps: CollapsedQRProps) {
+        if (prevProps.value !== this.props.value && this.state.qrError) {
+            this.setState({ qrError: false });
+        }
+    }
+
+    componentWillUnmount() {
+        this.unmounted = true;
+    }
+
+    // react-native-qrcode-svg calls onError during its own render (the QR
+    // matrix is built in a useMemo), so defer the state update to avoid
+    // updating this component while a child is rendering
+    handleQRError = () => {
+        setTimeout(() => {
+            if (!this.unmounted && !this.state.qrError) {
+                this.setState({ qrError: true });
+            }
+        }, 0);
     };
 
     toggleCollapse = () => {
@@ -166,7 +191,7 @@ export default class CollapsedQR extends React.Component<
     };
 
     render() {
-        const { collapsed, enlargeQR, tempQRRef, showSpeedOptions } =
+        const { collapsed, enlargeQR, tempQRRef, showSpeedOptions, qrError } =
             this.state;
         const {
             value,
@@ -212,7 +237,10 @@ export default class CollapsedQR extends React.Component<
                 const tempRef = React.createRef<QRCodeElement>();
                 this.setState({ tempQRRef: tempRef, qrReady: false }, () => {
                     const checkReady = () => {
-                        if (this.state.qrReady) {
+                        // resolve on qrError too: the temp QR never becomes
+                        // ready when the value cannot be encoded, and sharing
+                        // as text still works
+                        if (this.state.qrReady || this.state.qrError) {
                             resolve();
                         } else {
                             requestAnimationFrame(checkReady);
@@ -255,6 +283,7 @@ export default class CollapsedQR extends React.Component<
                             logoMargin={10}
                             quietZone={40}
                             parent={this}
+                            onError={this.handleQRError}
                         />
                     </View>
                 )}
@@ -266,7 +295,7 @@ export default class CollapsedQR extends React.Component<
                         valueStyle={valueStyle}
                     />
                 )}
-                {!collapsed && value && (
+                {!collapsed && value && !qrError && (
                     <View>
                         <TouchableOpacity
                             style={{
@@ -320,6 +349,7 @@ export default class CollapsedQR extends React.Component<
                                                     }
                                                     logoMargin={10}
                                                     quietZone={width / 20}
+                                                    onError={this.handleQRError}
                                                 />
                                             </View>
                                         </View>
@@ -345,6 +375,7 @@ export default class CollapsedQR extends React.Component<
                                 }
                                 logoMargin={10}
                                 quietZone={width / 40}
+                                onError={this.handleQRError}
                             />
                         </TouchableOpacity>
                         {satAmount != null &&

--- a/hooks/useQRAnimation.ts
+++ b/hooks/useQRAnimation.ts
@@ -51,57 +51,69 @@ export const useQRAnimation = ({
     const generateInfo = useCallback(() => {
         if (!data) return;
 
-        // BBQr encoding
-        const input = Base64Utils.base64ToBytes(data);
-        const splitResult = splitQRs(input, fileType, DEFAULT_SPLIT_OPTIONS);
-        setBbqrParts(splitResult.parts);
-
-        // BC-UR encoding
-        const maxFragmentLength = 200;
-        const firstSeqNum = 0;
-
-        if (encoderType === 'psbt') {
-            const messageBuffer = Buffer.from(data, 'base64');
-            const cryptoPSBT = new CryptoPSBT(messageBuffer);
-            bcurEncoderRef.current = cryptoPSBT.toUREncoder(
-                maxFragmentLength,
-                firstSeqNum
+        // this runs from a render effect with no error boundary above it;
+        // a throw on malformed data would take down the whole app
+        try {
+            // BBQr encoding
+            const input = Base64Utils.base64ToBytes(data);
+            const splitResult = splitQRs(
+                input,
+                fileType,
+                DEFAULT_SPLIT_OPTIONS
             );
-        } else {
-            const messageBuffer =
-                encoderType === 'generic'
-                    ? Buffer.from(data, 'utf-8')
-                    : Buffer.from(data, 'hex');
-            const ur = UR.fromBuffer(messageBuffer);
-            bcurEncoderRef.current = new UREncoder(
-                ur,
-                maxFragmentLength,
-                firstSeqNum
-            );
-        }
+            setBbqrParts(splitResult.parts);
 
-        // Set initial bcurPart
-        if (bcurEncoderRef.current) {
-            const part = bcurEncoderRef.current.nextPart();
-            setBcurPart(encoderType === 'psbt' ? part.toUpperCase() : part);
-        }
+            // BC-UR encoding
+            const maxFragmentLength = 200;
+            const firstSeqNum = 0;
 
-        // Clear any existing interval
-        if (intervalRef.current) {
-            clearInterval(intervalRef.current);
-        }
+            if (encoderType === 'psbt') {
+                const messageBuffer = Buffer.from(data, 'base64');
+                const cryptoPSBT = new CryptoPSBT(messageBuffer);
+                bcurEncoderRef.current = cryptoPSBT.toUREncoder(
+                    maxFragmentLength,
+                    firstSeqNum
+                );
+            } else {
+                const messageBuffer =
+                    encoderType === 'generic'
+                        ? Buffer.from(data, 'utf-8')
+                        : Buffer.from(data, 'hex');
+                const ur = UR.fromBuffer(messageBuffer);
+                bcurEncoderRef.current = new UREncoder(
+                    ur,
+                    maxFragmentLength,
+                    firstSeqNum
+                );
+            }
 
-        // Start animation interval
-        const length = splitResult.parts.length;
-        const interval = getQRAnimationInterval(qrAnimationSpeed);
-
-        intervalRef.current = setInterval(() => {
-            setFrameIndex((prev) => (prev === length - 1 ? 0 : prev + 1));
+            // Set initial bcurPart
             if (bcurEncoderRef.current) {
                 const part = bcurEncoderRef.current.nextPart();
                 setBcurPart(encoderType === 'psbt' ? part.toUpperCase() : part);
             }
-        }, interval);
+
+            // Clear any existing interval
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current);
+            }
+
+            // Start animation interval
+            const length = splitResult.parts.length;
+            const interval = getQRAnimationInterval(qrAnimationSpeed);
+
+            intervalRef.current = setInterval(() => {
+                setFrameIndex((prev) => (prev === length - 1 ? 0 : prev + 1));
+                if (bcurEncoderRef.current) {
+                    const part = bcurEncoderRef.current.nextPart();
+                    setBcurPart(
+                        encoderType === 'psbt' ? part.toUpperCase() : part
+                    );
+                }
+            }, interval);
+        } catch (e) {
+            console.log('useQRAnimation: failed to generate QR frames', e);
+        }
     }, [data, encoderType, fileType, qrAnimationSpeed]);
 
     // Generate info when data or speed changes

--- a/utils/QRAnimationUtils.ts
+++ b/utils/QRAnimationUtils.ts
@@ -1,3 +1,8 @@
+// Longest payload that fits in a single QR code: version 40 byte-mode holds
+// 2331 bytes at ECC level M (react-native-qrcode-svg's default). Longer data
+// must be displayed as animated BC-ur/BBQr frames.
+export const SINGLE_FRAME_QR_MAX_LEN = 2300;
+
 export const QR_ANIMATION_SPEEDS = {
     fast: 250,
     medium: 1000,


### PR DESCRIPTION
# Description

Fixes a fatal crash reported via TestFlight feedback (v13.2.0 build 1159, iPhone 14, iOS 27.0, user comment "QR BBR crashed"): scanning a multi-part BBQr PSBT aborted the app with SIGABRT via an unhandled JS exception (`RCTExceptionsManager reportFatal` -> `RCTFatal`).

Root cause chain:

1. The scanner joins the BBQr parts and `handleAnything` routes the payload to the PSBT view (same pattern applies to TxHex and CashuToken).
2. These views render through `AnimatedQRDisplay`, which defaults to the single-frame tab and passes the entire payload to a single `QRCode`.
3. `react-native-qrcode-svg` rethrows during render when the data exceeds single-QR capacity (2331 bytes at its default ECC level M) and no `onError` prop is provided. There is no error boundary in the app, so the throw is fatal in release builds.
4. Multi-part BBQr payloads exceed single-QR capacity by definition, so scanning any large PSBT crashed 100% of the time on the resulting screen.

Changes:

- `AnimatedQRDisplay`: hide the single-frame tab when the payload cannot fit in one QR code, so users land directly on the animated BC-ur/BBQr tabs
- `CollapsedQR`: pass `onError` to all `QRCode` instances and blank the QR container on encoding failure instead of crashing; the share ready-loop also resolves on error so text sharing keeps working
- `useQRAnimation`: wrap frame generation in try/catch since it runs in a render effect where a throw on malformed data is fatal

No new locale strings, no dependency changes.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I've run `yarn run tsc` and made sure my code compiles correctly
- [ ] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [ ] I've run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I've run `yarn run test` and made sure all of the tests pass

(Local verify not yet run; relying on CI for this draft. Will confirm before marking ready.)

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

(Device testing pending; repro case is scanning a >2.4 KB PSBT as BBQr, which previously hard-crashed on the PSBT screen.)

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
