### PR TITLE
tools: add startup timing instrumentation with copyable report

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -293,6 +293,7 @@ import ActivityExport from './views/Tools/ActivityExport';
 import BumpFee from './views/Tools/BumpFee';
 import CurrencyConverter from './views/Tools/CurrencyConverter';
 import DeveloperTools from './views/Tools/DeveloperTools';
+import StartupTiming from './views/Tools/StartupTiming';
 import Rebalance from './views/Tools/Rebalance';
 import RebalancingChannels from './views/Tools/RebalancingChannels';
 import SignVerifyMessage from './views/Tools/SignVerifyMessage';
@@ -1526,6 +1527,12 @@ export default class App extends React.PureComponent {
                                                                 name="DeveloperTools" // @ts-ignore:next-line
                                                                 component={
                                                                     DeveloperTools
+                                                                }
+                                                            />
+                                                            <Stack.Screen
+                                                                name="StartupTiming" // @ts-ignore:next-line
+                                                                component={
+                                                                    StartupTiming
                                                                 }
                                                             />
                                                             <Stack.Screen

--- a/components/StealthModeWrapper.tsx
+++ b/components/StealthModeWrapper.tsx
@@ -3,6 +3,7 @@ import { Platform, View } from 'react-native';
 
 import { StealthAppContainer } from '../views/Stealth';
 import StealthModeUtils, { StealthApp } from '../utils/StealthModeUtils';
+import { markStartupPhase } from '../utils/StartupTimingUtils';
 import Storage from '../storage';
 
 interface StealthModeWrapperProps {
@@ -39,15 +40,18 @@ const StealthModeWrapper: React.FC<StealthModeWrapperProps> = ({
     }, []);
 
     const checkStealthStatus = async () => {
+        markStartupPhase('stealthCheckStart');
         // Only check on Android
         if (Platform.OS !== 'android') {
             setIsLoading(false);
+            markStartupPhase('stealthGateCleared');
             return;
         }
 
         try {
             // Check native stealth status first (most reliable)
             const nativeActive = await StealthModeUtils.isStealthModeActive();
+            markStartupPhase('stealthNativeChecked');
 
             // Get JS settings to cross-reference
             const settingsStr = await Storage.getItem(STORAGE_KEY);
@@ -79,6 +83,7 @@ const StealthModeWrapper: React.FC<StealthModeWrapperProps> = ({
             console.error('Error checking stealth status:', error);
         } finally {
             setIsLoading(false);
+            markStartupPhase('stealthGateCleared');
         }
     };
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+// First import so t0 approximates JS start; uses no polyfilled globals
+import {markStartupPhase} from './utils/StartupTimingUtils';
 import './polyfills';
 import 'react-native-gesture-handler';
 import { enableScreens } from 'react-native-screens';
@@ -30,5 +32,9 @@ LogBox.ignoreLogs([
   'Updating fee rate estimates timed out',
   'NodeException'
 ]);
+
+// All top-level imports (including the full App screen graph and store
+// singleton construction) have evaluated by the time this line runs
+markStartupPhase('bundleEvaluated');
 
 AppRegistry.registerComponent(appName, () => App);

--- a/locales/en.json
+++ b/locales/en.json
@@ -1003,6 +1003,8 @@
     "views.Tools.NostrKeys.allMintsAlreadyAdded": "All discovered mints are already in your wallet",
     "views.Tools.NostrKeys.noSeed": "No Cashu seed available. Add a mint first to initialize your wallet.",
     "views.Tools.developerTools.title": "Developer Tools",
+    "views.Tools.startupTiming.title": "Startup Timing",
+    "views.Tools.startupTiming.explainer": "Timing of this session's app startup, from JS start to the first completed node connection, including keychain operation counts. Copy and share this report when diagnosing slow startups. It contains no secrets: long storage key names are truncated.",
     "views.Tools.developerTools.noItemsExist": "No items exist",
     "views.Tools.developerTools.abandonChannel.title": "Abandon Channel",
     "views.Tools.developerTools.abandonChannel.message": "Are you sure you want to abandon this channel? The channel will be removed from the database and you may lose funds if you haven't already recovered them.",

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -1,5 +1,7 @@
 import * as Keychain from 'react-native-keychain';
 
+import { recordStorageOp } from '../utils/StartupTimingUtils';
+
 const KEY_PREFIX = 'zeus:';
 
 class Storage {
@@ -18,17 +20,22 @@ class Storage {
 
     getItem = async (key: string) => {
         const prefixedKey = this.prefixKey(key);
-        const response: any = await Keychain.getInternetCredentials(
-            prefixedKey,
-            {
-                cloudSync: false
-            }
-        );
+        const startedAt = Date.now();
+        try {
+            const response: any = await Keychain.getInternetCredentials(
+                prefixedKey,
+                {
+                    cloudSync: false
+                }
+            );
 
-        if (response && response.password) {
-            return response.password;
+            if (response && response.password) {
+                return response.password;
+            }
+            return false;
+        } finally {
+            recordStorageOp('get', key, Date.now() - startedAt);
         }
-        return false;
     };
 
     setItem = async (key: string, value: any) => {
@@ -48,24 +55,34 @@ class Storage {
             return this.removeItem(key);
         }
 
-        const response = await Keychain.setInternetCredentials(
-            prefixedKey,
-            prefixedKey,
-            stringValue,
-            {
-                cloudSync: false
-            }
-        );
-        return response;
+        const startedAt = Date.now();
+        try {
+            const response = await Keychain.setInternetCredentials(
+                prefixedKey,
+                prefixedKey,
+                stringValue,
+                {
+                    cloudSync: false
+                }
+            );
+            return response;
+        } finally {
+            recordStorageOp('set', key, Date.now() - startedAt);
+        }
     };
 
     removeItem = async (key: string) => {
         const prefixedKey = this.prefixKey(key);
-        const response = await Keychain.resetInternetCredentials({
-            server: prefixedKey,
-            cloudSync: false
-        });
-        return response;
+        const startedAt = Date.now();
+        try {
+            const response = await Keychain.resetInternetCredentials({
+                server: prefixedKey,
+                cloudSync: false
+            });
+            return response;
+        } finally {
+            recordStorageOp('remove', key, Date.now() - startedAt);
+        }
     };
 }
 

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -8,6 +8,10 @@ import BackendUtils from '../utils/BackendUtils';
 import { getSupportedBiometryType } from '../utils/BiometricUtils';
 import { localeString } from '../utils/LocaleUtils';
 import MigrationsUtils from '../utils/MigrationUtils';
+import {
+    markStartupPhase,
+    sealStartupTiming
+} from '../utils/StartupTimingUtils';
 import { doTorRequest, RequestMethod } from '../utils/TorUtils';
 import {
     DEFAULT_SCORER_URL,
@@ -1928,11 +1932,13 @@ export default class SettingsStore {
     };
 
     public getSettings = async (silentUpdate: boolean = false) => {
+        markStartupPhase('getSettingsFirstCall');
         if (!silentUpdate) this.loading = true;
         try {
             await MigrationsUtils.keychainCloudSyncMigration();
 
             const modernSettings: any = await Storage.getItem(STORAGE_KEY);
+            markStartupPhase('settingsBlobRead');
 
             if (modernSettings) {
                 console.log('attempting to load modern settings');
@@ -1947,6 +1953,7 @@ export default class SettingsStore {
                     parsedSettings
                 );
                 this.settings = parsedSettings;
+                markStartupPhase('settingsMigrationsChecked');
             } else {
                 console.log('attempting to load legacy settings');
 
@@ -1976,6 +1983,7 @@ export default class SettingsStore {
         } finally {
             this.isMigrating = false;
             if (!silentUpdate) this.loading = false;
+            markStartupPhase('settingsLoaded');
         }
 
         return this.settings;
@@ -2307,6 +2315,12 @@ export default class SettingsStore {
             BackendUtils.clearCachedCalls();
             // remove fetchLock on reconnect
             this.fetchLock = false;
+        }
+        if (!status) {
+            // First completed connect ends the startup window; collection
+            // stops here so steady-state operation records nothing
+            markStartupPhase('connectComplete');
+            sealStartupTiming();
         }
         this.connecting = status;
         return this.connecting;

--- a/utils/StartupTimingUtils.test.ts
+++ b/utils/StartupTimingUtils.test.ts
@@ -1,0 +1,83 @@
+import {
+    __resetStartupTimingForTests,
+    getSlowestStorageOps,
+    getStartupMarks,
+    getStartupTimingReport,
+    getStorageOpStats,
+    markStartupPhase,
+    recordStorageOp,
+    sealStartupTiming
+} from './StartupTimingUtils';
+
+describe('StartupTimingUtils', () => {
+    beforeEach(() => {
+        __resetStartupTimingForTests();
+    });
+
+    it('records marks in order with non-decreasing offsets', () => {
+        markStartupPhase('bundleEvaluated');
+        markStartupPhase('settingsLoaded');
+        const marks = getStartupMarks();
+        expect(marks.map((m) => m.name)).toEqual([
+            'bundleEvaluated',
+            'settingsLoaded'
+        ]);
+        expect(marks[1].atMs).toBeGreaterThanOrEqual(marks[0].atMs);
+    });
+
+    it('ignores duplicate marks', () => {
+        markStartupPhase('settingsLoaded');
+        markStartupPhase('settingsLoaded');
+        expect(getStartupMarks().length).toBe(1);
+    });
+
+    it('stops recording after sealing', () => {
+        markStartupPhase('connectComplete');
+        sealStartupTiming();
+        markStartupPhase('afterSeal');
+        recordStorageOp('get', 'zeus-settings-v2', 5);
+        expect(getStartupMarks().map((m) => m.name)).toEqual([
+            'connectComplete'
+        ]);
+        expect(getStorageOpStats()).toEqual({});
+    });
+
+    it('aggregates storage op stats and keeps the slowest ops', () => {
+        for (let i = 1; i <= 12; i++) {
+            recordStorageOp('get', `key-${i}`, i * 10);
+        }
+        recordStorageOp('set', 'zeus-settings-v2', 40);
+
+        const stats = getStorageOpStats();
+        expect(stats.get.count).toBe(12);
+        expect(stats.get.maxMs).toBe(120);
+        expect(stats.get.totalMs).toBe(780);
+        expect(stats.set.count).toBe(1);
+
+        const slowest = getSlowestStorageOps();
+        expect(slowest.length).toBe(10);
+        expect(slowest[0].durationMs).toBe(120);
+        expect(slowest[slowest.length - 1].durationMs).toBeLessThanOrEqual(
+            slowest[0].durationMs
+        );
+    });
+
+    it('redacts long keys that may embed hashes or pubkeys', () => {
+        const hashKey =
+            'lnurlpay:2f9d1c4e8b7a6f5d4c3b2a190817263544536271809f8e7d6c5b4a3928171605';
+        recordStorageOp('get', hashKey, 7);
+        const slowest = getSlowestStorageOps();
+        expect(slowest[0].key).not.toContain(hashKey.slice(24));
+        expect(slowest[0].key).toContain(`len ${hashKey.length}`);
+    });
+
+    it('renders a report with deltas and stats', () => {
+        markStartupPhase('bundleEvaluated');
+        recordStorageOp('get', 'zeus-settings-v2', 25);
+        const report = getStartupTimingReport();
+        expect(report).toContain('bundleEvaluated');
+        expect(report).toContain('Keychain ops before connect:');
+        expect(report).toContain('get: n=1 total=25ms max=25ms');
+        expect(report).toContain('25ms get zeus-settings-v2');
+    });
+});

--- a/utils/StartupTimingUtils.ts
+++ b/utils/StartupTimingUtils.ts
@@ -1,0 +1,123 @@
+// Session-only startup phase timing. Imported first from index.js so t0
+// approximates JS engine start; nothing here is persisted and collection
+// stops once the first connect completes (sealStartupTiming), so steady-state
+// operation records nothing. Kept dependency-free: this module is evaluated
+// before shims and polyfills.
+
+export interface StartupMark {
+    name: string;
+    atMs: number;
+    wallClock: number;
+}
+
+export interface StorageOpStats {
+    count: number;
+    totalMs: number;
+    maxMs: number;
+}
+
+export interface SlowStorageOp {
+    op: string;
+    key: string;
+    durationMs: number;
+}
+
+const SLOWEST_OPS_KEPT = 10;
+// Key names can embed payment hashes and node pubkeys; reports are meant to
+// be copy-pasted into support channels, so anything longer is truncated.
+const KEY_REDACT_LENGTH = 24;
+
+let t0 = Date.now();
+let sealed = false;
+let marks: StartupMark[] = [];
+let markedNames = new Set<string>();
+let statsByOp: { [op: string]: StorageOpStats } = {};
+let slowestOps: SlowStorageOp[] = [];
+
+const redactKey = (key: string): string =>
+    key.length > KEY_REDACT_LENGTH
+        ? `${key.slice(0, KEY_REDACT_LENGTH)}…(len ${key.length})`
+        : key;
+
+export const markStartupPhase = (name: string): void => {
+    if (sealed || markedNames.has(name)) return;
+    markedNames.add(name);
+    const now = Date.now();
+    marks.push({ name, atMs: now - t0, wallClock: now });
+    // Surfaced in adb logcat (ReactNativeJS) so device bug reports carry
+    // phase timestamps even if the in-app report is never opened
+    console.log(`[StartupTiming] ${name} +${now - t0}ms`);
+};
+
+export const sealStartupTiming = (): void => {
+    sealed = true;
+};
+
+export const recordStorageOp = (
+    op: string,
+    key: string,
+    durationMs: number
+): void => {
+    if (sealed) return;
+    const stats =
+        statsByOp[op] || (statsByOp[op] = { count: 0, totalMs: 0, maxMs: 0 });
+    stats.count++;
+    stats.totalMs += durationMs;
+    if (durationMs > stats.maxMs) stats.maxMs = durationMs;
+
+    slowestOps.push({ op, key: redactKey(key), durationMs });
+    slowestOps.sort((a, b) => b.durationMs - a.durationMs);
+    if (slowestOps.length > SLOWEST_OPS_KEPT) {
+        slowestOps = slowestOps.slice(0, SLOWEST_OPS_KEPT);
+    }
+};
+
+export const getStartupMarks = (): StartupMark[] => [...marks];
+
+export const getStorageOpStats = (): { [op: string]: StorageOpStats } => ({
+    ...statsByOp
+});
+
+export const getSlowestStorageOps = (): SlowStorageOp[] => [...slowestOps];
+
+export const getStartupTimingReport = (): string => {
+    const lines: string[] = [
+        `Startup timing (t0 = ${new Date(t0).toISOString()})`
+    ];
+    let previousAtMs = 0;
+    marks.forEach((mark) => {
+        lines.push(
+            `+${mark.atMs}ms ${mark.name} (Δ ${mark.atMs - previousAtMs}ms)`
+        );
+        previousAtMs = mark.atMs;
+    });
+    const opNames = Object.keys(statsByOp);
+    if (opNames.length > 0) {
+        lines.push('Keychain ops before connect:');
+        opNames.forEach((op) => {
+            const s = statsByOp[op];
+            lines.push(
+                `  ${op}: n=${s.count} total=${s.totalMs}ms max=${s.maxMs}ms`
+            );
+        });
+    }
+    if (slowestOps.length > 0) {
+        lines.push('Slowest keychain ops:');
+        slowestOps.forEach((s) => {
+            lines.push(`  ${s.durationMs}ms ${s.op} ${s.key}`);
+        });
+    }
+    return lines.join('\n');
+};
+
+// Test hook: collection state is module-level so real usage needs no wiring
+export const __resetStartupTimingForTests = (): void => {
+    t0 = Date.now();
+    sealed = false;
+    marks = [];
+    markedNames = new Set<string>();
+    statsByOp = {};
+    slowestOps = [];
+};
+
+markStartupPhase('jsStart');

--- a/views/Tools/DeveloperTools.tsx
+++ b/views/Tools/DeveloperTools.tsx
@@ -900,6 +900,22 @@ export default class DeveloperTools extends React.Component<
                     }}
                     scrollEventThrottle={16}
                 >
+                    <TouchableOpacity
+                        onPress={() => navigation.navigate('StartupTiming')}
+                        style={[
+                            styles.categoryContainer,
+                            { backgroundColor: themeColor('secondary') }
+                        ]}
+                    >
+                        <Text
+                            style={{
+                                ...styles.categoryTitle,
+                                color: themeColor('text')
+                            }}
+                        >
+                            {localeString('views.Tools.startupTiming.title')}
+                        </Text>
+                    </TouchableOpacity>
                     {categories
                         .filter((c) =>
                             c.commands.some((c) =>

--- a/views/Tools/StartupTiming.tsx
+++ b/views/Tools/StartupTiming.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import Header from '../../components/Header';
+import Screen from '../../components/Screen';
+import CopyButton from '../../components/CopyButton';
+
+import { localeString } from '../../utils/LocaleUtils';
+import { themeColor } from '../../utils/ThemeUtils';
+import { getStartupTimingReport } from '../../utils/StartupTimingUtils';
+
+interface StartupTimingProps {
+    navigation: NativeStackNavigationProp<any, any>;
+}
+
+export default class StartupTiming extends React.Component<
+    StartupTimingProps,
+    {}
+> {
+    render() {
+        const { navigation } = this.props;
+        const report = getStartupTimingReport();
+
+        return (
+            <Screen>
+                <Header
+                    leftComponent="Back"
+                    centerComponent={{
+                        text: localeString('views.Tools.startupTiming.title'),
+                        style: {
+                            color: themeColor('text'),
+                            fontFamily: 'PPNeueMontreal-Book'
+                        }
+                    }}
+                    navigation={navigation}
+                />
+                <ScrollView contentContainerStyle={styles.container}>
+                    <Text
+                        style={[
+                            styles.explainer,
+                            { color: themeColor('secondaryText') }
+                        ]}
+                    >
+                        {localeString('views.Tools.startupTiming.explainer')}
+                    </Text>
+                    <View
+                        style={[
+                            styles.reportContainer,
+                            { backgroundColor: themeColor('secondary') }
+                        ]}
+                    >
+                        <View style={styles.reportHeaderRow}>
+                            <CopyButton
+                                copyValue={report}
+                                iconOnly={true}
+                                iconSize={20}
+                            />
+                        </View>
+                        <Text
+                            style={[
+                                styles.reportText,
+                                { color: themeColor('text') }
+                            ]}
+                        >
+                            {report}
+                        </Text>
+                    </View>
+                </ScrollView>
+            </Screen>
+        );
+    }
+}
+
+const styles = StyleSheet.create({
+    container: {
+        gap: 10,
+        marginTop: 15,
+        width: '90%',
+        alignSelf: 'center',
+        paddingBottom: 20
+    },
+    explainer: {
+        fontSize: 13,
+        fontFamily: 'PPNeueMontreal-Book'
+    },
+    reportContainer: {
+        padding: 16,
+        borderRadius: 10
+    },
+    reportHeaderRow: {
+        flexDirection: 'row',
+        justifyContent: 'flex-end'
+    },
+    reportText: {
+        fontSize: 12,
+        fontFamily: 'DroidSansMono'
+    }
+});

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -44,6 +44,7 @@ import Screen from '../../components/Screen';
 import WalletHeader from '../../components/WalletHeader';
 
 import BackendUtils from '../../utils/BackendUtils';
+import { markStartupPhase } from '../../utils/StartupTimingUtils';
 import { getSupportedBiometryType } from '../../utils/BiometricUtils';
 import LinkingUtils from '../../utils/LinkingUtils';
 import {
@@ -328,9 +329,13 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             SettingsStore: { updateSettings }
         } = this.props;
 
+        markStartupPhase('walletMounted');
+
         const supportedBiometryType = await getSupportedBiometryType();
 
         await updateSettings({ supportedBiometryType });
+
+        markStartupPhase('biometrySettingUpdated');
 
         this.handleFocus();
     }
@@ -526,6 +531,8 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
 
     async fetchData(transientRetryCount = 0) {
         const { SettingsStore } = this.props;
+
+        markStartupPhase('fetchDataStart');
 
         // ensure we don't run this twice in parallel
         const seq = SettingsStore.acquireFetchLock();
@@ -1239,6 +1246,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         } else {
             try {
                 await NodeInfoStore.getNodeInfo();
+                markStartupPhase('nodeInfoLoaded');
                 if (BackendUtils.supportsAccounts()) {
                     await UTXOsStore.listAccounts();
                 }


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

Two active field reports (an Android user stuck on "connecting" against remote LND REST, and a Galaxy S25 user with 2 minutes of black screen plus ~7 minutes to connect) have been expensive to diagnose because remote-node users have no in-app logs: only embedded LND/LDK expose log viewers, so the existing console.log phase markers are unreachable without adb.

This adds session-only startup timing instrumentation:

- `utils/StartupTimingUtils.ts` records named phase marks relative to JS start, and aggregates keychain operation timings (count/total/max per op plus the ten slowest, with key names truncated since they can embed payment hashes and pubkeys). Every mark is also `console.log`ged, so an Android bug report zip (Developer options > Take bug report) carries phase timestamps in logcat even if the user never opens the in-app report.
- Marks cover the known startup milestones: JS start, bundle evaluated, stealth gate cleared (the Android black-screen phase), settings blob read, migrations checked, settings loaded, wallet mount, biometry settings write, fetchData start, node info loaded, connect complete.
- `storage/index.ts` times each keychain get/set/remove during the startup window.
- A new Startup Timing screen under Tools > Developer Tools renders the report with a copy button, so a user can paste it into a support channel. Example output:

```
Startup timing (t0 = 2026-08-23T17:21:04.512Z)
+0ms jsStart (Δ 0ms)
+842ms bundleEvaluated (Δ 842ms)
+901ms stealthCheckStart (Δ 59ms)
...
Keychain ops before connect:
  get: n=14 total=310ms max=95ms
  set: n=2 total=141ms max=88ms
Slowest keychain ops:
  95ms get zeus-settings-v2
```

Collection seals once the first connect completes (`setConnectingStatus(false)`), so steady-state operation records nothing; after sealing, the per-op overhead is a timestamp and an early-return. Nothing is persisted, no behavior changes; every addition is observability only.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [x] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes (`utils/StartupTimingUtils.test.ts`: mark ordering, dedup, sealing, stat aggregation, key redaction, report rendering)
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Device test plan (pending): cold start on both platforms, confirm marks appear in the report and logcat, confirm the report screen renders and copies, and confirm no visible startup behavior change. One backend per family (remote REST plus one on-device) should be sufficient since the instrumentation is backend-agnostic.

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
