### PR TITLE
fix(nwc): stop returning the invoice as a cashu payment preimage

### DIFF
--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1410,3 +1410,93 @@ describe('NostrWalletConnectStore sign_message', () => {
         expect(response.result.methods).toEqual(['get_info']);
     });
 });
+
+describe('NostrWalletConnectStore cashu pay_invoice preimage', () => {
+    const invoice = 'lnbc1cashupreimagetest';
+    const preimage = 'a'.repeat(64);
+
+    // Drives handleCashuPayInvoice past its guards to the response shape.
+    // The melt has already succeeded by that point, so only the fields the
+    // response is built from need to be real.
+    const buildCashuStore = (
+        cashuInvoice: any,
+        payments: any[] = []
+    ): NostrWalletConnectStore => {
+        const store = buildPayInvoiceTestStore();
+        (store as any).cashuStore = {
+            selectedMintUrl: 'https://mint.example',
+            totalBalanceSats: 100_000,
+            paymentError: false,
+            paymentErrorMsg: '',
+            payReq: new Invoice({
+                payment_request: invoice,
+                num_satoshis: '100'
+            } as any),
+            getPayReqError: null,
+            getPayReq: jest.fn().mockResolvedValue(undefined),
+            payLnInvoiceFromEcash: jest.fn().mockResolvedValue(cashuInvoice),
+            isProperlyConfigured: () => true,
+            payments
+        };
+        // isCashuConfigured is a computed, so satisfy its inputs rather
+        // than trying to redefine it
+        store.cashuEnabled = true;
+        jest.spyOn(store as any, 'finalizePayment').mockResolvedValue(
+            undefined
+        );
+        return store;
+    };
+
+    const payWith = async (cashuInvoice: any, payments: any[] = []) => {
+        const store = buildCashuStore(cashuInvoice, payments);
+        const connection = seedPayInvoiceConnection(store);
+        return (store as any).handleCashuPayInvoice(connection, { invoice });
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(
+            NostrConnectUtils,
+            'getPayInvoiceAmountSats'
+        ).mockResolvedValue(100);
+    });
+
+    it('returns the melt preimage when there is one', async () => {
+        const response = await payWith({
+            isFailed: false,
+            getPreimage: preimage,
+            getPaymentRequest: invoice,
+            getFee: 1
+        });
+
+        expect(response.result.preimage).toBe(preimage);
+    });
+
+    it('never returns the invoice as the preimage', async () => {
+        // Regression: this used to fall back to getPaymentRequest, handing
+        // NIP-47 clients a bolt11 string as proof of payment.
+        const response = await payWith({
+            isFailed: false,
+            getPreimage: '',
+            getPaymentRequest: invoice,
+            getFee: 1
+        });
+
+        expect(response.result.preimage).not.toBe(invoice);
+        expect(response.result.preimage).toBe('');
+    });
+
+    it('falls back to the payments-list preimage, as the lightning leg does', async () => {
+        const response = await payWith(
+            {
+                isFailed: false,
+                getPreimage: '',
+                getPaymentRequest: invoice,
+                getFee: 1
+            },
+            [{ getPaymentRequest: invoice, getPreimage: preimage, getFee: 1 }]
+        );
+
+        expect(response.result.preimage).toBe(preimage);
+    });
+});

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -2570,10 +2570,11 @@ export default class NostrWalletConnectStore {
 
         return {
             result: {
+                // Never fall back to the invoice itself: NIP-47 clients
+                // treat this field as proof of payment, and a bolt11
+                // string is not one. Mirrors the lightning leg.
                 preimage:
-                    cashuInvoice.getPreimage ||
-                    cashuInvoice.getPaymentRequest ||
-                    '',
+                    cashuInvoice.getPreimage || payment?.getPreimage || '',
                 fees_paid: satsToMillisats(feeSats)
             },
             error: undefined


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000** (internal security audit finding M11, part a)

The NIP-47 `pay_invoice` response for a **cashu** payment fell back to the bolt11 invoice when the melt produced no preimage (`stores/NostrWalletConnectStore.ts:2573-2577`):

```ts
preimage:
    cashuInvoice.getPreimage ||
    cashuInvoice.getPaymentRequest ||
    '',
```

NIP-47 clients treat `preimage` as proof of payment. A bolt11 string is not one — it's the *request*, it's public, and the client already has it, since it's what they sent us. Returning it means:

- a payment that settled without a recoverable preimage is indistinguishable from one that produced a real receipt, and
- anything downstream verifying `sha256(preimage) === payment_hash` receives a value that cannot possibly match.

## Fix

The lightning leg had this exact fallback and lost it in **#4334**, which tightened it to `preimage || payment?.getPreimage || ''` (`:2406`). This brings the cashu leg in line: prefer the melt's preimage, fall back to the payments-list entry — already looked up two lines above to compute `feeSats`, so no new work — and otherwise return empty rather than something false.

Worth noting the *activity record* written by `finalizePayment` here was already honest: #4334 gave `buildSettledPaymentFallback` the same treatment, and `:2560` passes `preimage: cashuInvoice.getPreimage` with no fallback. So internal accounting was correct and only the wire response lied — which is why this survived the earlier NWC work.

This is part (a) of M11. Parts (b) partial-MPP reported as success and (c) the unvalidated single-mint `meltResult.state` are untouched and remain open; both are in `CashuStore` and are substantially larger.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

`yarn verify` green (1289 → 1292). Three new tests in `stores/NostrWalletConnectStore.test.ts` drive `handleCashuPayInvoice` past its guards to the response shape: the melt preimage is returned when present, the invoice is **never** returned as the preimage, and the payments-list fallback works as it does on the lightning leg.

**Two of the three fail against the pre-fix code** (verified by stashing the store change and re-running), per the CONTRIBUTING "Test Coverage" requirement.

Note `isCashuConfigured` is a MobX computed and can't be `jest.spyOn`'d with `'get'` — the test satisfies its inputs (`cashuEnabled` plus a stubbed `isProperlyConfigured()`) instead. Flagging it because it's a trap for anyone extending these tests.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Not device-tested. A real check needs an NWC client paying a lightning invoice from an ecash balance and inspecting the `pay_invoice` response: the `preimage` field should be a real 32-byte hex preimage, or empty — never the bolt11 string that was sent.

Behaviour change worth a maintainer opinion: a settled melt with no recoverable preimage now returns `preimage: ""` instead of the invoice. Clients that (incorrectly) treated any non-empty value as success will now see an empty one. That matches what the lightning leg has done since #4334, so this makes the two consistent rather than introducing something new.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Cashu-specific and backend-independent — it needs an ecash balance and an NWC connection with `pay_invoice`, on any backend.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

No new strings.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
