### PR TITLE
views: Bolt12Address: copy + QR with Address and Offer tabs

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1964,6 +1964,7 @@
     "views.Settings.Bolt12Address.requestButton": "Request Paycode",
     "views.Settings.Bolt12Address.changeButton": "Change Paycode",
     "views.Settings.Bolt12Address.handle": "Your handle",
+    "views.Settings.Bolt12Address.offer": "Offer",
     "views.Settings.Bolt12Address.error.noBolt12": "No BOLT 12 offer found",
     "views.Settings.Bolt12Address.error.failedToGetOffer": "Failed to get offer",
     "views.Settings.Bolt12Address.error.handleTaken": "Handle is taken",

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -169,6 +169,7 @@ interface LightningAddressSettings {
 
 interface Bolt12AddressSettings {
     localPart: string;
+    offer?: string;
 }
 
 interface EcashSettings {

--- a/views/Settings/Bolt12Address.tsx
+++ b/views/Settings/Bolt12Address.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
-import { Text, View, StyleSheet, ScrollView } from 'react-native';
+import { Platform, Text, View, StyleSheet, ScrollView } from 'react-native';
 import { inject, observer } from 'mobx-react';
+import { ButtonGroup } from '@rneui/themed';
+import NfcManager from 'react-native-nfc-manager';
+
 import { themeColor } from '../../utils/ThemeUtils';
 
 import Button from '../../components/Button';
+import CollapsedQR from '../../components/CollapsedQR';
 import Header from '../../components/Header';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import Screen from '../../components/Screen';
@@ -12,6 +16,7 @@ import TextInput from '../../components/TextInput';
 
 import { localeString } from '../../utils/LocaleUtils';
 import BackendUtils from '../../utils/BackendUtils';
+import { getButtonGroupStyles } from '../../utils/buttonGroupStyles';
 
 import SettingsStore from '../../stores/SettingsStore';
 
@@ -23,6 +28,9 @@ interface Bolt12AddressSettingsProps {
 interface Bolt12AddressSettingsState {
     newLocalPart: string;
     existingLocalPart: string;
+    existingOffer: string;
+    selectedIndex: number;
+    nfcSupported: boolean;
     loading: boolean;
     error: string;
 }
@@ -47,6 +55,9 @@ export default class Bolt12AddressSettings extends React.Component<
     state = {
         newLocalPart: '',
         existingLocalPart: '',
+        existingOffer: '',
+        selectedIndex: 0,
+        nfcSupported: false,
         loading: false,
         error: ''
     };
@@ -56,10 +67,55 @@ export default class Bolt12AddressSettings extends React.Component<
         const { getSettings } = SettingsStore;
         const settings = await getSettings();
 
+        const existingLocalPart = settings?.bolt12Address?.localPart || '';
+        const existingOffer = settings?.bolt12Address?.offer || '';
+
         this.setState({
             newLocalPart: '',
-            existingLocalPart: settings?.bolt12Address?.localPart || ''
+            existingLocalPart,
+            existingOffer
         });
+
+        if (existingLocalPart && !existingOffer) {
+            this.lookupOffer(existingLocalPart);
+        }
+
+        if (Platform.OS === 'android') {
+            try {
+                const nfcSupported = await NfcManager.isSupported();
+                this.setState({ nfcSupported });
+            } catch {
+                this.setState({ nfcSupported: false });
+            }
+        }
+    }
+
+    // addresses created before the offer string was persisted in settings:
+    // recover it from the node's active offers by the label set at creation
+    async lookupOffer(localPart: string) {
+        const { SettingsStore } = this.props;
+        const { updateSettings } = SettingsStore;
+
+        const address = `${localPart}@${HOST}`;
+
+        try {
+            const data = await BackendUtils.listOffers();
+            const match = (data?.offers || []).find(
+                (offer: any) => offer.label === address && offer.bolt12
+            );
+            if (!match) return;
+            if (this.state.existingLocalPart !== localPart) return;
+
+            await updateSettings({
+                bolt12Address: {
+                    localPart,
+                    offer: match.bolt12
+                }
+            });
+            this.setState({ existingOffer: match.bolt12 });
+        } catch (e) {
+            console.error('Failed to look up BOLT 12 address offer:', e);
+        }
     }
 
     async requestPaymentAddress() {
@@ -105,6 +161,7 @@ export default class Bolt12AddressSettings extends React.Component<
 
             if (res.status === 409) {
                 this.setState({
+                    loading: false,
                     error: localeString(
                         'views.Settings.Bolt12Address.error.handleTaken'
                     )
@@ -112,6 +169,7 @@ export default class Bolt12AddressSettings extends React.Component<
                 return;
             } else if (res.status !== 201) {
                 this.setState({
+                    loading: false,
                     error: localeString(
                         'views.Settings.Bolt12Address.error.failedToCreate'
                     )
@@ -121,17 +179,21 @@ export default class Bolt12AddressSettings extends React.Component<
 
             await updateSettings({
                 bolt12Address: {
-                    localPart: this.state.newLocalPart
+                    localPart: this.state.newLocalPart,
+                    offer: data.bolt12
                 }
             });
             this.setState({
                 newLocalPart: '',
                 existingLocalPart: this.state.newLocalPart,
+                existingOffer: data.bolt12,
+                selectedIndex: 0,
                 loading: false
             });
         } catch (e) {
             console.error(e);
             this.setState({
+                loading: false,
                 error: localeString(
                     'views.Settings.Bolt12Address.error.failedToCreate'
                 )
@@ -142,7 +204,56 @@ export default class Bolt12AddressSettings extends React.Component<
 
     render() {
         const { navigation } = this.props;
-        const { newLocalPart, existingLocalPart, loading, error } = this.state;
+        const {
+            newLocalPart,
+            existingLocalPart,
+            existingOffer,
+            selectedIndex,
+            nfcSupported,
+            loading,
+            error
+        } = this.state;
+
+        const address = `${existingLocalPart}@${HOST}`;
+
+        const tabs = [
+            {
+                title: localeString('general.address'),
+                value: `lightning:${address}`,
+                copyValue: address,
+                label: address
+            },
+            ...(existingOffer
+                ? [
+                      {
+                          title: localeString(
+                              'views.Settings.Bolt12Address.offer'
+                          ),
+                          value: `lightning:${existingOffer}`,
+                          copyValue: existingOffer,
+                          label: existingOffer
+                      }
+                  ]
+                : [])
+        ];
+        const active = tabs[selectedIndex] || tabs[0];
+
+        const groupStyles = getButtonGroupStyles();
+        const tabButtons = tabs.map((tab, idx) => ({
+            element: () => (
+                <Text
+                    style={{
+                        ...styles.tabText,
+                        color:
+                            selectedIndex === idx
+                                ? themeColor('background')
+                                : themeColor('text')
+                    }}
+                >
+                    {tab.title}
+                </Text>
+            )
+        }));
 
         return (
             <Screen>
@@ -164,16 +275,33 @@ export default class Bolt12AddressSettings extends React.Component<
                 <ScrollView style={{ flex: 1 }}>
                     {error && <ErrorMessage message={error} />}
                     {existingLocalPart ? (
-                        <View style={{ padding: 20 }}>
-                            <Text
-                                style={{
-                                    ...styles.handle,
-                                    color: themeColor('text'),
-                                    paddingBottom: 10
-                                }}
-                            >
-                                {`${existingLocalPart}@${HOST}`}
-                            </Text>
+                        <View style={{ paddingHorizontal: 15 }}>
+                            {existingOffer && (
+                                <ButtonGroup
+                                    onPress={(index) =>
+                                        this.setState({ selectedIndex: index })
+                                    }
+                                    selectedIndex={selectedIndex}
+                                    buttons={tabButtons}
+                                    selectedButtonStyle={
+                                        groupStyles.selectedButtonStyle
+                                    }
+                                    containerStyle={groupStyles.containerStyle}
+                                    innerBorderStyle={
+                                        groupStyles.innerBorderStyle
+                                    }
+                                />
+                            )}
+                            <CollapsedQR
+                                value={active.value}
+                                copyValue={active.copyValue}
+                                expanded
+                                textBottom
+                                truncateLongValue
+                                hideText
+                                labelBottom={active.label}
+                                nfcSupported={nfcSupported}
+                            />
                             <View style={styles.button}>
                                 <Button
                                     title={localeString(
@@ -182,7 +310,9 @@ export default class Bolt12AddressSettings extends React.Component<
                                     onPress={() => {
                                         this.setState({
                                             existingLocalPart: '',
-                                            newLocalPart: ''
+                                            existingOffer: '',
+                                            newLocalPart: '',
+                                            selectedIndex: 0
                                         });
                                     }}
                                 />
@@ -254,12 +384,10 @@ export default class Bolt12AddressSettings extends React.Component<
 }
 
 const styles = StyleSheet.create({
-    handle: {
-        fontSize: 20,
-        alignSelf: 'center',
+    secondaryText: {
         fontFamily: 'PPNeueMontreal-Book'
     },
-    secondaryText: {
+    tabText: {
         fontFamily: 'PPNeueMontreal-Book'
     },
     button: {


### PR DESCRIPTION
# Description

Closes #4444

|A|B|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-20 at 15 27 17" src="https://github.com/user-attachments/assets/3702b2fe-20b3-418d-bc39-f396da43f485" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-20 at 15 27 19" src="https://github.com/user-attachments/assets/73980011-7c43-49f0-9f22-6473d9dbe310" />|


Adds copy, QR, share, and NFC (Android) to the BOLT 12 address screen, matching the ZEUS Pay Lightning address QR view (`views/LightningAddress/LightningAddressQR.tsx`). Rendered inline on `views/Settings/Bolt12Address.tsx` rather than behind a separate QR route, so the address is immediately copyable per @ajaysehwal's ask in the #4406 review.

Two tabs, mirroring the ZEUS Pay Address/Noffer group:

- **Address**: the `user@twelve.cash` paycode. QR encodes `lightning:user@twelve.cash` (same convention as the ZEUS Pay view); copy value is the bare address.
- **Offer**: the underlying `lno...` BOLT 12 offer. QR encodes `lightning:lno...` (same convention as `views/PayCode.tsx`); copy value is the bare offer string.

## Offer string sourcing

Only `bolt12Address.localPart` was persisted, so:

- On creation, the `bolt12` string from the `createOffer` response is now persisted in a new optional `bolt12Address.offer` settings field. Purely additive optional field; existing blobs read as `undefined` and no migration is needed.
- For addresses created before this change, the screen recovers the offer via `listOffers`, matching on the `label` set at creation (`user@twelve.cash`), then persists it. If the lookup fails or finds nothing, the screen still works with just the Address tab (no tab group shown).

Also resets the loading indicator on the twelve.cash registration error paths (409 / non-201 / network error), which previously left the header spinner running forever.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Note: the screen is only reachable where `supportsBolt12Address()` is true, which is currently CLNRest only.

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
