### PR TITLE
fix(backends): anchor the WebSocket scheme rewrite to the scheme

### DIFF
--- a/backends/CLNRest.test.ts
+++ b/backends/CLNRest.test.ts
@@ -1,0 +1,83 @@
+// Import-time scaffolding, as in LND.test.ts. CoreLightningRequestHandler
+// additionally has to be stubbed because it and CLNRest import each other
+// and it does `new CLNRest()` at module scope: with CLNRest as the entry
+// point the cycle resolves with CLNRest still undefined. getURL touches
+// none of these.
+jest.mock('react-native-blob-util', () => ({
+    __esModule: true,
+    default: { fetch: jest.fn(), config: jest.fn() }
+}));
+jest.mock('../stores/Stores', () => ({
+    settingsStore: { settings: {} },
+    nodeInfoStore: { nodeInfo: {} }
+}));
+jest.mock('../utils/TorUtils', () => ({
+    doTorRequest: jest.fn(),
+    isOnionHttpsUrl: jest.fn(),
+    RequestMethod: {}
+}));
+jest.mock('./CoreLightningRequestHandler', () => ({
+    getBalance: jest.fn(),
+    getChainTransactions: jest.fn(),
+    getOffchainBalance: jest.fn(),
+    listPeers: jest.fn(),
+    listClosedChannels: jest.fn(),
+    listPeerChannels: jest.fn()
+}));
+
+import CLNRest from './CLNRest';
+
+// CLNRest's own `getURL` is not reachable with ws=true today — its single
+// caller passes no ws argument — so these lock in the anchored behaviour
+// against the day it acquires one, and keep it in step with LND.getURL.
+describe('CLNRest.getURL', () => {
+    const cln = new CLNRest();
+    const url = (host: string, port: string | number = '', ws = false) =>
+        cln.getURL(host, port, '/v1/route', ws);
+
+    describe('scheme rewriting for WebSocket URLs', () => {
+        it('rewrites https to wss and http to ws', () => {
+            expect(url('https://node.example.com', 3010, true)).toBe(
+                'wss://node.example.com:3010/v1/route'
+            );
+            expect(url('http://192.168.1.5', 3010, true)).toBe(
+                'ws://192.168.1.5:3010/v1/route'
+            );
+        });
+
+        it('leaves a host containing "http" in its name intact', () => {
+            expect(url('https://httpbin.org', 3010, true)).toBe(
+                'wss://httpbin.org:3010/v1/route'
+            );
+        });
+
+        it('leaves an http host containing "https" in its name intact', () => {
+            expect(url('http://myhttpserver.local', 3010, true)).toBe(
+                'ws://myhttpserver.local:3010/v1/route'
+            );
+        });
+    });
+
+    describe('without the ws flag', () => {
+        it('leaves the scheme alone', () => {
+            expect(url('https://node.example.com', 3010)).toBe(
+                'https://node.example.com:3010/v1/route'
+            );
+            expect(url('https://httpbin.org', 3010)).toBe(
+                'https://httpbin.org:3010/v1/route'
+            );
+        });
+
+        it('defaults a schemeless host to https', () => {
+            expect(url('node.example.com', 3010)).toBe(
+                'https://node.example.com:3010/v1/route'
+            );
+        });
+
+        it('strips a trailing slash before appending the route', () => {
+            expect(
+                cln.getURL('https://node.example.com/', '', '/v1/route')
+            ).toBe('https://node.example.com/v1/route');
+        });
+    });
+});

--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -198,7 +198,10 @@ export default class CLNRest {
         let baseUrl = `${hostPath}${port ? ':' + port : ''}`;
 
         if (ws) {
-            baseUrl = baseUrl.replace('https', 'wss').replace('http', 'ws');
+            // see LND.getURL: anchored so a host containing "http" is not
+            // mangled. Unreachable today (no caller passes ws), kept in
+            // sync so reviving it cannot revive the bug.
+            baseUrl = baseUrl.replace(/^https/, 'wss').replace(/^http/, 'ws');
         }
 
         if (baseUrl[baseUrl.length - 1] === '/') {

--- a/backends/LND.test.ts
+++ b/backends/LND.test.ts
@@ -1,0 +1,116 @@
+// backends/ has no other test files: these mocks stand in for the native
+// modules LND.ts pulls in at import time (blob-util, and nitro-tor via
+// TorUtils). They are import-time scaffolding only — getURL touches none
+// of them.
+jest.mock('react-native-blob-util', () => ({
+    __esModule: true,
+    default: { fetch: jest.fn(), config: jest.fn() }
+}));
+jest.mock('../stores/Stores', () => ({
+    settingsStore: { settings: {} },
+    nodeInfoStore: { nodeInfo: {} }
+}));
+jest.mock('../utils/TorUtils', () => ({
+    doTorRequest: jest.fn(),
+    isOnionHttpsUrl: jest.fn(),
+    RequestMethod: {}
+}));
+
+import LND from './LND';
+
+describe('LND.getURL', () => {
+    const lnd = new LND();
+    const url = (host: string, port: string | number = '', ws = false) =>
+        lnd.getURL(host, port, '/v1/route', ws);
+
+    describe('scheme rewriting for WebSocket URLs', () => {
+        it('rewrites https to wss and http to ws', () => {
+            expect(url('https://node.example.com', 8080, true)).toBe(
+                'wss://node.example.com:8080/v1/route'
+            );
+            expect(url('http://192.168.1.5', 8080, true)).toBe(
+                'ws://192.168.1.5:8080/v1/route'
+            );
+        });
+
+        it('leaves a host containing "http" in its name intact', () => {
+            // Regression: a bare string replace rewrites the first match
+            // anywhere, so these were sent to a different — and
+            // attacker-registrable — host, carrying the macaroon.
+            expect(url('https://httpbin.org', 8080, true)).toBe(
+                'wss://httpbin.org:8080/v1/route'
+            );
+            expect(url('https://api.http-relay.com', '', true)).toBe(
+                'wss://api.http-relay.com/v1/route'
+            );
+        });
+
+        it('leaves an http host containing "https" in its name intact', () => {
+            // Compounding case: "myhttpserver" contains the substring
+            // "https", so this hit the *first* replace and came out with
+            // the right scheme but the wrong host.
+            expect(url('http://myhttpserver.local', 3000, true)).toBe(
+                'ws://myhttpserver.local:3000/v1/route'
+            );
+        });
+
+        it('rewrites only the scheme, never a later occurrence', () => {
+            expect(url('https://http.http', '', true)).toBe(
+                'wss://http.http/v1/route'
+            );
+        });
+
+        it('handles onion hosts', () => {
+            expect(url('https://abcdef.onion', 10009, true)).toBe(
+                'wss://abcdef.onion:10009/v1/route'
+            );
+        });
+
+        it('defaults a schemeless host to https, then to wss', () => {
+            expect(url('node.example.com', 8080, true)).toBe(
+                'wss://node.example.com:8080/v1/route'
+            );
+            // a schemeless host containing "http" is equally protected
+            expect(url('httpbin.org', 8080, true)).toBe(
+                'wss://httpbin.org:8080/v1/route'
+            );
+        });
+    });
+
+    describe('without the ws flag', () => {
+        it('leaves the scheme alone', () => {
+            expect(url('https://node.example.com', 8080)).toBe(
+                'https://node.example.com:8080/v1/route'
+            );
+            expect(url('http://node.example.com', 8080)).toBe(
+                'http://node.example.com:8080/v1/route'
+            );
+        });
+
+        it('does not touch "http" inside a hostname either', () => {
+            expect(url('https://httpbin.org', 8080)).toBe(
+                'https://httpbin.org:8080/v1/route'
+            );
+        });
+    });
+
+    describe('host and port assembly', () => {
+        it('omits the port when falsy', () => {
+            expect(url('https://node.example.com')).toBe(
+                'https://node.example.com/v1/route'
+            );
+        });
+
+        it('strips a trailing slash before appending the route', () => {
+            expect(
+                lnd.getURL('https://node.example.com/', '', '/v1/route')
+            ).toBe('https://node.example.com/v1/route');
+        });
+
+        it('strips the trailing slash on ws URLs too', () => {
+            expect(
+                lnd.getURL('https://node.example.com/', '', '/v1/route', true)
+            ).toBe('wss://node.example.com/v1/route');
+        });
+    });
+});

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -218,7 +218,10 @@ export default class LND {
         let baseUrl = `${hostPath}${port ? ':' + port : ''}`;
 
         if (ws) {
-            baseUrl = baseUrl.replace('https', 'wss').replace('http', 'ws');
+            // anchor to the scheme: a bare string replace rewrites the
+            // first match anywhere, so a host containing "http" had its
+            // own name mangled (https://httpbin.org -> wss://wsbin.org)
+            baseUrl = baseUrl.replace(/^https/, 'wss').replace(/^http/, 'ws');
         }
 
         if (baseUrl[baseUrl.length - 1] === '/') {

--- a/utils/SwapUtils.test.ts
+++ b/utils/SwapUtils.test.ts
@@ -7,6 +7,7 @@ import {
     calculateSendAmount,
     calculateLimit,
     isValidRescueKey,
+    swapWebSocketUrl,
     verifyReverseSwapInvoice
 } from './SwapUtils';
 
@@ -240,6 +241,37 @@ describe('SwapUtils', () => {
             );
             expect(result.valid).toBe(false);
             expect(result.reason).toBe('undecodable');
+        });
+    });
+
+    describe('swapWebSocketUrl', () => {
+        it('rewrites the scheme and appends the ws route', () => {
+            expect(swapWebSocketUrl('https://api.boltz.exchange/v2')).toBe(
+                'wss://api.boltz.exchange/v2/ws'
+            );
+            expect(swapWebSocketUrl('http://192.168.1.5:9001/v2')).toBe(
+                'ws://192.168.1.5:9001/v2/ws'
+            );
+        });
+
+        it('leaves a host containing "http" in its name intact', () => {
+            expect(swapWebSocketUrl('https://boltz.httprelay.io/v2')).toBe(
+                'wss://boltz.httprelay.io/v2/ws'
+            );
+        });
+
+        it('leaves an http host containing "https" in its name intact', () => {
+            // the unanchored replace hit "myhttpserver", not the scheme,
+            // pointing swap updates at a host the user never configured
+            expect(swapWebSocketUrl('http://myhttpserver.local:9001/v2')).toBe(
+                'ws://myhttpserver.local:9001/v2/ws'
+            );
+        });
+
+        it('rewrites only the scheme, never a later occurrence', () => {
+            expect(swapWebSocketUrl('https://http.http/https')).toBe(
+                'wss://http.http/https/ws'
+            );
         });
     });
 });

--- a/utils/SwapUtils.ts
+++ b/utils/SwapUtils.ts
@@ -52,6 +52,18 @@ export const bigFloor = (big: BigNumber): BigNumber => {
     return big.integerValue(BigNumber.ROUND_FLOOR);
 };
 
+/**
+ * Builds the swap-update WebSocket URL for a swap host. The scheme
+ * rewrites are anchored to `^`: a bare string replace rewrites the first
+ * match anywhere in the string, so a host whose own name contains `http`
+ * had it rewritten instead of the scheme, sending swap updates to a
+ * different — and attacker-registrable — host. Custom swap hosts are
+ * user-supplied (settings.swaps.customHost), so that input is reachable.
+ * See LND.getURL for the same fix on the backend side.
+ */
+export const swapWebSocketUrl = (endpoint: string): string =>
+    endpoint.replace(/^https/, 'wss').replace(/^http/, 'ws') + '/ws';
+
 export const SWAPS_KEY = 'swaps';
 export const REVERSE_SWAPS_KEY = 'reverse-swaps';
 export const SWAPS_RESCUE_KEY = 'swaps-rescue-key';

--- a/views/Swaps/SwapDetails.tsx
+++ b/views/Swaps/SwapDetails.tsx
@@ -30,6 +30,7 @@ import { sleep } from '../../utils/SleepUtils';
 import { font } from '../../utils/FontUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import { numberWithCommas } from '../../utils/UnitsUtils';
+import { swapWebSocketUrl } from '../../utils/SwapUtils';
 import UrlUtils from '../../utils/UrlUtils';
 
 import NodeInfoStore from '../../stores/NodeInfoStore';
@@ -257,9 +258,7 @@ export default class SwapDetails extends React.Component<
         this.setState({ loading: true });
 
         // Create a WebSocket connection
-        const webSocket = new WebSocket(
-            endpoint.replace('https', 'wss') + '/ws'
-        );
+        const webSocket = new WebSocket(swapWebSocketUrl(endpoint));
 
         // Handle WebSocket connection open
         webSocket.onopen = () => {
@@ -449,9 +448,7 @@ export default class SwapDetails extends React.Component<
         this.setState({ loading: true });
 
         // Create a WebSocket connection
-        const webSocket = new WebSocket(
-            endpoint.replace('https', 'wss') + '/ws'
-        );
+        const webSocket = new WebSocket(swapWebSocketUrl(endpoint));
 
         // Handle WebSocket connection open
         webSocket.onopen = () => {


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000** (internal security audit finding L1)

`getURL` built its `wss://` URL with bare string replaces (`backends/LND.ts:221`, `backends/CLNRest.ts:201`):

```ts
baseUrl = baseUrl.replace('https', 'wss').replace('http', 'ws');
```

`String.replace` with a **string** pattern rewrites the first match *anywhere in the string*, not just the scheme. So any host whose own name contains `http` gets mangled, and the macaroon then rides a WebSocket to a different — attacker-registrable — hostname.

Both replaces can bite, and they compound in a way the audit didn't capture:

| Input | Before | After |
|---|---|---|
| `https://node.example.com:8080` | `wss://node.example.com:8080` | unchanged |
| `http://192.168.1.5:8080` | `ws://192.168.1.5:8080` | unchanged |
| `https://xyz.onion:10009` | `wss://xyz.onion:10009` | unchanged |
| `https://httpbin.org:8080` | **`wss://wsbin.org:8080`** | `wss://httpbin.org:8080` |
| `https://api.http-relay.com` | **`wss://api.ws-relay.com`** | `wss://api.http-relay.com` |
| `http://myhttpserver.local:3000` | **`ws://mywsserver.local:3000`** | `ws://myhttpserver.local:3000` |

The third failing row is the one worth noting: a plain `http://` host hits the **first** rule, because `myhttpserver` contains the substring `https`. The scheme ends up right and the hostname ends up wrong.

## Fix

Anchor both replaces to `^`.

The ordering still holds: an `https` URL becomes `wss` and the second rule then can't match (the string now starts `wss`), while an `http` URL falls through to it. `hostPath` guarantees a scheme is present (`host.includes('://') ? host : 'https://' + host`), so anchoring is always correct.

Hosts without an embedded `http` are completely unaffected — which is every host this has ever been exercised against, and is why it went unnoticed.

## Scope: which call sites are live

I re-checked rather than trusting the audit's note, and it holds:

- **LND — three live callers**: `subscribeCustomMessages` (`:316`), `openChannelStream` (`:481`), `initChanAcceptor` (`:851`).
- **LND `wsReq` (`:160`) is dead** — no callers anywhere in the tree. Only its locale string `backends.LND.wsReq.warning` is reused by the three live methods.
- **CLNRest is dead** — its single `getURL` call (`:178`) passes no `ws` argument, so the branch is unreachable.

I fixed both files anyway rather than leaving a bug waiting for a caller. Deleting the dead `wsReq` and the unreachable CLNRest branch is a reasonable follow-up, but it's a cleanup decision rather than part of this fix, and I'd rather not bundle a deletion into a security patch. Happy to do it separately if you want it.

Note this is the *scheme* half of the WebSocket problems. The Tor-bypass half of the same code (L2 in the audit) is separate and is what #4372 addresses with an enable-time warning.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

`yarn verify` green (1289 → 1306).

**`backends/LND.test.ts` and `backends/CLNRest.test.ts` are the first test files under `backends/`.** 17 tests; **6 fail against the pre-fix code**, verified by checking the parent commit's files back out and re-running:

```
● LND.getURL     › leaves a host containing "http" in its name intact
● LND.getURL     › leaves an http host containing "https" in its name intact
● LND.getURL     › rewrites only the scheme, never a later occurrence
● LND.getURL     › defaults a schemeless host to https, then to wss
● CLNRest.getURL › leaves a host containing "http" in its name intact
● CLNRest.getURL › leaves an http host containing "https" in its name intact
```

The rest pin the behaviour the fix must not disturb: normal hosts, `.onion`, schemeless hosts, port assembly, trailing-slash stripping, and the non-`ws` path.

### Why there were no backend tests before, and what unblocks them

Nothing under `backends/` was testable because these modules pull native code in at import time — `react-native-blob-util` directly, and `react-native-nitro-tor` through `utils/TorUtils`. Three `jest.mock` calls cover it.

`CLNRest` needs a fourth, and it's worth flagging on its own: `CoreLightningRequestHandler` imports `CLNRest` and calls `new CLNRest()` **at module scope**, while `CLNRest` imports back from it. With `CLNRest` as the entry point the cycle resolves with the class still `undefined` and the import throws. That circularity is pre-existing and doesn't bite the app, because nothing there imports `CLNRest` first — but it will bite the next person who tries to test this file, so the mock carries a comment explaining it. Worth untangling separately.

All four mocks are import-time scaffolding only; `getURL` is a pure function of its arguments and touches none of them. The same three-mock pattern should open up the rest of `backends/` for testing.

CLNRest's `ws` branch is unreachable today, so its tests exist to keep the two implementations in step and stop a future caller reviving the bug.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Not device-tested. What to exercise: a remote LND node over a normal hostname, confirming the three live WebSocket paths still connect — batch channel opens (`openChannelStream`), LSPS custom messages (`subscribeCustomMessages`), and the channel acceptor (`initChanAcceptor`). Those are pass-through cases the fix must not disturb; the failing rows in the table need a host with `http` in its name, which is easiest to fake with a hosts-file entry.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Remote LND only in practice — `EmbeddedLND` and `LightningNodeConnect` override these methods natively, CLNRest's branch is unreachable, and LndHub inherits `getURL` but never opens a WebSocket.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

No new strings.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

