### PR TITLE
fix(fees): reject implausible on-chain fee rates before they can spend

### DIFF
--- a/components/OnchainFeeInput.tsx
+++ b/components/OnchainFeeInput.tsx
@@ -9,6 +9,7 @@ import { feeStore, settingsStore } from '../stores/Stores';
 
 import { themeColor } from '../utils/ThemeUtils';
 import { localeString } from '../utils/LocaleUtils';
+import { isPlausibleSatPerVbyte } from '../utils/FeeUtils';
 
 interface OnchainFeeInputProps {
     navigation: NativeStackNavigationProp<any, any>;
@@ -132,7 +133,7 @@ export default function OnchainFeeInput(props: OnchainFeeInputProps) {
                         setNewFee(text);
                         onChangeFee(text);
                     }}
-                    error={!newFee || newFee === '0'}
+                    error={!newFee || !isPlausibleSatPerVbyte(newFee)}
                 />
             )}
         </>

--- a/locales/en.json
+++ b/locales/en.json
@@ -652,6 +652,7 @@
     "views.EditFee.minimumFee": "Minimum fee",
     "views.EditFee.confirmFee": "Confirm Fee",
     "views.EditFee.error": "Error fetching fee rates",
+    "views.EditFee.customFeeTooHigh": "Enter a fee rate between 1 and 2000 sats/vB",
     "views.Invoice.title": "Invoice",
     "views.Invoice.paid": "Paid",
     "views.Invoice.unpaid": "Unpaid",

--- a/stores/FeeStore.ts
+++ b/stores/FeeStore.ts
@@ -8,6 +8,7 @@ import NodeInfoStore from './NodeInfoStore';
 import BackendUtils from '../utils/BackendUtils';
 import Base64Utils from '../utils/Base64Utils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
+import { sanitizeRecommendedFees } from '../utils/FeeUtils';
 import UrlUtils from '../utils/UrlUtils';
 import ForwardEvent from '../models/ForwardEvent';
 
@@ -62,9 +63,27 @@ export default class FeeStore {
             .then((response: any) => {
                 const status = response.info().status;
                 if (status == 200) {
+                    // These rates are applied without the user having to
+                    // look at them — including by the reverse-swap claim,
+                    // which broadcasts on a websocket event — so an
+                    // implausible response is rejected outright rather
+                    // than trusted. Consumers already handle a failed
+                    // fetch by showing an error and asking for a rate.
+                    const sanitized = sanitizeRecommendedFees(response.json());
+                    if (!sanitized) {
+                        console.error(
+                            'Rejected implausible recommended fees response'
+                        );
+                        runInAction(() => {
+                            this.recommendedFees = {};
+                            this.loading = false;
+                            this.error = true;
+                        });
+                        return;
+                    }
                     runInAction(() => {
                         this.loading = false;
-                        this.recommendedFees = response.json();
+                        this.recommendedFees = sanitized;
                     });
                     return this.recommendedFees;
                 } else {

--- a/utils/FeeUtils.test.ts
+++ b/utils/FeeUtils.test.ts
@@ -1,6 +1,19 @@
-import FeeUtils from './FeeUtils';
+import FeeUtils, {
+    isPlausibleSatPerVbyte,
+    sanitizeRecommendedFees,
+    MAX_SAT_PER_VBYTE
+} from './FeeUtils';
 
 const satoshisPerBTC = 100_000_000;
+
+// shape of a real mempool /v1/fees/recommended response
+const VALID_FEES = {
+    fastestFee: 12,
+    halfHourFee: 10,
+    hourFee: 8,
+    economyFee: 3,
+    minimumFee: 1
+};
 
 describe('FeeUtils', () => {
     describe('calculateDefaultRoutingFee', () => {
@@ -68,6 +81,90 @@ describe('FeeUtils', () => {
             expect(FeeUtils.toFixed(-500000 / satoshisPerBTC, true)).toEqual(
                 '-0.00500000'
             );
+        });
+    });
+
+    describe('isPlausibleSatPerVbyte', () => {
+        it('accepts ordinary and genuinely high rates', () => {
+            expect(isPlausibleSatPerVbyte(1)).toBe(true);
+            expect(isPlausibleSatPerVbyte(12)).toBe(true);
+            expect(isPlausibleSatPerVbyte(700)).toBe(true);
+            expect(isPlausibleSatPerVbyte(MAX_SAT_PER_VBYTE)).toBe(true);
+            // strings, as typed into the fee inputs
+            expect(isPlausibleSatPerVbyte('25')).toBe(true);
+        });
+
+        it('rejects rates above the sanity ceiling', () => {
+            expect(isPlausibleSatPerVbyte(MAX_SAT_PER_VBYTE + 1)).toBe(false);
+            expect(isPlausibleSatPerVbyte(50_000)).toBe(false);
+            expect(isPlausibleSatPerVbyte(100_000)).toBe(false);
+            expect(isPlausibleSatPerVbyte('99999')).toBe(false);
+        });
+
+        it('rejects zero, negative, and non-numeric input', () => {
+            expect(isPlausibleSatPerVbyte(0)).toBe(false);
+            expect(isPlausibleSatPerVbyte(0.5)).toBe(false);
+            expect(isPlausibleSatPerVbyte(-10)).toBe(false);
+            expect(isPlausibleSatPerVbyte(Infinity)).toBe(false);
+            expect(isPlausibleSatPerVbyte(NaN)).toBe(false);
+            expect(isPlausibleSatPerVbyte('')).toBe(false);
+            expect(isPlausibleSatPerVbyte('abc')).toBe(false);
+            expect(isPlausibleSatPerVbyte(null)).toBe(false);
+            expect(isPlausibleSatPerVbyte(undefined)).toBe(false);
+            expect(isPlausibleSatPerVbyte({})).toBe(false);
+        });
+    });
+
+    describe('sanitizeRecommendedFees', () => {
+        it('passes a well-formed response through as numbers', () => {
+            expect(sanitizeRecommendedFees(VALID_FEES)).toEqual(VALID_FEES);
+        });
+
+        it('coerces numeric strings', () => {
+            expect(
+                sanitizeRecommendedFees({ ...VALID_FEES, fastestFee: '12' })
+            ).toEqual(VALID_FEES);
+        });
+
+        it('rejects the whole response when any rate is implausible', () => {
+            // the audit scenario: a compromised or broken fee source
+            expect(
+                sanitizeRecommendedFees({ ...VALID_FEES, fastestFee: 50_000 })
+            ).toBeNull();
+            // an absurd value on a key the user may have set as preferred
+            // must not survive just because fastestFee looks sane
+            expect(
+                sanitizeRecommendedFees({ ...VALID_FEES, economyFee: 100_000 })
+            ).toBeNull();
+            expect(
+                sanitizeRecommendedFees({ ...VALID_FEES, minimumFee: 0 })
+            ).toBeNull();
+            expect(
+                sanitizeRecommendedFees({ ...VALID_FEES, hourFee: -1 })
+            ).toBeNull();
+        });
+
+        it('rejects a response with no fastestFee to fall back to', () => {
+            const { fastestFee, ...withoutFastest } = VALID_FEES;
+            expect(fastestFee).toBe(12);
+            expect(sanitizeRecommendedFees(withoutFastest)).toBeNull();
+        });
+
+        it('tolerates a response missing optional keys', () => {
+            expect(sanitizeRecommendedFees({ fastestFee: 12 })).toEqual({
+                fastestFee: 12
+            });
+            expect(
+                sanitizeRecommendedFees({ fastestFee: 12, hourFee: null })
+            ).toEqual({ fastestFee: 12 });
+        });
+
+        it('rejects malformed payloads', () => {
+            expect(sanitizeRecommendedFees(null)).toBeNull();
+            expect(sanitizeRecommendedFees(undefined)).toBeNull();
+            expect(sanitizeRecommendedFees('nope')).toBeNull();
+            expect(sanitizeRecommendedFees([])).toBeNull();
+            expect(sanitizeRecommendedFees({})).toBeNull();
         });
     });
 });

--- a/utils/FeeUtils.ts
+++ b/utils/FeeUtils.ts
@@ -1,3 +1,68 @@
+/**
+ * Sanity bounds for on-chain fee rates, in sat/vB.
+ *
+ * The ceiling is not a prediction of what fees can legitimately reach —
+ * it is the point past which a value is better explained by a broken or
+ * hostile fee source than by mempool conditions. It sits well above the
+ * highest rates seen in real congestion so that a genuine fee spike is
+ * never rejected, while still bounding what an unvalidated API response
+ * can hand to a transaction the user does not individually approve.
+ */
+export const MIN_SAT_PER_VBYTE = 1;
+export const MAX_SAT_PER_VBYTE = 2000;
+
+/**
+ * Keys of the mempool `/v1/fees/recommended` response. Every consumer
+ * falls back to `fastestFee`, so a response without it is unusable.
+ */
+export const RECOMMENDED_FEE_KEYS = [
+    'fastestFee',
+    'halfHourFee',
+    'hourFee',
+    'economyFee',
+    'minimumFee'
+] as const;
+
+export const isPlausibleSatPerVbyte = (value: unknown): boolean => {
+    const rate = Number(value);
+    return (
+        Number.isFinite(rate) &&
+        rate >= MIN_SAT_PER_VBYTE &&
+        rate <= MAX_SAT_PER_VBYTE
+    );
+};
+
+/**
+ * Validates a mempool recommended-fees response before any of it can
+ * become a fee rate.
+ *
+ * Returns null — meaning "treat this like a failed fetch" — if the
+ * payload is malformed, is missing `fastestFee`, or carries any
+ * implausible rate. Rejecting the whole response rather than dropping
+ * the offending key is deliberate: a source that reports one absurd rate
+ * has not shown itself trustworthy for the others, and partial
+ * acceptance would still let the bad key through to whichever rate the
+ * user has set as their preferred one.
+ */
+export const sanitizeRecommendedFees = (
+    raw: any
+): { [key: string]: number } | null => {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+
+    const sanitized: { [key: string]: number } = {};
+
+    for (const key of RECOMMENDED_FEE_KEYS) {
+        const value = raw[key];
+        if (value === undefined || value === null) continue;
+        if (!isPlausibleSatPerVbyte(value)) return null;
+        sanitized[key] = Number(value);
+    }
+
+    if (sanitized.fastestFee === undefined) return null;
+
+    return sanitized;
+};
+
 class FeeUtils {
     static DEFAULT_ROUTING_FEE_PERCENT = 0.05;
 

--- a/views/EditFee.tsx
+++ b/views/EditFee.tsx
@@ -22,6 +22,7 @@ import Screen from '../components/Screen';
 
 import { themeColor } from '../utils/ThemeUtils';
 import { localeString } from '../utils/LocaleUtils';
+import { isPlausibleSatPerVbyte } from '../utils/FeeUtils';
 import UrlUtils from '../utils/UrlUtils';
 
 import MempoolSpace from '../assets/images/affiliates/Mempool.svg';
@@ -88,6 +89,13 @@ export default class EditFee extends React.Component<
         const { selectedFee, fee, customFee } = this.state;
         const { navigation, FeeStore, route } = this.props;
         const displayOnly = route.params?.displayOnly;
+        // A typed rate is never silently corrected: an out-of-range value
+        // is surfaced and blocks confirmation, so what gets broadcast is
+        // always the number the user actually entered.
+        const customFeeInvalid =
+            selectedFee === 'custom' &&
+            !!customFee &&
+            !isPlausibleSatPerVbyte(customFee);
         const { recommendedFees, loading, error, getOnchainFeesviaMempool } =
             FeeStore;
 
@@ -389,6 +397,21 @@ export default class EditFee extends React.Component<
                                     />
                                 </TouchableWithoutFeedback>
 
+                                {customFeeInvalid && (
+                                    <Text
+                                        style={{
+                                            color: themeColor('warning'),
+                                            fontFamily: 'PPNeueMontreal-Book',
+                                            textAlign: 'center',
+                                            marginTop: 10
+                                        }}
+                                    >
+                                        {localeString(
+                                            'views.EditFee.customFeeTooHigh'
+                                        )}
+                                    </Text>
+                                )}
+
                                 <View style={styles.confirmButton}>
                                     <Button
                                         title={localeString(
@@ -405,7 +428,8 @@ export default class EditFee extends React.Component<
                                         disabled={
                                             !fee ||
                                             (selectedFee === 'custom' &&
-                                                !customFee)
+                                                !customFee) ||
+                                            customFeeInvalid
                                         }
                                     />
                                 </View>

--- a/views/Swaps/index.tsx
+++ b/views/Swaps/index.tsx
@@ -33,6 +33,7 @@ import ModalBox from '../../components/ModalBox';
 import Switch from '../../components/Switch';
 
 import { font } from '../../utils/FontUtils';
+import { isPlausibleSatPerVbyte } from '../../utils/FeeUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import { SATS_PER_BTC } from '../../utils/UnitsUtils';
@@ -218,10 +219,20 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
                 ? true
                 : currentInputSatsBN.isLessThanOrEqualTo(maxSendAmount));
 
+        // A reverse swap's claim is built and broadcast automatically on a
+        // websocket event using this rate, with no further chance to set
+        // one. Starting a swap without a usable rate would fall back to
+        // 2 sats/vB at claim time, which can fail to confirm before the
+        // timeout and hand the lockup back to the host, so require one up
+        // front instead. The rate is editable in the fee section above.
+        const feeRateUsable =
+            !reverse || isPlausibleSatPerVbyte(this.state.fee);
+
         const newIsValid =
             invoiceAddressValid &&
             inputAmountValidAndWithinLimits &&
-            outputGreaterThanZero;
+            outputGreaterThanZero &&
+            feeRateUsable;
 
         if (this.state.isValid !== newIsValid) {
             this.setState({ isValid: newIsValid });
@@ -484,7 +495,8 @@ export default class Swap extends React.PureComponent<SwapProps, SwapState> {
             prevState.inputSats !== this.state.inputSats ||
             prevState.outputSats !== this.state.outputSats ||
             prevState.invoice !== this.state.invoice ||
-            prevState.reverse !== this.state.reverse
+            prevState.reverse !== this.state.reverse ||
+            prevState.fee !== this.state.fee
         ) {
             this.checkIsValid();
         }


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000** (internal security audit finding M5)

`FeeStore.getOnchainFeesviaMempool` assigned the mempool `/v1/fees/recommended` response straight into `recommendedFees` with no validation of any kind — not shape, not type, not range:

```ts
this.recommendedFees = response.json();
```

Four things read that observable: `OnchainFeeInput` (the default rate for on-chain sends), `FeeEstimate`, `EditFee`, and `views/Swaps/index.tsx`. The swaps path is the one that matters. The rate it takes becomes a route param, and `SwapDetails.createReverseClaimTransaction` builds and broadcasts the reverse-swap claim at `feeRate: Number(fee || 2)` **automatically, on a `TransactionMempool` / `TransactionConfirmed` websocket event** (`views/Swaps/SwapDetails.tsx:517-535`). There is no confirmation step anywhere in that path — by the time the user could react, the transaction is out.

So a compromised or simply broken fee source returning 50,000 sat/vB donates the claimed output to miners with the user never having seen a number. The custom fee input had no upper bound either, so the same outcome was reachable by a typo.

### One correction to the audit's framing

The audit says the user "never sees or approves the fee". More precisely: the Swaps screen *does* render an `OnchainFeeInput` for reverse swaps, but it sits inside a collapsed `feeSettingToggle` section and is pre-filled from the API, so the default flow never requires anyone to look at it. The claim broadcast itself remains entirely unattended. I've corrected the audit entry.

## Fix

Validate at the source, since `FeeStore` is the single chokepoint all four consumers read from.

**`utils/FeeUtils.ts`** — `isPlausibleSatPerVbyte` and `sanitizeRecommendedFees`. The latter returns `null` (meaning "treat as a failed fetch") when the payload is malformed, is missing `fastestFee`, or carries any rate outside `[1, 2000]` sat/vB. The store then takes its existing error path, which every consumer already handles by showing an error and asking for a rate — so this reuses a tested failure mode rather than inventing one.

Two deliberate choices worth reviewing:

- **Reject the whole response, don't drop the offending key.** A source reporting one absurd rate has not earned trust for the rest, and partial acceptance would still let a bad value through whichever key the user set as `preferredMempoolRate`.
- **The ceiling is not a forecast.** 2000 sat/vB is the point past which a value is better explained by a broken or hostile source than by the mempool. It sits far above observed real congestion so a genuine fee spike is never rejected. Happy to move it if you have a better number — it's a single named constant.

**`views/EditFee.tsx`** — an out-of-range custom fee is surfaced and blocks confirmation rather than being clamped. Typed rates are validated but never silently corrected, so what gets broadcast is always the number the user actually entered. (Same reasoning as #4354's `sanitizeSatPerVbyte`, which deliberately has no upper bound for exactly this reason.)

**`components/OnchainFeeInput.tsx`** — the manual-entry branch's `error` condition was `!newFee || newFee === '0'`; it now uses the shared validator.

### The part that needed care

Rejecting a bad response would otherwise have opened a worse hole than it closed, and I want this called out explicitly for review.

`checkIsValid` in the Swaps view did not consider the fee at all, so a reverse swap could be initiated with `fee: ''`. Combined with the claim's `Number(fee || 2)` fallback, a rejected fee response would have meant broadcasting the claim at **2 sat/vB** — which can fail to confirm before the swap timeout and hand the lockup back to the host. That trades bounded overpayment for total loss of the swap, which is strictly worse.

So reverse swaps now require a usable rate up front, alongside the existing amount and address checks, and `componentDidUpdate` revalidates when `fee` changes. There is always a way forward: the fee section is expandable and accepts a manual rate. Note this failure mode already existed on master for plain API outages (a non-200 leaves `fee` empty the same way); this PR is what makes it unreachable rather than what introduces it.

## Deliberately not in this PR

M5 has two other legs, both of which are UX decisions rather than validation, and both of which I'd rather not design unilaterally inside a funds-touching change:

1. **The reverse-swap claim still auto-broadcasts without confirmation.** This PR bounds *what* it can broadcast at, not the fact that it does so unattended. A confirmation step (or a threshold above which one is required) is the fuller fix.
2. **`views/Tools/Sweep.tsx` still does `send_all` with no VerifyOnChain screen** — one tap, full balance, at the API rate. Now a validated rate, but still unconfirmed.

Also unchanged: the `Number(fee || 2)` fallback itself, and the fact that a disabled Initiate button doesn't explain *why* it's disabled (consistent with how the existing amount/address checks behave).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

`yarn verify` green. 9 new tests in `utils/FeeUtils.test.ts` (1289 → 1298, no existing tests touched): ordinary and genuinely-high rates accepted, the audit's 50,000 / 100,000 sat/vB scenario rejected, zero / negative / fractional / `NaN` / `Infinity` / non-numeric / `null` rejected, numeric strings coerced, an absurd value on a non-`fastestFee` key rejecting the whole payload, a response with no `fastestFee` rejected, optional keys tolerated, and malformed payloads (`null`, string, array, `{}`) rejected.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

**Not device-tested.** The checks I'd want run, since most of this is failure-path behaviour that unit tests can't reach:

- normal path unaffected: on-chain send picks up the recommended rate as before; `EditFee` presets still confirm
- custom fee: `2000` confirms, `2001` shows the error and disables Confirm
- reverse swap with fees unavailable (airplane mode, or point `Settings > Privacy` at a dead mempool instance): Initiate stays disabled until a rate is typed into the fee section, and a swap created that way still claims
- ideally: a fake mempool instance returning `{"fastestFee": 50000, ...}` to confirm the rejection path end to end

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Fee fetching is backend-independent, but the on-chain send path is worth exercising on one backend that supports on-chain sends.

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

One new key, `views.EditFee.customFeeTooHigh`, `locales/en.json` only. It embeds the bounds as literals ("between 1 and 2000 sats/vB") to keep it translatable as a single sentence — worth a second opinion if you'd rather it were interpolated from the constant.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
