### PR TITLE
refactor(migrations): stamp settings blob, single write

### DIFF
--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -32,8 +32,8 @@ jest.mock('../utils/LocaleUtils', () => ({
 jest.mock('../utils/MigrationUtils', () => ({
     keychainCloudSyncMigration: jest.fn().mockResolvedValue(undefined),
     purgeRescueKeyFiles: jest.fn().mockResolvedValue(undefined),
-    migrateRgsDefaultToZeus: jest.fn().mockResolvedValue(undefined),
-    migrateInvoiceExpiryDisplay: jest.fn().mockResolvedValue(undefined),
+    runSettingsMigrations: jest.fn().mockResolvedValue(undefined),
+    migrateRetiredSwapHosts: jest.fn().mockResolvedValue(undefined),
     legacySettingsMigrations: jest.fn().mockResolvedValue({}),
     storageMigrationV2: jest.fn().mockResolvedValue(undefined)
 }));

--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -33,7 +33,6 @@ jest.mock('../utils/MigrationUtils', () => ({
     keychainCloudSyncMigration: jest.fn().mockResolvedValue(undefined),
     purgeRescueKeyFiles: jest.fn().mockResolvedValue(undefined),
     runSettingsMigrations: jest.fn().mockResolvedValue(undefined),
-    migrateRetiredSwapHosts: jest.fn().mockResolvedValue(undefined),
     legacySettingsMigrations: jest.fn().mockResolvedValue({}),
     storageMigrationV2: jest.fn().mockResolvedValue(undefined)
 }));

--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -35,9 +35,9 @@ jest.mock('../utils/MigrationUtils', () => ({
     // getSettings adopts the return value (the queue's authoritative
     // object when consolidation routes through updateSettings), so the
     // stub must hand the settings back rather than resolve undefined
-    runSettingsMigrations: jest.fn().mockImplementation(
-        async (settings: any) => settings
-    ),
+    runSettingsMigrations: jest
+        .fn()
+        .mockImplementation(async (settings: any) => settings),
     legacySettingsMigrations: jest.fn().mockResolvedValue({}),
     storageMigrationV2: jest.fn().mockResolvedValue(undefined)
 }));
@@ -85,15 +85,27 @@ const seedSettings = (settings: any) => {
 const persistedSettings = () => JSON.parse(StorageMock._backing[STORAGE_KEY]);
 
 let logSpy: jest.SpyInstance;
+let errorSpy: jest.SpyInstance;
 
 beforeEach(() => {
     for (const key of Object.keys(StorageMock._backing)) {
         delete StorageMock._backing[key];
     }
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 });
 
 afterEach(() => {
+    // getSettings swallows load failures (console.error, then falls
+    // through with defaults), which has repeatedly let a stale
+    // MigrationUtils mock pass this suite without ever completing the
+    // load path; fail loudly instead
+    expect(
+        errorSpy.mock.calls.filter(
+            ([message]) => message === 'Could not load settings'
+        )
+    ).toEqual([]);
+    errorSpy.mockRestore();
     logSpy.mockRestore();
 });
 

--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -32,7 +32,12 @@ jest.mock('../utils/LocaleUtils', () => ({
 jest.mock('../utils/MigrationUtils', () => ({
     keychainCloudSyncMigration: jest.fn().mockResolvedValue(undefined),
     purgeRescueKeyFiles: jest.fn().mockResolvedValue(undefined),
-    runSettingsMigrations: jest.fn().mockResolvedValue(undefined),
+    // getSettings adopts the return value (the queue's authoritative
+    // object when consolidation routes through updateSettings), so the
+    // stub must hand the settings back rather than resolve undefined
+    runSettingsMigrations: jest.fn().mockImplementation(
+        async (settings: any) => settings
+    ),
     legacySettingsMigrations: jest.fn().mockResolvedValue({}),
     storageMigrationV2: jest.fn().mockResolvedValue(undefined)
 }));

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -25,6 +25,13 @@ import LoginRequest from '../models/LoginRequest';
 const LEGACY_STORAGE_KEY = 'zeus-settings';
 export const STORAGE_KEY = 'zeus-settings-v2';
 
+// Version stamp for the CONTENT of the settings blob (the storage key's
+// -v2 suffix versions the key namespace, not the content). Blobs stamped
+// with the current version skip all one-shot settings migrations at load
+// (#4470). Bump when adding a migration — see
+// MigrationUtils.runSettingsMigrations.
+export const SETTINGS_VERSION = 1;
+
 export const LEGACY_CURRENCY_CODES_KEY = 'currency-codes';
 export const CURRENCY_CODES_KEY = 'zeus-currency-codes';
 export const FAVORITE_CURRENCIES_KEY = 'zeus-favorite-currencies';
@@ -188,6 +195,8 @@ interface SwapsSettings {
 }
 
 export interface Settings {
+    // see SETTINGS_VERSION; absent on blobs predating the stamp
+    settingsVersion?: number;
     nodes?: Array<Node>;
     selectedNode?: number;
     justDeletedWallet?: boolean;
@@ -1486,6 +1495,7 @@ export const DEFAULT_SLIDE_TO_PAY_THRESHOLD = 10000;
 
 export default class SettingsStore {
     @observable settings: Settings = {
+        settingsVersion: SETTINGS_VERSION,
         privacy: {
             defaultBlockExplorer: 'mempool.space',
             customBlockExplorer: '',
@@ -1971,15 +1981,8 @@ export default class SettingsStore {
                 console.log('attempting to load modern settings');
                 const parsedSettings = JSON.parse(modernSettings);
                 this.settings = parsedSettings;
-                await MigrationsUtils.migrateRgsDefaultsToV2(parsedSettings);
-                await MigrationsUtils.migrateSwapHostsToBoltz(parsedSettings);
+                await MigrationsUtils.runSettingsMigrations(parsedSettings);
                 await MigrationsUtils.migrateRetiredSwapHosts(parsedSettings);
-                await MigrationsUtils.migrateInvoiceExpiryDisplay(
-                    parsedSettings
-                );
-                await MigrationsUtils.migrateOlympusHostsToZeusLsp(
-                    parsedSettings
-                );
                 this.settings = parsedSettings;
             } else {
                 console.log('attempting to load legacy settings');

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1399,7 +1399,7 @@ export const LEGACY_ZEUS_SWAP_HOST_MAINNET = 'https://swaps.zeuslsp.com/api/v2';
 export const LEGACY_ZEUS_SWAP_HOST_TESTNET =
     'https://testnet-swaps.zeuslsp.com/api/v2';
 // Swap providers that have shut down; users pinned to one are moved
-// back to the default host by MigrationUtils.migrateRetiredSwapHosts
+// back to the default host by MigrationUtils.applyRetiredSwapHosts
 export const RETIRED_SWAP_HOSTS_MAINNET = ['https://boltz-api.eldamar.icu/v2'];
 
 export const DEFAULT_NOSTR_RELAYS_2023 = [
@@ -1982,7 +1982,6 @@ export default class SettingsStore {
                 const parsedSettings = JSON.parse(modernSettings);
                 this.settings = parsedSettings;
                 await MigrationsUtils.runSettingsMigrations(parsedSettings);
-                await MigrationsUtils.migrateRetiredSwapHosts(parsedSettings);
                 this.settings = parsedSettings;
             } else {
                 console.log('attempting to load legacy settings');

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -8,6 +8,7 @@ import BackendUtils from '../utils/BackendUtils';
 import { getSupportedBiometryType } from '../utils/BiometricUtils';
 import { localeString } from '../utils/LocaleUtils';
 import MigrationsUtils from '../utils/MigrationUtils';
+import { SETTINGS_VERSION } from '../utils/SettingsVersion';
 import { doTorRequest, RequestMethod } from '../utils/TorUtils';
 import {
     DEFAULT_SCORER_URL,
@@ -26,11 +27,10 @@ const LEGACY_STORAGE_KEY = 'zeus-settings';
 export const STORAGE_KEY = 'zeus-settings-v2';
 
 // Version stamp for the CONTENT of the settings blob (the storage key's
-// -v2 suffix versions the key namespace, not the content). Blobs stamped
-// with the current version skip all one-shot settings migrations at load
-// (#4470). Bump when adding a migration — see
-// MigrationUtils.runSettingsMigrations.
-export const SETTINGS_VERSION = 1;
+// -v2 suffix versions the key namespace, not the content). Defined in a
+// dependency-free module so version-gating tests exercise the real
+// value; re-exported here for consumers of the settings schema.
+export { SETTINGS_VERSION };
 
 export const LEGACY_CURRENCY_CODES_KEY = 'currency-codes';
 export const CURRENCY_CODES_KEY = 'zeus-currency-codes';

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1981,8 +1981,12 @@ export default class SettingsStore {
                 console.log('attempting to load modern settings');
                 const parsedSettings = JSON.parse(modernSettings);
                 this.settings = parsedSettings;
-                await MigrationsUtils.runSettingsMigrations(parsedSettings);
-                this.settings = parsedSettings;
+                // when consolidation routes through the updateSettings
+                // queue the authoritative object is the queue's, not this
+                // call's snapshot, so adopt the return value
+                this.settings = await MigrationsUtils.runSettingsMigrations(
+                    parsedSettings
+                );
             } else {
                 console.log('attempting to load legacy settings');
 

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1969,7 +1969,14 @@ export default class SettingsStore {
         }
     };
 
-    public getSettings = async (silentUpdate: boolean = false) => {
+    // fromQueue is true only for the call inside applySettingsUpdate's
+    // critical section; runSettingsMigrations branches on it to decide
+    // whether a consolidation may piggyback on that update's write or
+    // must enqueue one.
+    public getSettings = async (
+        silentUpdate: boolean = false,
+        fromQueue: boolean = false
+    ) => {
         if (!silentUpdate) this.loading = true;
         try {
             await MigrationsUtils.keychainCloudSyncMigration();
@@ -1985,7 +1992,8 @@ export default class SettingsStore {
                 // queue the authoritative object is the queue's, not this
                 // call's snapshot, so adopt the return value
                 this.settings = await MigrationsUtils.runSettingsMigrations(
-                    parsedSettings
+                    parsedSettings,
+                    fromQueue
                 );
             } else {
                 console.log('attempting to load legacy settings');
@@ -2061,7 +2069,9 @@ export default class SettingsStore {
     ) => {
         this.settingsUpdateInProgress = true;
         try {
-            const existingSettings = await this.getSettings();
+            // fromQueue: this is the queue's critical section, so a
+            // pending consolidation folds into this update's write
+            const existingSettings = await this.getSettings(false, true);
             // Functional updates read the settings inside the critical
             // section, so callers whose new value depends on the current
             // one (delete node X from the array) cannot act on a snapshot

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -30,6 +30,7 @@ jest.mock('../stores/LSPStore', () => ({}));
 jest.mock('../utils/BackendUtils', () => ({}));
 
 jest.mock('../stores/SettingsStore', () => ({
+    SETTINGS_VERSION: 1,
     DEFAULT_FIAT_RATES_SOURCE: 'Zeus',
     DEFAULT_FIAT: 'USD',
     DEFAULT_LSP_MAINNET: 'https://flow.zeuslsp.com',
@@ -155,6 +156,7 @@ describe('MigrationUtils', () => {
             slideToPayThreshold: 10000
         },
         requestSimpleTaproot: true,
+        settingsVersion: 1,
         speedloader: 'https://egs.lnze.us/'
     };
 
@@ -356,96 +358,38 @@ describe('MigrationUtils', () => {
         });
     });
 
-    describe('migrateSwapHostsToBoltz', () => {
-        const EncryptedStorage = require('react-native-encrypted-storage');
-        const { settingsStore } = require('../stores/Stores');
-
-        beforeEach(() => {
-            EncryptedStorage.getItem.mockReset();
-            EncryptedStorage.setItem.mockReset();
-            settingsStore.setSettings.mockReset();
-        });
-
-        it('migrates retired ZEUS swap hosts to the Boltz defaults', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+    describe('applySwapHostsToBoltz', () => {
+        it('migrates retired ZEUS swap hosts to the Boltz defaults', () => {
             const settings: any = {
                 swaps: {
                     hostMainnet: 'https://swaps.zeuslsp.com/api/v2',
-                    hostTestnet: 'https://testnet-swaps.zeuslsp.com/api/v2',
-                    customHost: '',
-                    proEnabled: false
+                    hostTestnet: 'https://testnet-swaps.zeuslsp.com/api/v2'
                 }
             };
 
-            await MigrationUtils.migrateSwapHostsToBoltz(settings);
-
-            expect(settings.swaps.hostMainnet).toBe(
-                'https://api.boltz.exchange/v2'
-            );
-            expect(settings.swaps.hostTestnet).toBe(
-                'https://api.testnet.boltz.exchange/v2'
-            );
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
-            expect(settingsStore.setSettings.mock.calls[0][0]).toBe(settings);
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'swap-hosts-boltz',
-                'true'
-            );
+            expect(MigrationUtils.applySwapHostsToBoltz(settings)).toBe(true);
+            expect(settings.swaps).toEqual({
+                hostMainnet: 'https://api.boltz.exchange/v2',
+                hostTestnet: 'https://api.testnet.boltz.exchange/v2'
+            });
         });
 
-        it('leaves non-ZEUS hosts untouched and does not rewrite storage', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+        it('leaves non-ZEUS hosts untouched', () => {
             const settings: any = {
-                swaps: {
-                    hostMainnet: 'https://api.middle-way.space/v2',
-                    hostTestnet: 'Custom',
-                    customHost: 'https://my-boltz.local/v2',
-                    proEnabled: false
-                }
+                swaps: { hostMainnet: 'https://my-custom-swaps.com/api' }
             };
 
-            await MigrationUtils.migrateSwapHostsToBoltz(settings);
-
+            expect(MigrationUtils.applySwapHostsToBoltz(settings)).toBe(false);
             expect(settings.swaps.hostMainnet).toBe(
-                'https://api.middle-way.space/v2'
-            );
-            expect(settings.swaps.hostTestnet).toBe('Custom');
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'swap-hosts-boltz',
-                'true'
+                'https://my-custom-swaps.com/api'
             );
         });
 
-        it('only sets the flag when settings have no swaps block', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+        it('is a no-op without a swaps block', () => {
             const settings: any = {};
 
-            await MigrationUtils.migrateSwapHostsToBoltz(settings);
-
+            expect(MigrationUtils.applySwapHostsToBoltz(settings)).toBe(false);
             expect(settings).toEqual({});
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'swap-hosts-boltz',
-                'true'
-            );
-        });
-
-        it('is a no-op when the migration flag is already set', async () => {
-            EncryptedStorage.getItem.mockResolvedValue('true');
-            const settings: any = {
-                swaps: {
-                    hostMainnet: 'https://swaps.zeuslsp.com/api/v2'
-                }
-            };
-
-            await MigrationUtils.migrateSwapHostsToBoltz(settings);
-
-            expect(settings.swaps.hostMainnet).toBe(
-                'https://swaps.zeuslsp.com/api/v2'
-            );
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
         });
     });
 
@@ -562,18 +506,8 @@ describe('MigrationUtils', () => {
         });
     });
 
-    describe('migrateInvoiceExpiryDisplay', () => {
-        const EncryptedStorage = require('react-native-encrypted-storage');
-        const { settingsStore } = require('../stores/Stores');
-
-        beforeEach(() => {
-            EncryptedStorage.getItem.mockReset();
-            EncryptedStorage.setItem.mockReset();
-            settingsStore.setSettings.mockReset();
-        });
-
-        it('repairs inconsistent expiry/timePeriod on v2 settings', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+    describe('applyInvoiceExpiryDisplay', () => {
+        it('repairs expiry display fields when out of sync with expirySeconds', () => {
             const settings: any = {
                 invoices: {
                     expiry: '3600',
@@ -582,77 +516,45 @@ describe('MigrationUtils', () => {
                 }
             };
 
-            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
-
+            expect(MigrationUtils.applyInvoiceExpiryDisplay(settings)).toBe(
+                true
+            );
             expect(settings.invoices).toEqual({
                 expiry: '1',
                 timePeriod: 'Hours',
                 expirySeconds: '3600'
             });
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'invoices-expiry-display-fix-v2',
-                'true'
-            );
         });
 
-        it('persists the settings object rather than a JSON string', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
-            const settings: any = {
-                invoices: {
-                    expiry: '3600',
-                    timePeriod: 'Hours',
-                    expirySeconds: '3600'
-                }
-            };
-
-            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
-
-            // Guards against regressing #4150: passing a stringified payload
-            // briefly turns the MobX `settings` observable into a string,
-            // which can crash observers reading nested keys.
-            const persistedSettings =
-                settingsStore.setSettings.mock.calls[0][0];
-            expect(typeof persistedSettings).not.toBe('string');
-            expect(persistedSettings).toBe(settings);
-        });
-
-        it('backfills missing expirySeconds + timePeriod for pre-Feb-2024 installs', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+        it('backfills expirySeconds + timePeriod on pre-Feb-2024 installs with only `expiry: 3600`', () => {
             const settings: any = { invoices: { expiry: '3600' } };
 
-            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
-
+            expect(MigrationUtils.applyInvoiceExpiryDisplay(settings)).toBe(
+                true
+            );
             expect(settings.invoices).toEqual({
                 expiry: '1',
                 timePeriod: 'Hours',
                 expirySeconds: '3600'
             });
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'invoices-expiry-display-fix-v2',
-                'true'
-            );
         });
 
-        it('backfills missing expirySeconds when expiry + timePeriod are valid', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+        it('backfills missing expirySeconds when expiry + timePeriod are valid', () => {
             const settings: any = {
                 invoices: { expiry: '2', timePeriod: 'Hours' }
             };
 
-            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
-
+            expect(MigrationUtils.applyInvoiceExpiryDisplay(settings)).toBe(
+                true
+            );
             expect(settings.invoices).toEqual({
                 expiry: '2',
                 timePeriod: 'Hours',
                 expirySeconds: '7200'
             });
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
         });
 
-        it('leaves consistent settings untouched and does not rewrite storage', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+        it('leaves consistent settings untouched', () => {
             const settings: any = {
                 invoices: {
                     expiry: '2',
@@ -661,83 +563,23 @@ describe('MigrationUtils', () => {
                 }
             };
 
-            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
-
+            expect(MigrationUtils.applyInvoiceExpiryDisplay(settings)).toBe(
+                false
+            );
             expect(settings.invoices).toEqual({
                 expiry: '2',
                 timePeriod: 'Hours',
                 expirySeconds: '7200'
             });
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'invoices-expiry-display-fix-v2',
-                'true'
-            );
         });
 
-        it('is a no-op when the migration flag is already set', async () => {
-            EncryptedStorage.getItem.mockResolvedValue('true');
-            const settings: any = {
-                invoices: {
-                    expiry: '3600',
-                    timePeriod: 'Hours',
-                    expirySeconds: '3600'
-                }
-            };
-
-            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
-
-            expect(settings.invoices.expiry).toBe('3600');
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
-        });
-
-        it('only sets the flag when settings have no invoices block', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
-            const settings: any = {};
-
-            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
-
-            expect(settings).toEqual({});
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'invoices-expiry-display-fix-v2',
-                'true'
-            );
-        });
-
-        it('re-runs for users who already ran the v1 migration', async () => {
-            // v1 set 'invoices-expiry-display-fix' before the guard was
-            // fixed; v2 must run independently.
-            EncryptedStorage.getItem.mockImplementation((key: string) =>
-                key === 'invoices-expiry-display-fix-v2'
-                    ? Promise.resolve(null)
-                    : Promise.resolve('true')
-            );
-            const settings: any = { invoices: { expiry: '3600' } };
-
-            await MigrationUtils.migrateInvoiceExpiryDisplay(settings);
-
-            expect(settings.invoices).toEqual({
-                expiry: '1',
-                timePeriod: 'Hours',
-                expirySeconds: '3600'
-            });
+        it('is a no-op without an invoices block', () => {
+            expect(MigrationUtils.applyInvoiceExpiryDisplay({})).toBe(false);
         });
     });
 
-    describe('migrateOlympusHostsToZeusLsp', () => {
-        const EncryptedStorage = require('react-native-encrypted-storage');
-        const { settingsStore } = require('../stores/Stores');
-
-        beforeEach(() => {
-            EncryptedStorage.getItem.mockReset();
-            EncryptedStorage.setItem.mockReset();
-            settingsStore.setSettings.mockReset();
-        });
-
-        it('rewrites all six old default hosts on v2 settings', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+    describe('applyOlympusHostsToZeusLsp', () => {
+        it('rewrites all six old default hosts', () => {
             const settings: any = {
                 lspMainnet: 'https://0conf.lnolymp.us',
                 lspTestnet: 'https://testnet-0conf.lnolymp.us',
@@ -747,8 +589,9 @@ describe('MigrationUtils', () => {
                 lsps1RestMutinynet: 'https://mutinynet-lsps1.lnolymp.us'
             };
 
-            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
-
+            expect(MigrationUtils.applyOlympusHostsToZeusLsp(settings)).toBe(
+                true
+            );
             expect(settings).toEqual({
                 lspMainnet: 'https://flow.zeuslsp.com',
                 lspTestnet: 'https://flow.testnet.zeuslsp.com',
@@ -757,20 +600,201 @@ describe('MigrationUtils', () => {
                 lsps1RestTestnet: 'https://lsps1.testnet.zeuslsp.com',
                 lsps1RestMutinynet: 'https://lsps1.mutinynet.zeuslsp.com'
             });
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'zeuslsp-hosts-2026',
-                'true'
+        });
+
+        it('leaves custom hosts untouched', () => {
+            const settings: any = {
+                lspMainnet: 'https://my-custom-lsp.com',
+                lsps1RestMainnet: 'https://my-custom-lsps1.com'
+            };
+
+            expect(MigrationUtils.applyOlympusHostsToZeusLsp(settings)).toBe(
+                false
             );
+            expect(settings).toEqual({
+                lspMainnet: 'https://my-custom-lsp.com',
+                lsps1RestMainnet: 'https://my-custom-lsps1.com'
+            });
+        });
+
+        it('leaves unset hosts unset so runtime falls back to new defaults', () => {
+            const settings: any = {};
+
+            expect(MigrationUtils.applyOlympusHostsToZeusLsp(settings)).toBe(
+                false
+            );
+            expect(settings).toEqual({});
+        });
+    });
+
+    describe('applyRgsDefaultsToV2', () => {
+        it('rewrites both v1 default endpoints on mainnet nodes', () => {
+            const settings: any = {
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'mainnet',
+                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
+                    },
+                    {
+                        implementation: 'ldk-node',
+                        // ldkNetwork unset counts as mainnet
+                        ldkRgsServer:
+                            'https://rapidsync.lightningdevkit.org/snapshot'
+                    }
+                ]
+            };
+
+            expect(MigrationUtils.applyRgsDefaultsToV2(settings)).toBe(true);
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://rgs.zeusln.com/snapshot/v2'
+            );
+            expect(settings.nodes[1].ldkRgsServer).toBe(
+                'https://rapidsync.lightningdevkit.org/snapshot/v2'
+            );
+        });
+
+        it('rewrites the v1 testnet default on testnet nodes', () => {
+            const settings: any = {
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'testnet',
+                        ldkRgsServer:
+                            'https://rapidsync.lightningdevkit.org/testnet/snapshot'
+                    }
+                ]
+            };
+
+            expect(MigrationUtils.applyRgsDefaultsToV2(settings)).toBe(true);
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://rapidsync.lightningdevkit.org/testnet/v2/snapshot'
+            );
+        });
+
+        it('does not apply mappings across networks', () => {
+            const settings: any = {
+                nodes: [
+                    {
+                        // mainnet URL on a testnet node: misconfigured
+                        // either way, not this migration's to fix
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'testnet',
+                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
+                    },
+                    {
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'mainnet',
+                        ldkRgsServer:
+                            'https://rapidsync.lightningdevkit.org/testnet/snapshot'
+                    }
+                ]
+            };
+
+            expect(MigrationUtils.applyRgsDefaultsToV2(settings)).toBe(false);
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://rgs.zeusln.com/snapshot'
+            );
+            expect(settings.nodes[1].ldkRgsServer).toBe(
+                'https://rapidsync.lightningdevkit.org/testnet/snapshot'
+            );
+        });
+
+        it('leaves custom URLs untouched', () => {
+            const settings: any = {
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'mainnet',
+                        ldkRgsServer: 'https://my-custom-rgs.com/snapshot'
+                    }
+                ]
+            };
+
+            expect(MigrationUtils.applyRgsDefaultsToV2(settings)).toBe(false);
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://my-custom-rgs.com/snapshot'
+            );
+        });
+
+        it('leaves unset values unset so runtime falls back to new defaults', () => {
+            const settings: any = {
+                nodes: [{ implementation: 'ldk-node', ldkNetwork: 'mainnet' }]
+            };
+
+            expect(MigrationUtils.applyRgsDefaultsToV2(settings)).toBe(false);
+            expect(settings.nodes[0].ldkRgsServer).toBeUndefined();
+        });
+
+        it('is idempotent', () => {
+            const settings: any = {
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
+                    }
+                ]
+            };
+
+            expect(MigrationUtils.applyRgsDefaultsToV2(settings)).toBe(true);
+            expect(MigrationUtils.applyRgsDefaultsToV2(settings)).toBe(false);
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://rgs.zeusln.com/snapshot/v2'
+            );
+        });
+
+        it('is a no-op without nodes', () => {
+            expect(MigrationUtils.applyRgsDefaultsToV2({})).toBe(false);
+        });
+    });
+
+    describe('runSettingsMigrations', () => {
+        const EncryptedStorage = require('react-native-encrypted-storage');
+        const { settingsStore } = require('../stores/Stores');
+
+        beforeEach(() => {
+            EncryptedStorage.getItem.mockReset();
+            EncryptedStorage.setItem.mockReset();
+            settingsStore.setSettings.mockReset();
+        });
+
+        it('skips everything when the blob is already stamped', async () => {
+            const settings: any = {
+                settingsVersion: 1,
+                lspMainnet: 'https://0conf.lnolymp.us'
+            };
+
+            await MigrationUtils.runSettingsMigrations(settings);
+
+            expect(settings.lspMainnet).toBe('https://0conf.lnolymp.us');
+            expect(EncryptedStorage.getItem).not.toHaveBeenCalled();
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+        });
+
+        it('consolidates an unstamped blob with a single write and stamps it', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                lspMainnet: 'https://0conf.lnolymp.us',
+                swaps: { hostMainnet: 'https://swaps.zeuslsp.com/api/v2' }
+            };
+
+            await MigrationUtils.runSettingsMigrations(settings);
+
+            expect(settings.lspMainnet).toBe('https://flow.zeuslsp.com');
+            expect(settings.swaps.hostMainnet).toBe(
+                'https://api.boltz.exchange/v2'
+            );
+            expect(settings.settingsVersion).toBe(1);
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+            // retired per-migration flags are never written again
+            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
         });
 
         it('persists the settings object rather than a JSON string', async () => {
             EncryptedStorage.getItem.mockResolvedValue(null);
-            const settings: any = {
-                lspMainnet: 'https://0conf.lnolymp.us'
-            };
+            const settings: any = {};
 
-            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
+            await MigrationUtils.runSettingsMigrations(settings);
 
             const persistedSettings =
                 settingsStore.setSettings.mock.calls[0][0];
@@ -778,64 +802,90 @@ describe('MigrationUtils', () => {
             expect(persistedSettings).toBe(settings);
         });
 
-        it('leaves custom hosts untouched and does not rewrite storage', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+        it('honors retired per-migration flags during consolidation', async () => {
+            EncryptedStorage.getItem.mockImplementation((key: string) =>
+                Promise.resolve(key === 'zeuslsp-hosts-2026' ? 'true' : null)
+            );
             const settings: any = {
-                lspMainnet: 'https://my-custom-lsp.com',
-                lsps1RestMainnet: 'https://my-custom-lsps1.com'
+                lspMainnet: 'https://0conf.lnolymp.us',
+                swaps: { hostMainnet: 'https://swaps.zeuslsp.com/api/v2' }
             };
 
-            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
+            await MigrationUtils.runSettingsMigrations(settings);
 
-            expect(settings).toEqual({
-                lspMainnet: 'https://my-custom-lsp.com',
-                lsps1RestMainnet: 'https://my-custom-lsps1.com'
-            });
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'zeuslsp-hosts-2026',
-                'true'
+            // Olympus host migration already ran on this install — the
+            // (user-restored) old value must not be rewritten again
+            expect(settings.lspMainnet).toBe('https://0conf.lnolymp.us');
+            // the un-flagged swap migration still applies
+            expect(settings.swaps.hostMainnet).toBe(
+                'https://api.boltz.exchange/v2'
+            );
+            expect(settings.settingsVersion).toBe(1);
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+        });
+
+        it('honors rgs-defaults-v2 but ignores the superseded rgs-default-zeus flag', async () => {
+            // typical existing install: the retired v1 migration already ran
+            // and pinned the v1 ZEUS default — its flag must not gate the v2
+            // rewrite, only rgs-defaults-v2 does
+            EncryptedStorage.getItem.mockImplementation((key: string) =>
+                Promise.resolve(key === 'rgs-default-zeus' ? 'true' : null)
+            );
+            const settings: any = {
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'mainnet',
+                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
+                    }
+                ]
+            };
+
+            await MigrationUtils.runSettingsMigrations(settings);
+
+            expect(settings.nodes[0].ldkRgsServer).toBe(
+                'https://rgs.zeusln.com/snapshot/v2'
+            );
+
+            EncryptedStorage.getItem.mockImplementation((key: string) =>
+                Promise.resolve(key === 'rgs-defaults-v2' ? 'true' : null)
+            );
+            const flagged: any = {
+                nodes: [
+                    {
+                        implementation: 'ldk-node',
+                        ldkNetwork: 'mainnet',
+                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
+                    }
+                ]
+            };
+
+            await MigrationUtils.runSettingsMigrations(flagged);
+
+            expect(flagged.nodes[0].ldkRgsServer).toBe(
+                'https://rgs.zeusln.com/snapshot'
             );
         });
 
-        it('leaves unset hosts unset so runtime falls back to new defaults', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
-            const settings: any = {};
-
-            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
-
-            expect(settings).toEqual({});
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'zeuslsp-hosts-2026',
-                'true'
-            );
-        });
-
-        it('is a no-op when the migration flag is already set', async () => {
+        it('stamps with one write even when nothing needed migrating, then goes quiet', async () => {
             EncryptedStorage.getItem.mockResolvedValue('true');
             const settings: any = {
-                lspMainnet: 'https://0conf.lnolymp.us'
+                lspMainnet: 'https://flow.zeuslsp.com'
             };
 
-            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
+            await MigrationUtils.runSettingsMigrations(settings);
 
-            expect(settings.lspMainnet).toBe('https://0conf.lnolymp.us');
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
-        });
-
-        it('is idempotent when run twice without the flag', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
-            const settings: any = {
-                lspMainnet: 'https://0conf.lnolymp.us'
-            };
-
-            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
-            await MigrationUtils.migrateOlympusHostsToZeusLsp(settings);
-
-            expect(settings.lspMainnet).toBe('https://flow.zeuslsp.com');
+            expect(settings.settingsVersion).toBe(1);
             expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+
+            // second run: stamped — zero storage traffic
+            EncryptedStorage.getItem.mockClear();
+            settingsStore.setSettings.mockClear();
+
+            await MigrationUtils.runSettingsMigrations(settings);
+
+            expect(EncryptedStorage.getItem).not.toHaveBeenCalled();
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
         });
     });
 
@@ -894,226 +944,6 @@ describe('MigrationUtils', () => {
 
             expect(RNFS.unlink).not.toHaveBeenCalledWith(LEGACY_PATH);
             expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
-        });
-    });
-
-    describe('migrateRgsDefaultsToV2', () => {
-        const EncryptedStorage = require('react-native-encrypted-storage');
-        const { settingsStore } = require('../stores/Stores');
-
-        beforeEach(() => {
-            EncryptedStorage.getItem.mockReset();
-            EncryptedStorage.setItem.mockReset();
-            settingsStore.setSettings.mockReset();
-        });
-
-        it('rewrites both v1 default endpoints on mainnet nodes', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
-            const settings: any = {
-                nodes: [
-                    {
-                        implementation: 'ldk-node',
-                        ldkNetwork: 'mainnet',
-                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
-                    },
-                    {
-                        implementation: 'ldk-node',
-                        // ldkNetwork unset counts as mainnet
-                        ldkRgsServer:
-                            'https://rapidsync.lightningdevkit.org/snapshot'
-                    }
-                ]
-            };
-
-            await MigrationUtils.migrateRgsDefaultsToV2(settings);
-
-            expect(settings.nodes[0].ldkRgsServer).toBe(
-                'https://rgs.zeusln.com/snapshot/v2'
-            );
-            expect(settings.nodes[1].ldkRgsServer).toBe(
-                'https://rapidsync.lightningdevkit.org/snapshot/v2'
-            );
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'rgs-defaults-v2',
-                'true'
-            );
-        });
-
-        it('persists the settings object rather than a JSON string', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
-            const settings: any = {
-                nodes: [
-                    {
-                        implementation: 'ldk-node',
-                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
-                    }
-                ]
-            };
-
-            await MigrationUtils.migrateRgsDefaultsToV2(settings);
-
-            const persistedSettings =
-                settingsStore.setSettings.mock.calls[0][0];
-            expect(typeof persistedSettings).not.toBe('string');
-            expect(persistedSettings).toBe(settings);
-        });
-
-        it('leaves custom URLs untouched and does not rewrite storage', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
-            const settings: any = {
-                nodes: [
-                    {
-                        implementation: 'ldk-node',
-                        ldkNetwork: 'mainnet',
-                        ldkRgsServer: 'https://my-custom-rgs.com/snapshot'
-                    }
-                ]
-            };
-
-            await MigrationUtils.migrateRgsDefaultsToV2(settings);
-
-            expect(settings.nodes[0].ldkRgsServer).toBe(
-                'https://my-custom-rgs.com/snapshot'
-            );
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'rgs-defaults-v2',
-                'true'
-            );
-        });
-
-        it('leaves unset values unset so runtime falls back to new defaults', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
-            const settings: any = {
-                nodes: [{ implementation: 'ldk-node', ldkNetwork: 'mainnet' }]
-            };
-
-            await MigrationUtils.migrateRgsDefaultsToV2(settings);
-
-            expect(settings.nodes[0].ldkRgsServer).toBeUndefined();
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'rgs-defaults-v2',
-                'true'
-            );
-        });
-
-        it('rewrites the v1 testnet default on testnet nodes', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
-            const settings: any = {
-                nodes: [
-                    {
-                        implementation: 'ldk-node',
-                        ldkNetwork: 'testnet',
-                        ldkRgsServer:
-                            'https://rapidsync.lightningdevkit.org/testnet/snapshot'
-                    }
-                ]
-            };
-
-            await MigrationUtils.migrateRgsDefaultsToV2(settings);
-
-            expect(settings.nodes[0].ldkRgsServer).toBe(
-                'https://rapidsync.lightningdevkit.org/testnet/v2/snapshot'
-            );
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
-        });
-
-        it('does not apply mappings across networks', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
-            const settings: any = {
-                nodes: [
-                    {
-                        // mainnet URL on a testnet node: misconfigured
-                        // either way, not this migration's to fix
-                        implementation: 'ldk-node',
-                        ldkNetwork: 'testnet',
-                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
-                    },
-                    {
-                        implementation: 'ldk-node',
-                        ldkNetwork: 'mainnet',
-                        ldkRgsServer:
-                            'https://rapidsync.lightningdevkit.org/testnet/snapshot'
-                    }
-                ]
-            };
-
-            await MigrationUtils.migrateRgsDefaultsToV2(settings);
-
-            expect(settings.nodes[0].ldkRgsServer).toBe(
-                'https://rgs.zeusln.com/snapshot'
-            );
-            expect(settings.nodes[1].ldkRgsServer).toBe(
-                'https://rapidsync.lightningdevkit.org/testnet/snapshot'
-            );
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-        });
-
-        it('is a no-op when the migration flag is already set', async () => {
-            EncryptedStorage.getItem.mockResolvedValue('true');
-            const settings: any = {
-                nodes: [
-                    {
-                        implementation: 'ldk-node',
-                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
-                    }
-                ]
-            };
-
-            await MigrationUtils.migrateRgsDefaultsToV2(settings);
-
-            expect(settings.nodes[0].ldkRgsServer).toBe(
-                'https://rgs.zeusln.com/snapshot'
-            );
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
-        });
-
-        it('is idempotent when run twice without the flag', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
-            const settings: any = {
-                nodes: [
-                    {
-                        implementation: 'ldk-node',
-                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
-                    }
-                ]
-            };
-
-            await MigrationUtils.migrateRgsDefaultsToV2(settings);
-            await MigrationUtils.migrateRgsDefaultsToV2(settings);
-
-            expect(settings.nodes[0].ldkRgsServer).toBe(
-                'https://rgs.zeusln.com/snapshot/v2'
-            );
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
-        });
-
-        it('ignores the superseded rgs-default-zeus flag', async () => {
-            // typical existing install: the retired migration already ran
-            // and pinned the v1 ZEUS default — its flag must not gate the
-            // v2 rewrite
-            EncryptedStorage.getItem.mockImplementation((key: string) =>
-                Promise.resolve(key === 'rgs-default-zeus' ? 'true' : null)
-            );
-            const settings: any = {
-                nodes: [
-                    {
-                        implementation: 'ldk-node',
-                        ldkNetwork: 'mainnet',
-                        ldkRgsServer: 'https://rgs.zeusln.com/snapshot'
-                    }
-                ]
-            };
-
-            await MigrationUtils.migrateRgsDefaultsToV2(settings);
-
-            expect(settings.nodes[0].ldkRgsServer).toBe(
-                'https://rgs.zeusln.com/snapshot/v2'
-            );
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -32,7 +32,6 @@ jest.mock('../stores/LSPStore', () => ({}));
 jest.mock('../utils/BackendUtils', () => ({}));
 
 jest.mock('../stores/SettingsStore', () => ({
-    SETTINGS_VERSION: 1,
     DEFAULT_FIAT_RATES_SOURCE: 'Zeus',
     DEFAULT_FIAT: 'USD',
     DEFAULT_LSP_MAINNET: 'https://flow.zeuslsp.com',
@@ -95,6 +94,9 @@ jest.mock('../storage', () => ({
 }));
 
 import MigrationUtils from './MigrationUtils';
+// the real constant, deliberately not mocked: after a version bump these
+// gating tests must run against the bumped value
+import { SETTINGS_VERSION } from './SettingsVersion';
 
 // Mock console logs to keep test output clean
 const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -158,7 +160,7 @@ describe('MigrationUtils', () => {
             slideToPayThreshold: 10000
         },
         requestSimpleTaproot: true,
-        settingsVersion: 1,
+        settingsVersion: SETTINGS_VERSION,
         speedloader: 'https://egs.lnze.us/'
     };
 
@@ -717,7 +719,7 @@ describe('MigrationUtils', () => {
         it('skips everything when the blob is already stamped', async () => {
             settingsStore.settingsUpdateInProgress = false;
             const settings: any = {
-                settingsVersion: 1,
+                settingsVersion: SETTINGS_VERSION,
                 lspMainnet: 'https://0conf.lnolymp.us'
             };
 
@@ -732,15 +734,13 @@ describe('MigrationUtils', () => {
         it('routes the write through the updateSettings queue when outside it', async () => {
             settingsStore.settingsUpdateInProgress = false;
             settingsStore.updateSettings.mockResolvedValue({
-                settingsVersion: 1
+                settingsVersion: SETTINGS_VERSION
             });
             const settings: any = {
                 swaps: { hostMainnet: 'https://boltz-api.eldamar.icu/v2' }
             };
 
-            const result = await MigrationUtils.runSettingsMigrations(
-                settings
-            );
+            const result = await MigrationUtils.runSettingsMigrations(settings);
 
             expect(settingsStore.updateSettings).toHaveBeenCalledWith({});
             // the potentially stale snapshot is never written directly,
@@ -748,7 +748,7 @@ describe('MigrationUtils', () => {
             // on fresh state
             expect(settingsStore.setSettings).not.toHaveBeenCalled();
             expect(EncryptedStorage.getItem).not.toHaveBeenCalled();
-            expect(result).toEqual({ settingsVersion: 1 });
+            expect(result).toEqual({ settingsVersion: SETTINGS_VERSION });
         });
 
         it('does not clobber a concurrent update when called outside the queue', async () => {
@@ -788,7 +788,7 @@ describe('MigrationUtils', () => {
             expect(result.swaps.hostMainnet).toBe(
                 'https://api.boltz.exchange/v2'
             );
-            expect(result.settingsVersion).toBe(1);
+            expect(result.settingsVersion).toBe(SETTINGS_VERSION);
             expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
             expect(settingsStore.setSettings).toHaveBeenCalledWith(fresh);
         });
@@ -806,7 +806,7 @@ describe('MigrationUtils', () => {
             expect(settings.swaps.hostMainnet).toBe(
                 'https://api.boltz.exchange/v2'
             );
-            expect(settings.settingsVersion).toBe(1);
+            expect(settings.settingsVersion).toBe(SETTINGS_VERSION);
             expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
             // retired per-migration flags are never written again
             expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
@@ -842,7 +842,7 @@ describe('MigrationUtils', () => {
             expect(settings.swaps.hostMainnet).toBe(
                 'https://api.boltz.exchange/v2'
             );
-            expect(settings.settingsVersion).toBe(1);
+            expect(settings.settingsVersion).toBe(SETTINGS_VERSION);
             expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
         });
 
@@ -900,7 +900,7 @@ describe('MigrationUtils', () => {
             expect(settings.swaps.hostMainnet).toBe(
                 'https://api.boltz.exchange/v2'
             );
-            expect(settings.settingsVersion).toBe(1);
+            expect(settings.settingsVersion).toBe(SETTINGS_VERSION);
             expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
 
             EncryptedStorage.getItem.mockImplementation((key: string) =>
@@ -929,7 +929,7 @@ describe('MigrationUtils', () => {
 
             await MigrationUtils.runSettingsMigrations(settings);
 
-            expect(settings.settingsVersion).toBe(1);
+            expect(settings.settingsVersion).toBe(SETTINGS_VERSION);
             expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
 
             // second run: stamped — zero storage traffic

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -706,10 +706,6 @@ describe('MigrationUtils', () => {
             EncryptedStorage.setItem.mockReset();
             settingsStore.setSettings.mockReset();
             settingsStore.updateSettings.mockReset();
-            // most cases exercise the consolidation itself, which in
-            // production runs inside the updateSettings queue's critical
-            // section (applySettingsUpdate -> getSettings -> here)
-            settingsStore.settingsUpdateInProgress = true;
         });
 
         afterEach(() => {
@@ -717,7 +713,6 @@ describe('MigrationUtils', () => {
         });
 
         it('skips everything when the blob is already stamped', async () => {
-            settingsStore.settingsUpdateInProgress = false;
             const settings: any = {
                 settingsVersion: SETTINGS_VERSION,
                 lspMainnet: 'https://0conf.lnolymp.us'
@@ -732,7 +727,6 @@ describe('MigrationUtils', () => {
         });
 
         it('routes the write through the updateSettings queue when outside it', async () => {
-            settingsStore.settingsUpdateInProgress = false;
             settingsStore.updateSettings.mockResolvedValue({
                 settingsVersion: SETTINGS_VERSION
             });
@@ -751,6 +745,27 @@ describe('MigrationUtils', () => {
             expect(result).toEqual({ settingsVersion: SETTINGS_VERSION });
         });
 
+        it('enqueues even while an unrelated update is in flight', async () => {
+            // settingsUpdateInProgress only means some update is in
+            // flight somewhere; being on the queue's call stack arrives
+            // as the inQueue parameter. An outside caller during an
+            // unrelated update is exactly when a direct write would
+            // clobber, so it must still enqueue.
+            settingsStore.settingsUpdateInProgress = true;
+            settingsStore.updateSettings.mockResolvedValue({
+                settingsVersion: SETTINGS_VERSION
+            });
+            const stale: any = {
+                swaps: { hostMainnet: 'https://boltz-api.eldamar.icu/v2' }
+            };
+
+            await MigrationUtils.runSettingsMigrations(stale);
+
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.getItem).not.toHaveBeenCalled();
+            expect(settingsStore.updateSettings).toHaveBeenCalledWith({});
+        });
+
         it('does not clobber a concurrent update when called outside the queue', async () => {
             EncryptedStorage.getItem.mockResolvedValue(null);
 
@@ -765,23 +780,19 @@ describe('MigrationUtils', () => {
                 supportedBiometryType: 'FaceID'
             };
 
-            settingsStore.settingsUpdateInProgress = false;
             settingsStore.updateSettings.mockImplementation(async () => {
                 // emulate applySettingsUpdate: getSettings re-enters
-                // runSettingsMigrations inside the critical section
-                settingsStore.settingsUpdateInProgress = true;
-                try {
-                    return await MigrationUtils.runSettingsMigrations(fresh);
-                } finally {
-                    settingsStore.settingsUpdateInProgress = false;
-                }
+                // runSettingsMigrations inside the critical section and
+                // persists the returned object itself
+                return await MigrationUtils.runSettingsMigrations(fresh, true);
             });
 
             const result = await MigrationUtils.runSettingsMigrations(stale);
 
-            // the stale snapshot must never be persisted
-            expect(settingsStore.setSettings).not.toHaveBeenCalledWith(stale);
-            // the fresh state is migrated, stamped and persisted with the
+            // neither the stale snapshot nor anything else is written
+            // directly; the queue's critical section owns the persist
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            // the fresh state is migrated and stamped with the
             // concurrent update intact
             expect(result).toBe(fresh);
             expect(result.supportedBiometryType).toBe('FaceID');
@@ -789,39 +800,42 @@ describe('MigrationUtils', () => {
                 'https://api.boltz.exchange/v2'
             );
             expect(result.settingsVersion).toBe(SETTINGS_VERSION);
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
-            expect(settingsStore.setSettings).toHaveBeenCalledWith(fresh);
         });
 
-        it('consolidates an unstamped blob with a single write and stamps it', async () => {
+        it('consolidates an unstamped blob in memory inside the queue, without writing', async () => {
             EncryptedStorage.getItem.mockResolvedValue(null);
             const settings: any = {
                 lspMainnet: 'https://0conf.lnolymp.us',
                 swaps: { hostMainnet: 'https://swaps.zeuslsp.com/api/v2' }
             };
 
-            await MigrationUtils.runSettingsMigrations(settings);
+            await MigrationUtils.runSettingsMigrations(settings, true);
 
             expect(settings.lspMainnet).toBe('https://flow.zeuslsp.com');
             expect(settings.swaps.hostMainnet).toBe(
                 'https://api.boltz.exchange/v2'
             );
             expect(settings.settingsVersion).toBe(SETTINGS_VERSION);
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+            // applySettingsUpdate persists right after getSettings
+            // returns; a direct write here would be redundant, and
+            // enqueueing would deadlock behind the awaiting task
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(settingsStore.updateSettings).not.toHaveBeenCalled();
             // retired per-migration flags are never written again
             expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
         });
 
-        it('persists the settings object rather than a JSON string', async () => {
+        it('returns the same object so the queue persists the migrated blob', async () => {
             EncryptedStorage.getItem.mockResolvedValue(null);
             const settings: any = {};
 
-            await MigrationUtils.runSettingsMigrations(settings);
+            const result = await MigrationUtils.runSettingsMigrations(
+                settings,
+                true
+            );
 
-            const persistedSettings =
-                settingsStore.setSettings.mock.calls[0][0];
-            expect(typeof persistedSettings).not.toBe('string');
-            expect(persistedSettings).toBe(settings);
+            expect(result).toBe(settings);
+            expect(result.settingsVersion).toBe(SETTINGS_VERSION);
         });
 
         it('honors retired per-migration flags during consolidation', async () => {
@@ -833,9 +847,9 @@ describe('MigrationUtils', () => {
                 swaps: { hostMainnet: 'https://swaps.zeuslsp.com/api/v2' }
             };
 
-            await MigrationUtils.runSettingsMigrations(settings);
+            await MigrationUtils.runSettingsMigrations(settings, true);
 
-            // Olympus host migration already ran on this install — the
+            // Olympus host migration already ran on this install, so the
             // (user-restored) old value must not be rewritten again
             expect(settings.lspMainnet).toBe('https://0conf.lnolymp.us');
             // the un-flagged swap migration still applies
@@ -843,7 +857,6 @@ describe('MigrationUtils', () => {
                 'https://api.boltz.exchange/v2'
             );
             expect(settings.settingsVersion).toBe(SETTINGS_VERSION);
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
         });
 
         it('honors rgs-defaults-v2 but ignores the superseded rgs-default-zeus flag', async () => {
@@ -863,7 +876,7 @@ describe('MigrationUtils', () => {
                 ]
             };
 
-            await MigrationUtils.runSettingsMigrations(settings);
+            await MigrationUtils.runSettingsMigrations(settings, true);
 
             expect(settings.nodes[0].ldkRgsServer).toBe(
                 'https://rgs.zeusln.com/snapshot/v2'
@@ -882,7 +895,7 @@ describe('MigrationUtils', () => {
                 ]
             };
 
-            await MigrationUtils.runSettingsMigrations(flagged);
+            await MigrationUtils.runSettingsMigrations(flagged, true);
 
             expect(flagged.nodes[0].ldkRgsServer).toBe(
                 'https://rgs.zeusln.com/snapshot'
@@ -895,13 +908,12 @@ describe('MigrationUtils', () => {
                 swaps: { hostMainnet: 'https://boltz-api.eldamar.icu/v2' }
             };
 
-            await MigrationUtils.runSettingsMigrations(settings);
+            await MigrationUtils.runSettingsMigrations(settings, true);
 
             expect(settings.swaps.hostMainnet).toBe(
                 'https://api.boltz.exchange/v2'
             );
             expect(settings.settingsVersion).toBe(SETTINGS_VERSION);
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
 
             EncryptedStorage.getItem.mockImplementation((key: string) =>
                 Promise.resolve(
@@ -912,7 +924,7 @@ describe('MigrationUtils', () => {
                 swaps: { hostMainnet: 'https://boltz-api.eldamar.icu/v2' }
             };
 
-            await MigrationUtils.runSettingsMigrations(flagged);
+            await MigrationUtils.runSettingsMigrations(flagged, true);
 
             // the retirement migration already ran on this install; the
             // (user-restored) host must not be rewritten again
@@ -921,22 +933,21 @@ describe('MigrationUtils', () => {
             );
         });
 
-        it('stamps with one write even when nothing needed migrating, then goes quiet', async () => {
+        it('stamps even when nothing needed migrating, then goes quiet', async () => {
             EncryptedStorage.getItem.mockResolvedValue('true');
             const settings: any = {
                 lspMainnet: 'https://flow.zeuslsp.com'
             };
 
-            await MigrationUtils.runSettingsMigrations(settings);
+            await MigrationUtils.runSettingsMigrations(settings, true);
 
             expect(settings.settingsVersion).toBe(SETTINGS_VERSION);
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
 
-            // second run: stamped — zero storage traffic
+            // second run: stamped, zero storage traffic
             EncryptedStorage.getItem.mockClear();
             settingsStore.setSettings.mockClear();
 
-            await MigrationUtils.runSettingsMigrations(settings);
+            await MigrationUtils.runSettingsMigrations(settings, true);
 
             expect(EncryptedStorage.getItem).not.toHaveBeenCalled();
             expect(settingsStore.setSettings).not.toHaveBeenCalled();

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -21,7 +21,9 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 }));
 jest.mock('../stores/Stores', () => ({
     settingsStore: {
-        setSettings: jest.fn()
+        settingsUpdateInProgress: false,
+        setSettings: jest.fn(),
+        updateSettings: jest.fn()
     }
 }));
 jest.mock('../stores/ChannelBackupStore', () => ({}));
@@ -701,9 +703,19 @@ describe('MigrationUtils', () => {
             EncryptedStorage.getItem.mockReset();
             EncryptedStorage.setItem.mockReset();
             settingsStore.setSettings.mockReset();
+            settingsStore.updateSettings.mockReset();
+            // most cases exercise the consolidation itself, which in
+            // production runs inside the updateSettings queue's critical
+            // section (applySettingsUpdate -> getSettings -> here)
+            settingsStore.settingsUpdateInProgress = true;
+        });
+
+        afterEach(() => {
+            settingsStore.settingsUpdateInProgress = false;
         });
 
         it('skips everything when the blob is already stamped', async () => {
+            settingsStore.settingsUpdateInProgress = false;
             const settings: any = {
                 settingsVersion: 1,
                 lspMainnet: 'https://0conf.lnolymp.us'
@@ -714,6 +726,71 @@ describe('MigrationUtils', () => {
             expect(settings.lspMainnet).toBe('https://0conf.lnolymp.us');
             expect(EncryptedStorage.getItem).not.toHaveBeenCalled();
             expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(settingsStore.updateSettings).not.toHaveBeenCalled();
+        });
+
+        it('routes the write through the updateSettings queue when outside it', async () => {
+            settingsStore.settingsUpdateInProgress = false;
+            settingsStore.updateSettings.mockResolvedValue({
+                settingsVersion: 1
+            });
+            const settings: any = {
+                swaps: { hostMainnet: 'https://boltz-api.eldamar.icu/v2' }
+            };
+
+            const result = await MigrationUtils.runSettingsMigrations(
+                settings
+            );
+
+            expect(settingsStore.updateSettings).toHaveBeenCalledWith({});
+            // the potentially stale snapshot is never written directly,
+            // and its flags are not read; the queued re-entry does both
+            // on fresh state
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.getItem).not.toHaveBeenCalled();
+            expect(result).toEqual({ settingsVersion: 1 });
+        });
+
+        it('does not clobber a concurrent update when called outside the queue', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+
+            // snapshot read before a concurrent updateSettings landed
+            const stale: any = {
+                swaps: { hostMainnet: 'https://boltz-api.eldamar.icu/v2' }
+            };
+            // state as the queue's critical section re-reads it, with
+            // the concurrent update's key present
+            const fresh: any = {
+                swaps: { hostMainnet: 'https://boltz-api.eldamar.icu/v2' },
+                supportedBiometryType: 'FaceID'
+            };
+
+            settingsStore.settingsUpdateInProgress = false;
+            settingsStore.updateSettings.mockImplementation(async () => {
+                // emulate applySettingsUpdate: getSettings re-enters
+                // runSettingsMigrations inside the critical section
+                settingsStore.settingsUpdateInProgress = true;
+                try {
+                    return await MigrationUtils.runSettingsMigrations(fresh);
+                } finally {
+                    settingsStore.settingsUpdateInProgress = false;
+                }
+            });
+
+            const result = await MigrationUtils.runSettingsMigrations(stale);
+
+            // the stale snapshot must never be persisted
+            expect(settingsStore.setSettings).not.toHaveBeenCalledWith(stale);
+            // the fresh state is migrated, stamped and persisted with the
+            // concurrent update intact
+            expect(result).toBe(fresh);
+            expect(result.supportedBiometryType).toBe('FaceID');
+            expect(result.swaps.hostMainnet).toBe(
+                'https://api.boltz.exchange/v2'
+            );
+            expect(result.settingsVersion).toBe(1);
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+            expect(settingsStore.setSettings).toHaveBeenCalledWith(fresh);
         });
 
         it('consolidates an unstamped blob with a single write and stamps it', async () => {

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -393,18 +393,8 @@ describe('MigrationUtils', () => {
         });
     });
 
-    describe('migrateRetiredSwapHosts', () => {
-        const EncryptedStorage = require('react-native-encrypted-storage');
-        const { settingsStore } = require('../stores/Stores');
-
-        beforeEach(() => {
-            EncryptedStorage.getItem.mockReset();
-            EncryptedStorage.setItem.mockReset();
-            settingsStore.setSettings.mockReset();
-        });
-
-        it('moves a shut-down provider back to the default mainnet host', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+    describe('applyRetiredSwapHosts', () => {
+        it('moves a shut-down provider back to the default mainnet host', () => {
             const settings: any = {
                 swaps: {
                     hostMainnet: 'https://boltz-api.eldamar.icu/v2',
@@ -414,24 +404,16 @@ describe('MigrationUtils', () => {
                 }
             };
 
-            await MigrationUtils.migrateRetiredSwapHosts(settings);
-
+            expect(MigrationUtils.applyRetiredSwapHosts(settings)).toBe(true);
             expect(settings.swaps.hostMainnet).toBe(
                 'https://api.boltz.exchange/v2'
             );
             expect(settings.swaps.hostTestnet).toBe(
                 'https://api.testnet.boltz.exchange/v2'
             );
-            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
-            expect(settingsStore.setSettings.mock.calls[0][0]).toBe(settings);
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'swap-hosts-retired-eldamar',
-                'true'
-            );
         });
 
-        it('leaves a custom host pointed at a retired provider alone', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+        it('leaves a custom host pointed at a retired provider alone', () => {
             const settings: any = {
                 swaps: {
                     hostMainnet: 'Custom',
@@ -440,21 +422,14 @@ describe('MigrationUtils', () => {
                 }
             };
 
-            await MigrationUtils.migrateRetiredSwapHosts(settings);
-
+            expect(MigrationUtils.applyRetiredSwapHosts(settings)).toBe(false);
             expect(settings.swaps.hostMainnet).toBe('Custom');
             expect(settings.swaps.customHost).toBe(
                 'https://boltz-api.eldamar.icu/v2'
             );
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'swap-hosts-retired-eldamar',
-                'true'
-            );
         });
 
-        it('leaves still-operating providers untouched', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+        it('leaves still-operating providers untouched', () => {
             const settings: any = {
                 swaps: {
                     hostMainnet: 'https://swap.coinos.io/v2',
@@ -462,47 +437,17 @@ describe('MigrationUtils', () => {
                 }
             };
 
-            await MigrationUtils.migrateRetiredSwapHosts(settings);
-
+            expect(MigrationUtils.applyRetiredSwapHosts(settings)).toBe(false);
             expect(settings.swaps.hostMainnet).toBe(
                 'https://swap.coinos.io/v2'
             );
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'swap-hosts-retired-eldamar',
-                'true'
-            );
         });
 
-        it('only sets the flag when settings have no swaps block', async () => {
-            EncryptedStorage.getItem.mockResolvedValue(null);
+        it('is a no-op without a swaps block', () => {
             const settings: any = {};
 
-            await MigrationUtils.migrateRetiredSwapHosts(settings);
-
+            expect(MigrationUtils.applyRetiredSwapHosts(settings)).toBe(false);
             expect(settings).toEqual({});
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
-                'swap-hosts-retired-eldamar',
-                'true'
-            );
-        });
-
-        it('is a no-op when the migration flag is already set', async () => {
-            EncryptedStorage.getItem.mockResolvedValue('true');
-            const settings: any = {
-                swaps: {
-                    hostMainnet: 'https://boltz-api.eldamar.icu/v2'
-                }
-            };
-
-            await MigrationUtils.migrateRetiredSwapHosts(settings);
-
-            expect(settings.swaps.hostMainnet).toBe(
-                'https://boltz-api.eldamar.icu/v2'
-            );
-            expect(settingsStore.setSettings).not.toHaveBeenCalled();
-            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
         });
     });
 
@@ -864,6 +809,38 @@ describe('MigrationUtils', () => {
 
             expect(flagged.nodes[0].ldkRgsServer).toBe(
                 'https://rgs.zeusln.com/snapshot'
+            );
+        });
+
+        it('applies the retired-swap-host rewrite only when its flag is unset', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                swaps: { hostMainnet: 'https://boltz-api.eldamar.icu/v2' }
+            };
+
+            await MigrationUtils.runSettingsMigrations(settings);
+
+            expect(settings.swaps.hostMainnet).toBe(
+                'https://api.boltz.exchange/v2'
+            );
+            expect(settings.settingsVersion).toBe(1);
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+
+            EncryptedStorage.getItem.mockImplementation((key: string) =>
+                Promise.resolve(
+                    key === 'swap-hosts-retired-eldamar' ? 'true' : null
+                )
+            );
+            const flagged: any = {
+                swaps: { hostMainnet: 'https://boltz-api.eldamar.icu/v2' }
+            };
+
+            await MigrationUtils.runSettingsMigrations(flagged);
+
+            // the retirement migration already ran on this install; the
+            // (user-restored) host must not be rewritten again
+            expect(flagged.swaps.hostMainnet).toBe(
+                'https://boltz-api.eldamar.icu/v2'
             );
         });
 

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -30,6 +30,7 @@ import {
     DEFAULT_NOSTR_RELAYS_2023,
     PosEnabled,
     DEFAULT_SLIDE_TO_PAY_THRESHOLD,
+    SETTINGS_VERSION,
     STORAGE_KEY,
     LEGACY_CURRENCY_CODES_KEY,
     CURRENCY_CODES_KEY
@@ -311,16 +312,30 @@ class MigrationsUtils {
             newSettings.locale = localeMigrationMapping[newSettings.locale];
         }
 
-        const MOD_KEY = 'lsp-taproot-mod';
-        const mod = await EncryptedStorage.getItem(MOD_KEY);
+        // One-shot MOD_KEY migrations. The flags are still read (once —
+        // this path only runs while a legacy blob exists) so migrations a
+        // previous app version already applied are not re-applied over
+        // values the user has since changed. They are no longer written,
+        // and no intermediate setSettings calls are made: the migrated
+        // blob is persisted once by storageMigrationV2 and stamped with
+        // settingsVersion, which the modern load path checks instead
+        // (#4470: fewer keystore ops).
+        const [mod, mod2, mod3, mod4, mod5, mod6, mod7, mod8] =
+            await Promise.all([
+                EncryptedStorage.getItem('lsp-taproot-mod'),
+                EncryptedStorage.getItem('lsp-preview-mod'),
+                EncryptedStorage.getItem('neutrino-peers-mod1'),
+                EncryptedStorage.getItem('lsps1-hosts1'),
+                EncryptedStorage.getItem('millisat_amounts'),
+                EncryptedStorage.getItem('egs-host'),
+                EncryptedStorage.getItem('bimodal-bug-9085'),
+                EncryptedStorage.getItem('nostr-relays-2024')
+            ]);
+
         if (!mod) {
             newSettings.requestSimpleTaproot = true;
-            await settingsStore.setSettings(newSettings);
-            await EncryptedStorage.setItem(MOD_KEY, 'true');
         }
 
-        const MOD_KEY2 = 'lsp-preview-mod';
-        const mod2 = await EncryptedStorage.getItem(MOD_KEY2);
         if (!mod2) {
             if (newSettings?.lspMainnet === 'https://lsp-preview.lnolymp.us') {
                 newSettings.lspMainnet = DEFAULT_LSP_MAINNET;
@@ -328,12 +343,8 @@ class MigrationsUtils {
             if (newSettings?.lspTestnet === 'https://testnet-lsp.lnolymp.us') {
                 newSettings.lspTestnet = DEFAULT_LSP_TESTNET;
             }
-            await settingsStore.setSettings(newSettings);
-            await EncryptedStorage.setItem(MOD_KEY2, 'true');
         }
 
-        const MOD_KEY3 = 'neutrino-peers-mod1';
-        const mod3 = await EncryptedStorage.getItem(MOD_KEY3);
         if (!mod3) {
             const neutrinoPeersMainnetOld = [
                 'btcd1.lnolymp.us',
@@ -349,12 +360,8 @@ class MigrationsUtils {
                 newSettings.neutrinoPeersMainnet =
                     DEFAULT_NEUTRINO_PEERS_MAINNET;
             }
-            await settingsStore.setSettings(newSettings);
-            await EncryptedStorage.setItem(MOD_KEY3, 'true');
         }
 
-        const MOD_KEY4 = 'lsps1-hosts1';
-        const mod4 = await EncryptedStorage.getItem(MOD_KEY4);
         if (!mod4) {
             if (!newSettings?.lsps1HostMainnet) {
                 newSettings.lsps1HostMainnet = DEFAULT_LSPS1_HOST_MAINNET;
@@ -378,13 +385,8 @@ class MigrationsUtils {
             if (!newSettings?.lsps1Token) {
                 newSettings.lsps1Token = '';
             }
-
-            await settingsStore.setSettings(newSettings);
-            await EncryptedStorage.setItem(MOD_KEY4, 'true');
         }
 
-        const MOD_KEY5 = 'millisat_amounts';
-        const mod5 = await EncryptedStorage.getItem(MOD_KEY5);
         if (!mod5) {
             if (!newSettings?.display?.showMillisatoshiAmounts) {
                 if (!newSettings.display) {
@@ -395,38 +397,23 @@ class MigrationsUtils {
                     newSettings.display.showMillisatoshiAmounts = true;
                 }
             }
-
-            await settingsStore.setSettings(newSettings);
-            await EncryptedStorage.setItem(MOD_KEY5, 'true');
         }
 
-        const MOD_KEY6 = 'egs-host';
-        const mod6 = await EncryptedStorage.getItem(MOD_KEY6);
         if (!mod6) {
             if (!newSettings?.speedloader) {
                 newSettings.speedloader = DEFAULT_SPEEDLOADER;
                 newSettings.customSpeedloader = '';
             }
-
-            await settingsStore.setSettings(newSettings);
-            await EncryptedStorage.setItem(MOD_KEY6, 'true');
         }
 
         // switch off bimodal pathfinding while bug exists
         // https://github.com/lightningnetwork/lnd/issues/9085
-        const MOD_KEY7 = 'bimodal-bug-9085';
-        const mod7 = await EncryptedStorage.getItem(MOD_KEY7);
         if (!mod7) {
             if (newSettings?.bimodalPathfinding) {
                 newSettings.bimodalPathfinding = false;
             }
-
-            await settingsStore.setSettings(newSettings);
-            await EncryptedStorage.setItem(MOD_KEY7, 'true');
         }
 
-        const MOD_KEY8 = 'nostr-relays-2024';
-        const mod8 = await EncryptedStorage.getItem(MOD_KEY8);
         if (!mod8) {
             if (
                 JSON.stringify(newSettings?.lightningAddress?.nostrRelays) ===
@@ -434,12 +421,7 @@ class MigrationsUtils {
             ) {
                 newSettings.lightningAddress.nostrRelays = DEFAULT_NOSTR_RELAYS;
             }
-
-            await settingsStore.setSettings(newSettings);
-            await EncryptedStorage.setItem(MOD_KEY8, 'true');
         }
-
-        await this.migrateInvoiceExpiryDisplay(newSettings);
 
         // migrate old POS squareEnabled setting to posEnabled
         if (newSettings?.pos?.squareEnabled) {
@@ -463,19 +445,75 @@ class MigrationsUtils {
                 DEFAULT_SLIDE_TO_PAY_THRESHOLD;
         }
 
-        // migrate retired v1 RGS endpoints to v2 (BOLT 12 offer support)
-        await this.migrateRgsDefaultsToV2(newSettings);
-
-        // migrate old default Olympus LSP hosts to new zeuslsp.com hosts
-        await this.migrateOlympusHostsToZeusLsp(newSettings);
-
-        // migrate retired ZEUS swap server hosts to Boltz
-        await this.migrateSwapHostsToBoltz(newSettings);
+        // shared one-shot migrations + settingsVersion stamp; the result
+        // is persisted once by storageMigrationV2
+        await this.applySettingsMigrations(newSettings);
 
         // move users off swap providers that have shut down
         await this.migrateRetiredSwapHosts(newSettings);
 
         return newSettings;
+    }
+
+    // ------------------------------------------------------------------
+    // Consolidated settings migrations (#4470)
+    //
+    // The blob carries a settingsVersion stamp (SETTINGS_VERSION in
+    // SettingsStore). A stamped blob skips migrations entirely, so the
+    // modern load path performs zero migration keystore reads per boot.
+    // Blobs without the stamp (installs predating it) get a one-time
+    // consolidation: the retired per-migration EncryptedStorage flags
+    // are read once so already-applied migrations are not re-applied
+    // over values the user has since changed, the needed mutations run
+    // in memory, and a single setSettings persists the result together
+    // with the stamp — migrated values and migration state can no
+    // longer diverge if we crash mid-way. The retired flags are never
+    // written again; leftover entries are inert and cleared by Clear
+    // All Data.
+    //
+    // Adding a future migration: bump SETTINGS_VERSION, gate the new
+    // mutation on the blob's prior version (settings.settingsVersion ??
+    // 0), and leave the existing blocks untouched.
+    // ------------------------------------------------------------------
+    public async runSettingsMigrations(settings: any) {
+        if ((settings?.settingsVersion ?? 0) >= SETTINGS_VERSION) {
+            return settings;
+        }
+
+        await this.applySettingsMigrations(settings);
+
+        // single write: migrated values and stamp land atomically
+        await settingsStore.setSettings(settings);
+        return settings;
+    }
+
+    // Applies every migration below the current SETTINGS_VERSION in
+    // memory and stamps the blob. Does NOT persist — runSettingsMigrations
+    // (modern path) and storageMigrationV2 (legacy path) own the write.
+    public async applySettingsMigrations(settings: any): Promise<boolean> {
+        const [rgsDone, olympusDone, swapDone, expiryDone] = await Promise.all([
+            EncryptedStorage.getItem('rgs-defaults-v2'),
+            EncryptedStorage.getItem('zeuslsp-hosts-2026'),
+            EncryptedStorage.getItem('swap-hosts-boltz'),
+            EncryptedStorage.getItem('invoices-expiry-display-fix-v2')
+        ]);
+
+        let changed = false;
+        if (!rgsDone) {
+            changed = this.applyRgsDefaultsToV2(settings) || changed;
+        }
+        if (!olympusDone) {
+            changed = this.applyOlympusHostsToZeusLsp(settings) || changed;
+        }
+        if (!swapDone) {
+            changed = this.applySwapHostsToBoltz(settings) || changed;
+        }
+        if (!expiryDone) {
+            changed = this.applyInvoiceExpiryDisplay(settings) || changed;
+        }
+
+        settings.settingsVersion = SETTINGS_VERSION;
+        return changed;
     }
 
     // Rewrite persisted v1 RGS endpoints to their v2 equivalents in a
@@ -490,13 +528,8 @@ class MigrationsUtils {
     // ('rgs-default-zeus'), which pinned the then-default into every
     // mainnet node; the values it wrote are matched here, so its flag is
     // no longer consulted and unset values are no longer pinned (#4470:
-    // fewer keystore ops). Must run on both the legacy and modern
-    // (zeus-settings-v2) paths.
-    public async migrateRgsDefaultsToV2(settings: any) {
-        const MOD_KEY_RGS_V2 = 'rgs-defaults-v2';
-        const modRgsV2 = await EncryptedStorage.getItem(MOD_KEY_RGS_V2);
-        if (modRgsV2) return settings;
-
+    // fewer keystore ops).
+    public applyRgsDefaultsToV2(settings: any): boolean {
         const urlMigrationsByNetwork: {
             [network: string]: { [oldUrl: string]: string };
         } = {
@@ -527,22 +560,14 @@ class MigrationsUtils {
                 }
             }
         }
-
-        if (changed) await settingsStore.setSettings(settings);
-        await EncryptedStorage.setItem(MOD_KEY_RGS_V2, 'true');
-        return settings;
+        return changed;
     }
 
     // Rewrite persisted old-default Olympus LSP hosts (lnolymp.us) to the
     // new zeuslsp.com hosts. Only values still equal to an old default are
     // touched; custom hosts are left alone. Unset values need no migration —
-    // runtime falls back to the (updated) DEFAULT_* constants. Must run on
-    // both the legacy and modern (zeus-settings-v2) paths.
-    public async migrateOlympusHostsToZeusLsp(settings: any) {
-        const MOD_KEY_ZEUSLSP = 'zeuslsp-hosts-2026';
-        const mod = await EncryptedStorage.getItem(MOD_KEY_ZEUSLSP);
-        if (mod) return settings;
-
+    // runtime falls back to the (updated) DEFAULT_* constants.
+    public applyOlympusHostsToZeusLsp(settings: any): boolean {
         const hostMigrations: Array<{
             settingsKey: string;
             oldHost: string;
@@ -587,21 +612,11 @@ class MigrationsUtils {
                 changed = true;
             }
         }
-
-        if (changed) {
-            await settingsStore.setSettings(settings);
-        }
-        await EncryptedStorage.setItem(MOD_KEY_ZEUSLSP, 'true');
-        return settings;
+        return changed;
     }
 
-    // migrate users pointed at the retired ZEUS swap server to Boltz.
-    // Must run on both the legacy and modern (zeus-settings-v2) paths.
-    public async migrateSwapHostsToBoltz(settings: any) {
-        const MOD_KEY_SWAP_HOSTS = 'swap-hosts-boltz';
-        const modSwapHosts = await EncryptedStorage.getItem(MOD_KEY_SWAP_HOSTS);
-        if (modSwapHosts) return settings;
-
+    // migrate users pointed at the retired ZEUS swap server to Boltz
+    public applySwapHostsToBoltz(settings: any): boolean {
         let changed = false;
         if (settings?.swaps) {
             if (settings.swaps.hostMainnet === LEGACY_ZEUS_SWAP_HOST_MAINNET) {
@@ -614,9 +629,7 @@ class MigrationsUtils {
             }
         }
 
-        if (changed) await settingsStore.setSettings(settings);
-        await EncryptedStorage.setItem(MOD_KEY_SWAP_HOSTS, 'true');
-        return settings;
+        return changed;
     }
 
     // Move users pinned to a swap provider that has shut down back to the
@@ -652,47 +665,39 @@ class MigrationsUtils {
     // "3600 hours" while invoices still expired in one hour. Derive a
     // canonical seconds value (stored → derived from expiry+timePeriod
     // → '3600') and rewrite all three fields from it when anything is
-    // missing or inconsistent. Must run on both the legacy and modern
-    // (zeus-settings-v2) paths.
-    public async migrateInvoiceExpiryDisplay(settings: any) {
-        const MOD_KEY_INVOICE_EXPIRY = 'invoices-expiry-display-fix-v2';
-        const modInvoiceExpiry = await EncryptedStorage.getItem(
-            MOD_KEY_INVOICE_EXPIRY
-        );
-        if (modInvoiceExpiry) return settings;
-
+    // missing or inconsistent (#4149). Value-conditional: consistent
+    // settings are left untouched.
+    public applyInvoiceExpiryDisplay(settings: any): boolean {
         const invoices: any = settings?.invoices;
-        if (invoices) {
-            const storedValid = Number(invoices.expirySeconds) > 0;
-            const derivable = invoices.expiry && invoices.timePeriod;
-            const canonical = storedValid
-                ? invoices.expirySeconds
-                : derivable
-                ? expirySecondsFromInput(
-                      invoices.expiry,
-                      invoices.timePeriod as TimePeriod
-                  )
-                : '3600';
+        if (!invoices) return false;
 
-            const inconsistent =
-                !invoices.expiry ||
-                !invoices.timePeriod ||
-                invoices.expirySeconds !== canonical ||
-                expirySecondsFromInput(
-                    invoices.expiry,
-                    invoices.timePeriod as TimePeriod
-                ) !== canonical;
+        const storedValid = Number(invoices.expirySeconds) > 0;
+        const derivable = invoices.expiry && invoices.timePeriod;
+        const canonical = storedValid
+            ? invoices.expirySeconds
+            : derivable
+            ? expirySecondsFromInput(
+                  invoices.expiry,
+                  invoices.timePeriod as TimePeriod
+              )
+            : '3600';
 
-            if (inconsistent) {
-                const repaired = displayFromExpirySeconds(canonical);
-                invoices.expiry = repaired.expiry;
-                invoices.timePeriod = repaired.timePeriod;
-                invoices.expirySeconds = canonical;
-                await settingsStore.setSettings(settings);
-            }
-        }
-        await EncryptedStorage.setItem(MOD_KEY_INVOICE_EXPIRY, 'true');
-        return settings;
+        const inconsistent =
+            !invoices.expiry ||
+            !invoices.timePeriod ||
+            invoices.expirySeconds !== canonical ||
+            expirySecondsFromInput(
+                invoices.expiry,
+                invoices.timePeriod as TimePeriod
+            ) !== canonical;
+
+        if (!inconsistent) return false;
+
+        const repaired = displayFromExpirySeconds(canonical);
+        invoices.expiry = repaired.expiry;
+        invoices.timePeriod = repaired.timePeriod;
+        invoices.expirySeconds = canonical;
+        return true;
     }
 
     // Rescue-key export file cleanup, in two parts with different cadences.

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -30,11 +30,12 @@ import {
     DEFAULT_NOSTR_RELAYS_2023,
     PosEnabled,
     DEFAULT_SLIDE_TO_PAY_THRESHOLD,
-    SETTINGS_VERSION,
     STORAGE_KEY,
     LEGACY_CURRENCY_CODES_KEY,
     CURRENCY_CODES_KEY
 } from '../stores/SettingsStore';
+
+import { SETTINGS_VERSION } from './SettingsVersion';
 
 import { LEGACY_NOTES_KEY, NOTES_KEY } from '../stores/NotesStore';
 import { LEGACY_CONTACTS_KEY, CONTACTS_KEY } from '../stores/ContactStore';

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -449,9 +449,6 @@ class MigrationsUtils {
         // is persisted once by storageMigrationV2
         await this.applySettingsMigrations(newSettings);
 
-        // move users off swap providers that have shut down
-        await this.migrateRetiredSwapHosts(newSettings);
-
         return newSettings;
     }
 
@@ -491,12 +488,14 @@ class MigrationsUtils {
     // memory and stamps the blob. Does NOT persist — runSettingsMigrations
     // (modern path) and storageMigrationV2 (legacy path) own the write.
     public async applySettingsMigrations(settings: any): Promise<boolean> {
-        const [rgsDone, olympusDone, swapDone, expiryDone] = await Promise.all([
-            EncryptedStorage.getItem('rgs-defaults-v2'),
-            EncryptedStorage.getItem('zeuslsp-hosts-2026'),
-            EncryptedStorage.getItem('swap-hosts-boltz'),
-            EncryptedStorage.getItem('invoices-expiry-display-fix-v2')
-        ]);
+        const [rgsDone, olympusDone, swapDone, retiredSwapDone, expiryDone] =
+            await Promise.all([
+                EncryptedStorage.getItem('rgs-defaults-v2'),
+                EncryptedStorage.getItem('zeuslsp-hosts-2026'),
+                EncryptedStorage.getItem('swap-hosts-boltz'),
+                EncryptedStorage.getItem('swap-hosts-retired-eldamar'),
+                EncryptedStorage.getItem('invoices-expiry-display-fix-v2')
+            ]);
 
         let changed = false;
         if (!rgsDone) {
@@ -507,6 +506,9 @@ class MigrationsUtils {
         }
         if (!swapDone) {
             changed = this.applySwapHostsToBoltz(settings) || changed;
+        }
+        if (!retiredSwapDone) {
+            changed = this.applyRetiredSwapHosts(settings) || changed;
         }
         if (!expiryDone) {
             changed = this.applyInvoiceExpiryDisplay(settings) || changed;
@@ -637,13 +639,11 @@ class MigrationsUtils {
     // entry in SWAP_HOST_KEYS_MAINNET, so the provider dropdown renders no
     // selection while every swap request goes to a dead endpoint. Custom
     // hosts are left alone: a retired host is only rewritten when it was
-    // picked from the dropdown, not typed in as a custom host. Must run on
-    // both the legacy and modern (zeus-settings-v2) paths.
-    public async migrateRetiredSwapHosts(settings: any) {
-        const MOD_KEY_RETIRED_SWAP_HOSTS = 'swap-hosts-retired-eldamar';
-        const mod = await EncryptedStorage.getItem(MOD_KEY_RETIRED_SWAP_HOSTS);
-        if (mod) return settings;
-
+    // picked from the dropdown, not typed in as a custom host. Retired
+    // flag: 'swap-hosts-retired-eldamar' (honored in
+    // applySettingsMigrations; installs that ran the migration before the
+    // stamp existed are not re-migrated over a since-changed value).
+    public applyRetiredSwapHosts(settings: any): boolean {
         let changed = false;
         if (
             settings?.swaps?.hostMainnet &&
@@ -652,10 +652,7 @@ class MigrationsUtils {
             settings.swaps.hostMainnet = DEFAULT_SWAP_HOST_MAINNET;
             changed = true;
         }
-
-        if (changed) await settingsStore.setSettings(settings);
-        await EncryptedStorage.setItem(MOD_KEY_RETIRED_SWAP_HOSTS, 'true');
-        return settings;
+        return changed;
     }
 
     // Repair invoice expiry display fields when out of sync with

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -477,11 +477,26 @@ class MigrationsUtils {
             return settings;
         }
 
-        await this.applySettingsMigrations(settings);
+        if (settingsStore.settingsUpdateInProgress) {
+            // Already inside the updateSettings queue's critical section
+            // (applySettingsUpdate -> getSettings -> here): persisting
+            // directly is serialized with every other update, and
+            // enqueueing would deadlock behind the very task awaiting us.
+            await this.applySettingsMigrations(settings);
 
-        // single write: migrated values and stamp land atomically
-        await settingsStore.setSettings(settings);
-        return settings;
+            // single write: migrated values and stamp land atomically
+            await settingsStore.setSettings(settings);
+            return settings;
+        }
+
+        // Outside the queue `settings` is a snapshot that can go stale
+        // before the write lands (the blob read and the flag reads all
+        // yield), and setSettings overwrites wholesale, so a concurrent
+        // updateSettings landing in that window would be clobbered.
+        // Route the persist through the queue instead: the enqueued
+        // no-op update re-runs getSettings, which re-enters this method
+        // on fresh state inside the critical section (branch above).
+        return await settingsStore.updateSettings({});
     }
 
     // Applies every migration below the current SETTINGS_VERSION in

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -463,45 +463,52 @@ class MigrationsUtils {
     // consolidation: the retired per-migration EncryptedStorage flags
     // are read once so already-applied migrations are not re-applied
     // over values the user has since changed, the needed mutations run
-    // in memory, and a single setSettings persists the result together
-    // with the stamp — migrated values and migration state can no
-    // longer diverge if we crash mid-way. The retired flags are never
-    // written again; leftover entries are inert and cleared by Clear
-    // All Data.
+    // in memory, and a single write (applySettingsUpdate's persist on
+    // the modern path, storageMigrationV2's on the legacy path) lands
+    // the result together with the stamp, so migrated values and
+    // migration state can no longer diverge if we crash mid-way. The
+    // retired flags are never written again; leftover entries are inert
+    // and cleared by Clear All Data.
     //
     // Adding a future migration: bump SETTINGS_VERSION, gate the new
     // mutation on the blob's prior version (settings.settingsVersion ??
     // 0), and leave the existing blocks untouched.
     // ------------------------------------------------------------------
-    public async runSettingsMigrations(settings: any) {
+    public async runSettingsMigrations(
+        settings: any,
+        inQueue: boolean = false
+    ) {
         if ((settings?.settingsVersion ?? 0) >= SETTINGS_VERSION) {
             return settings;
         }
 
-        if (settingsStore.settingsUpdateInProgress) {
-            // Already inside the updateSettings queue's critical section
-            // (applySettingsUpdate -> getSettings -> here): persisting
-            // directly is serialized with every other update, and
-            // enqueueing would deadlock behind the very task awaiting us.
+        if (inQueue) {
+            // Inside the updateSettings queue's critical section
+            // (applySettingsUpdate -> getSettings(fromQueue) -> here):
+            // mutate in memory only. applySettingsUpdate persists right
+            // after this getSettings returns, so the migrated values and
+            // stamp ride that single serialized write; a write of our own
+            // would be redundant, and enqueueing would deadlock behind
+            // the very task awaiting us. The fact arrives as a parameter
+            // because settingsStore.settingsUpdateInProgress only says
+            // some update is in flight somewhere, not that we are on the
+            // queue's call stack.
             await this.applySettingsMigrations(settings);
-
-            // single write: migrated values and stamp land atomically
-            await settingsStore.setSettings(settings);
             return settings;
         }
 
         // Outside the queue `settings` is a snapshot that can go stale
-        // before the write lands (the blob read and the flag reads all
-        // yield), and setSettings overwrites wholesale, so a concurrent
-        // updateSettings landing in that window would be clobbered.
-        // Route the persist through the queue instead: the enqueued
-        // no-op update re-runs getSettings, which re-enters this method
-        // on fresh state inside the critical section (branch above).
+        // before any write lands (the blob read and the flag reads all
+        // yield), and a concurrent updateSettings landing in that window
+        // would be clobbered by persisting it. Never touch the snapshot;
+        // enqueue a no-op update instead: its critical section re-runs
+        // getSettings on fresh state, which re-enters this method through
+        // the inQueue branch above.
         return await settingsStore.updateSettings({});
     }
 
     // Applies every migration below the current SETTINGS_VERSION in
-    // memory and stamps the blob. Does NOT persist — runSettingsMigrations
+    // memory and stamps the blob. Does NOT persist: applySettingsUpdate
     // (modern path) and storageMigrationV2 (legacy path) own the write.
     public async applySettingsMigrations(settings: any): Promise<boolean> {
         const [rgsDone, olympusDone, swapDone, retiredSwapDone, expiryDone] =

--- a/utils/SettingsVersion.ts
+++ b/utils/SettingsVersion.ts
@@ -1,0 +1,8 @@
+// Version stamped into the zeus-settings-v2 blob as settingsVersion.
+// A blob at the current version skips all one-shot settings migrations
+// (see MigrationUtils.runSettingsMigrations); older or unstamped blobs
+// get a single consolidation pass. Lives in its own dependency-free
+// module so tests that must mock stores/SettingsStore (for its React
+// Native imports) still exercise the real constant instead of a
+// hardcoded copy that would keep old gating tests green after a bump.
+export const SETTINGS_VERSION = 1;


### PR DESCRIPTION
# Description

Relates to issue: #4470 (implements the "fold the one-shot migration flags" checkbox).

## Problem

Startup pays for the migration system on every boot (#4470 field report: 9-minute boots on a Galaxy S25 with a degraded KeyMint):

- The modern load path reads **5 EncryptedStorage migration flags on every `getSettings()` call**, and `getSettings()` runs 3+ times per boot, so 15+ serialized keystore touches in steady state, forever.
- A first run after upgrade can add up to 5 full-blob writes + 5 flag writes (two migrations wrote the blob **unconditionally**).
- The legacy upgrade path runs 8 MOD_KEY blocks, each doing flag read → **full-blob `setSettings`** → flag write, before `storageMigrationV2` persists the blob again: ~12 redundant blob writes.

## Design

**Version-stamp the blob content.** `settingsVersion` (new top-level scalar, `SETTINGS_VERSION = 1`, defined in the dependency-free `utils/SettingsVersion.ts` and re-exported from `SettingsStore`) lives in the blob itself:

- **Stamped blob → migrations skipped with zero keystore reads.** The check is on the already-parsed object.
- **Unstamped blob → one-time consolidation:** read the 5 retired flags once (so migrations a previous version already applied are not re-applied over values the user has since changed), apply the needed mutations in memory, and let **a single write** land values + stamp together. The retired flags are never written again; leftovers are inert and cleared by Clear All Data.
- **The consolidation write is serialized through `updateSettingsQueue`.** Queue membership is passed explicitly (`applySettingsUpdate` → `getSettings(fromQueue)` → `runSettingsMigrations(settings, inQueue)`). Inside the queue's critical section the consolidation only mutates in memory; the migrated values and stamp ride the enclosing update's own persist, so there is exactly one blob write. Outside the queue the snapshot is never touched: a no-op `updateSettings({})` is enqueued, and its critical section redoes the consolidation on fresh state. A concurrent settings update (e.g. the biometry-type write on first boot) can never be clobbered by a stale pre-migration snapshot, regardless of what else is in flight.
- **Legacy path:** the 8 MOD_KEY flags are read in one `Promise.all` batch, blocks are pure mutations, and the single persist stays in `storageMigrationV2`. MOD_KEY flags are also never written anymore (after migration the blob is stamped, so they're never consulted again).
- The five shared migrations become pure, individually-tested mutations (`applyRgsDefaultsToV2`, `applyOlympusHostsToZeusLsp`, `applySwapHostsToBoltz`, `applyRetiredSwapHosts`, `applyInvoiceExpiryDisplay`); the orchestrator (`runSettingsMigrations`) owns flag reads and write routing (the write itself belongs to `applySettingsUpdate` on the modern path and `storageMigrationV2` on the legacy path). **Migration logic is byte-for-byte unchanged.**

## Before / after

| | Before | After |
|---|---|---|
| Steady-state load, migrated install | 5 flag reads per `getSettings()`, 15+ keystore touches per boot, forever | **0** (stamp check on the parsed blob) |
| First boot after upgrade | Up to 5 blob writes + 5 flag writes, interleavable with a crash | One pass, **one write** carrying values + stamp |
| Crash mid-migration | Migrated values and done-flags can diverge | Atomic: nothing persists until the single write lands |
| Legacy-blob upgrade | ~12 redundant blob writes | **1** persist (in `storageMigrationV2`) |
| Concurrent update during migration | A mid-migration blob write could silently erase it | Serialized through `updateSettingsQueue` |
| Migration functions | 5 methods, each doing its own storage I/O | 5 pure mutations + 1 orchestrator |
| `SETTINGS_VERSION` in tests | Hardcoded copy inside a jest mock (would pin gating tests to v1 after a bump) | Real constant imported from a dependency-free module |

## Future migrations

Bump `SETTINGS_VERSION`, add one pure mutation to `applySettingsMigrations` gated on the blob's prior version (`priorVersion < 2`), and leave the existing blocks untouched. A blob below the current version runs every admitted block in file order and is re-stamped at the current version in the same single write, so users who skip releases catch up in one pass. Blocks are exactly-once: a gate admits a blob only if it was stamped below that block's version, so earlier blocks never re-run on later upgrades (the v1 blocks are gated too, protecting values a post-stamp user restored). Contracts for new migrations: pure, synchronous, in-memory; value-conditional and idempotent as defense in depth (pre-stamp app downgrades and crash retries still re-run them); gated on version, never on new keystore flags. A gate-consistency test asserts the highest gate equals `SETTINGS_VERSION`, failing CI on a forgotten bump or a bump without a gated block. A version number is frozen once any public build (alphas and TestFlight included) ships stamping it; migrations added after that take a fresh bump. Within that constraint, unreleased migrations may share a bump, as #4475 and #4542 folded into version 1 here.

## Migration plan

| Cohort | Effect |
|---|---|
| Fresh installs | Born stamped (inline defaults include `settingsVersion`); consolidation never runs |
| Current v2 users (flags set) | One consolidation pass: flags honored, nothing re-applied, stamp written in a single write; zero migration I/O afterward |
| v2 users missing some flags (skipped releases) | Un-flagged migrations apply (value-conditional, identical logic), stamp written, one write |
| Legacy-blob upgraders | Same end state as today in **one** persist; MOD_KEY flags from ancient installs still honored |
| iCloud-restored old blob (fresh device) | No stamp, no local flags → all migrations correctly re-run on the restored data. This is **more correct** than flag-based state, which lives apart from the data it describes |
| App downgrade after stamping | Old code ignores the extra field and re-runs its value-conditional migrations (idempotent); re-upgrade re-honors the flags it wrote. Best-effort, as today |

- **Crash mid-migration**: nothing persisted until the single write lands → clean retry next boot. Strictly better than today, where blob writes and flag writes could interleave with a crash.
- **Idempotent**: all mutations are value-conditional; consolidation re-running is harmless.
- **Shallow-merge safety**: `settingsVersion` is a top-level scalar, carried by `updateSettings` spreads; no nested-group hazard.
- **No new keychain keys**; no registry changes apply (`DataClearUtils` wipes EncryptedStorage + blob wholesale already).
- **Revert story**: fully revert-safe. Reverting leaves a harmless extra field in blobs and the retired flags were only read, never removed; old code resumes flag-based behavior exactly where it left off (flags for migrations consolidated in the interim are unset → old code re-applies value-conditional logic, idempotent).

## Relationship to #4475 and #4542

Both landed on master first, so this PR absorbed them per the contingency documented in earlier revisions: the RGS mutation is `applyRgsDefaultsToV2`, carrying master's per-network v1 → v2 URL map verbatim and honoring `rgs-defaults-v2` (the superseded `rgs-default-zeus` flag is deliberately not consulted, matching master); #4542's retired-swap-host migration folded in as `applyRetiredSwapHosts`, honoring `swap-hosts-retired-eldamar`. `SETTINGS_VERSION` stays 1 because neither change shipped in a release before the stamp.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

_Migration suite restructured: mutations are tested pure (all prior domain cases preserved: swap hosts, retired swap hosts, Olympus hosts, expiry-triplet repair, RGS defaults), plus a `runSettingsMigrations` orchestrator suite covering stamp short-circuit, single-write consolidation, retired-flag honoring, queue routing (direct in-queue persist, no stale-snapshot write, concurrent-update clobber repro), object-not-string persistence, and steady-state silence. `stores/SettingsStore.test.ts` now fails loudly if `getSettings` swallows a load error, closing the silent-mock-drift trap._

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

_Device testing round pending; versions will be recorded here._

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

_Settings-load path affects all backends equally; upgrade testing on one embedded + one remote wallet should cover it, versions to be recorded here._

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding


