### PR TITLE
Activity: fix crash toggling filters while a date filter is set

### DIFF
--- a/views/Activity/ActivityFilter.tsx
+++ b/views/Activity/ActivityFilter.tsx
@@ -118,7 +118,17 @@ export default class ActivityFilter extends React.Component<
         const { filters, setFilters } = ActivityStore;
         const locale = SettingsStore.settings.locale;
 
-        const newFilters = JSON.parse(JSON.stringify(filters));
+        // The JSON round-trip deep-clones the filters but turns the
+        // startDate/endDate Date instances into ISO strings, which throws
+        // downstream (getFullYear in ActivityFilterUtils, toLocaleDateString
+        // in render). Revive them like ActivityStore.getFilters does.
+        const newFilters: Filter = JSON.parse(
+            JSON.stringify(filters),
+            (key, value) =>
+                (key === 'startDate' || key === 'endDate') && value
+                    ? new Date(value)
+                    : value
+        );
 
         const toggleAllSwapFilters = (shouldTurnOn: boolean) => {
             newFilters.swaps = shouldTurnOn;


### PR DESCRIPTION
# Description

Fixes a reproducible hard crash on the Activity filter screen: once a start or end date filter is set, toggling any filter switch (received, sent, etc.) crashes the app, and because date filters are persisted the crash repeats on every attempt until filters are reset.

Root cause: `handleToggle` deep-clones the filter blob with `JSON.parse(JSON.stringify(filters))`, which converts the `startDate`/`endDate` `Date` instances into ISO strings. The next `setFilters` call then throws twice over: `ActivityFilterUtils` calls `filter.startDate.getFullYear()` on a string, and the filter screen render calls `toLocaleDateString()` on it. With no error boundary in the app, the render throw is fatal on release builds.

Fix: revive the dates during the clone with the same reviver `ActivityStore.getFilters` already uses for the persisted blob.

Repro (before the fix): Activity > filter > set a start date > toggle any switch.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

The crash is backend-agnostic (the throw happens before any backend call); device tests pending.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
