### PR TITLE
backends: LDK: fix settled force-closes stuck as pending

### DIFF
--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -492,8 +492,11 @@ export default class LdkNode {
             string,
             import('../ldknode/LdkNode.d').LightningBalance[]
         >();
+        // claimableOnChannelClose is the normal balance of an OPEN channel, so
+        // it is meaningless for entries in the active list. For a channel that
+        // is no longer active it means the opposite: the close has not been
+        // broadcast/confirmed yet, so the channel is still unresolved.
         for (const lb of balances.lightningBalances) {
-            if (lb.type === 'claimableOnChannelClose') continue;
             if (activeChannelIds.has(lb.channelId)) continue;
             const list = channelLightningBalances.get(lb.channelId) || [];
             list.push(lb);
@@ -530,18 +533,31 @@ export default class LdkNode {
         const pendingForceClosing: any[] = [];
         const waitingClose: any[] = [];
 
+        // A close is cooperative if the node's own closure record says so, or
+        // if every remaining balance entry came from a coop close. The closure
+        // record is the stronger signal: a coop close that has not been
+        // broadcast yet only carries claimableOnChannelClose entries, which
+        // have no source to inspect.
+        const isCoopCloseForChannel = (
+            channelId: string,
+            lbs: import('../ldknode/LdkNode.d').LightningBalance[]
+        ) =>
+            LdkNode.isCooperativeReason(
+                closedChannelMap.get(channelId)?.closureReason
+            ) ||
+            lbs.every(
+                (lb) =>
+                    lb.type === 'claimableAwaitingConfirmations' &&
+                    lb.source === 'coopClose'
+            );
+
         // Cooperative closes with balance entries (claimableAwaitingConfirmations
         // with source: coopClose)
         channelLightningBalances.forEach((lbs, channelId) => {
             // Skip channels whose sweeps have already confirmed
             if (confirmedSweepChannelIds.has(channelId)) return;
 
-            const isCoopClose = lbs.every(
-                (lb) =>
-                    lb.type === 'claimableAwaitingConfirmations' &&
-                    lb.source === 'coopClose'
-            );
-            if (!isCoopClose) return;
+            if (!isCoopCloseForChannel(channelId, lbs)) return;
 
             const totalSats = lbs.reduce(
                 (sum, lb) => sum + lb.amountSatoshis,
@@ -576,12 +592,7 @@ export default class LdkNode {
             if (confirmedSweepChannelIds.has(channelId)) return;
 
             // Skip coop closes (already handled above)
-            const isCoopClose = lbs.every(
-                (lb) =>
-                    lb.type === 'claimableAwaitingConfirmations' &&
-                    lb.source === 'coopClose'
-            );
-            if (isCoopClose) return;
+            if (isCoopCloseForChannel(channelId, lbs)) return;
 
             // Check for pending timelock
             let blocksTilMaturity = 0;
@@ -668,7 +679,21 @@ export default class LdkNode {
             }
         });
 
-        // Closed channels with no balance entries that still need attention
+        // Cooperative closes with no remaining balance entries: keep showing
+        // them as pending briefly so the close stays visible right after it
+        // happens.
+        //
+        // Force closes are deliberately absent here. Reaching this point means
+        // the node reports no lightning balances and no pending sweeps for the
+        // channel, so every claim has settled and the channel belongs in the
+        // closed list: LDK archives a channel monitor only once it is fully
+        // resolved, and keeps reporting what is still claimable for as long as
+        // the monitor exists.
+        //
+        // In particular this must NOT be gated on lastLocalBalanceMsat. That
+        // field records the balance at the moment of close and never changes,
+        // so treating it as an outstanding claim pins settled channels in the
+        // pending list permanently.
         const channelIdsWithBalances = new Set<string>();
         channelLightningBalances.forEach((_, id) =>
             channelIdsWithBalances.add(id)
@@ -680,64 +705,28 @@ export default class LdkNode {
             if (channelIdsWithBalances.has(cc.channelId)) continue;
             // Skip channels that never had a funding tx broadcast
             if (!cc.fundingTxo_txid) continue;
+            if (!LdkNode.isCooperativeReason(cc.closureReason)) continue;
 
-            const isCoop = LdkNode.isCooperativeReason(cc.closureReason);
+            const ageSecs =
+                Math.floor(Date.now() / 1000) - cc.closedAtTimestamp;
+            if (ageSecs > 10 * 60) continue;
+
             const localBalanceSats = cc.lastLocalBalanceMsat
                 ? Math.floor(cc.lastLocalBalanceMsat / 1000)
                 : 0;
 
-            // Cooperative closes: show as pending for 10 minutes
-            if (isCoop) {
-                const ageSecs =
-                    Math.floor(Date.now() / 1000) - cc.closedAtTimestamp;
-                if (ageSecs > 10 * 60) continue;
-
-                pendingClosing.push({
-                    channel: {
-                        remote_pubkey: cc.counterpartyNodeId || '',
-                        channel_point: cc.fundingTxo_txid
-                            ? `${cc.fundingTxo_txid}:${cc.fundingTxo_vout || 0}`
-                            : '',
-                        capacity: (cc.channelCapacitySats || 0).toString(),
-                        local_balance: localBalanceSats.toString(),
-                        remote_balance: '0'
-                    },
-                    closing_txid: ''
-                });
-                continue;
-            }
-
-            // Force closes with non-zero local balance but no balance
-            // entries: commitment tx may not have been broadcast yet.
-            // Skip if sweeps already confirmed — funds are recovered.
-            // Also skip if the closure reason already indicates the
-            // commitment tx confirmed on-chain — if LDK reports no
-            // remaining balances, the sweep has fully settled.
-            const commitmentConfirmed =
-                cc.closureReason?.type === 'commitmentTxConfirmed' ||
-                cc.closureReason?.type === 'counterpartyForceClosed';
-            if (
-                localBalanceSats > 0 &&
-                !confirmedSweepChannelIds.has(cc.channelId) &&
-                !commitmentConfirmed
-            ) {
-                pendingForceClosing.push({
-                    channel: {
-                        remote_pubkey: cc.counterpartyNodeId || '',
-                        channel_point: cc.fundingTxo_txid
-                            ? `${cc.fundingTxo_txid}:${cc.fundingTxo_vout || 0}`
-                            : '',
-                        capacity: (
-                            cc.channelCapacitySats || localBalanceSats
-                        ).toString(),
-                        local_balance: localBalanceSats.toString(),
-                        remote_balance: '0',
-                        pendingClose: true
-                    },
-                    blocks_til_maturity: 0,
-                    closing_txid: ''
-                });
-            }
+            pendingClosing.push({
+                channel: {
+                    remote_pubkey: cc.counterpartyNodeId || '',
+                    channel_point: `${cc.fundingTxo_txid}:${
+                        cc.fundingTxo_vout || 0
+                    }`,
+                    capacity: (cc.channelCapacitySats || 0).toString(),
+                    local_balance: localBalanceSats.toString(),
+                    remote_balance: '0'
+                },
+                closing_txid: ''
+            });
         }
 
         // total_limbo_balance: sats in close-side limbo (cooperative closes
@@ -746,7 +735,6 @@ export default class LdkNode {
         // so ChannelsStore can read it uniformly across backends.
         let totalLimboBalance = new BigNumber(0);
         for (const lb of balances.lightningBalances) {
-            if (lb.type === 'claimableOnChannelClose') continue;
             if (activeChannelIds.has(lb.channelId)) continue;
             totalLimboBalance = totalLimboBalance.plus(lb.amountSatoshis);
         }
@@ -813,13 +801,14 @@ export default class LdkNode {
             return channelBalanceEntries.get(channelId)!;
         };
 
+        // claimableOnChannelClose is the normal balance of an OPEN channel; for
+        // a channel that is no longer active it means the close has not been
+        // broadcast/confirmed yet, so the channel is still unresolved.
         for (const lb of balances.lightningBalances) {
-            if (lb.type === 'claimableOnChannelClose') continue;
             if (activeChannelIds.has(lb.channelId)) continue;
             ensureEntry(lb.channelId).lightningBalances.push(lb);
         }
 
-        const confirmedSweepChannelIds = new Set<string>();
         for (const sb of balances.pendingBalancesFromChannelClosures) {
             if (!sb.channelId || activeChannelIds.has(sb.channelId)) continue;
 
@@ -829,7 +818,6 @@ export default class LdkNode {
                 sb.confirmationHeight != null &&
                 sb.confirmationHeight <= currentBlockHeight
             ) {
-                confirmedSweepChannelIds.add(sb.channelId);
                 continue;
             }
 
@@ -859,28 +847,17 @@ export default class LdkNode {
 
             // Skip channels that still have outstanding balances — they
             // belong in the pending tab until fully swept/confirmed
-            if (hasBalanceEntries) {
-                continue;
-            }
+            if (hasBalanceEntries) continue;
 
-            // Force closes with non-zero local balance but no balance
-            // entries may have unbroadcast commitment transactions —
-            // keep them in pending until funds are recovered.
-            // Allow through if sweeps already confirmed on-chain,
-            // or if the closure reason indicates the commitment tx
-            // already confirmed (funds fully settled by LDK).
-            const commitmentConfirmed =
-                cc.closureReason?.type === 'commitmentTxConfirmed' ||
-                cc.closureReason?.type === 'counterpartyForceClosed';
-            if (
-                !isCoop &&
-                cc.lastLocalBalanceMsat &&
-                cc.lastLocalBalanceMsat > 0 &&
-                !confirmedSweepChannelIds.has(cc.channelId) &&
-                !commitmentConfirmed
-            ) {
-                continue;
-            }
+            // Anything reaching here has no lightning balances and no pending
+            // sweeps, so the node considers every claim settled — LDK archives
+            // a channel monitor only once it is fully resolved, and reports
+            // what remains claimable for as long as the monitor exists.
+            //
+            // lastLocalBalanceMsat is deliberately NOT consulted: it records
+            // the balance at the moment of close and never changes, so using it
+            // to infer outstanding funds pinned settled channels in the pending
+            // list forever.
 
             // Calculate capacity and balance
             const balanceSats = cc.lastLocalBalanceMsat


### PR DESCRIPTION
# Description

A force-closed LDK Node channel could stay in the pending channels list forever, and be excluded from the closed list at the same time.

Found on a real wallet: a channel force-closed **2026-04-28** (~4 months ago), fully settled, was still rendering as a pending force-close.

### Root cause

`getPendingChannels()` and `getClosedChannels()` both treated the closure record's `lastLocalBalanceMsat` as an outstanding claim. It isn't — it's a snapshot of the balance at the moment of close, frozen in the record forever. A channel with a non-zero closing balance stayed pending unless one of two escapes fired:

- **a confirmed sweep entry** from `listBalances()`, which is derived from channel monitors. LDK archives a monitor once the channel is fully resolved, after which no such entry can ever appear again.
- **a `closureReason` of `commitmentTxConfirmed` or `counterpartyForceClosed`** — 2 of the 15 possible closure reasons.

The affected channel closed with `outdatedChannelManager` and its monitor had long been archived, so neither escape was reachable. The control case sits in the same wallet: another channel also closed with `outdatedChannelManager` but with `lastLocalBalanceMsat: 0` appears correctly in the closed list. The frozen historical balance is the only difference.

### Fix

Decide pending vs closed purely from what the node currently reports. No lightning balances and no pending sweeps ⇒ every claim has settled, which LDK guarantees since it keeps reporting what is claimable for as long as the monitor exists.

- Removed the `lastLocalBalanceMsat > 0` gate and the `commitmentConfirmed` allowlist from both methods.
- Stopped filtering `claimableOnChannelClose` for channels **no longer in `listChannels`**. On an open channel it's just the current balance; on a closed one it means the close hasn't been broadcast yet — the real version of the case the old heuristic was reaching for.
- Coop-close detection now also consults the closure record. This is required by the previous point: an unbroadcast coop close carries only `claimableOnChannelClose` entries, which have no `source` to inspect, and would otherwise be misreported as a force close.

### Verification

Measured on the affected wallet by temporarily instrumenting both methods (instrumentation not included in this PR):

| | before | after |
|---|---|---|
| pending force-closing | 2 | 1 |
| closed | 5 | 6 |
| `total_limbo_balance` | 295 503 | 295 503 |

The stale channel moved to closed. The genuinely pending one (force-closed the same day, monitor live, 104 blocks til maturity) correctly stayed pending. The wallet's 11 closure records now partition cleanly into 6 closed + 1 pending + 4 never-funded, with none in both buckets or neither.

`total_limbo_balance` is unchanged, as expected — it is computed from live balances, so the stuck channel never inflated it.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

`backends/` has no test harness. The change was verified against a real LDK Node wallet with the stuck channel, as recorded above.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS — iOS 26.4, iPhone 17 Pro simulator

**Draft:** Android testing still outstanding.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node — ldk-node `v0.7.0-zeus-vss-enhanced.1`, mainnet wallet with 2 open channels and 11 closure records
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Only `backends/LdkNode.ts` is touched, so no other backend is affected.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
