### PR TITLE
Currency Converter: fix keyboard dismissing after every keystroke

### DIFF
--- a/components/CurrencyConverterContent.tsx
+++ b/components/CurrencyConverterContent.tsx
@@ -74,6 +74,11 @@ export default class CurrencyConverterContent extends React.Component<
     CurrencyConverterContentState
 > {
     private blurListener: (() => void) | undefined;
+    // react-native-draglist suffixes every row key with a generation counter
+    // that increments whenever `data` changes identity, remounting all rows
+    // and dismissing the keyboard mid-typing. Reuse the same array while the
+    // currency set is unchanged so value edits never remount the inputs.
+    private currencyKeys: string[] = [];
     constructor(props: CurrencyConverterContentProps) {
         super(props);
         this.state = {
@@ -384,6 +389,17 @@ export default class CurrencyConverterContent extends React.Component<
         ]).start();
     };
 
+    getStableCurrencyKeys = (): string[] => {
+        const keys = Object.keys(this.state.inputValues);
+        if (
+            keys.length !== this.currencyKeys.length ||
+            keys.some((key, index) => key !== this.currencyKeys[index])
+        ) {
+            this.currencyKeys = keys;
+        }
+        return this.currencyKeys;
+    };
+
     handleAddPress = () => {
         const { navigation, fromModal, onNavigateAway } = this.props;
         if (onNavigateAway) onNavigateAway();
@@ -526,7 +542,7 @@ export default class CurrencyConverterContent extends React.Component<
                     >
                         <TypedDragList
                             onReordered={this.onReordered}
-                            data={Object.keys(inputValues)}
+                            data={this.getStableCurrencyKeys()}
                             keyExtractor={(item) => String(item)}
                             scrollEnabled={false}
                             renderItem={({


### PR DESCRIPTION
# Description

Fixes the Currency Converter only accepting one keystroke at a time: after typing or deleting a single digit, the focused input would lose focus and the keyboard would close.

Root cause: `react-native-draglist` appends a generation counter to every row key and bumps it whenever the `data` prop changes identity (remounting all rows). `CurrencyConverterContent` passed a fresh `Object.keys(inputValues)` array on every render, so each keystroke's `setState` remounted every row, including the focused `TextInput`, which dismissed the keyboard.

Fix: cache the currency keys array and only replace it when the set or order of currencies actually changes (add/delete/reorder). Value edits keep the same array identity, so rows never remount mid-typing. Row contents still update because the inline `renderItem` gets a new identity per render, which triggers row re-renders without remounts.

This also fixes the report of taps on converter currencies doing nothing in the keypad currency modal (Telegram, 2026-08-20). `ModalBox` listens to `keyboardWillChangeFrame` on iOS and re-renders the modal subtree as soon as the keyboard starts presenting, so the freshly focused input was remounted and blurred before the keyboard finished appearing: tap, keyboard flash, nothing. The Tools > Currency Converter screen was less affected because it has no keyboard-driven re-render; only keystrokes triggered the remount there, which is why the issue was hard to reproduce for testers using that entry point (or Android, where `ModalBox` adds no keyboard listener). With the stable array identity, re-renders from any source no longer remount rows.

Test steps:
1. Menu > Tools > Currency Converter: type multi-digit amounts into several currencies without the keyboard closing.
2. Keypad > currency toggle > Converter tab (iOS especially): tap each currency input; the keyboard should appear and stay, and typing should convert values live.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

