### PR TITLE
stores: no node calls until a wallet is picked

### DIFF
--- a/stores/BalanceStore.test.ts
+++ b/stores/BalanceStore.test.ts
@@ -1,4 +1,4 @@
-jest.mock('../stores/Stores', () => ({}));
+jest.mock('./Stores', () => ({}));
 jest.mock('react-native-blob-util', () => ({}));
 jest.mock('../ldknode/LdkNodeInjection', () => ({}));
 jest.mock('./SettingsStore', () => ({}));

--- a/stores/BalanceStore.test.ts
+++ b/stores/BalanceStore.test.ts
@@ -1,0 +1,86 @@
+jest.mock('../stores/Stores', () => ({}));
+jest.mock('react-native-blob-util', () => ({}));
+jest.mock('../ldknode/LdkNodeInjection', () => ({}));
+jest.mock('./SettingsStore', () => ({}));
+jest.mock('../utils/BackendUtils', () => ({
+    __esModule: true,
+    default: {
+        getBlockchainBalance: jest.fn(),
+        getLightningBalance: jest.fn(),
+        supportsOnchainBalance: jest.fn(() => true)
+    }
+}));
+
+import { observable, runInAction } from 'mobx';
+
+import BalanceStore from './BalanceStore';
+import BackendUtils from '../utils/BackendUtils';
+
+const blockchainBalance = {
+    total_balance: '0',
+    confirmed_balance: '0',
+    unconfirmed_balance: '0'
+};
+const lightningBalance = { balance: '0', pending_open_balance: '0' };
+
+const newSettingsStore = (walletSelectionPending: boolean) =>
+    observable({
+        settings: { nodes: [{}], selectedNode: 0 } as any,
+        walletSelectionPending,
+        hasCredentials: () => true
+    });
+
+// Writing settings again is what startup does: getSettings() runs several
+// times and assigns a freshly parsed object each time.
+const rewriteSettings = (settingsStore: any) =>
+    runInAction(() => {
+        settingsStore.settings = { nodes: [{}], selectedNode: 0 };
+    });
+
+describe('BalanceStore settings reaction', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (BackendUtils.getBlockchainBalance as jest.Mock).mockResolvedValue(
+            blockchainBalance
+        );
+        (BackendUtils.getLightningBalance as jest.Mock).mockResolvedValue(
+            lightningBalance
+        );
+    });
+
+    it('does not reach a node while the user is still choosing a wallet on startup', () => {
+        const settingsStore = newSettingsStore(true);
+        new BalanceStore(settingsStore as any);
+
+        rewriteSettings(settingsStore);
+
+        expect(BackendUtils.getBlockchainBalance).not.toHaveBeenCalled();
+        expect(BackendUtils.getLightningBalance).not.toHaveBeenCalled();
+    });
+
+    it('fetches balances when no wallet selection is pending', () => {
+        const settingsStore = newSettingsStore(false);
+        new BalanceStore(settingsStore as any);
+
+        rewriteSettings(settingsStore);
+
+        expect(BackendUtils.getBlockchainBalance).toHaveBeenCalled();
+        expect(BackendUtils.getLightningBalance).toHaveBeenCalled();
+    });
+
+    it('fetches again once the wallet has been picked', () => {
+        const settingsStore = newSettingsStore(true);
+        new BalanceStore(settingsStore as any);
+
+        rewriteSettings(settingsStore);
+        expect(BackendUtils.getLightningBalance).not.toHaveBeenCalled();
+
+        runInAction(() => {
+            settingsStore.walletSelectionPending = false;
+        });
+        rewriteSettings(settingsStore);
+
+        expect(BackendUtils.getBlockchainBalance).toHaveBeenCalled();
+        expect(BackendUtils.getLightningBalance).toHaveBeenCalled();
+    });
+});

--- a/stores/BalanceStore.ts
+++ b/stores/BalanceStore.ts
@@ -29,6 +29,10 @@ export default class BalanceStore {
         reaction(
             () => this.settingsStore.settings,
             () => {
+                // While the user is still choosing a wallet on startup no
+                // wallet is active yet, but the credentials loaded from
+                // settings still point at the previously used one.
+                if (this.settingsStore.walletSelectionPending) return;
                 if (this.settingsStore.hasCredentials()) {
                     this.getBlockchainBalance(false, false);
                     this.getLightningBalance(false);

--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -22,7 +22,10 @@ jest.mock('react-native-encrypted-storage', () => ({
     removeItem: jest.fn().mockResolvedValue(undefined)
 }));
 
-jest.mock('../utils/BackendUtils', () => ({}));
+jest.mock('../utils/BackendUtils', () => ({
+    __esModule: true,
+    default: { clearCachedCalls: jest.fn() }
+}));
 jest.mock('../utils/BiometricUtils', () => ({
     getSupportedBiometryType: jest.fn().mockResolvedValue(undefined)
 }));
@@ -33,7 +36,9 @@ jest.mock('../utils/MigrationUtils', () => ({
     keychainCloudSyncMigration: jest.fn().mockResolvedValue(undefined),
     purgeRescueKeyFiles: jest.fn().mockResolvedValue(undefined),
     migrateRgsDefaultToZeus: jest.fn().mockResolvedValue(undefined),
+    migrateSwapHostsToBoltz: jest.fn().mockResolvedValue(undefined),
     migrateInvoiceExpiryDisplay: jest.fn().mockResolvedValue(undefined),
+    migrateOlympusHostsToZeusLsp: jest.fn().mockResolvedValue(undefined),
     legacySettingsMigrations: jest.fn().mockResolvedValue({}),
     storageMigrationV2: jest.fn().mockResolvedValue(undefined)
 }));
@@ -91,6 +96,65 @@ beforeEach(() => {
 
 afterEach(() => {
     logSpy.mockRestore();
+});
+
+describe('SettingsStore startup wallet selection', () => {
+    const nodeSettings = (selectNodeOnStartup: boolean) => ({
+        selectNodeOnStartup,
+        selectedNode: 0,
+        nodes: [{ implementation: 'lnd', macaroonHex: 'abcd' }]
+    });
+
+    it('holds off node access while a wallet is still to be picked', async () => {
+        seedSettings(nodeSettings(true));
+        const store = new SettingsStore();
+
+        await store.getSettings();
+
+        // credentials of the previously used wallet are loaded, so the
+        // latch is what keeps anything from reaching it
+        expect(store.hasCredentials()).toBe(true);
+        expect(store.walletSelectionPending).toBe(true);
+    });
+
+    it('holds nothing off when the setting is disabled', async () => {
+        seedSettings(nodeSettings(false));
+        const store = new SettingsStore();
+
+        await store.getSettings();
+
+        expect(store.walletSelectionPending).toBe(false);
+    });
+
+    it('does not raise the latch once startup has handed over', async () => {
+        seedSettings(nodeSettings(true));
+        const store = new SettingsStore();
+        store.setInitialStart(false);
+
+        await store.getSettings();
+
+        expect(store.walletSelectionPending).toBe(false);
+    });
+});
+
+describe('SettingsStore.setConnectingStatus', () => {
+    it('ends a pending startup wallet selection when a wallet is activated', () => {
+        const store = new SettingsStore();
+        store.walletSelectionPending = true;
+
+        store.setConnectingStatus(true);
+
+        expect(store.walletSelectionPending).toBe(false);
+    });
+
+    it('leaves the pending flag alone when connecting is turned off', () => {
+        const store = new SettingsStore();
+        store.walletSelectionPending = true;
+
+        store.setConnectingStatus(false);
+
+        expect(store.walletSelectionPending).toBe(true);
+    });
 });
 
 describe('SettingsStore.updateSettings', () => {

--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -135,6 +135,28 @@ describe('SettingsStore startup wallet selection', () => {
 
         expect(store.walletSelectionPending).toBe(false);
     });
+
+    it('raises the latch again on the next settings write unless startup has ended', async () => {
+        seedSettings(nodeSettings(true));
+        const store = new SettingsStore();
+        await store.getSettings();
+        expect(store.walletSelectionPending).toBe(true);
+
+        // Dropping the latch on its own does not survive the next write
+        // while startup is still on: every write reloads the node
+        // properties, and that raises it again
+        store.setWalletSelectionPending(false);
+        await store.updateSettings({ lurkerMode: true });
+        expect(store.walletSelectionPending).toBe(true);
+
+        // Ending startup first is what keeps it down. The POS branch in
+        // Wallet.tsx relies on this, because that path never reaches
+        // setConnectingStatus(true)
+        store.setInitialStart(false);
+        store.setWalletSelectionPending(false);
+        await store.updateSettings({ lurkerMode: false });
+        expect(store.walletSelectionPending).toBe(false);
+    });
 });
 
 describe('SettingsStore.setConnectingStatus', () => {

--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -37,6 +37,7 @@ jest.mock('../utils/MigrationUtils', () => ({
     purgeRescueKeyFiles: jest.fn().mockResolvedValue(undefined),
     migrateRgsDefaultsToV2: jest.fn().mockResolvedValue(undefined),
     migrateSwapHostsToBoltz: jest.fn().mockResolvedValue(undefined),
+    migrateRetiredSwapHosts: jest.fn().mockResolvedValue(undefined),
     migrateInvoiceExpiryDisplay: jest.fn().mockResolvedValue(undefined),
     migrateOlympusHostsToZeusLsp: jest.fn().mockResolvedValue(undefined),
     legacySettingsMigrations: jest.fn().mockResolvedValue({}),

--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -35,7 +35,7 @@ jest.mock('../utils/LocaleUtils', () => ({
 jest.mock('../utils/MigrationUtils', () => ({
     keychainCloudSyncMigration: jest.fn().mockResolvedValue(undefined),
     purgeRescueKeyFiles: jest.fn().mockResolvedValue(undefined),
-    migrateRgsDefaultToZeus: jest.fn().mockResolvedValue(undefined),
+    migrateRgsDefaultsToV2: jest.fn().mockResolvedValue(undefined),
     migrateSwapHostsToBoltz: jest.fn().mockResolvedValue(undefined),
     migrateInvoiceExpiryDisplay: jest.fn().mockResolvedValue(undefined),
     migrateOlympusHostsToZeusLsp: jest.fn().mockResolvedValue(undefined),

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1677,6 +1677,11 @@ export default class SettingsStore {
     @observable public lndDir?: string;
     @observable public isSqlite?: boolean;
     @observable public initialStart: boolean = true;
+    // Set while startup hands the user the wallet list because of
+    // Display > Select wallet on startup, and cleared once a wallet is
+    // picked. Node credentials still point at the previously used
+    // wallet during that window, so nothing may reach a node.
+    @observable public walletSelectionPending: boolean = false;
     @observable public embeddedLndStarted: boolean = false;
     @observable public walletJustCreated: boolean = false;
     @observable public lndFolderMissing: boolean = false;
@@ -1727,6 +1732,10 @@ export default class SettingsStore {
 
     public setInitialStart = (status: boolean) => {
         this.initialStart = status;
+    };
+
+    public setWalletSelectionPending = (status: boolean) => {
+        this.walletSelectionPending = status;
     };
 
     public setLndFolderMissing = (status: boolean) => {
@@ -1862,6 +1871,12 @@ export default class SettingsStore {
 
     @action
     private updateNodeProperties = (settings: Settings) => {
+        // The credentials loaded below belong to the previously used wallet.
+        // If the user asked to pick a wallet on startup, nothing may reach a
+        // node with them until a wallet is actually activated.
+        if (this.initialStart && settings?.selectNodeOnStartup) {
+            this.walletSelectionPending = true;
+        }
         const node: any =
             settings?.nodes?.length &&
             settings?.nodes[settings.selectedNode || 0];
@@ -2305,6 +2320,8 @@ export default class SettingsStore {
             this.error = false;
             this.errorMsg = '';
             this.lndFolderMissing = false;
+            // A wallet is being activated, so startup selection is over
+            this.walletSelectionPending = false;
             BackendUtils.clearCachedCalls();
             // remove fetchLock on reconnect
             this.fetchLock = false;

--- a/stores/startupWalletSelection.test.ts
+++ b/stores/startupWalletSelection.test.ts
@@ -1,0 +1,197 @@
+// Regression cover for #4016. With Display > Select wallet on startup
+// enabled, nothing may reach a node until the user picks one, and the
+// window that is easiest to lose is the switch itself: updateSettings
+// assigns this.settings inside setSettings, which is not an action, before
+// updateNodeProperties loads the newly selected wallet's credentials. Any
+// reaction on settings therefore runs once while the credentials still
+// belong to the previously used wallet.
+
+jest.mock('react-native-biometrics', () => ({ BiometryType: {} }));
+jest.mock('react-native-blob-util', () => ({
+    fs: {
+        dirs: { LibraryDir: '/lib', DocumentDir: '/docs' }
+    }
+}));
+jest.mock('react-native-encrypted-storage', () => ({
+    getItem: jest.fn().mockResolvedValue(null),
+    setItem: jest.fn().mockResolvedValue(undefined),
+    removeItem: jest.fn().mockResolvedValue(undefined)
+}));
+
+jest.mock('../utils/BackendUtils', () => ({
+    __esModule: true,
+    default: {
+        clearCachedCalls: jest.fn(),
+        getBlockchainBalance: jest.fn(),
+        getLightningBalance: jest.fn(),
+        supportsOnchainBalance: jest.fn(() => true)
+    }
+}));
+jest.mock('../utils/BiometricUtils', () => ({
+    getSupportedBiometryType: jest.fn().mockResolvedValue(undefined)
+}));
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (s: string) => s
+}));
+jest.mock('../utils/MigrationUtils', () => ({
+    keychainCloudSyncMigration: jest.fn().mockResolvedValue(undefined),
+    migrateRgsDefaultToZeus: jest.fn().mockResolvedValue(undefined),
+    migrateSwapHostsToBoltz: jest.fn().mockResolvedValue(undefined),
+    migrateInvoiceExpiryDisplay: jest.fn().mockResolvedValue(undefined),
+    migrateOlympusHostsToZeusLsp: jest.fn().mockResolvedValue(undefined),
+    legacySettingsMigrations: jest.fn().mockResolvedValue({}),
+    storageMigrationV2: jest.fn().mockResolvedValue(undefined)
+}));
+jest.mock('../utils/TorUtils', () => ({
+    doTorRequest: jest.fn(),
+    RequestMethod: {}
+}));
+jest.mock('../utils/LdkNodeUtils', () => ({
+    DEFAULT_SCORER_URL: '',
+    DEFAULT_VSS_SERVER: '',
+    getDefaultEsploraServer: jest.fn().mockReturnValue(''),
+    getDefaultRgsServer: jest.fn().mockReturnValue('')
+}));
+jest.mock('../storage', () => {
+    const backing: Record<string, string> = {};
+    return {
+        _backing: backing,
+        getItem: jest.fn(async (key: string) => backing[key] ?? false),
+        setItem: jest.fn(async (key: string, value: any) => {
+            backing[key] =
+                typeof value === 'string' ? value : JSON.stringify(value);
+            return true;
+        }),
+        removeItem: jest.fn(async (key: string) => {
+            delete backing[key];
+            return true;
+        })
+    };
+});
+
+import { reaction } from 'mobx';
+
+import SettingsStore, { STORAGE_KEY } from './SettingsStore';
+import BalanceStore from './BalanceStore';
+import BackendUtils from '../utils/BackendUtils';
+
+const StorageMock: any = jest.requireMock('../storage');
+
+const previousWallet = { implementation: 'lnd', macaroonHex: 'aaaa' };
+const pickedWallet = { implementation: 'lnd', macaroonHex: 'bbbb' };
+const nodes = [previousWallet, pickedWallet];
+
+const seedStartupSettings = () => {
+    StorageMock._backing[STORAGE_KEY] = JSON.stringify({
+        selectNodeOnStartup: true,
+        selectedNode: 0,
+        nodes
+    });
+};
+
+// What Wallets.tsx commits when the user picks the second wallet
+const commitSwitch = (store: SettingsStore) =>
+    store.updateSettings({ nodes, selectedNode: 1 } as any);
+
+let logSpy: jest.SpyInstance;
+
+beforeEach(() => {
+    for (const key of Object.keys(StorageMock._backing)) {
+        delete StorageMock._backing[key];
+    }
+    jest.clearAllMocks();
+    (BackendUtils.getBlockchainBalance as jest.Mock).mockResolvedValue({
+        total_balance: '0',
+        confirmed_balance: '0',
+        unconfirmed_balance: '0'
+    });
+    (BackendUtils.getLightningBalance as jest.Mock).mockResolvedValue({
+        balance: '0',
+        pending_open_balance: '0'
+    });
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    logSpy.mockRestore();
+});
+
+describe('startup wallet selection', () => {
+    it('raises the latch while loading the previously used credentials', async () => {
+        seedStartupSettings();
+        const settingsStore = new SettingsStore();
+
+        await settingsStore.getSettings();
+
+        expect(settingsStore.macaroonHex).toEqual('aaaa');
+        expect(settingsStore.walletSelectionPending).toBe(true);
+    });
+
+    it('exposes the previous wallet to settings reactions while a switch commits', async () => {
+        seedStartupSettings();
+        const settingsStore = new SettingsStore();
+        await settingsStore.getSettings();
+
+        const credentialsSeen: (string | undefined)[] = [];
+        const dispose = reaction(
+            () => settingsStore.settings,
+            () => credentialsSeen.push(settingsStore.macaroonHex)
+        );
+
+        await commitSwitch(settingsStore);
+        dispose();
+
+        // Every write during the switch lands before the new wallet's
+        // credentials do, which is why the latch has to stay up until the
+        // switch is confirmed. On an emulator this showed up as three
+        // balance pairs going to the previously used wallet.
+        expect(credentialsSeen.length).toBeGreaterThan(0);
+        expect(credentialsSeen.every((macaroon) => macaroon === 'aaaa')).toBe(
+            true
+        );
+        expect(settingsStore.macaroonHex).toEqual('bbbb');
+    });
+
+    it('does not fetch balances from the previous wallet while a switch commits', async () => {
+        seedStartupSettings();
+        const settingsStore = new SettingsStore();
+        new BalanceStore(settingsStore);
+        await settingsStore.getSettings();
+
+        await commitSwitch(settingsStore);
+
+        expect(BackendUtils.getBlockchainBalance).not.toHaveBeenCalled();
+        expect(BackendUtils.getLightningBalance).not.toHaveBeenCalled();
+    });
+
+    it('fetches again once the switch is confirmed', async () => {
+        seedStartupSettings();
+        const settingsStore = new SettingsStore();
+        new BalanceStore(settingsStore);
+        await settingsStore.getSettings();
+        await commitSwitch(settingsStore);
+
+        // What every wallet activation path calls
+        settingsStore.setConnectingStatus(true);
+        await settingsStore.updateSettings({ nodes, selectedNode: 1 } as any);
+
+        expect(BackendUtils.getBlockchainBalance).toHaveBeenCalled();
+        expect(BackendUtils.getLightningBalance).toHaveBeenCalled();
+    });
+
+    it('leaves the latch down when the setting is disabled', async () => {
+        StorageMock._backing[STORAGE_KEY] = JSON.stringify({
+            selectNodeOnStartup: false,
+            selectedNode: 0,
+            nodes
+        });
+        const settingsStore = new SettingsStore();
+        new BalanceStore(settingsStore);
+        await settingsStore.getSettings();
+
+        await commitSwitch(settingsStore);
+
+        expect(settingsStore.walletSelectionPending).toBe(false);
+        expect(BackendUtils.getLightningBalance).toHaveBeenCalled();
+    });
+});

--- a/stores/startupWalletSelection.test.ts
+++ b/stores/startupWalletSelection.test.ts
@@ -35,7 +35,8 @@ jest.mock('../utils/LocaleUtils', () => ({
 }));
 jest.mock('../utils/MigrationUtils', () => ({
     keychainCloudSyncMigration: jest.fn().mockResolvedValue(undefined),
-    migrateRgsDefaultToZeus: jest.fn().mockResolvedValue(undefined),
+    purgeRescueKeyFiles: jest.fn().mockResolvedValue(undefined),
+    migrateRgsDefaultsToV2: jest.fn().mockResolvedValue(undefined),
     migrateSwapHostsToBoltz: jest.fn().mockResolvedValue(undefined),
     migrateInvoiceExpiryDisplay: jest.fn().mockResolvedValue(undefined),
     migrateOlympusHostsToZeusLsp: jest.fn().mockResolvedValue(undefined),

--- a/stores/startupWalletSelection.test.ts
+++ b/stores/startupWalletSelection.test.ts
@@ -38,6 +38,7 @@ jest.mock('../utils/MigrationUtils', () => ({
     purgeRescueKeyFiles: jest.fn().mockResolvedValue(undefined),
     migrateRgsDefaultsToV2: jest.fn().mockResolvedValue(undefined),
     migrateSwapHostsToBoltz: jest.fn().mockResolvedValue(undefined),
+    migrateRetiredSwapHosts: jest.fn().mockResolvedValue(undefined),
     migrateInvoiceExpiryDisplay: jest.fn().mockResolvedValue(undefined),
     migrateOlympusHostsToZeusLsp: jest.fn().mockResolvedValue(undefined),
     legacySettingsMigrations: jest.fn().mockResolvedValue({}),

--- a/views/Settings/Wallets.tsx
+++ b/views/Settings/Wallets.tsx
@@ -73,6 +73,7 @@ const TypedDragList = DragList as unknown as React.ComponentType<Props<Node>>;
 @observer
 export default class Nodes extends React.Component<NodesProps, NodesState> {
     isInitialFocus = true;
+    private walletSwitchInFlight = false;
 
     state = {
         nodes: [],
@@ -266,6 +267,10 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
             nodeIndex: number,
             nodeActive: boolean
         ) => {
+            // A switch is still committing: ignore repeat taps. A second
+            // tap would take the nodeActive branch and drop the latch
+            // before the first tap's settings assignment lands.
+            if (this.walletSwitchInFlight) return;
             if (SettingsStore.settings?.justDeletedWallet) {
                 await this.handleJustDeletedWallet(nodeIndex);
                 return;
@@ -329,13 +334,18 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
                     });
                 }
 
-                await updateSettings({
-                    nodes,
-                    selectedNode: nodeIndex
-                }).then(() => {
-                    setConnectingStatus(true);
-                    this.navigateAfterWalletSelection();
-                });
+                this.walletSwitchInFlight = true;
+                try {
+                    await updateSettings({
+                        nodes,
+                        selectedNode: nodeIndex
+                    }).then(() => {
+                        setConnectingStatus(true);
+                        this.navigateAfterWalletSelection();
+                    });
+                } finally {
+                    this.walletSwitchInFlight = false;
+                }
             }
         };
 

--- a/views/Settings/Wallets.tsx
+++ b/views/Settings/Wallets.tsx
@@ -200,6 +200,7 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
             updateSettings,
             setConnectingStatus,
             setInitialStart,
+            setWalletSelectionPending,
             implementation,
             initialStart
         } = SettingsStore;
@@ -272,6 +273,9 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
             if (initialStart) {
                 setInitialStart(false);
             }
+            // The active-node branch below skips connecting, so it never
+            // reaches setConnectingStatus, which clears this elsewhere
+            setWalletSelectionPending(false);
             if (nodeActive) {
                 // if already on selected node, just pop to
                 // the Wallet view, skip connecting procedures

--- a/views/Settings/Wallets.tsx
+++ b/views/Settings/Wallets.tsx
@@ -273,10 +273,14 @@ export default class Nodes extends React.Component<NodesProps, NodesState> {
             if (initialStart) {
                 setInitialStart(false);
             }
-            // The active-node branch below skips connecting, so it never
-            // reaches setConnectingStatus, which clears this elsewhere
-            setWalletSelectionPending(false);
             if (nodeActive) {
+                // This branch skips connecting, so it is the one path that
+                // never reaches setConnectingStatus, which clears the latch
+                // everywhere else. Clearing it any earlier would drop the
+                // latch before updateSettings assigns settings, and the
+                // BalanceStore reaction would fire while the credentials
+                // still belong to the previously used wallet.
+                setWalletSelectionPending(false);
                 // if already on selected node, just pop to
                 // the Wallet view, skip connecting procedures
                 this.navigateAfterWalletSelection();

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -469,6 +469,9 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 navigation.navigate('Lockscreen', { shareIntentData });
             } else if (posEnabled && posStatus === 'unselected') {
                 setPosStatus('active');
+                // POS never hands over to the wallet list, so the latch
+                // raised while settings loaded must not outlive startup
+                SettingsStore.setWalletSelectionPending(false);
                 if (!this.state.unlocked) {
                     this.startListeners();
                     this.setState({ unlocked: true });

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -469,8 +469,11 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 navigation.navigate('Lockscreen', { shareIntentData });
             } else if (posEnabled && posStatus === 'unselected') {
                 setPosStatus('active');
-                // POS never hands over to the wallet list, so the latch
-                // raised while settings loaded must not outlive startup
+                // POS takes over from startup here. End startup first, so
+                // the settings writes inside fetchData cannot raise the
+                // latch again, then drop the latch raised while settings
+                // loaded: this path never reaches setConnectingStatus(true)
+                SettingsStore.setInitialStart(false);
                 SettingsStore.setWalletSelectionPending(false);
                 if (!this.state.unlocked) {
                     this.startListeners();


### PR DESCRIPTION
# Description

Relates to issue: **#4016**

With `Display > Select wallet on startup` enabled, the wallet list opens without activating a wallet, but the previously used wallet was still contacted in the background.

`Wallet.tsx` handles the setting correctly — it returns before `fetchData()`. The requests come from somewhere else: `BalanceStore` sets up a reaction on the whole `settings` object in its constructor and fetches balances whenever `hasCredentials()` is true. During startup `getSettings()` runs several times, and each call assigns a freshly parsed settings object, so the reaction fires again and again. `updateNodeProperties()` has already loaded the credentials of `nodes[selectedNode]` by then, so those fetches go to the last used wallet.

Measured on an emulator with a local HTTP server standing in for the node: after a restart, with the wallet list open and nothing selected, the server received **10 requests** — five `/v1/balance/blockchain` + `/v1/balance/channels` pairs, then quiet. It is a burst during startup, not polling. With this change it receives **none**, and selecting a wallet still connects normally.

### The change

`SettingsStore` now carries `walletSelectionPending`.

It is raised in `updateNodeProperties()` — the same place the node credentials are loaded — so the latch is up before anything can react to them. My first attempt set it from `Wallet.tsx` instead, next to the navigation, and that was too late: the reaction had already fired five times with credentials by the time the view got there, which cut the requests from 10 to 6 rather than to 0.

It is cleared in `setConnectingStatus(true)`, which every wallet activation path already calls, so new wallets created or imported from the startup list are covered too. `Wallets.tsx` clears it explicitly in the one branch that skips connecting because the node is already active.

The `BalanceStore` reaction returns early while the latch is set.

### Scope

Only wallets whose credentials are a macaroon or an access key were affected, since `hasCredentials()` checks those two. An LNDHub wallet has neither, so it never triggered this — I reproduced against LNDHub first and saw no requests at all.

The node process itself never started: `startLnd()` runs inside `fetchData()`, which the existing guard already skips. What leaked were the balance requests.

### Note on the test mock

`stores/SettingsStore.test.ts` mocked `MigrationUtils` without `migrateSwapHostsToBoltz` and `migrateOlympusHostsToZeusLsp`, so `getSettings()` threw into its own `catch` and never reached `updateNodeProperties()`. I added them — without that the new tests would have passed without exercising anything.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

Eight new tests: three in a new `stores/BalanceStore.test.ts` covering the reaction gate, and five in `stores/SettingsStore.test.ts` covering when the latch is raised and cleared. I checked each of them fails with the fix removed.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android — Android 16 (API 36), Pixel 9 Pro AVD, x86_64 emulator
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST) — pointed at a local stub server, which is what counts the requests
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [x] LndHub — local stub, used to confirm this path is not affected

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
