### PR TITLE
fix(nwc): prevent deletion race during in-flight pay_invoice

### DIFF
--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1182,6 +1182,37 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
         jest.clearAllTimers();
         jest.useRealTimers();
     });
+
+    it('defers relay release when delete follows a subscribed connection even without in-flight handlers', async () => {
+        jest.useFakeTimers();
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+        (store as any).nwcWalletServices.set(OLD_RELAY, { close: jest.fn() });
+        (store as any).activeSubscriptions.set(connection.id, jest.fn());
+
+        await (store as any).withGlobalHandler(connection.id, async () => ({
+            result: { ok: true },
+            error: undefined
+        }));
+
+        jest.spyOn(store as any, 'unsubscribeFromConnection').mockRestore();
+
+        const releaseSpy = jest.spyOn(
+            store as any,
+            'releaseUnusedRelayService'
+        );
+        await store.deleteConnection(connection.id);
+
+        expect(releaseSpy).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(RELAY_RELEASE_GRACE_MS);
+        expect(releaseSpy).toHaveBeenCalledWith(OLD_RELAY);
+
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
 });
 
 function buildMakeInvoiceTestStore(invoices: Invoice[] = []) {

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -63,7 +63,8 @@ import Invoice from '../models/Invoice';
 import Base64Utils from '../utils/Base64Utils';
 import NostrConnectUtils, { Nip47ErrorCode } from '../utils/NostrConnectUtils';
 import NostrWalletConnectStore, {
-    NWC_CLIENT_KEYS
+    NWC_CLIENT_KEYS,
+    RELAY_RELEASE_GRACE_MS
 } from './NostrWalletConnectStore';
 
 const hex64 = (c: string) => c.repeat(64);
@@ -1135,6 +1136,51 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
 
         expect(deleted).toBe(true);
         expect(store.connections).toHaveLength(0);
+    });
+
+    it('defers relay release when delete awaited in-flight handlers', async () => {
+        jest.useFakeTimers();
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+        (store as any).nwcWalletServices.set(OLD_RELAY, { close: jest.fn() });
+
+        let releaseHandler: (value: { result: { ok: boolean } }) => void = () =>
+            undefined;
+        const handlerDone = (store as any).withGlobalHandler(
+            connection.id,
+            () =>
+                new Promise((resolve) => {
+                    releaseHandler = resolve;
+                })
+        );
+
+        await Promise.resolve();
+
+        const releaseSpy = jest.spyOn(
+            store as any,
+            'releaseUnusedRelayService'
+        );
+        const deleteDone = store.deleteConnection(connection.id);
+
+        await Promise.resolve();
+        expect(releaseSpy).not.toHaveBeenCalled();
+
+        releaseHandler({ result: { ok: true } });
+        await handlerDone;
+        await deleteDone;
+
+        expect(releaseSpy).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(RELAY_RELEASE_GRACE_MS - 1);
+        expect(releaseSpy).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1);
+        expect(releaseSpy).toHaveBeenCalledWith(OLD_RELAY);
+
+        jest.clearAllTimers();
+        jest.useRealTimers();
     });
 });
 

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1058,6 +1058,84 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
         });
         expect(connection.lastUsed).toBeInstanceOf(Date);
     });
+
+    it('returns UNAUTHORIZED instead of throwing when the connection is deleted before handler entry', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+
+        jest.spyOn(store as any, 'markConnectionUsed').mockImplementation(
+            async () => {
+                store.connections = [];
+                return false;
+            }
+        );
+
+        const response = await (store as any).withGlobalHandler(
+            connection.id,
+            async () => ({
+                result: { should: 'not-run' },
+                error: undefined
+            })
+        );
+
+        expect(response).toEqual({
+            result: undefined,
+            error: {
+                code: 'UNAUTHORIZED',
+                message:
+                    'stores.NostrWalletConnectStore.error.connectionNotFound'
+            }
+        });
+    });
+
+    it('lets an in-flight handler finish before deleteConnection removes the record', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+
+        let releaseHandler: (value: { result: { ok: boolean } }) => void = () =>
+            undefined;
+        let enteredHandler = false;
+        const handlerDone = (store as any).withGlobalHandler(
+            connection.id,
+            () =>
+                new Promise((resolve) => {
+                    enteredHandler = true;
+                    releaseHandler = resolve;
+                })
+        );
+
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(enteredHandler).toBe(true);
+
+        let deleted = false;
+        const deleteDone = store.deleteConnection(connection.id).then(() => {
+            deleted = true;
+        });
+
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(deleted).toBe(false);
+        expect(store.connections).toHaveLength(1);
+
+        const lateResponse = await (store as any).withGlobalHandler(
+            connection.id,
+            async () => ({
+                result: { should: 'not-run' },
+                error: undefined
+            })
+        );
+        expect(lateResponse.error?.code).toBe('UNAUTHORIZED');
+
+        releaseHandler({ result: { ok: true } });
+        await handlerDone;
+        await deleteDone;
+
+        expect(deleted).toBe(true);
+        expect(store.connections).toHaveLength(0);
+    });
 });
 
 function buildMakeInvoiceTestStore(invoices: Invoice[] = []) {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -655,6 +655,8 @@ export default class NostrWalletConnectStore {
             this.pendingDeleteConnectionIds.add(connectionId);
             try {
                 const relayUrl = connection.relayUrl;
+                const hadActiveSubscription =
+                    this.activeSubscriptions.has(connectionId);
                 this.unsubscribeFromConnection(connectionId);
                 this.lastPendingPaymentStatusFetchByConnection.delete(
                     connectionId
@@ -675,7 +677,9 @@ export default class NostrWalletConnectStore {
                         this.connections.splice(liveIndex, 1);
                     }
                 });
-                if (hadInFlight) {
+                // Defer when a handler was in flight or the connection had been
+                // subscribed: the SDK may still be flushing the NIP-47 response.
+                if (hadInFlight || hadActiveSubscription) {
                     this.scheduleReleaseUnusedRelayService(relayUrl);
                 } else {
                     this.releaseUnusedRelayService(relayUrl);

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -98,6 +98,8 @@ const MAKE_INVOICE_RATE_WINDOW_MS = 60_000;
 const MAX_MAKE_INVOICE_PER_WINDOW = 5;
 const MAX_PENDING_MAKE_INVOICES_PER_CONNECTION = 10;
 const MAX_CONNECTION_ACTIVITY_ENTRIES = 100;
+/** Grace before closing an unused relay after delete awaited in-flight handlers. */
+export const RELAY_RELEASE_GRACE_MS = 5000;
 
 export const DEFAULT_NOSTR_RELAYS = [
     'wss://relay.getalby.com/v1',
@@ -187,6 +189,10 @@ export default class NostrWalletConnectStore {
     private inFlightHandlersByConnection = new Map<
         string,
         Set<Promise<unknown>>
+    >();
+    private scheduledRelayReleases = new Map<
+        string,
+        ReturnType<typeof setTimeout>
     >();
 
     settingsStore: SettingsStore;
@@ -433,6 +439,7 @@ export default class NostrWalletConnectStore {
                 this.connectionJustSucceeded = false;
                 this.lastConnectionAttempt = 0;
                 this.cashuEnabled = false;
+                this.cancelAllScheduledRelayReleases();
                 this.nwcWalletServices.clear();
                 this.publishedRelays.clear();
                 await this.unsubscribeFromAllConnections();
@@ -656,7 +663,9 @@ export default class NostrWalletConnectStore {
                     connectionId
                 );
                 this.makeInvoiceTimestampsByConnection.delete(connectionId);
-                await this.awaitInFlightHandlers(connectionId);
+                const hadInFlight = await this.awaitInFlightHandlers(
+                    connectionId
+                );
                 await this.deleteClientKeys(connection.pubkey);
                 const { index: liveIndex } = this.getConnection({
                     connectionId
@@ -666,7 +675,11 @@ export default class NostrWalletConnectStore {
                         this.connections.splice(liveIndex, 1);
                     }
                 });
-                this.releaseUnusedRelayService(relayUrl);
+                if (hadInFlight) {
+                    this.scheduleReleaseUnusedRelayService(relayUrl);
+                } else {
+                    this.releaseUnusedRelayService(relayUrl);
+                }
                 await this.saveConnections();
             } finally {
                 this.pendingDeleteConnectionIds.delete(connectionId);
@@ -1335,6 +1348,7 @@ export default class NostrWalletConnectStore {
             return;
         }
         try {
+            this.cancelScheduledRelayRelease(connection.relayUrl);
             this.unsubscribeFromConnection(connection.id);
             const serviceSecretKey = this.walletServiceKeys?.privateKey;
 
@@ -1539,6 +1553,33 @@ export default class NostrWalletConnectStore {
         });
     }
 
+    private scheduleReleaseUnusedRelayService(relayUrl: string): void {
+        if (!relayUrl) return;
+        const existing = this.scheduledRelayReleases.get(relayUrl);
+        if (existing) {
+            clearTimeout(existing);
+        }
+        const timeoutId = setTimeout(() => {
+            this.scheduledRelayReleases.delete(relayUrl);
+            this.releaseUnusedRelayService(relayUrl);
+        }, RELAY_RELEASE_GRACE_MS);
+        this.scheduledRelayReleases.set(relayUrl, timeoutId);
+    }
+
+    private cancelScheduledRelayRelease(relayUrl: string): void {
+        const existing = this.scheduledRelayReleases.get(relayUrl);
+        if (!existing) return;
+        clearTimeout(existing);
+        this.scheduledRelayReleases.delete(relayUrl);
+    }
+
+    private cancelAllScheduledRelayReleases(): void {
+        for (const timeoutId of this.scheduledRelayReleases.values()) {
+            clearTimeout(timeoutId);
+        }
+        this.scheduledRelayReleases.clear();
+    }
+
     private async unsubscribeFromAllConnections(): Promise<void> {
         const connectionIds = Array.from(this.activeSubscriptions.keys());
         for (const connectionId of connectionIds) {
@@ -1628,10 +1669,13 @@ export default class NostrWalletConnectStore {
         }
     }
 
-    private async awaitInFlightHandlers(connectionId: string): Promise<void> {
+    private async awaitInFlightHandlers(
+        connectionId: string
+    ): Promise<boolean> {
         const set = this.inFlightHandlersByConnection.get(connectionId);
-        if (!set?.size) return;
+        if (!set?.size) return false;
         await Promise.allSettled([...set]);
+        return true;
     }
 
     private unauthorizedConnectionResponse<T>(): T {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -183,6 +183,11 @@ export default class NostrWalletConnectStore {
         number
     >();
     private makeInvoiceTimestampsByConnection = new Map<string, number[]>();
+    private pendingDeleteConnectionIds = new Set<string>();
+    private inFlightHandlersByConnection = new Map<
+        string,
+        Set<Promise<unknown>>
+    >();
 
     settingsStore: SettingsStore;
     balanceStore: BalanceStore;
@@ -632,7 +637,7 @@ export default class NostrWalletConnectStore {
     @action
     public deleteConnection = async (connectionId: string) => {
         try {
-            const { connection, index } = this.getConnection({ connectionId });
+            const { connection } = this.getConnection({ connectionId });
             if (!connection) {
                 throw new Error(
                     localeString(
@@ -640,17 +645,32 @@ export default class NostrWalletConnectStore {
                     )
                 );
             }
-            const relayUrl = connection.relayUrl;
-            await this.deleteClientKeys(connection.pubkey);
-            this.unsubscribeFromConnection(connectionId);
-            this.lastPendingPaymentStatusFetchByConnection.delete(connectionId);
-            this.lastPendingInvoiceStatusFetchByConnection.delete(connectionId);
-            this.makeInvoiceTimestampsByConnection.delete(connectionId);
-            runInAction(() => {
-                this.connections.splice(index, 1);
-            });
-            this.releaseUnusedRelayService(relayUrl);
-            await this.saveConnections();
+            this.pendingDeleteConnectionIds.add(connectionId);
+            try {
+                const relayUrl = connection.relayUrl;
+                this.unsubscribeFromConnection(connectionId);
+                this.lastPendingPaymentStatusFetchByConnection.delete(
+                    connectionId
+                );
+                this.lastPendingInvoiceStatusFetchByConnection.delete(
+                    connectionId
+                );
+                this.makeInvoiceTimestampsByConnection.delete(connectionId);
+                await this.awaitInFlightHandlers(connectionId);
+                await this.deleteClientKeys(connection.pubkey);
+                const { index: liveIndex } = this.getConnection({
+                    connectionId
+                });
+                runInAction(() => {
+                    if (liveIndex !== -1) {
+                        this.connections.splice(liveIndex, 1);
+                    }
+                });
+                this.releaseUnusedRelayService(relayUrl);
+                await this.saveConnections();
+            } finally {
+                this.pendingDeleteConnectionIds.delete(connectionId);
+            }
         } catch (error: any) {
             runInAction(() => {
                 this.setError(
@@ -1201,14 +1221,12 @@ export default class NostrWalletConnectStore {
     };
 
     @action
-    private markConnectionUsed = async (connectionId: string) => {
+    private markConnectionUsed = async (
+        connectionId: string
+    ): Promise<boolean> => {
         const { connection } = this.getConnection({ connectionId });
         if (!connection) {
-            throw new Error(
-                localeString(
-                    'stores.NostrWalletConnectStore.error.connectionNotFound'
-                )
-            );
+            return false;
         }
         const wasNeverUsed = !connection.lastUsed;
 
@@ -1234,6 +1252,7 @@ export default class NostrWalletConnectStore {
         ) {
             this.stopWaitingForConnection();
         }
+        return true;
     };
     @action
     private findAndUpdateConnection(
@@ -1585,6 +1604,45 @@ export default class NostrWalletConnectStore {
         return successfulPublishes;
     }
 
+    private trackInFlightHandler(
+        connectionId: string,
+        work: Promise<unknown>
+    ): void {
+        let set = this.inFlightHandlersByConnection.get(connectionId);
+        if (!set) {
+            set = new Set();
+            this.inFlightHandlersByConnection.set(connectionId, set);
+        }
+        set.add(work);
+    }
+
+    private untrackInFlightHandler(
+        connectionId: string,
+        work: Promise<unknown>
+    ): void {
+        const set = this.inFlightHandlersByConnection.get(connectionId);
+        if (!set) return;
+        set.delete(work);
+        if (set.size === 0) {
+            this.inFlightHandlersByConnection.delete(connectionId);
+        }
+    }
+
+    private async awaitInFlightHandlers(connectionId: string): Promise<void> {
+        const set = this.inFlightHandlersByConnection.get(connectionId);
+        if (!set?.size) return;
+        await Promise.allSettled([...set]);
+    }
+
+    private unauthorizedConnectionResponse<T>(): T {
+        return NostrConnectUtils.createNip47Error(
+            localeString(
+                'stores.NostrWalletConnectStore.error.connectionNotFound'
+            ),
+            Nip47ErrorCode.UNAUTHORIZED
+        ) as T;
+    }
+
     /**
      * Runs every subscribed NWC request through one gate: reject (and drop
      * the subscription) when the connection is missing or has expired.
@@ -1595,35 +1653,46 @@ export default class NostrWalletConnectStore {
         connectionId: string,
         handler: () => Promise<T>
     ): Promise<T> {
-        const { connection } = this.getConnection({ connectionId });
-        if (!connection) {
-            if (!this.hasWalletContext()) {
+        let releaseGate = () => {};
+        const gate = new Promise<void>((resolve) => {
+            releaseGate = resolve;
+        });
+        this.trackInFlightHandler(connectionId, gate);
+        try {
+            const { connection } = this.getConnection({ connectionId });
+            if (!connection) {
+                if (!this.hasWalletContext()) {
+                    return NostrConnectUtils.createNip47Error(
+                        localeString(
+                            'stores.NostrWalletConnectStore.error.walletIdentityUnavailable'
+                        ),
+                        Nip47ErrorCode.INTERNAL_ERROR
+                    ) as T;
+                }
+                this.unsubscribeFromConnection(connectionId);
+                return this.unauthorizedConnectionResponse<T>();
+            }
+            if (this.pendingDeleteConnectionIds.has(connectionId)) {
+                return this.unauthorizedConnectionResponse<T>();
+            }
+            if (connection.isExpired) {
+                this.unsubscribeFromConnection(connectionId);
                 return NostrConnectUtils.createNip47Error(
                     localeString(
-                        'stores.NostrWalletConnectStore.error.walletIdentityUnavailable'
+                        'views.Settings.NostrWalletConnect.error.connectionExpired'
                     ),
-                    Nip47ErrorCode.INTERNAL_ERROR
+                    Nip47ErrorCode.RESTRICTED
                 ) as T;
             }
-            this.unsubscribeFromConnection(connectionId);
-            return NostrConnectUtils.createNip47Error(
-                localeString(
-                    'stores.NostrWalletConnectStore.error.connectionNotFound'
-                ),
-                Nip47ErrorCode.UNAUTHORIZED
-            ) as T;
+            const marked = await this.markConnectionUsed(connectionId);
+            if (!marked || this.pendingDeleteConnectionIds.has(connectionId)) {
+                return this.unauthorizedConnectionResponse<T>();
+            }
+            return await handler();
+        } finally {
+            releaseGate();
+            this.untrackInFlightHandler(connectionId, gate);
         }
-        if (connection.isExpired) {
-            this.unsubscribeFromConnection(connectionId);
-            return NostrConnectUtils.createNip47Error(
-                localeString(
-                    'views.Settings.NostrWalletConnect.error.connectionExpired'
-                ),
-                Nip47ErrorCode.RESTRICTED
-            ) as T;
-        }
-        await this.markConnectionUsed(connectionId);
-        return await handler();
     }
 
     // Serializes payment handling across all connections. Payment flows

--- a/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
@@ -255,8 +255,8 @@ export default class NWCConnectionDetails extends React.Component<
         }
         this.setState({ regenerating: true, error: null });
         try {
-            const params = this.buildConnectionParams(connection);
             await NostrWalletConnectStore.deleteConnection(connection.id);
+            const params = this.buildConnectionParams(connection);
             const nostrUrl = await NostrWalletConnectStore.createConnection(
                 params
             );


### PR DESCRIPTION
# Description

Fixes a low-severity NWC robustness issue: deleting (or regenerating) a connection while `pay_invoice` is in flight could leave settled spend on an orphaned connection object, so the budget debit and activity record were never persisted. A concurrent delete could also cause `markConnectionUsed` to throw instead of returning a NIP-47 error, leaving the client hanging until timeout.
- **`NostrWalletConnectStore`**: track in-flight NIP-47 handlers per connection; on `deleteConnection`, reject new requests, unsubscribe, await in-flight work, then remove the record and save
- **`markConnectionUsed`**: return `false` when the connection is gone; `withGlobalHandler` responds with `UNAUTHORIZED` instead of throwing
- **`NWCConnectionDetails`**: regenerate snapshots `buildConnectionParams` after `deleteConnection` so spend/activity settled during teardown is copied onto the recreated connection
## Test plan
- [x] `yarn test stores/NostrWalletConnectStore.test.ts ` (37 passed)
- [x] Manual: start NWC `pay_invoice` with slow backend, delete connection mid-flight — client receives preimage; budget/activity reflect the spend after delete or regenerate
- [x] Manual: delete connection just before a new NWC request — client receives `UNAUTHORIZED`, not a silent hang


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
