### PR TITLE
Currency modal: dismiss dialog window before navigating to Select Currency

### DIFF
--- a/components/CurrencyConverterContent.tsx
+++ b/components/CurrencyConverterContent.tsx
@@ -50,7 +50,7 @@ interface CurrencyConverterContentProps {
     showToolbar?: boolean;
     fromModal?: boolean;
     onInputValuesChanged?: (count: number) => void;
-    onNavigateAway?: () => void;
+    onNavigateAway?: (navigate: () => void) => void;
 }
 
 interface CurrencyConverterContentState {
@@ -402,11 +402,19 @@ export default class CurrencyConverterContent extends React.Component<
 
     handleAddPress = () => {
         const { navigation, fromModal, onNavigateAway } = this.props;
-        if (onNavigateAway) onNavigateAway();
-        navigation.navigate('SelectCurrency', {
-            currencyConverter: true,
-            fromModal: fromModal || false
-        });
+        const navigate = () =>
+            navigation.navigate('SelectCurrency', {
+                currencyConverter: true,
+                fromModal: fromModal || false
+            });
+        // In the modal, let the host dismiss its window first and navigate
+        // from its callback; navigating while the window is still up strands
+        // an invisible dialog over the pushed screen on Android (#4451).
+        if (onNavigateAway) {
+            onNavigateAway(navigate);
+        } else {
+            navigate();
+        }
     };
 
     render() {

--- a/components/CurrencySelectorModal.tsx
+++ b/components/CurrencySelectorModal.tsx
@@ -83,9 +83,18 @@ export default class CurrencySelectorModal extends React.Component<
         this.close();
     };
 
-    handleConverterNavigateAway = () => {
+    handleConverterNavigateAway = (navigate: () => void) => {
         this.pendingReopen = true;
-        this.close();
+        // Skip the slide-down animation: its completion is what dismisses
+        // the underlying dialog window, and Android stops driving it once a
+        // pushed screen occludes the window, leaving an invisible dialog
+        // that eats every tap on Select Currency (#4451). Dismiss
+        // immediately and only navigate once the closed state is committed.
+        if (this.modalRef.current) {
+            this.modalRef.current.closeImmediate(navigate);
+        } else {
+            navigate();
+        }
     };
 
     render() {

--- a/components/ModalBox.tsx
+++ b/components/ModalBox.tsx
@@ -760,4 +760,49 @@ export default class ModalBox extends React.PureComponent<
             }
         }
     }
+
+    /*
+     * Close without animating. The animated close only dismisses the
+     * underlying RN Modal once the slide-down finishes, and on Android that
+     * animation stops advancing when the dialog window is occluded (e.g. by
+     * a navigation push), leaving an invisible dialog that swallows every
+     * tap on the screen below. Callers that navigate right after closing
+     * must use this instead of close(); onDone fires once the closed state
+     * has been committed, so navigation can safely start.
+     */
+    closeImmediate(onDone?: () => void) {
+        if (this.props.isDisabled) return;
+        if (
+            !this.state.isOpen &&
+            !this.state.isAnimateOpen &&
+            !this.state.isAnimateClose
+        ) {
+            if (onDone) onDone();
+            return;
+        }
+        this.stopAnimateOpen();
+        this.stopAnimateClose();
+        if (this.backHandlerSubscription) {
+            this.backHandlerSubscription.remove();
+            this.backHandlerSubscription = null;
+        }
+        this.setState(
+            {
+                isOpen: false,
+                isAnimateOpen: false,
+                isAnimateClose: false,
+                isAnimateBackdrop: false
+            },
+            () => {
+                this.state.position.setValue(
+                    this.props.entry === 'top'
+                        ? -this.state.containerHeight
+                        : this.state.containerHeight
+                );
+                this.state.backdropOpacity.setValue(0);
+                if (this.props.onClosed) this.props.onClosed();
+                if (onDone) onDone();
+            }
+        );
+    }
 }

--- a/components/ModalBox.tsx
+++ b/components/ModalBox.tsx
@@ -768,10 +768,11 @@ export default class ModalBox extends React.PureComponent<
      * a navigation push), leaving an invisible dialog that swallows every
      * tap on the screen below. Callers that navigate right after closing
      * must use this instead of close(); onDone fires once the closed state
-     * has been committed, so navigation can safely start.
+     * has been committed, so navigation can safely start. Ignores
+     * isDisabled: that prop guards user-initiated open/close, and a caller
+     * navigating away needs the dialog torn down unconditionally.
      */
     closeImmediate(onDone?: () => void) {
-        if (this.props.isDisabled) return;
         if (
             !this.state.isOpen &&
             !this.state.isAnimateOpen &&
@@ -782,6 +783,10 @@ export default class ModalBox extends React.PureComponent<
         }
         this.stopAnimateOpen();
         this.stopAnimateClose();
+        // stopAnimateOpen/Close only stop the position animation; an
+        // in-flight backdrop fade-in would keep driving backdropOpacity
+        // past the setValue(0) below and park it at 1
+        if (this.state.animBackdrop) this.state.animBackdrop.stop();
         if (this.backHandlerSubscription) {
             this.backHandlerSubscription.remove();
             this.backHandlerSubscription = null;


### PR DESCRIPTION
# Description

Fixes #4451: on Android, tapping any currency (favorites included) on the Select Currency screen reached from the keypad currency modal's Converter tab did nothing, stranding the user on the list. The Settings > Currency Converter entry point was unaffected.

Root cause, established from the reporter's logcat and screen recording: the converter's add button starts the ModalBox slide-down animation and calls `navigation.navigate('SelectCurrency')` in the same tick. The ModalBox is an RN `Modal` (`coverScreen`), i.e. a separate Android dialog window, and that window is only dismissed once the close animation's completion callback flips `isAnimateClose` so `visible` goes false. Android stops driving the animation once the pushed screen occludes the dialog window, so the invisible dialog stayed alive (3.5 seconds in the reporter's trace) and received every tap meant for Select Currency. The logcat shows the taps landing on the dialog's window (`ViewPostIme` on the modal's `VRI[MainActivity]@b8d78ba`) while Select Currency was on screen, with no JS `onPress` ever firing; gesture handling was left wedged afterwards ("Can't cancel already finished gesture").

Fix:
- New `ModalBox.closeImmediate(onDone?)`: commits the closed state without animating (so the dialog window is torn down deterministically) and invokes `onDone` after the commit.
- The converter's navigate-away path now dismisses the modal via `closeImmediate` and navigates from its callback, so Select Currency is only pushed once the dialog is gone. The animated close is still used everywhere the modal closes without a navigation (Currencies tab select, backdrop press, swipe).
- The reopen-on-focus flow (`pendingReopen`) is unchanged and already worked in the reporter's recording.

Repro (before the fix, Android): keypad > tap the fiat chip > Currency Converter tab > "+" > tap any currency. The tap does nothing. After the fix the currency is added and the modal reopens on the Converter tab.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

## Locales

- [ ] I've added new translatable text, wrapped with the `localeString` function
- [x] I haven't added any new translatable text
- [ ] I acknowledge that all new translations are handled on Transfix and not in-repo

## Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this change
- [x] No new dependencies introduced
- [ ] New dependencies introduced and vetted
- [ ] Verified that the package.json and yarn.lock files are in sync

## Other

- [ ] I've documented new flows or processes in the repo's README or docs folder
- [x] No documentation changes needed
