### PR TITLE
fix(swaps): stop overwriting a swap's state with an HTTP status code

### DIFF
--- a/stores/SwapStore.test.ts
+++ b/stores/SwapStore.test.ts
@@ -1,0 +1,175 @@
+// First test file for SwapStore. The mocks below are import-time
+// scaffolding: SwapStore pulls in native modules (blob-util, encrypted
+// storage via SettingsStore) and ESM-only crypto packages that jest's
+// transformIgnorePatterns does not cover (ecpair). getLockupTransaction
+// uses only ReactNativeBlobUtil and Storage, both of which are driven
+// directly by these tests.
+jest.mock('react-native-blob-util', () => ({
+    __esModule: true,
+    default: { fetch: jest.fn(), config: jest.fn() }
+}));
+jest.mock('../utils/TorUtils', () => ({
+    doTorRequest: jest.fn(),
+    isOnionHttpsUrl: jest.fn(),
+    RequestMethod: {}
+}));
+jest.mock('../storage', () => ({
+    __esModule: true,
+    default: { getItem: jest.fn(), setItem: jest.fn(), removeItem: jest.fn() }
+}));
+jest.mock('../utils/LocaleUtils', () => ({ localeString: (k: string) => k }));
+jest.mock('../utils/ThemeUtils', () => ({ themeColor: () => '#000' }));
+jest.mock('ecpair', () => ({ ECPairFactory: () => ({}) }));
+jest.mock('@bitcoinerlab/secp256k1', () => ({ __esModule: true, default: {} }));
+jest.mock('bitcoinjs-lib', () => ({
+    crypto: { sha256: jest.fn() },
+    initEccLib: jest.fn()
+}));
+jest.mock('./SettingsStore', () => ({
+    __esModule: true,
+    default: class {},
+    DEFAULT_SWAP_HOST_MAINNET: 'https://api.boltz.exchange/v2',
+    DEFAULT_SWAP_HOST_TESTNET: 'https://api.testnet.boltz.exchange/v2',
+    SWAP_HOST_KEYS_MAINNET: [],
+    SWAP_HOST_KEYS_TESTNET: []
+}));
+
+import ReactNativeBlobUtil from 'react-native-blob-util';
+import Storage from '../storage';
+import SwapStore from './SwapStore';
+import { SwapState, SwapType } from '../models/Swap';
+
+const SWAP_ID = 'swap-abc';
+const LOCKUP = {
+    id: 'lockup-tx-id',
+    hex: 'deadbeef',
+    timeoutBlockHeight: 800000,
+    timeoutEta: 1700000000
+};
+
+const buildStore = () =>
+    new SwapStore(
+        { nodeInfo: { isTestNet: false } } as any,
+        { settings: { swaps: {} } } as any
+    );
+
+/** Returns the swap array handed to Storage.setItem by the call. */
+const runGetLockupTransaction = async (
+    storedSwaps: any[],
+    httpStatus = 200
+): Promise<any[]> => {
+    (Storage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify(storedSwaps)
+    );
+    (ReactNativeBlobUtil.fetch as jest.Mock).mockResolvedValue({
+        info: () => ({ status: httpStatus }),
+        json: () => LOCKUP
+    });
+
+    await buildStore().getLockupTransaction(SWAP_ID, 'https://host.example/v2');
+
+    const call = (Storage.setItem as jest.Mock).mock.calls.at(-1);
+    return call ? JSON.parse(call[1]) : [];
+};
+
+describe('SwapStore.getLockupTransaction', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('leaves the swap state untouched while storing the lockup tx', async () => {
+        // Regression: the HTTP status was spread onto the swap because the
+        // local was named `status`, replacing the SwapState with 200.
+        const swaps = await runGetLockupTransaction([
+            {
+                id: SWAP_ID,
+                type: SwapType.Submarine,
+                status: SwapState.TransactionClaimed
+            }
+        ]);
+
+        expect(swaps[0].status).toBe(SwapState.TransactionClaimed);
+        expect(swaps[0].status).not.toBe(200);
+        expect(swaps[0].lockupTransaction).toEqual(LOCKUP);
+    });
+
+    it.each([
+        SwapState.TransactionClaimed,
+        SwapState.TransactionRefunded,
+        SwapState.SwapExpired,
+        SwapState.InvoiceFailedToPay
+    ])(
+        'preserves terminal state %s, which SwapDetails tests by membership',
+        async (state) => {
+            // SwapDetails decides a swap is settled with
+            // finalStatus.includes(swapData?.status) against SwapState
+            // strings, so a numeric status silently un-settles the swap
+            // and makes it resubscribe.
+            const swaps = await runGetLockupTransaction([
+                { id: SWAP_ID, type: SwapType.Submarine, status: state }
+            ]);
+
+            expect(swaps[0].status).toBe(state);
+        }
+    );
+
+    it('does not add a status to a swap that had none', async () => {
+        const swaps = await runGetLockupTransaction([
+            { id: SWAP_ID, type: SwapType.Submarine }
+        ]);
+
+        expect(swaps[0].status).toBeUndefined();
+        expect(swaps[0].lockupTransaction).toEqual(LOCKUP);
+    });
+
+    it('only touches the matching swap', async () => {
+        const swaps = await runGetLockupTransaction([
+            {
+                id: 'other-swap',
+                type: SwapType.Submarine,
+                status: SwapState.InvoiceSettled
+            },
+            {
+                id: SWAP_ID,
+                type: SwapType.Submarine,
+                status: SwapState.TransactionMempool
+            }
+        ]);
+
+        expect(swaps[0]).toEqual({
+            id: 'other-swap',
+            type: SwapType.Submarine,
+            status: SwapState.InvoiceSettled
+        });
+        expect(swaps[1].status).toBe(SwapState.TransactionMempool);
+        expect(swaps[1].lockupTransaction).toEqual(LOCKUP);
+    });
+
+    it('writes nothing on a non-200 response', async () => {
+        await runGetLockupTransaction(
+            [
+                {
+                    id: SWAP_ID,
+                    type: SwapType.Submarine,
+                    status: SwapState.TransactionMempool
+                }
+            ],
+            404
+        );
+
+        expect(Storage.setItem as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it('returns the lockup transaction to the caller', async () => {
+        (Storage.getItem as jest.Mock).mockResolvedValue(JSON.stringify([]));
+        (ReactNativeBlobUtil.fetch as jest.Mock).mockResolvedValue({
+            info: () => ({ status: 200 }),
+            json: () => LOCKUP
+        });
+
+        await expect(
+            buildStore().getLockupTransaction(
+                SWAP_ID,
+                'https://host.example/v2'
+            )
+        ).resolves.toEqual(LOCKUP);
+    });
+});

--- a/stores/SwapStore.ts
+++ b/stores/SwapStore.ts
@@ -279,9 +279,12 @@ export default class SwapStore {
                 this.getHeaders
             );
 
-            const status = response.info().status;
+            // named httpStatus, not status: spreading a local called
+            // `status` into a swap is what overwrote the swap's own
+            // SwapState here
+            const httpStatus = response.info().status;
             const data = response.json();
-            if (status == 200) {
+            if (httpStatus == 200) {
                 const lockupTransaction = {
                     id: data.id,
                     hex: data.hex,
@@ -294,7 +297,6 @@ export default class SwapStore {
                     swap.id === id
                         ? {
                               ...swap,
-                              status,
                               lockupTransaction
                           }
                         : swap


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000** (internal security audit finding L23)

`SwapStore.getLockupTransaction` stored the fetch's HTTP status on the swap record. The local was named `status`, and it got spread into an object that already has a `status` field:

```ts
const status = response.info().status;   // 200
...
? {
      ...swap,
      status,              // <- clobbers the swap's SwapState
      lockupTransaction
  }
```

So a successful lockup-transaction fetch replaced the swap's `SwapState` string with the number `200`.

## Why it's more than cosmetic

`views/Swaps/SwapDetails.tsx:119-137` decides whether a swap is already settled by membership test:

```ts
finalStatus.includes(swapData?.status)
failedStatus.includes(swapData?.status)
```

Both arrays hold `SwapState` **strings**, so both return `false` for `200`. A swap that had reached `transaction.claimed`, `transaction.refunded` or `swap.expired` therefore stopped short-circuiting and fell through to `getSwapUpdates(...)`, reopening a websocket subscription for a swap that was already over.

In the list, the same value renders as **"No updates"** in orange — `SwapStore.formatStatus` returns that for anything non-string, and `statusColor` falls through to its `default` case.

The record heals on the next status fetch, which is why this stayed invisible for so long; nothing else ever writes `200` there deliberately.

## Fix

Drop the field from the spread, and rename the local to `httpStatus`.

The rename is the real fix for recurrence rather than tidying: the name collision *was* the bug, and nothing about a local called `status` signalled that spreading it into a swap was unsafe. `getSwapFees` and `createReverseSwap` in the same file use the identical `const status = response.info().status` idiom without spreading it, so the name is established in this file — which is exactly why this was easy to miss in review the first time.

## Why dropping the field is safe

Recorded here so a reviewer doesn't have to re-derive it.

The change only stops *overwriting* — it never removes an existing value. A swap that already had a real `SwapState` now keeps it; a swap that had none keeps none, where it previously acquired `200`. So the only question is whether `undefined` and `200` behave differently at any read site. They don't:

| Consumer | `200` | `undefined` |
|---|---|---|
| `finalStatus.includes(...)` (`SwapDetails.tsx:119`) | `false` | `false` |
| `failedStatus.includes(...)` (`:120`, `:137`) | `false` | `false` |
| `skipStatusesForSubmarineSwap.includes(...)` (`SwapStore.ts:632`) | `false` | `false` |
| `skipStatusesForReverseSwap.includes(...)` (`:634`) | `false` | `false` |
| `formatStatus` (`SwapsPane.tsx:121`) | `typeof !== 'string'` → "No updates" | `!status` → "No updates" |
| `statusColor` (`SwapsPane.tsx:116`) | `default` → orange | `default` → orange |

`formatStatus` guards on **both** `!status` and `typeof status !== 'string'`, which is what makes the two indistinguishable at the display layer.

There is also no truthiness check to diverge on — that being the one pattern where truthy `200` could differ from falsy `undefined`. Grepping `if (swap.status)`, `swap.status &&`, `!swapData.status` and ternary forms across `views/Swaps/`, `stores/SwapStore.ts` and `components/` returns nothing.

Three adjacent things checked while confirming:

- The other `=== 200` / `== 200` comparisons in the tree are unrelated HTTP locals — `SwapStore.ts:212` and `:243` (`getSwapFees`), `components/LayerBalances/LightningSwipeableRow.tsx:298` (an LNURL fetch). None reads a swap record.
- `views/Swaps/Refund.tsx:374` consumes the **return value** (`swapData.lockupTransaction = await getLockupTransaction(...)`), which this PR does not touch.
- `models/Swap.ts:32` declares `status: SwapState`. The `200` was always a type violation; it only compiled because the storage round-trip goes through `any`.

Worth stating explicitly: there is no *correct* `SwapState` to write here either. Fetching a lockup transaction is not a state transition — no enum value corresponds to it, and `updateSwapStatus` plus the websocket handler own that field. This isn't a write that needed the right value; it's a write that shouldn't exist.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

`yarn verify` green (1289 → 1298).

**`stores/SwapStore.test.ts` is the first test file for this store.** 9 tests; **7 fail against the pre-fix code**, verified by checking the parent commit's `SwapStore.ts` back out and re-running:

```
● leaves the swap state untouched while storing the lockup tx
● preserves terminal state transaction.claimed …
● preserves terminal state transaction.refunded …
● preserves terminal state swap.expired …
● preserves terminal state invoice.failedToPay …
● does not add a status to a swap that had none
● only touches the matching swap
```

The four terminal-state cases are the ones that matter: they are exactly the values `SwapDetails` tests by membership, so they encode *why* this was more than a display bug rather than just asserting a field.

The two that pass either way pin behaviour the fix must not disturb — nothing is written on a non-200 response, and the lockup transaction is still returned to the caller (which is what `views/Swaps/Refund.tsx:374` consumes).

### What made this untestable before

`SwapStore` pulls native code and ESM-only packages in at import: encrypted storage through `SettingsStore`, and `ecpair`, which jest's `transformIgnorePatterns` does not cover. I mocked those rather than widening the shared whitelist in `package.json`, so the change stays local to this file.

`getLockupTransaction` itself only touches `ReactNativeBlobUtil` and `Storage`, both driven directly by the tests — the mocks are import-time scaffolding and the assertions run against the real method. The same pattern should open up the rest of `SwapStore`, which is the largest untested store carrying funds logic.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Not device-tested. The check: run a submarine swap to a terminal state (claimed or refunded), reopen its details so `getLockupTransaction` runs, then leave and return — the status should still read as its `SwapState` and the view should short-circuit instead of reopening a socket. Before this change it would show "No updates" and resubscribe.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Swap-side and backend-independent; any backend that can pay the swap invoice exercises it.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

No new strings.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

