### PR TITLE
Show status for unconfirmed on-chain transactions

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -10,6 +10,7 @@ import {
     getBalance,
     getChainTransactions,
     getOffchainBalance,
+    getUTXOs as getChainUTXOs,
     listPeers,
     listClosedChannels,
     listPeerChannels
@@ -617,7 +618,7 @@ export default class CLNRest {
             feebase: data.base_fee_msat,
             feeppm: data.fee_rate
         });
-    getUTXOs = () => this.postRequest('/v1/listfunds');
+    getUTXOs = async () => await getChainUTXOs();
     signMessage = (message: string) =>
         this.postRequest('/v1/signmessage', {
             message

--- a/backends/CoreLightningRequestHandler.test.ts
+++ b/backends/CoreLightningRequestHandler.test.ts
@@ -1,0 +1,107 @@
+const mockPostRequest = jest.fn();
+
+// the handler constructs its CLNRest instance at import time, so postRequest
+// has to resolve the mock lazily
+jest.mock('./CLNRest', () => ({
+    __esModule: true,
+    default: class {
+        postRequest(...args: Array<any>) {
+            return mockPostRequest(...args);
+        }
+    }
+}));
+// only used by getChainTransactions, but importing it pulls in the whole
+// store graph
+jest.mock('../utils/AddressUtils', () => ({ __esModule: true, default: {} }));
+
+import { getUTXOs } from './CoreLightningRequestHandler';
+
+const listfunds = (outputs: Array<any>) => ({ outputs, channels: [] });
+
+const respond = (funds: any, info?: any) =>
+    mockPostRequest.mockImplementation((route: string) => {
+        if (route === '/v1/listfunds') return Promise.resolve(funds);
+        if (route === '/v1/getinfo')
+            return info
+                ? Promise.resolve(info)
+                : Promise.reject(new Error('getinfo failed'));
+        return Promise.reject(new Error(`unexpected route ${route}`));
+    });
+
+describe('CoreLightningRequestHandler.getUTXOs', () => {
+    beforeEach(() => mockPostRequest.mockReset());
+
+    it('derives a confirmation count from the blockheight and the tip', async () => {
+        // listfunds outputs carry no confirmations field; before this was
+        // normalized every CLN UTXO reported 0 confirmations
+        respond(listfunds([{ txid: 'a', blockheight: 108 }]), {
+            blockheight: 200
+        });
+
+        const { outputs } = await getUTXOs();
+
+        expect(outputs[0].confirmations).toBe(93);
+    });
+
+    it('counts the tip block as one confirmation', async () => {
+        respond(listfunds([{ txid: 'a', blockheight: 200 }]), {
+            blockheight: 200
+        });
+
+        const { outputs } = await getUTXOs();
+
+        expect(outputs[0].confirmations).toBe(1);
+    });
+
+    it('reports 0 for an output with no blockheight', async () => {
+        respond(listfunds([{ txid: 'a', status: 'unconfirmed' }]), {
+            blockheight: 200
+        });
+
+        const { outputs } = await getUTXOs();
+
+        expect(outputs[0].confirmations).toBe(0);
+    });
+
+    it('omits the count when the tip is unknown', async () => {
+        respond(listfunds([{ txid: 'a', blockheight: 108 }]));
+
+        const { outputs } = await getUTXOs();
+
+        expect(outputs[0]).not.toHaveProperty('confirmations');
+    });
+
+    it('preserves the rest of the listfunds response', async () => {
+        respond(
+            listfunds([
+                {
+                    txid: 'a',
+                    output: 1,
+                    amount_msat: 984857000,
+                    blockheight: 108
+                }
+            ]),
+            { blockheight: 200 }
+        );
+
+        const { outputs, channels } = await getUTXOs();
+
+        expect(outputs[0]).toMatchObject({
+            txid: 'a',
+            output: 1,
+            amount_msat: 984857000,
+            blockheight: 108
+        });
+        expect(channels).toEqual([]);
+    });
+
+    it('rejects when listfunds fails', async () => {
+        mockPostRequest.mockImplementation((route: string) =>
+            route === '/v1/listfunds'
+                ? Promise.reject(new Error('listfunds failed'))
+                : Promise.resolve({ blockheight: 200 })
+        );
+
+        await expect(getUTXOs()).rejects.toThrow('listfunds failed');
+    });
+});

--- a/backends/CoreLightningRequestHandler.ts
+++ b/backends/CoreLightningRequestHandler.ts
@@ -318,3 +318,38 @@ export const getChainTransactions = async () => {
         transactions
     };
 };
+
+// listfunds outputs carry a blockheight but no confirmation count, so derive
+// one from the current tip. Outputs still in the mempool have no blockheight
+// and report 0; if the tip is unknown the count is left off entirely rather
+// than claiming the output is unconfirmed.
+export const getUTXOs = async () => {
+    const results = await Promise.allSettled([
+        api.postRequest('/v1/listfunds'),
+        api.postRequest('/v1/getinfo')
+    ]);
+    const [listfundsResult, getinfoResult]: any = results;
+
+    if (listfundsResult.status !== 'fulfilled') {
+        throw listfundsResult.reason;
+    }
+
+    const listfunds = listfundsResult.value;
+    const tip =
+        getinfoResult.status === 'fulfilled'
+            ? getinfoResult.value.blockheight
+            : undefined;
+
+    return {
+        ...listfunds,
+        outputs: (listfunds.outputs || []).map((output: any) => {
+            if (!tip) return output;
+            return {
+                ...output,
+                confirmations: output.blockheight
+                    ? tip - output.blockheight + 1
+                    : 0
+            };
+        })
+    };
+};

--- a/backends/CoreLightningRequestHandler.ts
+++ b/backends/CoreLightningRequestHandler.ts
@@ -285,7 +285,9 @@ export const getChainTransactions = async () => {
                 return {
                     amount: -Math.abs(withdrawal[3]) / 1000,
                     block_height: withdrawal[6],
-                    num_confirmations: getinfo.blockheight - withdrawal[6],
+                    num_confirmations: withdrawal[6]
+                        ? getinfo.blockheight - withdrawal[6] + 1
+                        : 0,
                     time_stamp: withdrawal[5],
                     txid: tx.hash,
                     dest_addresses: tx.dest_addresses
@@ -296,7 +298,9 @@ export const getChainTransactions = async () => {
                 return {
                     amount: deposit[3] / 1000,
                     block_height: deposit[6],
-                    num_confirmations: getinfo.blockheight - deposit[6],
+                    num_confirmations: deposit[6]
+                        ? getinfo.blockheight - deposit[6] + 1
+                        : 0,
                     time_stamp: deposit[5],
                     txid: tx.hash,
                     dest_addresses: tx.dest_addresses

--- a/models/Transaction.test.ts
+++ b/models/Transaction.test.ts
@@ -1,0 +1,57 @@
+jest.mock('../stores/Stores', () => ({}));
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+
+import Transaction from './Transaction';
+
+describe('Transaction.isConfirmed', () => {
+    it('is false for an unconfirmed lnd-style transaction', () => {
+        expect(new Transaction({ num_confirmations: 0 }).isConfirmed).toBe(
+            false
+        );
+        expect(new Transaction({}).isConfirmed).toBe(false);
+    });
+
+    it('is true once confirmations exist or status is confirmed', () => {
+        expect(new Transaction({ num_confirmations: 3 }).isConfirmed).toBe(
+            true
+        );
+        expect(new Transaction({ status: 'confirmed' }).isConfirmed).toBe(true);
+    });
+});
+
+describe('Transaction.getStatusDisplay', () => {
+    it('reports unconfirmed for lnd-style transactions with no status field', () => {
+        // lnd, embedded LND, LNC, and CLN transactions carry no status
+        // field; before the fix this returned '' for pending transactions
+        expect(new Transaction({ num_confirmations: 0 }).getStatusDisplay).toBe(
+            'general.unconfirmed'
+        );
+        expect(new Transaction({}).getStatusDisplay).toBe(
+            'general.unconfirmed'
+        );
+    });
+
+    it('reports unconfirmed for LDK Node pending transactions', () => {
+        expect(
+            new Transaction({ num_confirmations: 0, status: 'pending' })
+                .getStatusDisplay
+        ).toBe('general.unconfirmed');
+    });
+
+    it('reports confirmed for confirmed transactions', () => {
+        expect(new Transaction({ num_confirmations: 6 }).getStatusDisplay).toBe(
+            'general.confirmed'
+        );
+        expect(new Transaction({ status: 'confirmed' }).getStatusDisplay).toBe(
+            'general.confirmed'
+        );
+    });
+
+    it('passes through unknown backend status strings', () => {
+        expect(new Transaction({ status: 'replaced' }).getStatusDisplay).toBe(
+            'replaced'
+        );
+    });
+});

--- a/models/Transaction.ts
+++ b/models/Transaction.ts
@@ -129,9 +129,8 @@ export default class Transaction extends BaseModel {
 
     @computed public get getStatusDisplay(): string {
         if (this.isConfirmed) return localeString('general.confirmed');
-        if (this.status === 'pending')
-            return localeString('general.unconfirmed');
-        return this.status || '';
+        if (this.status && this.status !== 'pending') return this.status;
+        return localeString('general.unconfirmed');
     }
 
     @computed public get getNoteKey(): string {

--- a/models/Utxo.ts
+++ b/models/Utxo.ts
@@ -32,7 +32,7 @@ export default class Utxo extends BaseModel {
     }
 
     @computed public get getConfs(): number {
-        return Number(this.confirmations);
+        return Number(this.confirmations) || 0;
     }
 
     @computed public get getOutpoint(): string {

--- a/models/Utxo.ts
+++ b/models/Utxo.ts
@@ -10,7 +10,7 @@ interface Outpoint {
 export default class Utxo extends BaseModel {
     @observable address: string;
     account: string;
-    confirmations: string;
+    confirmations?: string | number;
     outpoint: Outpoint;
     txid: string;
     output: string | number;

--- a/views/Transaction.tsx
+++ b/views/Transaction.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import forEach from 'lodash/forEach';
-import isNull from 'lodash/isNull';
 import {
     StyleSheet,
     ScrollView,
@@ -104,7 +103,6 @@ export default class TransactionView extends React.Component<
             destAddresses,
             getFee,
             getFeePercentage,
-            status,
             getOutpoint,
             raw_tx_hex,
             getNoteKey
@@ -325,7 +323,7 @@ export default class TransactionView extends React.Component<
                         />
                     )}
 
-                    {!!num_confirmations && !isNull(num_confirmations) && (
+                    {num_confirmations != null && (
                         <KeyValue
                             keyValue={localeString('views.Transaction.numConf')}
                             value={num_confirmations}
@@ -334,12 +332,11 @@ export default class TransactionView extends React.Component<
                         />
                     )}
 
-                    {!!status && (
-                        <KeyValue
-                            keyValue={localeString('general.status')}
-                            value={transaction.getStatusDisplay}
-                        />
-                    )}
+                    <KeyValue
+                        keyValue={localeString('general.status')}
+                        value={transaction.getStatusDisplay}
+                        color={isConfirmed ? 'green' : 'red'}
+                    />
 
                     {!!date && (
                         <KeyValue

--- a/views/UTXOs/UTXO.tsx
+++ b/views/UTXOs/UTXO.tsx
@@ -58,8 +58,14 @@ export default class UTXO extends React.Component<UTXOProps, UTXOState> {
         const utxo = route.params?.utxo;
         const { testnet } = NodeInfoStore;
 
-        const { getOutpoint, address, getConfs, isUnconfirmed, blockheight } =
-            utxo;
+        const {
+            getOutpoint,
+            address,
+            confirmations,
+            getConfs,
+            isUnconfirmed,
+            blockheight
+        } = utxo;
         const amount = utxo.getAmount;
         const tx = utxo.txid || utxo.outpoint.txid_str;
 
@@ -153,12 +159,16 @@ export default class UTXO extends React.Component<UTXOProps, UTXOState> {
                             sensitive
                         />
 
-                        <KeyValue
-                            keyValue={localeString('views.Transaction.numConf')}
-                            value={getConfs}
-                            color={isUnconfirmed ? 'red' : 'green'}
-                            sensitive
-                        />
+                        {confirmations != null && (
+                            <KeyValue
+                                keyValue={localeString(
+                                    'views.Transaction.numConf'
+                                )}
+                                value={getConfs}
+                                color={isUnconfirmed ? 'red' : 'green'}
+                                sensitive
+                            />
+                        )}
 
                         {blockheight && (
                             <KeyValue

--- a/views/UTXOs/UTXO.tsx
+++ b/views/UTXOs/UTXO.tsx
@@ -153,16 +153,12 @@ export default class UTXO extends React.Component<UTXOProps, UTXOState> {
                             sensitive
                         />
 
-                        {!!getConfs && (
-                            <KeyValue
-                                keyValue={localeString(
-                                    'views.Transaction.numConf'
-                                )}
-                                value={getConfs}
-                                color={isUnconfirmed ? 'red' : 'green'}
-                                sensitive
-                            />
-                        )}
+                        <KeyValue
+                            keyValue={localeString('views.Transaction.numConf')}
+                            value={getConfs}
+                            color={isUnconfirmed ? 'red' : 'green'}
+                            sensitive
+                        />
 
                         {blockheight && (
                             <KeyValue


### PR DESCRIPTION
# Description

Relates to issue: **#4457**

Fixes the Transaction detail view giving no status for unconfirmed on-chain transactions. The confirmations row was gated on `!!num_confirmations`, hiding it exactly when the count is 0, and the Status row only rendered on LDK Node (the one backend that populates a `status` field), so on the lnd family and CLN a pending transaction showed neither. The Activity list labels the same transaction "Unconfirmed"; tapping through lost that information.

Changes:

- `views/Transaction.tsx`: render the confirmations row whenever the field is present ("Number of Confirmations: 0" now shows in red, making the previously dead color branch reachable) and render the Status row unconditionally, colored green/red by confirmation state
- `models/Transaction.ts`: `getStatusDisplay` falls back to "Unconfirmed" instead of `''` when no backend status string exists; unknown backend statuses still pass through
- `views/UTXOs/UTXO.tsx` + `models/Utxo.ts`: same hide bug fixed on the UTXO detail view; `getConfs` now returns 0 instead of NaN when the confirmations field is absent, which also repairs `isUnconfirmed` for that case
- `backends/CoreLightningRequestHandler.ts`: CLN confirmation math was off by one (a transaction mined in the tip block showed 0 confirmations and would have rendered as unconfirmed) and produced roughly the full chain height when the recorded block height was 0/absent; the tip block now counts as one confirmation and a missing height maps to 0

No new locale strings; `general.confirmed`, `general.unconfirmed`, and `views.Transaction.numConf` already exist.

Screenshots to follow with device testing.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

Added `models/Transaction.test.ts` covering `isConfirmed` and `getStatusDisplay` across lnd-style (no status field), LDK Node (pending/confirmed), and unknown-status shapes, including the empty-string regression this PR fixes.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding