### PR TITLE
SelectCurrency: never dead-end the modal add-currency tap

### DIFF
--- a/views/Settings/SelectCurrency.tsx
+++ b/views/Settings/SelectCurrency.tsx
@@ -106,19 +106,35 @@ export default class SelectCurrency extends React.Component<
                 }}
                 onPress={async () => {
                     if (currencyConverter && fromModal) {
-                        const inputValuesString = await Storage.getItem(
-                            CURRENCY_CODES_KEY
-                        );
-                        const inputValues = inputValuesString
-                            ? JSON.parse(inputValuesString)
-                            : {};
-                        if (!inputValues.hasOwnProperty(item.value)) {
-                            inputValues[item.value] = '';
-                            await Storage.setItem(
-                                CURRENCY_CODES_KEY,
-                                inputValues
+                        try {
+                            const inputValuesString = await Storage.getItem(
+                                CURRENCY_CODES_KEY
+                            );
+                            let inputValues: { [key: string]: string } = {};
+                            if (inputValuesString) {
+                                try {
+                                    inputValues = JSON.parse(inputValuesString);
+                                } catch {
+                                    // Unreadable blob: rebuild it below so
+                                    // adding a currency self-heals instead
+                                    // of dead-ending the tap.
+                                }
+                            }
+                            if (!inputValues.hasOwnProperty(item.value)) {
+                                inputValues[item.value] = '';
+                                await Storage.setItem(
+                                    CURRENCY_CODES_KEY,
+                                    inputValues
+                                );
+                            }
+                        } catch (error) {
+                            console.error(
+                                'Error adding currency to converter:',
+                                error
                             );
                         }
+                        // Always return to the converter modal, even if
+                        // storage failed, so the tap never appears dead.
                         navigation.goBack();
                     } else if (currencyConverter) {
                         navigation.popTo('CurrencyConverter', {


### PR DESCRIPTION
# Description

Companion to #4446, covering the second half of the currency modal report: after tapping the converter's add button, tapping a currency (including favorites) on the Select Currency screen could do nothing, stranding the user on the list. The Tools > Currency Converter entry point was unaffected.

Root cause: the `fromModal` branch of the row's `onPress` parses the stored `zeus-currency-codes` blob with no guard. If the stored value is unreadable, `JSON.parse` throws, the async handler aborts before `navigation.goBack()`, and the tap appears dead on every attempt. The Tools flow never parses storage on tap (it uses `popTo` with a route param), which is why it kept working.

Fix:
- A blob that fails to parse is rebuilt from scratch, so adding a currency self-heals the corruption instead of dead-ending.
- Storage errors are logged instead of silently swallowing navigation.
- `goBack()` now always runs, so the tap always returns to the converter modal.

Repro guidance for testers: corrupt the stored blob (or simulate `Storage.getItem` returning non-JSON), open the keypad currency modal > Converter tab > add button, tap a favorite. Before the fix the tap does nothing; after it, the currency is added and the modal returns.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Backend-agnostic UI/storage path; device tests pending.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
