### PR TITLE
config: default LDK RGS servers to v2 endpoints

### DIFF
--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1940,6 +1940,7 @@ export default class SettingsStore {
                 const parsedSettings = JSON.parse(modernSettings);
                 this.settings = parsedSettings;
                 await MigrationsUtils.migrateRgsDefaultToZeus(parsedSettings);
+                await MigrationsUtils.migrateRgsDefaultsToV2(parsedSettings);
                 await MigrationsUtils.migrateSwapHostsToBoltz(parsedSettings);
                 await MigrationsUtils.migrateInvoiceExpiryDisplay(
                     parsedSettings

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1939,7 +1939,6 @@ export default class SettingsStore {
                 console.log('attempting to load modern settings');
                 const parsedSettings = JSON.parse(modernSettings);
                 this.settings = parsedSettings;
-                await MigrationsUtils.migrateRgsDefaultToZeus(parsedSettings);
                 await MigrationsUtils.migrateRgsDefaultsToV2(parsedSettings);
                 await MigrationsUtils.migrateSwapHostsToBoltz(parsedSettings);
                 await MigrationsUtils.migrateInvoiceExpiryDisplay(

--- a/utils/LdkNodeUtils.ts
+++ b/utils/LdkNodeUtils.ts
@@ -46,11 +46,19 @@ export const ESPLORA_SERVERS_MUTINYNET: EsploraServer[] = [
 export const DEFAULT_VSS_SERVER = 'https://vss.zeusln.com/vss';
 
 // Default RGS (Rapid Gossip Sync) servers
+// The /v2 endpoints serve RGS format v2 snapshots, which include node
+// announcement data (features + addresses). LDK requires that data to
+// deliver BOLT 12 invoice_requests: DefaultMessageRouter only sends
+// onion messages to direct peers, so it must be able to look up an
+// offer's introduction node in the graph and connect to it directly.
 export const RGS_SERVERS_MAINNET: EsploraServer[] = [
-    { key: 'ZEUS (rgs.zeusln.com)', value: 'https://rgs.zeusln.com/snapshot' },
+    {
+        key: 'ZEUS (rgs.zeusln.com)',
+        value: 'https://rgs.zeusln.com/snapshot/v2'
+    },
     {
         key: 'LDK (rapidsync.lightningdevkit.org)',
-        value: 'https://rapidsync.lightningdevkit.org/snapshot'
+        value: 'https://rapidsync.lightningdevkit.org/snapshot/v2'
     }
 ];
 

--- a/utils/LdkNodeUtils.ts
+++ b/utils/LdkNodeUtils.ts
@@ -62,10 +62,12 @@ export const RGS_SERVERS_MAINNET: EsploraServer[] = [
     }
 ];
 
+// Note the path asymmetry: the LDK server routes testnet v2 at
+// /testnet/v2/snapshot, not /testnet/snapshot/v2 like mainnet.
 export const RGS_SERVERS_TESTNET: EsploraServer[] = [
     {
         key: 'LDK (rapidsync.lightningdevkit.org)',
-        value: 'https://rapidsync.lightningdevkit.org/testnet/snapshot'
+        value: 'https://rapidsync.lightningdevkit.org/testnet/v2/snapshot'
     }
 ];
 

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -885,14 +885,43 @@ describe('MigrationUtils', () => {
             );
         });
 
-        it('does not touch non-mainnet nodes', async () => {
+        it('rewrites the v1 testnet default on testnet nodes', async () => {
             EncryptedStorage.getItem.mockResolvedValue(null);
             const settings: any = {
                 nodes: [
                     {
                         implementation: 'ldk-node',
                         ldkNetwork: 'testnet',
+                        ldkRgsServer:
+                            'https://rapidsync.lightningdevkit.org/testnet/snapshot'
+                    }
+                ]
+            };
+
+            await MigrationUtils.migrateRgsDefaultsToV2(settings);
+
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://rapidsync.lightningdevkit.org/testnet/v2/snapshot'
+            );
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not apply mappings across networks', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                nodes: [
+                    {
+                        // mainnet URL on a testnet node: misconfigured
+                        // either way, not this migration's to fix
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'testnet',
                         ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
+                    },
+                    {
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'mainnet',
+                        ldkRgsServer:
+                            'https://rapidsync.lightningdevkit.org/testnet/snapshot'
                     }
                 ]
             };
@@ -901,6 +930,9 @@ describe('MigrationUtils', () => {
 
             expect(settings.nodes[0].ldkRgsServer).toBe(
                 'https://rgs.zeusln.com/snapshot'
+            );
+            expect(settings.nodes[1].ldkRgsServer).toBe(
+                'https://rapidsync.lightningdevkit.org/testnet/snapshot'
             );
             expect(settingsStore.setSettings).not.toHaveBeenCalled();
         });

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -945,20 +945,29 @@ describe('MigrationUtils', () => {
             expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
         });
 
-        it('runs after migrateRgsDefaultToZeus and converges legacy installs to v2', async () => {
-            // fresh legacy upgrade: neither flag set — the old migration
-            // pins the v1 ZEUS default, the new one upgrades it to v2
-            EncryptedStorage.getItem.mockResolvedValue(null);
+        it('ignores the superseded rgs-default-zeus flag', async () => {
+            // typical existing install: the retired migration already ran
+            // and pinned the v1 ZEUS default — its flag must not gate the
+            // v2 rewrite
+            EncryptedStorage.getItem.mockImplementation((key: string) =>
+                Promise.resolve(key === 'rgs-default-zeus' ? 'true' : null)
+            );
             const settings: any = {
-                nodes: [{ implementation: 'ldk-node', ldkNetwork: 'mainnet' }]
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'mainnet',
+                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
+                    }
+                ]
             };
 
-            await MigrationUtils.migrateRgsDefaultToZeus(settings);
             await MigrationUtils.migrateRgsDefaultsToV2(settings);
 
             expect(settings.nodes[0].ldkRgsServer).toBe(
                 'https://rgs.zeusln.com/snapshot/v2'
             );
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -783,6 +783,185 @@ describe('MigrationUtils', () => {
         });
     });
 
+    describe('migrateRgsDefaultsToV2', () => {
+        const EncryptedStorage = require('react-native-encrypted-storage');
+        const { settingsStore } = require('../stores/Stores');
+
+        beforeEach(() => {
+            EncryptedStorage.getItem.mockReset();
+            EncryptedStorage.setItem.mockReset();
+            settingsStore.setSettings.mockReset();
+        });
+
+        it('rewrites both v1 default endpoints on mainnet nodes', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'mainnet',
+                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
+                    },
+                    {
+                        implementation: 'ldk-node',
+                        // ldkNetwork unset counts as mainnet
+                        ldkRgsServer:
+                            'https://rapidsync.lightningdevkit.org/snapshot'
+                    }
+                ]
+            };
+
+            await MigrationUtils.migrateRgsDefaultsToV2(settings);
+
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://rgs.zeusln.com/snapshot/v2'
+            );
+            expect(settings.nodes[1].ldkRgsServer).toBe(
+                'https://rapidsync.lightningdevkit.org/snapshot/v2'
+            );
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'rgs-defaults-v2',
+                'true'
+            );
+        });
+
+        it('persists the settings object rather than a JSON string', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
+                    }
+                ]
+            };
+
+            await MigrationUtils.migrateRgsDefaultsToV2(settings);
+
+            const persistedSettings =
+                settingsStore.setSettings.mock.calls[0][0];
+            expect(typeof persistedSettings).not.toBe('string');
+            expect(persistedSettings).toBe(settings);
+        });
+
+        it('leaves custom URLs untouched and does not rewrite storage', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'mainnet',
+                        ldkRgsServer: 'https://my-custom-rgs.com/snapshot'
+                    }
+                ]
+            };
+
+            await MigrationUtils.migrateRgsDefaultsToV2(settings);
+
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://my-custom-rgs.com/snapshot'
+            );
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'rgs-defaults-v2',
+                'true'
+            );
+        });
+
+        it('leaves unset values unset so runtime falls back to new defaults', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                nodes: [{ implementation: 'ldk-node', ldkNetwork: 'mainnet' }]
+            };
+
+            await MigrationUtils.migrateRgsDefaultsToV2(settings);
+
+            expect(settings.nodes[0].ldkRgsServer).toBeUndefined();
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'rgs-defaults-v2',
+                'true'
+            );
+        });
+
+        it('does not touch non-mainnet nodes', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'testnet',
+                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
+                    }
+                ]
+            };
+
+            await MigrationUtils.migrateRgsDefaultsToV2(settings);
+
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://rgs.zeusln.com/snapshot'
+            );
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+        });
+
+        it('is a no-op when the migration flag is already set', async () => {
+            EncryptedStorage.getItem.mockResolvedValue('true');
+            const settings: any = {
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
+                    }
+                ]
+            };
+
+            await MigrationUtils.migrateRgsDefaultsToV2(settings);
+
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://rgs.zeusln.com/snapshot'
+            );
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
+        });
+
+        it('is idempotent when run twice without the flag', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
+                    }
+                ]
+            };
+
+            await MigrationUtils.migrateRgsDefaultsToV2(settings);
+            await MigrationUtils.migrateRgsDefaultsToV2(settings);
+
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://rgs.zeusln.com/snapshot/v2'
+            );
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+        });
+
+        it('runs after migrateRgsDefaultToZeus and converges legacy installs to v2', async () => {
+            // fresh legacy upgrade: neither flag set — the old migration
+            // pins the v1 ZEUS default, the new one upgrades it to v2
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                nodes: [{ implementation: 'ldk-node', ldkNetwork: 'mainnet' }]
+            };
+
+            await MigrationUtils.migrateRgsDefaultToZeus(settings);
+            await MigrationUtils.migrateRgsDefaultsToV2(settings);
+
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://rgs.zeusln.com/snapshot/v2'
+            );
+        });
+    });
+
     describe('migrateCashuSeedVersion', () => {
         beforeEach(() => {
             // Clear mock history before each test

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -462,10 +462,7 @@ class MigrationsUtils {
                 DEFAULT_SLIDE_TO_PAY_THRESHOLD;
         }
 
-        // migrate old default RGS server to new ZEUS RGS server
-        await this.migrateRgsDefaultToZeus(newSettings);
-
-        // migrate v1 RGS endpoints to v2 (BOLT 12 offer support)
+        // migrate retired v1 RGS endpoints to v2 (BOLT 12 offer support)
         await this.migrateRgsDefaultsToV2(newSettings);
 
         // migrate old default Olympus LSP hosts to new zeuslsp.com hosts
@@ -477,40 +474,18 @@ class MigrationsUtils {
         return newSettings;
     }
 
-    public async migrateRgsDefaultToZeus(settings: any) {
-        const MOD_KEY_RGS = 'rgs-default-zeus';
-        const modRgs = await EncryptedStorage.getItem(MOD_KEY_RGS);
-        if (modRgs) return settings;
-
-        const OLD_RGS_DEFAULT =
-            'https://rapidsync.lightningdevkit.org/snapshot';
-        const NEW_RGS_DEFAULT = 'https://rgs.zeusln.com/snapshot';
-        if (settings?.nodes && Array.isArray(settings.nodes)) {
-            for (const node of settings.nodes) {
-                const isMainnet =
-                    !node.ldkNetwork || node.ldkNetwork === 'mainnet';
-                if (
-                    isMainnet &&
-                    (!node.ldkRgsServer ||
-                        node.ldkRgsServer === OLD_RGS_DEFAULT)
-                ) {
-                    node.ldkRgsServer = NEW_RGS_DEFAULT;
-                }
-            }
-        }
-        await settingsStore.setSettings(settings);
-        await EncryptedStorage.setItem(MOD_KEY_RGS, 'true');
-        return settings;
-    }
-
-    // Rewrite persisted v1 RGS endpoints to their v2 equivalents. RGS v1
-    // snapshots lack node announcement data (features + addresses), which
-    // LDK requires to deliver BOLT 12 invoice_requests to an offer's
-    // introduction node. Only values still equal to a known old default
-    // are touched; custom URLs are left alone. Unset values need no
-    // migration — runtime falls back to the (updated) RGS_SERVERS_MAINNET
-    // constants. Must run after migrateRgsDefaultToZeus on both the
-    // legacy and modern (zeus-settings-v2) paths.
+    // Rewrite persisted v1 RGS endpoints to their v2 equivalents in a
+    // single pass. RGS v1 snapshots lack node announcement data (features
+    // + addresses), which LDK requires to deliver BOLT 12 invoice_requests
+    // to an offer's introduction node. Only values still equal to a known
+    // old default are touched; custom URLs are left alone. Unset values
+    // need no migration — runtime falls back to the (updated)
+    // RGS_SERVERS_MAINNET constants. Supersedes migrateRgsDefaultToZeus
+    // ('rgs-default-zeus'), which pinned the then-default into every
+    // mainnet node; the values it wrote are matched here, so its flag is
+    // no longer consulted and unset values are no longer pinned (#4470:
+    // fewer keystore ops). Must run on both the legacy and modern
+    // (zeus-settings-v2) paths.
     public async migrateRgsDefaultsToV2(settings: any) {
         const MOD_KEY_RGS_V2 = 'rgs-defaults-v2';
         const modRgsV2 = await EncryptedStorage.getItem(MOD_KEY_RGS_V2);

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -480,7 +480,9 @@ class MigrationsUtils {
     // to an offer's introduction node. Only values still equal to a known
     // old default are touched; custom URLs are left alone. Unset values
     // need no migration — runtime falls back to the (updated)
-    // RGS_SERVERS_MAINNET constants. Supersedes migrateRgsDefaultToZeus
+    // RGS_SERVERS_MAINNET / RGS_SERVERS_TESTNET constants. Mappings are
+    // scoped per network so a URL is only rewritten on nodes of the
+    // network it belongs to. Supersedes migrateRgsDefaultToZeus
     // ('rgs-default-zeus'), which pinned the then-default into every
     // mainnet node; the values it wrote are matched here, so its flag is
     // no longer consulted and unset values are no longer pinned (#4470:
@@ -491,20 +493,28 @@ class MigrationsUtils {
         const modRgsV2 = await EncryptedStorage.getItem(MOD_KEY_RGS_V2);
         if (modRgsV2) return settings;
 
-        const urlMigrations: { [oldUrl: string]: string } = {
-            'https://rgs.zeusln.com/snapshot':
-                'https://rgs.zeusln.com/snapshot/v2',
-            'https://rapidsync.lightningdevkit.org/snapshot':
-                'https://rapidsync.lightningdevkit.org/snapshot/v2'
+        const urlMigrationsByNetwork: {
+            [network: string]: { [oldUrl: string]: string };
+        } = {
+            mainnet: {
+                'https://rgs.zeusln.com/snapshot':
+                    'https://rgs.zeusln.com/snapshot/v2',
+                'https://rapidsync.lightningdevkit.org/snapshot':
+                    'https://rapidsync.lightningdevkit.org/snapshot/v2'
+            },
+            testnet: {
+                'https://rapidsync.lightningdevkit.org/testnet/snapshot':
+                    'https://rapidsync.lightningdevkit.org/testnet/v2/snapshot'
+            }
         };
 
         let changed = false;
         if (settings?.nodes && Array.isArray(settings.nodes)) {
             for (const node of settings.nodes) {
-                const isMainnet =
-                    !node.ldkNetwork || node.ldkNetwork === 'mainnet';
+                const urlMigrations =
+                    urlMigrationsByNetwork[node.ldkNetwork || 'mainnet'];
                 if (
-                    isMainnet &&
+                    urlMigrations &&
                     node.ldkRgsServer &&
                     urlMigrations[node.ldkRgsServer]
                 ) {

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -465,6 +465,9 @@ class MigrationsUtils {
         // migrate old default RGS server to new ZEUS RGS server
         await this.migrateRgsDefaultToZeus(newSettings);
 
+        // migrate v1 RGS endpoints to v2 (BOLT 12 offer support)
+        await this.migrateRgsDefaultsToV2(newSettings);
+
         // migrate old default Olympus LSP hosts to new zeuslsp.com hosts
         await this.migrateOlympusHostsToZeusLsp(newSettings);
 
@@ -497,6 +500,47 @@ class MigrationsUtils {
         }
         await settingsStore.setSettings(settings);
         await EncryptedStorage.setItem(MOD_KEY_RGS, 'true');
+        return settings;
+    }
+
+    // Rewrite persisted v1 RGS endpoints to their v2 equivalents. RGS v1
+    // snapshots lack node announcement data (features + addresses), which
+    // LDK requires to deliver BOLT 12 invoice_requests to an offer's
+    // introduction node. Only values still equal to a known old default
+    // are touched; custom URLs are left alone. Unset values need no
+    // migration — runtime falls back to the (updated) RGS_SERVERS_MAINNET
+    // constants. Must run after migrateRgsDefaultToZeus on both the
+    // legacy and modern (zeus-settings-v2) paths.
+    public async migrateRgsDefaultsToV2(settings: any) {
+        const MOD_KEY_RGS_V2 = 'rgs-defaults-v2';
+        const modRgsV2 = await EncryptedStorage.getItem(MOD_KEY_RGS_V2);
+        if (modRgsV2) return settings;
+
+        const urlMigrations: { [oldUrl: string]: string } = {
+            'https://rgs.zeusln.com/snapshot':
+                'https://rgs.zeusln.com/snapshot/v2',
+            'https://rapidsync.lightningdevkit.org/snapshot':
+                'https://rapidsync.lightningdevkit.org/snapshot/v2'
+        };
+
+        let changed = false;
+        if (settings?.nodes && Array.isArray(settings.nodes)) {
+            for (const node of settings.nodes) {
+                const isMainnet =
+                    !node.ldkNetwork || node.ldkNetwork === 'mainnet';
+                if (
+                    isMainnet &&
+                    node.ldkRgsServer &&
+                    urlMigrations[node.ldkRgsServer]
+                ) {
+                    node.ldkRgsServer = urlMigrations[node.ldkRgsServer];
+                    changed = true;
+                }
+            }
+        }
+
+        if (changed) await settingsStore.setSettings(settings);
+        await EncryptedStorage.setItem(MOD_KEY_RGS_V2, 'true');
         return settings;
     }
 


### PR DESCRIPTION
# Description

Relates to issue: #4470 (keystore-op reduction) — and fixes BOLT 12 offer payments on LDK Node (field report: Olympus channel, paying ACINQ Phoenix offers).

## Problem

BOLT 12 offer payments from LDK Node wallets consistently time out. Root cause: **our default RGS server serves v1 snapshots, which contain no node announcement data.** LDK's `DefaultMessageRouter` never relays onion messages multi-hop — to deliver a BOLT 12 `invoice_request` it looks up the offer's introduction node in the network graph and requires `announcement_info` (onion-message feature bit + addresses) to direct-connect ([messenger.rs](https://github.com/lightningdevkit/rust-lightning/blob/main/lightning/src/onion_message/messenger.rs)). With a v1-sourced graph, `announcement_info` is `None` for every node, so the `invoice_request` is never sent and the payment fails deterministically.

Only RGS **format v2** snapshots carry node announcements (features + addresses):

```
$ curl -s https://rgs.zeusln.com/snapshot/0            | xxd -l4  →  4c 44 4b 01  ("LDK" v1)
$ curl -s https://rgs.zeusln.com/snapshot/v2/0                    →  404
$ curl -s https://rapidsync.lightningdevkit.org/snapshot/v2/0     →  4c 44 4b 02  ("LDK" v2) ✓
$ curl -s https://rapidsync.lightningdevkit.org/testnet/v2/snapshot/0  →  4c 44 4b 02  ("LDK" v2) ✓
```

Note the LDK server's path asymmetry: testnet v2 lives at `/testnet/v2/snapshot`, not `/testnet/snapshot/v2`. An earlier revision of this PR probed the latter, got a 404, and wrongly concluded no testnet v2 snapshot exists; the testnet default and migration are now included.

Since the retired `migrateRgsDefaultToZeus` and wallet creation (`WalletConfiguration.tsx`) both pinned the default URL into each node's `ldkRgsServer`, changing the constants alone would not reach any existing wallet — hence the migration.

## Changes

- `utils/LdkNodeUtils.ts`: mainnet `RGS_SERVERS_MAINNET` entries now point at the `/snapshot/v2` endpoints (ZEUS + LDK); `RGS_SERVERS_TESTNET` now points at `/testnet/v2/snapshot`.
- `utils/MigrationUtils.ts`: `migrateRgsDefaultToZeus` is **replaced** by a single consolidated `migrateRgsDefaultsToV2` (flag `rgs-defaults-v2`, EncryptedStorage) that maps all three retired v1 default URLs (ZEUS mainnet, LDK mainnet, LDK testnet) to their v2 equivalents in one pass, with the URL maps scoped per network. Per #4470, the write/read cost drops: at most **one** settings-blob write (only when something actually changes — the old migration wrote the blob unconditionally) plus one flag write, and **no additional migration-flag read** on the `getSettings()` path (still 4 total; folding those into one is follow-up work per #4470).
- `stores/SettingsStore.ts`: modern (`zeus-settings-v2`) load path now calls the one consolidated migration.
- `utils/MigrationUtils.test.ts`: 9 unit tests incl. superseded-flag independence and cross-network isolation (suite green, 1426/1426).

## Migration plan (for storage-gate sign-off)

| Cohort | Effect |
|---|---|
| Fresh installs | New constants only; migration finds nothing to rewrite |
| Existing users (old `rgs-default-zeus` flag set, v1 ZEUS default pinned) | Rewritten to ZEUS v2 — the superseded flag is deliberately not consulted (covered by a test) |
| Users who manually selected the LDK server (v1) | Rewritten to LDK v2 (server choice preserved, format upgraded) |
| Stragglers who never ran a build ≥ #4062 (old LDK v1 default pinned) | Rewritten to LDK v2. Divergence from the retired migration's consolidation onto rgs.zeusln.com is accepted: tiny cohort, fully functional endpoint, simpler value-based rule |
| Legacy-blob upgraders | ldk-node shipped 2026-02, after the v2 storage migration — legacy blobs cannot contain `ldkRgsServer`, so this is a guaranteed no-op there (flag read/write only). Still wired on both load paths per house rule |
| Testnet nodes (v1 testnet default pinned at wallet creation) | Rewritten to LDK testnet v2 (`/testnet/v2/snapshot`) |
| Custom RGS URLs, other-network nodes, non-LDK wallets | Untouched. Maps are network-scoped: a mainnet URL pinned on a testnet node (or vice versa) is misconfigured either way and left alone (covered by a test) |
| Unset `ldkRgsServer` | **No longer pinned** (behavior change vs the retired migration): left unset, runtime falls back to the updated defaults |

- **Idempotent**: value-conditional rewrite; second run is a no-op. `setSettings` called only when something changed, awaited, with the real object (not a JSON string); flag set only after the write succeeds, so a crash mid-migration retries next boot.
- **Both load paths**: modern `getSettings` branch + `legacySettingsMigrations`.
- **No new keychain keys** — only a new EncryptedStorage migration flag (the sanctioned home for flags). Leftover `rgs-default-zeus` flag entries remain in EncryptedStorage; harmless and cleared by Clear All Data.
- **Revert story**: the migration only rewrites URL values; a revert needs no counter-migration. Worst case if reverted after some installs migrated: those wallets point at v2 endpoints, which remain valid once deployed. If the flag ever needs re-arming, bump the suffix per house rule.

## ⚠️ Draft — merge blockers

1. ~~`rgs.zeusln.com` must publish v2 snapshots at `/snapshot/v2/<ts>`~~ ✅ **Deployed 2026-08-24** — verified: `/snapshot/v2/0` returns `4c 44 4b 02`, 3.01 MB over HTTP/2 (size within 0.5% of LDK's reference v2 snapshot, confirming full node-announcement coverage); v1 endpoint and `/health` unaffected.
2. Manual two-platform testing (matrix below), including the upgrade-from-released-build scenario with a pre-existing LDK wallet (verify the blob diff shows only `ldkRgsServer` changing).
3. Maintainer sign-off on the migration plan.
4. Squash the three commits before merge (second is the migration collapse, third the testnet v2 inclusion).

**End-to-end verification once (1) is deployed**: on an LDK Node wallet with only an Olympus channel, pay a Phoenix-generated BOLT 12 offer. `ldk_node.log` should show a `ConnectionNeeded`/connect to the offer's introduction node (ACINQ, `3.33.236.230:9735`) followed by the invoice arriving and the HTLC settling via Olympus. Olympus already advertises `option_onion_messages` (bit 39, LND 0.21) for the reply leg.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

_Draft: device testing pending (blockers above)._

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

_Only LDK Node is affected (`ldkRgsServer` is only read by the LDK Node backend); LDK Node testing required before undrafting._

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

