### PR TITLE
build: harden reproducible-build input pinning (Gradle checksum + dependency locking)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -65,19 +65,6 @@ react {
 def enableProguardInReleaseBuilds = true
 
 /**
- * The preferred build flavor of JavaScriptCore (JSC)
- *
- * For example, to use the international variant, you can use:
- * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
- *
- * The international variant includes ICU i18n library and necessary data
- * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
- * give correct results when using with locales other than en-US. Note that
- * this variant is about 6MiB larger per architecture than default.
- */
-def jscFlavor = 'io.github.nickmartens:jsc-android:2026004.+'
-
-/**
  * Set this to true to create two separate APKs instead of one:
  *   - An APK that only works on ARM devices
  *   - An APK that only works on x86 devices
@@ -274,4 +261,3 @@ protobuf {
         }
     }
 }
-

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -261,3 +261,32 @@ protobuf {
         }
     }
 }
+
+/**
+ * Reproducible builds: lock the release dependency graph.
+ *
+ * Only the release classpaths are locked. They alone decide what ends up in a
+ * shipped APK, and :app is the one project that resolves the full transitive
+ * closure -- project dependencies such as :lndmobile and the autolinked React
+ * Native libraries contribute their external dependencies here. Locking those
+ * projects directly is not an option: they live under node_modules/, which is
+ * gitignored and regenerated on every `yarn install`.
+ *
+ * This complements yarn.lock rather than duplicating it. yarn.lock already
+ * pins every npm package to an exact version and hash; nothing pinned the
+ * Maven side, where direct coordinates are fixed but their transitive closure
+ * was free to drift.
+ *
+ * Lock state: android/app/gradle.lockfile
+ * Regenerate with: ./build.sh --write-locks
+ *
+ * Note this uses Gradle's default lock mode, so a missing lock file resolves
+ * as usual instead of failing the build. Once android/app/gradle.lockfile is
+ * committed, this can be tightened to `dependencyLocking { lockMode =
+ * LockMode.STRICT }` so an unlocked configuration fails closed.
+ */
+configurations.matching {
+    it.name in ['releaseRuntimeClasspath', 'releaseCompileClasspath']
+}.configureEach {
+    resolutionStrategy.activateDependencyLocking()
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,19 @@ buildscript {
         // LN address notifications
         classpath("com.google.gms:google-services:4.3.15")
     }
+
+    // Reproducible builds: lock the resolved build-tool classpath (AGP, the
+    // Kotlin plugin, the React Native Gradle plugin and their transitives) so
+    // the toolchain that produces a release cannot drift between rebuilds.
+    // Several of the classpath entries above are deliberately versionless --
+    // their versions come from the React Native Gradle plugin -- so the lock
+    // file is what actually records what was used.
+    //
+    // Lock state: android/gradle.lockfile
+    // Regenerate with: ./build.sh --write-locks
+    configurations.classpath {
+        resolutionStrategy.activateDependencyLocking()
+    }
 }
 
 allprojects {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/build.sh
+++ b/build.sh
@@ -11,10 +11,16 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-0}"
 # Default options for the Docker command
 TTY_FLAG="-it"
 
+# Regenerate the Gradle dependency lock files instead of just consuming them.
+# Locks are written from inside the pinned builder image on purpose, so the
+# recorded graph matches the toolchain that actually builds releases.
+WRITE_LOCKS=""
+
 # Parse arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --no-tty) TTY_FLAG="" ;; # Remove -it if --no-tty is provided
+        --write-locks) WRITE_LOCKS="--write-locks" ;;
         *) echo "Unknown parameter: $1" && exit 1 ;;
     esac
     shift
@@ -24,10 +30,11 @@ done
 docker run --rm $TTY_FLAG --name $CONTAINER_NAME \
     -e SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH \
     -e GRADLE_USER_HOME=/olympus/zeus/.gradle-cache \
+    -e WRITE_LOCKS="$WRITE_LOCKS" \
     -v "$(pwd):$ZEUS_PATH" $BUILDER_IMAGE bash -c \
      'echo -e "\n\n********************************\n*** Building ZEUS...\n********************************\n" && \
       cd /olympus/zeus ; yarn install --frozen-lockfile && \
-      cd /olympus/zeus/android ; ./gradlew generateCodegenArtifactsFromSchema && ./gradlew app:assembleRelease && \
+      cd /olympus/zeus/android ; ./gradlew $WRITE_LOCKS generateCodegenArtifactsFromSchema && ./gradlew $WRITE_LOCKS app:assembleRelease && \
 
       echo -e "\n\n********************************\n**** APKs and SHA256 Hashes\n********************************\n" && \
       cd /olympus/zeus && \

--- a/docs/ReproducibleBuilds.md
+++ b/docs/ReproducibleBuilds.md
@@ -12,6 +12,38 @@ Reproducible builds are available for Android only right now. You'll need Docker
 
 If you want to install the APK built this way onto your own smartphone, you'll need to sign it yourself (see next section). Note that the first time you install a build made using this procedure, you'll need to uninstall your current version of ZEUS and then install the one built here because certificates will not match. You'll lose your connection details and you'll need to reconfigure ZEUS again to connect to your nodes.
 
+## What is pinned
+
+A rebuild only matches byte for byte if every input is fixed. ZEUS pins them at every layer:
+
+- **Builder image** — `build.sh` references `reactnativecommunity/react-native-android` by digest, not by tag, so the JDK, SDK and NDK inside it cannot move.
+- **Timestamps** — `SOURCE_DATE_EPOCH` is exported into the container (default `0`).
+- **npm dependencies** — every entry in `package.json` is an exact version, and `yarn.lock` records an exact version, tarball URL and integrity hash for each resolved package. `build.sh` installs with `--frozen-lockfile`, so a lockfile that does not match `package.json` fails the build instead of silently re-resolving.
+- **Native libraries** — the embedded LND, LDK Node, CDK and Cashu restore binaries are fetched by `fetch-libraries.sh` and checked against the SHA256 hashes in `fetch-libraries-versions.json`.
+- **Gradle** — the wrapper verifies the Gradle distribution against `distributionSha256Sum`, and dependency locking pins the Maven graph (see below).
+
+Note that the `yarn.lock` files under `zeus_modules/` are not build inputs. Those modules are vendored with their `dist/` output committed to git, so they are pinned by the repository itself; their lockfiles only matter to someone regenerating that output.
+
+## Gradle dependency locking
+
+Direct Maven coordinates are written out in the `build.gradle` files, but their *transitive* closure is resolved at build time and was previously free to drift — Gradle picks the highest version among conflicting requests, so a new release of a transitive dependency could change what a rebuild produced. Dependency locking records the resolved graph so it cannot.
+
+Two lock files are kept:
+
+- `android/gradle.lockfile` — the buildscript classpath (Android Gradle Plugin, Kotlin plugin, React Native Gradle plugin). Several of these are declared without a version, so the lock file is the only record of what was used.
+- `android/app/gradle.lockfile` — `releaseRuntimeClasspath` and `releaseCompileClasspath`, which together determine what ends up in the APK. `:app` resolves the full closure, including the external dependencies contributed by `:lndmobile` and the autolinked React Native libraries.
+
+To regenerate them after changing an Android dependency, run the build with `--write-locks` and commit the result:
+
+```
+./build.sh --write-locks
+git diff --stat android/gradle.lockfile android/app/gradle.lockfile
+```
+
+Locks are generated inside the pinned builder image on purpose, so the recorded graph matches the toolchain that actually builds releases rather than whatever a contributor has installed locally.
+
+A changed lock file in a pull request is a meaningful review signal: it means the Maven graph moved, and the diff shows exactly which coordinates changed.
+
 ## Signing APKs
 
 1. Install signing utilities: `apt-get install -y apksigner`


### PR DESCRIPTION
# Description

Hardens the inputs to our reproducible Android build. Prompted by a review of whether our dependency pinning is airtight; the JS side turned out to be in good shape, the Maven side was not.

**The npm side needed no changes.** Every entry in `package.json` is already an exact version, and `yarn.lock` records an exact version, tarball URL and integrity hash for all 1367 resolved packages — the `^` ranges visible in the lockfile are the *requests* various packages made, not what gets installed. `build.sh` already installs with `--frozen-lockfile`. The `yarn.lock` files under `zeus_modules/` are likewise not build inputs: those modules ship their `dist/` output in git, so they are pinned by the repo itself. This is now written down in the docs so the question does not need re-deriving.

Three gaps are closed here:

**1. The Gradle distribution was unverified.** The wrapper downloaded `gradle-9.3.1-bin.zip` over HTTPS and ran whatever came back — the build tool itself was the one input we never checked. Adds `distributionSha256Sum`. The value was confirmed by downloading the distribution and hashing it, not by trusting the published `.sha256` alone.

**2. The Maven dependency graph could drift.** Direct coordinates are written out in the `build.gradle` files, but their transitive closure was resolved fresh every build, and Gradle picks the highest version among conflicting requests — so a new release of a transitive dependency could change what a rebuild produced with no change on our side. Adds dependency locking for the buildscript classpath and for `:app`'s release classpaths, plus `./build.sh --write-locks` to regenerate the lock files inside the pinned builder image.

Locking `:app` rather than `allprojects` is deliberate: most subprojects live under `node_modules/`, so `lockAllConfigurations` would write lock state into a gitignored directory that `yarn install` recreates. `:app` already resolves the full closure, including the external dependencies contributed by `:lndmobile` and the autolinked React Native libraries.

**3. A dynamic version in `app/build.gradle`.** `jscFlavor` was dead code from the RN template (`hermesEnabled=true`, and it is never referenced from the `dependencies` block), but it carried an `io.github.nickmartens:jsc-android:2026004.+` coordinate. Anyone auditing the build looks for exactly that pattern. Removed. No dynamic `+` coordinates remain in any Android Gradle file.

### Follow-up required before this fully takes effect

**The lock files are not in this PR.** They have to be generated by a `./build.sh --write-locks` run, which needs Docker. This uses Gradle's default lock mode, so until they are committed a missing lock file resolves as usual rather than failing the build — this PR is inert on its own and changes no build output. Once `android/gradle.lockfile` and `android/app/gradle.lockfile` land, this can be tightened to `LockMode.STRICT` to fail closed.

That first `--write-locks` run is also the execution test for the Gradle DSL changes, which I have not been able to run (see Testing below).

Worth flagging for contributors: once the lock files exist, any Android dependency change — including an RN upgrade that shifts the autolinked libraries — will fail the build until the locks are regenerated. That is the intent, and it is documented in `docs/ReproducibleBuilds.md`.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

All four green (`yarn verify`: 54 suites / 1149 tests). No TypeScript, JavaScript or locale files are touched by this PR, so the four PR CI checks exercise nothing that changed here — the meaningful verification is the Gradle one described below.

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

No utility files modified — the diff is Gradle config, a build script and docs.

What was verified:

- The Gradle checksum was confirmed independently: downloaded `gradle-9.3.1-bin.zip` (137 MB) and hashed it. Computed and published both `b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06`.
- `build.sh` `--write-locks` plumbing tested with a stubbed `docker` and a stubbed `gradlew`: unset yields `[app:assembleRelease]`, set yields `[--write-locks app:assembleRelease]`, with no stray empty argument in the unset case. `bash -n` passes; an unknown flag still exits 1.
- `jscFlavor` removal confirmed complete by grep; brace/paren balance checked on both edited Gradle files.

**Not verified, and needs a maintainer with Docker:** the Gradle DSL has not been executed. My environment has no Java, Android SDK or Docker, so I could not run `./gradlew`. The DSL follows the documented Gradle idiom, but a `./build.sh --write-locks` run is needed both to prove it evaluates and to produce the lock files. I did not want to imply otherwise by ticking the platform boxes below.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Not applicable in the usual sense — no app code changes, so there is no runtime behavior to exercise on a device. The build-level equivalent is the `--write-locks` run noted above, which is still outstanding.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

No backend code paths are touched by this PR.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

No user-facing strings added.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

No dependency was added, removed or bumped. `package.json` and `yarn.lock` are untouched; this PR only changes how the existing Maven graph is recorded.

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

`docs/ReproducibleBuilds.md` is updated in this PR: a "What is pinned" section covering every pinned layer, and a "Gradle dependency locking" section covering the `--write-locks` workflow.
