### PR TITLE
views: don't gate LNURL withdraws on wallet balance

### DIFF
--- a/components/LayerBalances/PaymentMethodList.tsx
+++ b/components/LayerBalances/PaymentMethodList.tsx
@@ -56,6 +56,9 @@ type DataRow = {
     account?: string;
     hidden?: boolean;
     satAmount?: number;
+    // LNURL withdraws fund the wallet, so rows must not be
+    // disabled or flagged on the wallet's existing balance
+    isWithdraw?: boolean;
 };
 
 const LAYER_LOCALE_MAP: Record<string, string> = {
@@ -90,7 +93,9 @@ const hasInsufficientBalance = (
     (satAmount !== undefined && satAmount > Number(balance));
 
 const Row = ({ item }: { item: DataRow }) => {
-    const insufficient = hasInsufficientBalance(item.balance, item.satAmount);
+    const insufficient =
+        !item.isWithdraw &&
+        hasInsufficientBalance(item.balance, item.satAmount);
     const layerLabel = LAYER_LOCALE_MAP[item.layer]
         ? localeString(LAYER_LOCALE_MAP[item.layer])
         : item.layer;
@@ -184,7 +189,9 @@ const SwipeableRow = ({
     clinkNoffer?: string;
     lnurlParams?: LNURLWithdrawParams | undefined;
 }) => {
-    const insufficient = hasInsufficientBalance(item.balance, item.satAmount);
+    const insufficient =
+        !item.isWithdraw &&
+        hasInsufficientBalance(item.balance, item.satAmount);
     const rowDisabled = item.disabled || insufficient;
     if (item.layer === 'Lightning') {
         return (
@@ -295,12 +302,18 @@ export default class PaymentMethodList extends Component<
         } = this.props;
         let DATA: DataRow[] = [];
 
+        const isWithdraw = lnurlParams?.tag === 'withdrawRequest';
+        const subtitle = isWithdraw
+            ? lnurlParams?.defaultDescription || lnurlParams?.domain
+            : lightning ?? lnurlParams?.tag;
+
         if (lightning || lnurlParams) {
             DATA.push({
                 layer: 'Lightning',
-                subtitle: lightning ?? lnurlParams?.tag,
+                subtitle,
                 balance: lightningBalance,
                 disabled: false,
+                isWithdraw,
                 satAmount
             });
 
@@ -310,9 +323,10 @@ export default class PaymentMethodList extends Component<
             ) {
                 DATA.push({
                     layer: 'Lightning via ecash',
-                    subtitle: lightning ?? lnurlParams?.tag,
+                    subtitle,
                     balance: ecashBalance,
                     disabled: false,
+                    isWithdraw,
                     satAmount
                 });
             }

--- a/locales/en.json
+++ b/locales/en.json
@@ -306,6 +306,7 @@
     "views.Accounts.title": "Accounts",
     "views.Accounts.select": "Select payment method",
     "views.Accounts.fetchTxFees": "Fetch on-chain transaction fees",
+    "views.ChoosePaymentMethod.selectReceiveMethod": "Select receive method",
     "views.EditFee.title": "Edit network fee",
     "views.EditFee.titleDisplayOnly": "Transaction fees",
     "views.LnurlPay.LnurlPay.amount": "Amount to pay",

--- a/views/ChoosePaymentMethod.tsx
+++ b/views/ChoosePaymentMethod.tsx
@@ -68,7 +68,7 @@ export default class ChoosePaymentMethod extends React.Component<
     private blurUnsubscribe?: () => void;
     private hasNavigatedAway = false;
 
-    state = {
+    state: ChoosePaymentMethodState = {
         value: '',
         satAmount: '',
         lightning: '',
@@ -162,8 +162,10 @@ export default class ChoosePaymentMethod extends React.Component<
         lnurlParams?: LNURLWithdrawParams;
     }) => {
         const lightning = override?.lightning ?? this.state.lightning;
+        const lnurlParams = override?.lnurlParams ?? this.state.lnurlParams;
         const { InvoicesStore, CashuStore } = this.props;
-        if (!lightning) return;
+        // for withdraws, lightning holds the raw LNURL, not a bolt11
+        if (!lightning || lnurlParams?.tag === 'withdrawRequest') return;
         const tasks: Promise<void>[] = [];
         if (InvoicesStore) {
             tasks.push(InvoicesStore.getPayReq(lightning).catch(() => {}));
@@ -186,6 +188,11 @@ export default class ChoosePaymentMethod extends React.Component<
             clinkNoffer,
             lnurlParams
         } = this.state;
+
+        // LNURL withdraws bring funds into the wallet;
+        // no local balance is required to redeem them
+        if (lnurlParams?.tag === 'withdrawRequest') return false;
+
         const satAmount = Number(this.state.satAmount);
 
         const onchain = Number(totalBlockchainBalance);
@@ -241,6 +248,16 @@ export default class ChoosePaymentMethod extends React.Component<
         const { totalBlockchainBalance, lightningBalance } = BalanceStore!;
         const { totalBalanceSats } = CashuStore!;
 
+        const isWithdraw = lnurlParams?.tag === 'withdrawRequest';
+        // only fixed-amount withdraws (min === max) have a single
+        // knowable amount before the redemption flow
+        const withdrawSatAmount =
+            isWithdraw &&
+            lnurlParams &&
+            lnurlParams.minWithdrawable === lnurlParams.maxWithdrawable
+                ? Math.floor(lnurlParams.maxWithdrawable / 1000)
+                : undefined;
+
         const hasInsufficientFunds = this.hasInsufficientFunds();
         const hasLightningPayment = !!(
             lightning ||
@@ -264,7 +281,11 @@ export default class ChoosePaymentMethod extends React.Component<
                 <Header
                     leftComponent="Back"
                     centerComponent={{
-                        text: localeString('views.Accounts.select'),
+                        text: isWithdraw
+                            ? localeString(
+                                  'views.ChoosePaymentMethod.selectReceiveMethod'
+                              )
+                            : localeString('views.Accounts.select'),
                         style: { color: themeColor('text') }
                     }}
                     navigation={navigation}
@@ -274,7 +295,7 @@ export default class ChoosePaymentMethod extends React.Component<
                 <RescanStatus navigation={navigation} />
                 <SyncingStatus navigation={navigation} />
 
-                {!!satAmount && (
+                {(!!satAmount || !!withdrawSatAmount) && (
                     <View style={styles.amountSection}>
                         <Text
                             style={[
@@ -284,10 +305,12 @@ export default class ChoosePaymentMethod extends React.Component<
                                 }
                             ]}
                         >
-                            {localeString('views.Payment.paymentAmount')}
+                            {isWithdraw
+                                ? localeString('views.Receive.amount')
+                                : localeString('views.Payment.paymentAmount')}
                         </Text>
                         <Amount
-                            sats={satAmount}
+                            sats={satAmount || withdrawSatAmount}
                             sensitive
                             jumboText
                             toggleable


### PR DESCRIPTION
# Description

Relates to issue: **#4472**

Fixes Azteco (and any other) LNURL-withdraw vouchers being unredeemable on fresh wallets when Cashu is enabled.

**Root cause:** since #3269, LNURL-withdraws route to the payment method chooser when Cashu is enabled so the user can pick a destination (Lightning wallet or ecash). But the chooser's insufficient-funds gating, written for spends, also applied to withdraws:

1. `ChoosePaymentMethod.hasInsufficientFunds()` returns true whenever total balance is 0, so a "Not enough funds" banner was shown for an operation that brings funds in.
2. `PaymentMethodList` treats any row with a zero balance as insufficient (since #3478), which set `disabled` on both destination rows. The tap handlers in `LightningSwipeableRow`/`EcashSwipeableRow` silently no-op when disabled, so taps did nothing.

On a fresh wallet (0 LN + 0 ecash + 0 on-chain) the voucher could not be redeemed at all. With any nonzero balance the flow worked, which is why this only surfaced with fresh wallets. Not specific to LDK Node.

**Changes:**
- Skip the insufficient-funds banner and the zero-balance/insufficient row disabling when the flow is an LNURL-withdraw (`lnurlParams.tag === 'withdrawRequest'`)
- Show the voucher amount at the top for fixed-amount withdraws (`minWithdrawable === maxWithdrawable`)
- Header now reads "Select receive method" instead of "Select payment method" for withdraws
- Row subtitle now shows the withdraw's `defaultDescription`/domain instead of the raw LNURL string
- Skip the bolt11 fee-estimate prefetch for withdraws (the `lightning` param holds the raw LNURL, not a bolt11, so the fetches always failed)

Note: local `yarn test` shows a pre-existing `PhotoUtils.test.ts` failure that also reproduces on a clean master checkout in this environment; it is unrelated to this change and CI should be green.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
