### PR TITLE
Handle LightningAddressStore promise rejections

### DIFF
--- a/stores/LightningAddressStore.ts
+++ b/stores/LightningAddressStore.ts
@@ -146,7 +146,9 @@ export default class LightningAddressStore {
     public deleteAndGenerateNewPreimages = async () => {
         this.loading = true;
         await Storage.setItem(HASHES_STORAGE_STRING, '');
-        this.generatePreimages(true);
+        this.generatePreimages(true).catch((e) =>
+            console.log('Error generating preimages', e)
+        );
     };
 
     @action
@@ -684,13 +686,17 @@ export default class LightningAddressStore {
                     this.localHashes === 0 &&
                     this.lightningAddressType === 'zaplocker'
                 ) {
-                    this.generatePreimages(true);
+                    this.generatePreimages(true).catch((e) =>
+                        console.log('Error generating preimages', e)
+                    );
                 } else if (
                     this.lightningAddress &&
                     new BigNumber(this.availableHashes).lt(50) &&
                     this.lightningAddressType === 'zaplocker'
                 ) {
-                    this.generatePreimages();
+                    this.generatePreimages().catch((e) =>
+                        console.log('Error generating preimages', e)
+                    );
                 }
             });
 
@@ -794,7 +800,9 @@ export default class LightningAddressStore {
             runInAction(() => {
                 this.redeeming = false;
             });
-            this.status(true);
+            this.status(true).catch((e) =>
+                console.log('Error fetching Lightning address status', e)
+            );
         } catch (error) {
             const error_msg = error?.toString();
             runInAction(() => {
@@ -886,7 +894,12 @@ export default class LightningAddressStore {
                     }
 
                     if (!skipStatus) {
-                        this.status(true);
+                        this.status(true).catch((e) =>
+                            console.log(
+                                'Error fetching Lightning address status',
+                                e
+                            )
+                        );
                     }
 
                     return true;
@@ -1155,7 +1168,13 @@ export default class LightningAddressStore {
                         ).then((success: any) => {
                             if (success?.success === true && localNotification)
                                 fireLocalNotification();
-                            if (!skipStatus) this.status(true);
+                            if (!skipStatus)
+                                this.status(true).catch((e) =>
+                                    console.log(
+                                        'Error fetching Lightning address status',
+                                        e
+                                    )
+                                );
                             return;
                         });
                     }
@@ -1177,7 +1196,13 @@ export default class LightningAddressStore {
                                         localNotification
                                     )
                                         fireLocalNotification();
-                                    if (!skipStatus) this.status(true);
+                                    if (!skipStatus)
+                                        this.status(true).catch((e) =>
+                                            console.log(
+                                                'Error fetching Lightning address status',
+                                                e
+                                            )
+                                        );
                                     return;
                                 });
                             }
@@ -1191,7 +1216,13 @@ export default class LightningAddressStore {
                         ).then((success) => {
                             if (success?.success === true && localNotification)
                                 fireLocalNotification();
-                            if (!skipStatus) this.status(true);
+                            if (!skipStatus)
+                                this.status(true).catch((e) =>
+                                    console.log(
+                                        'Error fetching Lightning address status',
+                                        e
+                                    )
+                                );
                             return;
                         });
                     }
@@ -1219,8 +1250,9 @@ export default class LightningAddressStore {
                     item.comment,
                     true,
                     localNotification
-                );
-                return;
+                ).catch((e) => {
+                    console.log('Error redeeming payment', e);
+                });
             }
         } else {
             for (const item of this.paid) {
@@ -1244,7 +1276,9 @@ export default class LightningAddressStore {
             }
         }
         runInAction(() => {
-            this.status(true);
+            this.status(true).catch((e) =>
+                console.log('Error fetching Lightning address status', e)
+            );
             this.redeemingAll = false;
         });
     };
@@ -1271,7 +1305,9 @@ export default class LightningAddressStore {
         }
 
         runInAction(() => {
-            this.status(true);
+            this.status(true).catch((e) =>
+                console.log('Error fetching Lightning address status', e)
+            );
             this.redeemingAll = false;
         });
     };
@@ -1304,7 +1340,7 @@ export default class LightningAddressStore {
                     comment,
                     false,
                     true
-                );
+                ).catch((e) => console.log('Error redeeming payment', e));
             } else {
                 this.lookupAttestations(hash, amount_msat)
                     .then(({ status }: { status?: string }) => {
@@ -1318,6 +1354,8 @@ export default class LightningAddressStore {
                             comment,
                             false,
                             true
+                        ).catch((e) =>
+                            console.log('Error redeeming payment', e)
                         );
                     })
                     .catch((e) =>
@@ -1356,8 +1394,15 @@ export default class LightningAddressStore {
                 runInAction(() => {
                     this.readyToAutomaticallyAccept = true;
                     if (this.socket && this.socket.connected) return;
-                    this.redeemAllOpenPaymentsZaplocker(true);
-                    this.subscribeUpdatesZaplocker();
+                    this.redeemAllOpenPaymentsZaplocker(true).catch((e) =>
+                        console.log('Error redeeming payments', e)
+                    );
+                    this.subscribeUpdatesZaplocker().catch((e) =>
+                        console.log(
+                            'Error subscribing to Lightning address updates',
+                            e
+                        )
+                    );
                 });
             }
             await sleep(3000);
@@ -1366,8 +1411,12 @@ export default class LightningAddressStore {
 
     public prepareToAutomaticallyAcceptCashu = () => {
         if (this.socket && this.socket.connected) return;
-        this.redeemAllOpenPaymentsCashu(true);
-        this.subscribeUpdatesCashu();
+        this.redeemAllOpenPaymentsCashu(true).catch((e) =>
+            console.log('Error redeeming payments', e)
+        );
+        this.subscribeUpdatesCashu().catch((e) =>
+            console.log('Error subscribing to Lightning address updates', e)
+        );
     };
 
     @action

--- a/views/Cashu/ReceiveEcash.tsx
+++ b/views/Cashu/ReceiveEcash.tsx
@@ -155,7 +155,9 @@ export default class ReceiveEcash extends React.Component<
             !lightningAddressHandle &&
             BackendUtils.supportsLightningAddress()
         ) {
-            status();
+            status().catch((e) =>
+                console.log('Error fetching Lightning address status', e)
+            );
         }
 
         this.setState({

--- a/views/LightningAddress/index.tsx
+++ b/views/LightningAddress/index.tsx
@@ -99,7 +99,7 @@ export default class LightningAddress extends React.Component<
 
         const skipStatus = route.params?.skipStatus;
 
-        if (!skipStatus) status();
+        if (!skipStatus) status().catch(this.handleStoreError);
 
         // triggers when loaded from navigation or back action
         navigation.addListener('focus', this.handleFocus);
@@ -114,9 +114,18 @@ export default class LightningAddress extends React.Component<
         if (this.isInitialFocus) {
             this.isInitialFocus = false;
         } else {
-            this.props.LightningAddressStore.status();
+            this.props.LightningAddressStore.status().catch(
+                this.handleStoreError
+            );
         }
     };
+
+    // LightningAddressStore methods record failures in the store's observable
+    // error/error_msg state (which this view renders) and then re-throw, so
+    // fire-and-forget call sites must catch the rejection to avoid an
+    // unhandled promise rejection.
+    private handleStoreError = (error: unknown) =>
+        console.log('LightningAddressStore error', error);
 
     copyLightningAddress = () => {
         const { LightningAddressStore } = this.props;
@@ -320,7 +329,9 @@ export default class LightningAddress extends React.Component<
                                         'views.Settings.LightningAddress.generateNew'
                                     )}
                                     onPress={() =>
-                                        deleteAndGenerateNewPreimages()
+                                        deleteAndGenerateNewPreimages().catch(
+                                            this.handleStoreError
+                                        )
                                     }
                                 />
                             )}
@@ -984,7 +995,11 @@ export default class LightningAddress extends React.Component<
                                                 margin: 15,
                                                 alignItems: 'center'
                                             }}
-                                            onPress={() => status()}
+                                            onPress={() =>
+                                                status().catch(
+                                                    this.handleStoreError
+                                                )
+                                            }
                                         >
                                             <Text
                                                 style={{
@@ -1048,7 +1063,11 @@ export default class LightningAddress extends React.Component<
                                             ListFooterComponent={
                                                 <Spacer height={100} />
                                             }
-                                            onRefresh={() => status()}
+                                            onRefresh={() =>
+                                                status().catch(
+                                                    this.handleStoreError
+                                                )
+                                            }
                                             refreshing={loading}
                                             keyExtractor={(_, index) =>
                                                 `${index}`
@@ -1064,12 +1083,18 @@ export default class LightningAddress extends React.Component<
                                                         lightningAddressType ===
                                                         'zaplocker'
                                                     ) {
-                                                        redeemAllOpenPaymentsZaplocker();
+                                                        redeemAllOpenPaymentsZaplocker().catch(
+                                                            this
+                                                                .handleStoreError
+                                                        );
                                                     } else if (
                                                         lightningAddressType ===
                                                         'cashu'
                                                     ) {
-                                                        redeemAllOpenPaymentsCashu();
+                                                        redeemAllOpenPaymentsCashu().catch(
+                                                            this
+                                                                .handleStoreError
+                                                        );
                                                     }
                                                 }}
                                                 disabled={!isReady}
@@ -1128,7 +1153,10 @@ export default class LightningAddress extends React.Component<
                                                             'Clear local hashes'
                                                         }
                                                         onPress={() =>
-                                                            deleteLocalHashes()
+                                                            deleteLocalHashes().catch(
+                                                                this
+                                                                    .handleStoreError
+                                                            )
                                                         }
                                                         secondary
                                                     />

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -295,7 +295,9 @@ export default class Receive extends React.Component<
             !lightningAddressHandle &&
             BackendUtils.supportsLightningAddress()
         ) {
-            status();
+            status().catch((e) =>
+                console.log('Error fetching Lightning address status', e)
+            );
         }
 
         const { flowLspNotConfigured } = NodeInfoStore.flowLspNotConfigured();

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1288,7 +1288,13 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                         SettingsStore.settings.lightningAddress
                             ?.notifications === 1
                     ) {
-                        LightningAddressStore.updatePushCredentials();
+                        LightningAddressStore.updatePushCredentials().catch(
+                            (e) =>
+                                console.log(
+                                    'Failed to update push credentials',
+                                    e
+                                )
+                        );
                     }
                 } catch (e) {
                     console.error('Lightning address error', e);


### PR DESCRIPTION
# Description

Relates to issue: **#2747**

`LightningAddressStore` methods follow a set-error-observables-then-rethrow pattern: on failure they populate `error`/`error_msg` (which the UI renders via `ErrorMessage`) and then rethrow. Every fire-and-forget call site therefore produced an unhandled promise rejection whenever the ZEUS Pay server was unreachable, including the `status()` calls in `componentDidMount`/`handleFocus` cited in the issue.

This PR keeps the store's rethrow contract (interactive flows like `EditProfile` and wallet startup depend on it) and adds `.catch` handlers at every fire-and-forget call site:

- `views/LightningAddress/index.tsx`: `status()` on mount, focus, tap-to-refresh and pull-to-refresh; the redeem-all buttons; `deleteAndGenerateNewPreimages()`; the dev-only `deleteLocalHashes()` button
- `views/Receive.tsx` / `views/Cashu/ReceiveEcash.tsx`: `status()` on mount
- `views/Wallet/Wallet.tsx`: `updatePushCredentials()` was un-awaited inside a try/catch, so rejections escaped it; it now has its own `.catch` (not an `await`, to avoid adding a network round trip to wallet startup)
- Store-internal fire-and-forget calls: `generatePreimages` from `status()` and `deleteAndGenerateNewPreimages`, the `status(true)` refreshes after redeems, the socket `paid` handler redeem calls, and the `redeemAllOpenPayments*`/`subscribeUpdates*` calls from the auto-accept paths

The Lightning address view routes its catches through a shared `handleStoreError` handler, adopting the pattern from #4168, which covered the `status()` call sites in this view.

Two behavior fixes fall out of this:

1. `redeemAllOpenPaymentsZaplocker` with attestation checking disabled (level 0) had an early `return` inside its loop: it redeemed only the first open payment and skipped the cleanup that resets `redeemingAll`, leaving the view stuck on the loading pattern until the next `status()` call. The loop now processes every payment and always reaches the cleanup, and the per-item `.catch` prevents a single failed redeem from stranding it the same way.
2. A rejected `lookupPreimageAndRedeemZaplocker` in the socket `paid` handler (its `lookupInvoice` fallback path can reject) no longer surfaces as an unhandled rejection.

No user-facing strings or dependencies changed.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

