### PR TITLE
stores: settle superseded getNodeInfo calls instead of leaving them pending

### DIFF
--- a/stores/NodeInfoStore.test.ts
+++ b/stores/NodeInfoStore.test.ts
@@ -1,0 +1,108 @@
+import NodeInfoStore from './NodeInfoStore';
+import BackendUtils from '../utils/BackendUtils';
+
+jest.mock('./ChannelsStore', () => ({
+    __esModule: true,
+    default: class ChannelsStore {}
+}));
+
+jest.mock('./SettingsStore', () => ({
+    __esModule: true,
+    default: class SettingsStore {}
+}));
+
+jest.mock('../utils/BackendUtils', () => ({
+    __esModule: true,
+    default: {
+        getMyNodeInfo: jest.fn(),
+        supportsOffers: jest.fn(() => false),
+        supportsListingOffers: jest.fn(() => false)
+    }
+}));
+
+jest.mock('../utils/ErrorUtils', () => ({
+    __esModule: true,
+    errorToUserFriendly: (error: string) => error
+}));
+
+jest.mock('../storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: jest.fn(async () => false),
+        setItem: jest.fn(async () => {}),
+        removeItem: jest.fn(async () => {})
+    }
+}));
+
+const getMyNodeInfoMock = BackendUtils.getMyNodeInfo as jest.Mock;
+
+// Resolves to { settled: true } if the promise settles within `ms`,
+// { settled: false } otherwise. Used to detect orphaned promises
+// without hanging the test.
+const settlesWithin = (promise: Promise<any>, ms: number) =>
+    Promise.race([
+        promise.then(
+            (value) => ({ settled: true, value }),
+            (error) => ({ settled: true, error })
+        ),
+        new Promise<{ settled: false }>((resolve) =>
+            setTimeout(() => resolve({ settled: false }), ms)
+        )
+    ]);
+
+describe('NodeInfoStore.getNodeInfo', () => {
+    beforeEach(() => {
+        getMyNodeInfoMock.mockReset();
+    });
+
+    it('settles a superseded call when the shared request succeeds', async () => {
+        // Both calls share one in-flight request, mirroring the
+        // request-dedup cache in backends/LND.ts which keys
+        // /v1/getinfo by bare URL.
+        let resolveBackend: (data: any) => void = () => {};
+        const backendPromise = new Promise((resolve) => {
+            resolveBackend = resolve;
+        });
+        getMyNodeInfoMock.mockReturnValue(backendPromise);
+
+        const store = new NodeInfoStore({} as any, {} as any);
+
+        const superseded = store.getNodeInfo();
+        const current = store.getNodeInfo();
+
+        resolveBackend({ identity_pubkey: 'pk1', version: '0.18.0-beta' });
+
+        const currentResult = await settlesWithin(current, 200);
+        expect(currentResult.settled).toBe(true);
+        expect((currentResult as any).value.nodeId).toEqual('pk1');
+
+        // Regression: before the fix, the success handler of a
+        // superseded call bailed out without resolving, leaving this
+        // promise pending forever (and, in the app, wedging Wallet's
+        // fetchData on the connecting overlay).
+        const supersededResult = await settlesWithin(superseded, 200);
+        expect(supersededResult.settled).toBe(true);
+    });
+
+    it('settles a superseded call when the shared request fails', async () => {
+        let rejectBackend: (error: any) => void = () => {};
+        const backendPromise = new Promise((_resolve, reject) => {
+            rejectBackend = reject;
+        });
+        getMyNodeInfoMock.mockReturnValue(backendPromise);
+
+        const store = new NodeInfoStore({} as any, {} as any);
+
+        const superseded = store.getNodeInfo();
+        const current = store.getNodeInfo();
+
+        rejectBackend(new Error('connection refused'));
+
+        const supersededResult = await settlesWithin(superseded, 200);
+        expect(supersededResult.settled).toBe(true);
+
+        const currentResult = await settlesWithin(current, 200);
+        expect(currentResult.settled).toBe(true);
+        expect((currentResult as any).error).toBeDefined();
+    });
+});

--- a/stores/NodeInfoStore.ts
+++ b/stores/NodeInfoStore.ts
@@ -66,6 +66,12 @@ export default class NodeInfoStore {
             BackendUtils.getMyNodeInfo()
                 .then((data: any) => {
                     if (this.currentRequest !== currentRequest) {
+                        // A newer getNodeInfo call superseded this one.
+                        // Settle anyway: callers like Wallet's fetchData
+                        // await this promise, and a bare return would leave
+                        // it pending forever, wedging fetchLock and the
+                        // connecting overlay until app restart.
+                        resolve('Old getNodeInfo call');
                         return;
                     }
                     const nodeInfo = new NodeInfo(data);


### PR DESCRIPTION
# Description

Fixes the most common cause of the app latching on "ZEUS is connecting to your node." forever on remote backends, reported recently by an Android user on v13.2.0 connecting to two LND (REST) nodes over LAN/Tailscale.

`NodeInfoStore.getNodeInfo` tracks the latest call via `this.currentRequest`. When a call discovers it has been superseded, its success handler bails out with a bare `return` inside the `new Promise` executor, so the returned promise never settles. The catch path already settles (`resolve('Old getNodeInfo call')`); the success path did not. The asymmetry dates to c8954f06e (v0.8.1), which wrapped what was previously a plain promise chain, where a bare return was harmless, in a `new Promise` executor, where it orphans the promise.

Consequences when the orphaned caller is `fetchData` (`views/Wallet/Wallet.tsx:1241`):

- `fetchDataCore` never returns, so the `finally` from #4398 never runs and `fetchLock` stays held
- `_navigating` stays set, so every subsequent focus/resume retry is skipped
- `connecting` never clears, so the spinner overlay stays up and the error screen with the Restart button (rendered under `!connecting`) is unreachable
- only re-selecting the wallet (which forces `setConnectingStatus(true)`) or killing the app recovers

The main boot-time trigger is the NWC service init fired on app resume (`Wallet.tsx`, `initializeService` -> `verifyServiceHealth` -> `getNodeInfo`), added in v0.12.0, which races the `fetchData` await. The request-dedup cache in `backends/LND.ts` keys `/v1/getinfo` by bare URL, so both callers share one in-flight request and the race fires reliably once overlapped, but only when the request succeeds, which matches the reported "fails most of the time, restart helps" pattern (cold starts run NWC init after the spinner clears; resumes run it before).

The fix settles the superseded call with the same sentinel the catch path uses. Callers already tolerate this resolution value today.

## Correctness proof

`stores/NodeInfoStore.test.ts` (first test in `stores/`) mocks the `BackendUtils` graph and has both overlapping `getNodeInfo` calls share one underlying request promise, mirroring the dedup cache. Run against the parent commit (unfixed store), the success-path test fails exactly as the analysis predicts: the superseded promise never settles within the 200 ms window, while the failure-path test passes because the catch path already settled. With the fix, both pass.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes (first test in `stores/`; reproduces the orphaned promise against the unfixed store and passes with the fix)
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Device test plan (pending, will check off above as completed): remote LND (REST) with an active NWC connection, background the app, resume, repeat several times; without the fix the wallet intermittently latches on the connecting overlay, with the fix it should always either connect or surface the error screen.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
