### PR TITLE
Seed Recovery: catch seed typos client-side (aezeed checksum + word normalization)

### DIFF
--- a/utils/AezeedUtils.test.ts
+++ b/utils/AezeedUtils.test.ts
@@ -8,7 +8,8 @@
 import {
     decodeAezeedEntropy,
     deriveEmbeddedNodeId,
-    deriveNodeIdFromEntropy
+    deriveNodeIdFromEntropy,
+    validateAezeedChecksum
 } from './AezeedUtils';
 
 const MNEMONIC = (
@@ -38,6 +39,37 @@ describe('decodeAezeedEntropy', () => {
         await expect(decodeAezeedEntropy(tampered)).rejects.toThrow(
             'Invalid seed checksum!'
         );
+    });
+});
+
+describe('validateAezeedChecksum', () => {
+    it('accepts an lnd-generated aezeed mnemonic', () => {
+        expect(() => validateAezeedChecksum(MNEMONIC)).not.toThrow();
+    });
+
+    it('rejects a mnemonic with a bad checksum', () => {
+        const tampered = [...MNEMONIC];
+        tampered[0] = 'ability';
+        expect(() => validateAezeedChecksum(tampered)).toThrow(
+            'Invalid seed checksum!'
+        );
+    });
+
+    it('rejects a non-zero aezeed version byte', () => {
+        // 'absurd' is wordlist index 8, putting a 1 in the leading version byte
+        const tampered = [...MNEMONIC];
+        tampered[0] = 'absurd';
+        expect(() => validateAezeedChecksum(tampered)).toThrow(
+            'Invalid seed or version!'
+        );
+    });
+
+    it('rejects a BIP39 mnemonic that is not an aezeed', () => {
+        const bip39 = (
+            'abandon abandon abandon abandon abandon abandon abandon ' +
+            'abandon abandon abandon abandon about'
+        ).split(' ');
+        expect(() => validateAezeedChecksum(bip39)).toThrow();
     });
 });
 

--- a/utils/AezeedUtils.ts
+++ b/utils/AezeedUtils.ts
@@ -37,15 +37,7 @@ function getAD(salt: Buffer) {
     return ad;
 }
 
-/**
- * Decrypts an aezeed cipher seed mnemonic (with the default passphrase) and
- * returns the 16 bytes of wallet entropy, which lnd uses directly as the
- * BIP32 master seed. Throws when the mnemonic is not a valid aezeed or was
- * enciphered with a non-default passphrase.
- */
-export async function decodeAezeedEntropy(
-    seedPhrase: string[]
-): Promise<Buffer> {
+function seedBytesFromWords(seedPhrase: string[]): Buffer {
     const bits = seedPhrase
         .map((word: string) => {
             const index = BIP39_WORD_LIST.indexOf(word);
@@ -56,21 +48,43 @@ export async function decodeAezeedEntropy(
     const seedBytes = (bits.match(/(.{1,8})/g) || []).map((bin: string) =>
         parseInt(bin, 2)
     );
-    const seed = Buffer.from(seedBytes);
+    return Buffer.from(seedBytes);
+}
+
+/**
+ * Validates an aezeed mnemonic's version byte and CRC32 checksum without
+ * paying the scrypt cost of a full decipher. Throws when the mnemonic is
+ * not a valid aezeed.
+ */
+export function validateAezeedChecksum(seedPhrase: string[]): void {
+    const seed = seedBytesFromWords(seedPhrase);
 
     if (!seed || seed.length === 0 || seed[0] !== AEZEED_VERSION) {
         throw new Error('Invalid seed or version!');
     }
 
-    const salt = seed.slice(SALT_OFFSET, SALT_OFFSET + SALT_LENGTH);
-    const password = Buffer.from(AEZEED_DEFAULT_PASSPHRASE, 'utf8');
-    const cipherSeed = seed.slice(1, SALT_OFFSET);
     const checksum = seed.slice(CHECKSUM_OFFSET);
-
     const newChecksum = crc32.calculate(seed.slice(0, CHECKSUM_OFFSET));
     if (newChecksum !== checksum.readUInt32BE(0)) {
         throw new Error('Invalid seed checksum!');
     }
+}
+
+/**
+ * Decrypts an aezeed cipher seed mnemonic (with the default passphrase) and
+ * returns the 16 bytes of wallet entropy, which lnd uses directly as the
+ * BIP32 master seed. Throws when the mnemonic is not a valid aezeed or was
+ * enciphered with a non-default passphrase.
+ */
+export async function decodeAezeedEntropy(
+    seedPhrase: string[]
+): Promise<Buffer> {
+    validateAezeedChecksum(seedPhrase);
+
+    const seed = seedBytesFromWords(seedPhrase);
+    const salt = seed.slice(SALT_OFFSET, SALT_OFFSET + SALT_LENGTH);
+    const password = Buffer.from(AEZEED_DEFAULT_PASSPHRASE, 'utf8');
+    const cipherSeed = seed.slice(1, SALT_OFFSET);
 
     const key = await scrypt(
         password,

--- a/views/Settings/SeedRecovery.tsx
+++ b/views/Settings/SeedRecovery.tsx
@@ -70,6 +70,7 @@ import {
 } from '../../utils/LdkNodeUtils';
 
 import { BIP39_WORD_LIST } from '../../utils/Bip39Utils';
+import { validateAezeedChecksum } from '../../utils/AezeedUtils';
 
 import SettingsStore, {
     DEFAULT_SWAP_HOST_MAINNET,
@@ -688,6 +689,14 @@ export default class SeedRecovery extends React.PureComponent<
             filteredData.length
         );
 
+        // Typed words keep the user's raw casing/spacing for display, but
+        // checksums and key derivation are case- and whitespace-sensitive,
+        // so everything that validates, restores, or persists a seed must
+        // use this canonical form.
+        const normalizedSeedArray = seedArray.map(
+            (word: string) => word?.toLowerCase()?.trim() || ''
+        );
+
         const restore = async () => {
             this.setState({
                 errorCreatingWallet: false,
@@ -697,8 +706,8 @@ export default class SeedRecovery extends React.PureComponent<
 
             // Validate all seed words against BIP39 wordlist before attempting restore
             const invalidWords: number[] = [];
-            seedArray.forEach((word: string, i: number) => {
-                if (!BIP39_WORD_LIST.includes(word?.toLowerCase()?.trim())) {
+            normalizedSeedArray.forEach((word: string, i: number) => {
+                if (!BIP39_WORD_LIST.includes(word)) {
                     invalidWords.push(i + 1); // 1-based index to match UI
                 }
             });
@@ -715,9 +724,7 @@ export default class SeedRecovery extends React.PureComponent<
             const { SettingsStore } = this.props;
             const { settings } = SettingsStore;
             const existingNodes = settings.nodes || [];
-            const seedWords = seedArray
-                .map((w: string) => w?.toLowerCase()?.trim())
-                .join(' ');
+            const seedWords = normalizedSeedArray.join(' ');
             const duplicateNode = existingNodes.find((node: any) => {
                 if (node.implementation === 'embedded-lnd' && node.seedPhrase) {
                     return (
@@ -744,7 +751,7 @@ export default class SeedRecovery extends React.PureComponent<
 
             if (implementation === 'ldk-node') {
                 // LDK Node restore
-                const mnemonic = seedArray.join(' ');
+                const mnemonic = normalizedSeedArray.join(' ');
 
                 // LDK seeds are BIP39, so verify the checksum up front.
                 if (!validateMnemonic(mnemonic, BIP39_WORD_LIST)) {
@@ -844,6 +851,22 @@ export default class SeedRecovery extends React.PureComponent<
             } else {
                 // Embedded LND restore
 
+                // Aezeed carries its own version byte and CRC32 checksum, so
+                // a typo can be caught right here; without this gate it only
+                // surfaces minutes later as a raw InitWallet error, after
+                // LND has been stopped and restarted with a fresh lndDir.
+                try {
+                    validateAezeedChecksum(normalizedSeedArray);
+                } catch (e) {
+                    this.setState({
+                        loading: false,
+                        errorMsg: localeString(
+                            'views.Settings.SeedRecovery.invalidChecksum'
+                        )
+                    });
+                    return;
+                }
+
                 // Only stop LND if it's actually running — calling
                 // stopLnd when the daemon isn't up causes
                 // LndmobileStopDaemon to never call back, stalling
@@ -881,7 +904,7 @@ export default class SeedRecovery extends React.PureComponent<
                 });
                 await optimizeNeutrinoPeers(network === 'testnet');
 
-                const recoveryCipherSeed = seedArray.join(' ');
+                const recoveryCipherSeed = normalizedSeedArray.join(' ');
 
                 const lndDir = uuidv4();
 
@@ -1453,7 +1476,8 @@ export default class SeedRecovery extends React.PureComponent<
                                                     const result =
                                                         await SwapStore.getRescuableSwaps(
                                                             {
-                                                                seedArray,
+                                                                seedArray:
+                                                                    normalizedSeedArray,
                                                                 host:
                                                                     rescueHost ===
                                                                     'Custom'
@@ -1478,9 +1502,8 @@ export default class SeedRecovery extends React.PureComponent<
                                                 }
                                             );
                                         } else if (restoreRescueKey) {
-                                            const mnemonic = seedArray
-                                                .join(' ')
-                                                .trim();
+                                            const mnemonic =
+                                                normalizedSeedArray.join(' ');
 
                                             if (!isValidRescueKey(mnemonic)) {
                                                 this.setState({


### PR DESCRIPTION
# Description

Follow-up to the v13.1.3 TestFlight crash in `NodeEntropy.fromBip39Mnemonic` (invalid mnemonic reaching the LDK native layer, fixed by the `validateMnemonic` gate in 13.2.0). Auditing the seed entry paths turned up two remaining ways user typos slip past us:

1. **Embedded LND restore had no client-side seed validation.** A typo'd aezeed passed the wordlist gate, then the app stopped LND, slept 2-4s, optimized neutrino peers, created a fresh `lndDir`, and started a new LND instance, only for `InitWallet` to reject the cipher seed with a raw error (and leave the orphaned `lndDir` behind, which on Android is never cleaned up). Aezeed carries its own version byte and CRC32 checksum, and `AezeedUtils` already knew how to check it but was only used by `SeedQRExport`. This PR extracts a cheap `validateAezeedChecksum` (no scrypt) and gates the embedded restore on it, so typos now fail instantly with the existing `invalidChecksum` message.

2. **Typed seed words were joined raw while all checks compared normalized copies.** BIP39/aezeed checksums and key derivation are case- and whitespace-sensitive, so a *correct* seed typed with a stray capital or trailing space passed the per-word gate and then failed checksum validation with a misleading error. On the swap rescue key path the raw string was also what got persisted and derived from. The words are now normalized (lowercase + trim) once in render, and that canonical form is used for every validation, restore, persistence, and derivation path (LDK, aezeed, swap rescue). The clipboard paste path already normalized exactly this way; word-by-word typing now matches it.

Deliberately **not** done: lowercasing inside `SwapUtils.isValidRescueKey`. If the validator normalized while callers persisted or derived from the raw string, a caps mnemonic would validate but derive different keys than its lowercase form. Normalizing at the input boundary avoids that class of mismatch entirely.

`decodeAezeedEntropy` behavior is unchanged (it now calls the extracted validator first, same checks in the same order).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

New `validateAezeedChecksum` tests cover: the lnd-generated golden-vector mnemonic passing, a bad checksum, a non-zero version byte, and a BIP39-but-not-aezeed mnemonic.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

(Draft until device testing is done: embedded LND restore with a typo'd seed, with a correct seed, LDK restore with mixed-case typed words, and rescue key save/restore.)

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

No new strings; the existing `views.Settings.SeedRecovery.invalidChecksum` message is reused for the aezeed gate.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding