### PR TITLE
fix(nwc): mask the connection string like every other credential

### DIFF
--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -1968,30 +1968,51 @@ export default class WalletConfiguration extends React.Component<
                                             'views.Settings.WalletConfiguration.nostrWalletConnectUrl'
                                         )}
                                     </Text>
-                                    <TextInput
-                                        placeholder={'nostr+walletconnect://'}
-                                        textColor={
-                                            nostrWalletConnectUrlError
-                                                ? themeColor('error')
-                                                : themeColor('text')
-                                        }
-                                        value={nostrWalletConnectUrl}
-                                        autoCapitalize="none"
-                                        onChangeText={(text: string) =>
-                                            this.setState({
-                                                nostrWalletConnectUrl: text
-                                                    .trim()
-                                                    .replace(/\s+/g, ' '),
-                                                nostrWalletConnectUrlError:
-                                                    !text.startsWith(
-                                                        'nostr+walletconnect://'
-                                                    ),
-                                                saved: false
-                                            })
-                                        }
-                                        locked={loading}
-                                        autoCorrect={false}
-                                    />
+                                    <View
+                                        style={{
+                                            flexDirection: 'row',
+                                            alignItems: 'center'
+                                        }}
+                                    >
+                                        <TextInput
+                                            placeholder={
+                                                'nostr+walletconnect://'
+                                            }
+                                            textColor={
+                                                nostrWalletConnectUrlError
+                                                    ? themeColor('error')
+                                                    : themeColor('text')
+                                            }
+                                            value={nostrWalletConnectUrl}
+                                            autoCapitalize="none"
+                                            secureTextEntry={this.state.hidden}
+                                            style={{
+                                                flex: 1,
+                                                marginRight: 15
+                                            }}
+                                            onChangeText={(text: string) =>
+                                                this.setState({
+                                                    nostrWalletConnectUrl: text
+                                                        .trim()
+                                                        .replace(/\s+/g, ' '),
+                                                    nostrWalletConnectUrlError:
+                                                        !text.startsWith(
+                                                            'nostr+walletconnect://'
+                                                        ),
+                                                    saved: false
+                                                })
+                                            }
+                                            locked={loading}
+                                            autoCorrect={false}
+                                        />
+                                        <ShowHideToggle
+                                            onPress={() =>
+                                                this.setState({
+                                                    hidden: !this.state.hidden
+                                                })
+                                            }
+                                        />
+                                    </View>
                                 </>
                             )}
                             {implementation === 'lndhub' && (


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000** (internal security audit finding L5)

The Nostr Wallet Connect URL was the only credential field on the wallet configuration screen rendered in the clear.

Every sibling — LndHub password (`:2214`), macaroon (`:2437`), rune (`:2538`), LNC pairing phrase (`:2756`) — passes `secureTextEntry={this.state.hidden}` and sits beside a `ShowHideToggle`. The `nostrWalletConnectUrl` input passed neither.

That's the wrong field to leave visible. `nostr+walletconnect://…` carries the connection **secret** in its query string, so it isn't an identifier — it's the spending credential for that connection. Anyone who reads it off the screen can pay from the wallet up to the connection's budget. Shoulder surfing, screen sharing, and screenshots on a settings screen users are told is safe to open.

## Fix

Applies the existing pattern verbatim: wrap the input in the same `flexDirection: 'row'` container, mask it with the shared `this.state.hidden`, and add the same `ShowHideToggle`. `ShowHideToggle` was already imported (`:55`).

Nothing else changes — the `nostr+walletconnect://` prefix validation, the whitespace trimming, the error colouring, and `locked={loading}` are all untouched.

### Note on the shared toggle

`hidden` is a single piece of state shared by all masked fields on this screen, so the toggle reveals whichever credential field is currently rendered. That's pre-existing behaviour and only one implementation's fields are visible at a time, so joining the pattern is the consistent choice rather than introducing per-field state. Flagging it in case you'd rather these were independent — that would be a separate, broader change.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

No utility files touched — this is a view-only change. `yarn verify` green (1289 tests, unchanged).

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

**Not device-tested, and this one genuinely needs eyes** — it's a layout change and there are no screenshots yet, which I know is thin for a UI PR. What to check: with `implementation = nostr-wallet-connect`, the URL renders masked by default, the toggle reveals and re-hides it, the input still resizes correctly beside the toggle (NWC URLs are long, so the `flex: 1` / `marginRight: 15` split is the thing to eyeball), pasting a URL still validates and the error colour still appears for a malformed one, and the field is still usable while `locked={loading}`.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Only the NWC client configuration screen is affected.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

No new strings.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
