### PR TITLE
Cashu: don't consume tokens before the self-custody sweep is ready

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2359,6 +2359,7 @@
     "stores.CashuStore.noPaymentRequestAvailable": "No payment request available",
     "stores.CashuStore.invalidMultimintPaymentAmount": "Invalid multimint payment amount. Please use a whole sat amount.",
     "stores.CashuStore.feeExceedsAmt": "Melt fees match or exceed token amount",
+    "stores.CashuStore.selfCustodySweepFailed": "The token was redeemed to your ecash balance at {{mintName}}, but the sweep to self-custody did not complete. Your funds are safe in your ecash balance.",
     "stores.CashuStore.autoSweep": "Cashu auto-sweep",
     "stores.CashuStore.notProperlyConfigured": "Cashu wallet is not properly configured. Please add at least one mint.",
     "stores.CashuStore.errorDiscoveringMints": "Failed to discover mints from Nostr relays",

--- a/stores/CashuStore.test.ts
+++ b/stores/CashuStore.test.ts
@@ -1,0 +1,270 @@
+jest.mock('../stores/Stores', () => ({
+    activityStore: {},
+    connectivityStore: {
+        isOffline: false,
+        start: jest.fn(),
+        onReconnect: jest.fn()
+    }
+}));
+
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+
+jest.mock('../utils/BackendUtils', () => ({
+    __esModule: true,
+    default: {}
+}));
+
+jest.mock('../utils/MigrationUtils', () => ({
+    __esModule: true,
+    default: {}
+}));
+
+jest.mock('../utils/NostrMintBackup', () => ({
+    deriveMintBackupKeypair: jest.fn(),
+    backupMintsToNostr: jest.fn(),
+    restoreMintsFromNostr: jest.fn()
+}));
+
+jest.mock('../utils/NostrUtils', () => ({
+    __esModule: true,
+    default: {}
+}));
+
+jest.mock('@nostr-dev-kit/ndk', () => ({
+    __esModule: true,
+    default: class NDK {},
+    NDKEvent: class NDKEvent {},
+    NDKKind: {}
+}));
+
+jest.mock('react-native-blob-util', () => ({}));
+
+jest.mock('../NavigationService', () => ({
+    __esModule: true,
+    default: {}
+}));
+
+jest.mock('../storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn()
+    }
+}));
+
+jest.mock('./SettingsStore', () => ({
+    __esModule: true,
+    default: class SettingsStore {},
+    DEFAULT_NOSTR_RELAYS: []
+}));
+
+jest.mock('../cashu-cdk', () => ({
+    __esModule: true,
+    default: {
+        isValidToken: jest.fn()
+    }
+}));
+
+import CashuDevKit from '../cashu-cdk';
+import CashuToken from '../models/CashuToken';
+import CashuStore from './CashuStore';
+
+const MINT_URL = 'https://mint.example.com';
+const ENCODED_TOKEN = 'cashuBo2FteBpodHRwczovL21pbnQ';
+const TOKEN_AMT = 1000;
+
+const makeDecoded = () =>
+    new CashuToken({
+        mint: MINT_URL,
+        unit: 'sat',
+        proofs: [
+            {
+                amount: TOKEN_AMT,
+                secret: 'plain-secret',
+                id: '009a1f293253e41e'
+            }
+        ]
+    });
+
+const makeStore = () => {
+    const invoicesStore = {
+        createInvoice: jest.fn()
+    };
+    const store = new CashuStore(
+        {} as any,
+        invoicesStore as any,
+        { channels: [] } as any,
+        {} as any
+    );
+    store.cdkInitialized = true;
+    store.receiveTokenCDK = jest.fn();
+    store.createMeltQuoteCDK = jest.fn();
+    store.meltCDK = jest.fn();
+    store.syncCDKBalances = jest.fn();
+
+    (CashuDevKit.isValidToken as jest.Mock).mockResolvedValue(true);
+
+    return { store, invoicesStore };
+};
+
+describe('CashuStore.claimToken toSelfCustody', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('does not consume the token when invoice creation fails', async () => {
+        const { store, invoicesStore } = makeStore();
+        invoicesStore.createInvoice.mockRejectedValue(
+            new Error('error creating invoice')
+        );
+
+        const result = await store.claimToken(
+            ENCODED_TOKEN,
+            makeDecoded(),
+            true
+        );
+
+        expect(store.receiveTokenCDK).not.toHaveBeenCalled();
+        expect(result.success).toBe(false);
+        expect(result.warningMessage).toBeUndefined();
+    });
+
+    it('does not consume the token when the melt fee probe fails', async () => {
+        const { store, invoicesStore } = makeStore();
+        invoicesStore.createInvoice.mockResolvedValue({
+            paymentRequest: 'lnbc1invoice'
+        });
+        (store.createMeltQuoteCDK as jest.Mock).mockRejectedValue(
+            new Error('mint unreachable')
+        );
+
+        const result = await store.claimToken(
+            ENCODED_TOKEN,
+            makeDecoded(),
+            true
+        );
+
+        expect(store.receiveTokenCDK).not.toHaveBeenCalled();
+        expect(result.success).toBe(false);
+        expect(result.errorMessage).toBe('mint unreachable');
+    });
+
+    it('does not consume the token when fees exceed its amount', async () => {
+        const { store, invoicesStore } = makeStore();
+        invoicesStore.createInvoice.mockResolvedValue({
+            paymentRequest: 'lnbc1invoice'
+        });
+        (store.createMeltQuoteCDK as jest.Mock).mockResolvedValue({
+            fee_reserve: TOKEN_AMT
+        });
+
+        const result = await store.claimToken(
+            ENCODED_TOKEN,
+            makeDecoded(),
+            true
+        );
+
+        expect(store.receiveTokenCDK).not.toHaveBeenCalled();
+        expect(result.success).toBe(false);
+        expect(result.errorMessage).toBe('stores.CashuStore.feeExceedsAmt');
+    });
+
+    it('receives then melts the full amount when there is no fee reserve', async () => {
+        const { store, invoicesStore } = makeStore();
+        invoicesStore.createInvoice.mockResolvedValue({
+            paymentRequest: 'lnbc1invoice'
+        });
+        (store.createMeltQuoteCDK as jest.Mock).mockResolvedValue({
+            fee_reserve: 0
+        });
+        (store.receiveTokenCDK as jest.Mock).mockResolvedValue(TOKEN_AMT);
+
+        const result = await store.claimToken(
+            ENCODED_TOKEN,
+            makeDecoded(),
+            true
+        );
+
+        expect(store.receiveTokenCDK).toHaveBeenCalledTimes(1);
+        expect(invoicesStore.createInvoice).toHaveBeenCalledTimes(1);
+        expect(store.meltCDK).toHaveBeenCalledWith(MINT_URL, 'lnbc1invoice');
+        expect(result).toEqual({ success: true, errorMessage: '' });
+    });
+
+    it('sizes the sweep from the actually received amount, not token face value', async () => {
+        const { store, invoicesStore } = makeStore();
+        invoicesStore.createInvoice
+            .mockResolvedValueOnce({ paymentRequest: 'lnbc1invoice' })
+            .mockResolvedValueOnce({ paymentRequest: 'lnbc2adjusted' });
+        (store.createMeltQuoteCDK as jest.Mock).mockResolvedValue({
+            fee_reserve: 2
+        });
+        // Mint charged 10 sats of input fees on the receive swap
+        (store.receiveTokenCDK as jest.Mock).mockResolvedValue(TOKEN_AMT - 10);
+
+        const result = await store.claimToken(
+            ENCODED_TOKEN,
+            makeDecoded(),
+            true
+        );
+
+        expect(invoicesStore.createInvoice).toHaveBeenCalledTimes(2);
+        expect(invoicesStore.createInvoice.mock.calls[1][0].value).toBe('988');
+        expect(store.meltCDK).toHaveBeenCalledWith(MINT_URL, 'lnbc2adjusted');
+        expect(result.success).toBe(true);
+    });
+
+    it('reports a warning, not a failure, when the sweep fails after the token was received', async () => {
+        const { store, invoicesStore } = makeStore();
+        invoicesStore.createInvoice.mockResolvedValue({
+            paymentRequest: 'lnbc1invoice'
+        });
+        (store.createMeltQuoteCDK as jest.Mock).mockResolvedValue({
+            fee_reserve: 0
+        });
+        (store.receiveTokenCDK as jest.Mock).mockResolvedValue(TOKEN_AMT);
+        (store.meltCDK as jest.Mock).mockRejectedValue(
+            new Error('Payment failed')
+        );
+
+        const result = await store.claimToken(
+            ENCODED_TOKEN,
+            makeDecoded(),
+            true
+        );
+
+        // The receive succeeded, so the value is in the wallet's mint
+        // balance; surfacing this as an error invites a retry that can
+        // only fail with "token already spent"
+        expect(result.success).toBe(true);
+        expect(result.errorMessage).toBe('');
+        expect(result.warningMessage).toBe(
+            'stores.CashuStore.selfCustodySweepFailed'
+        );
+    });
+
+    it('still maps a spent token to the alreadySpent error', async () => {
+        const { store, invoicesStore } = makeStore();
+        invoicesStore.createInvoice.mockResolvedValue({
+            paymentRequest: 'lnbc1invoice'
+        });
+        (store.createMeltQuoteCDK as jest.Mock).mockResolvedValue({
+            fee_reserve: 0
+        });
+        (store.receiveTokenCDK as jest.Mock).mockRejectedValue(
+            new Error('Token already spent')
+        );
+
+        const result = await store.claimToken(
+            ENCODED_TOKEN,
+            makeDecoded(),
+            true
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.errorMessage).toBe('stores.CashuStore.alreadySpent');
+    });
+});

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -5161,7 +5161,10 @@ export default class CashuStore {
                 : undefined;
 
             if (toSelfCustody) {
-                // For toSelfCustody, receive the token first then sweep via melt
+                // Prepare the sweep invoice and fee probe BEFORE receiving
+                // the token: receiving consumes it at the mint, so failures
+                // up to that point must leave the token unclaimed and
+                // retryable
                 const tokenAmt = decoded.getAmount;
 
                 const memo = `${localeString(
@@ -5173,11 +5176,6 @@ export default class CashuStore {
                     routeHints: true,
                     noLsp: true
                 };
-
-                // Pass signing key only when token is P2PK-locked (decoded has proofs)
-
-                await this.receiveTokenCDK(encodedToken, signingKey, mintUrl);
-                await this.syncCDKBalances();
 
                 // Create invoice for sweeping
                 let invoice = await this.invoicesStore.createInvoice({
@@ -5196,48 +5194,83 @@ export default class CashuStore {
                     };
                 }
 
-                // Create melt quote via CDK
+                // Probe the melt fee via CDK
                 const meltQuote = await this.createMeltQuoteCDK(
                     mintUrl,
                     invoice.paymentRequest
                 );
 
-                if (meltQuote.fee_reserve > 0) {
-                    const receiveAmtSat = tokenAmt - meltQuote.fee_reserve;
-                    if (receiveAmtSat <= 0) {
-                        this.loading = false;
-                        return {
-                            success: false,
-                            errorMessage: localeString(
-                                'stores.CashuStore.feeExceedsAmt'
-                            )
-                        };
-                    }
-
-                    // Recreate invoice with adjusted amount
-                    invoice = await this.invoicesStore.createInvoice({
-                        ...invoiceParams,
-                        memo: `${memo} [${localeString(
-                            'views.Cashu.CashuToken.feeAdjusted'
-                        )}]`,
-                        value: receiveAmtSat.toString()
-                    });
-
-                    if (!invoice?.paymentRequest) {
-                        this.loading = false;
-                        return {
-                            success: false,
-                            errorMessage: localeString(
-                                'stores.InvoicesStore.errorCreatingInvoice'
-                            )
-                        };
-                    }
+                if (meltQuote.fee_reserve >= tokenAmt) {
+                    this.loading = false;
+                    return {
+                        success: false,
+                        errorMessage: localeString(
+                            'stores.CashuStore.feeExceedsAmt'
+                        )
+                    };
                 }
 
-                // Melt via CDK to pay the invoice
-                await this.meltCDK(mintUrl, invoice.paymentRequest);
+                // Pass signing key only when token is P2PK-locked (decoded has proofs)
 
-                await this.syncCDKBalances(true); // Include transactions for activity
+                // Point of no return: this consumes the token and credits
+                // the wallet's own balance at the mint
+                const receivedAmt = await this.receiveTokenCDK(
+                    encodedToken,
+                    signingKey,
+                    mintUrl
+                );
+                await this.syncCDKBalances();
+
+                try {
+                    // The mint may credit less than face value (input fees),
+                    // so size the sweep from what was actually received
+                    const receiveAmtSat = receivedAmt - meltQuote.fee_reserve;
+                    if (receiveAmtSat <= 0) {
+                        throw new Error(
+                            localeString('stores.CashuStore.feeExceedsAmt')
+                        );
+                    }
+
+                    if (meltQuote.fee_reserve > 0 || receivedAmt !== tokenAmt) {
+                        // Recreate invoice with adjusted amount
+                        invoice = await this.invoicesStore.createInvoice({
+                            ...invoiceParams,
+                            memo: `${memo} [${localeString(
+                                'views.Cashu.CashuToken.feeAdjusted'
+                            )}]`,
+                            value: receiveAmtSat.toString()
+                        });
+
+                        if (!invoice?.paymentRequest) {
+                            throw new Error(
+                                localeString(
+                                    'stores.InvoicesStore.errorCreatingInvoice'
+                                )
+                            );
+                        }
+                    }
+
+                    // Melt via CDK to pay the invoice
+                    await this.meltCDK(mintUrl, invoice.paymentRequest);
+
+                    await this.syncCDKBalances(true); // Include transactions for activity
+                } catch (sweepError: any) {
+                    // The token is now spent and its value sits in the
+                    // wallet's own balance at the mint, so a failed sweep
+                    // must not read as a failed claim: a retry would only
+                    // hit "token already spent" against our own receive
+                    console.error('CDK claimToken sweep error:', sweepError);
+                    await this.syncCDKBalances(true);
+                    this.loading = false;
+                    return {
+                        success: true,
+                        errorMessage: '',
+                        warningMessage: localeString(
+                            'stores.CashuStore.selfCustodySweepFailed',
+                            { mintName: this.getMintName(mintUrl) }
+                        )
+                    };
+                }
             } else {
                 // Regular receive via CDK
                 await this.receiveTokenCDK(encodedToken, signingKey, mintUrl);

--- a/views/Cashu/CashuToken.tsx
+++ b/views/Cashu/CashuToken.tsx
@@ -563,17 +563,26 @@ export default class CashuTokenView extends React.Component<
                                 )}
                                 onPress={async () => {
                                     this.setState({
-                                        errorMessage: ''
+                                        errorMessage: '',
+                                        warningMessage: ''
                                     });
 
-                                    const { success, errorMessage } =
-                                        await claimToken(
-                                            encodedToken!,
-                                            decoded,
-                                            true
-                                        );
+                                    const {
+                                        success,
+                                        errorMessage,
+                                        warningMessage
+                                    } = await claimToken(
+                                        encodedToken!,
+                                        decoded,
+                                        true
+                                    );
 
-                                    if (success) {
+                                    if (warningMessage) {
+                                        this.setState({
+                                            success,
+                                            warningMessage
+                                        });
+                                    } else if (success) {
                                         this.setState({
                                             success
                                         });


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

Fixes the v13.2.0 reports of "Receive to self-custody" failing with a red "Token has already been spent" error while the token's value shows up in the ecash mint balance, leading users to believe their funds were lost.

## Root cause

`CashuStore.claimToken(toSelfCustody)` ran a non-atomic four-step flow that consumed the token as its very first step:

1. `receiveTokenCDK` (swaps the token into the wallet's own CDK balance at the mint; irreversible)
2. create the sweep invoice on the user's node
3. create a melt quote (fee probe)
4. melt to pay the invoice

Any failure in steps 2-4 (node not ready, mint can't route to a private mobile node, network blips) surfaced as a claim failure, with the claim buttons still enabled. A retry then re-ran step 1 and could only fail with "token already spent" against the wallet's own successful receive from the first attempt. The funds were safe in the mint balance the whole time, but nothing told the user that.

Additionally, the melt amount was computed from the token's face value (`decoded.getAmount`). On mints that charge input fees, the receive credits less than face value, so the melt could fail with insufficient funds every time.

Before the CDK migration (v12.x, cashu-ts) the invoice and melt quote were created before the token proofs were touched, so early failures left the token retryable. This restores that ordering under CDK.

## Changes

- `stores/CashuStore.ts`: prepare the sweep invoice and melt fee probe before receiving the token, so failures up to the point of no return leave the token unclaimed and retryable. The fee-exceeds-amount check also now happens before the receive.
- Size the sweep from the amount actually credited by the receive instead of token face value, fixing the melt on mints with input fees.
- If the sweep fails after the token has been received, return a partial-success warning ("redeemed to your ecash balance at {mint}, sweep did not complete, funds are safe") instead of a retryable error. The `CashuToken` view surfaces it via the existing `WarningMessage` banner and hides the claim buttons, so the "already spent" retry loop can no longer happen.
- `stores/CashuStore.test.ts` (new): regression tests for the ordering, the received-amount sizing, and the partial-success path. 5 of the 7 tests fail against the previous implementation.
- `locales/en.json`: new `stores.CashuStore.selfCustodySweepFailed` string.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

## Device test plan (pending)

1. Happy path: scan a token, "Receive to self-custody", verify LN balance credit and activity entry.
2. Fee-charging mint: same, verify melt succeeds with fee-adjusted amount.
3. Sweep failure: claim with channels that cannot receive (or airplane-mode the node after invoice creation); verify the warning banner names the mint, claim buttons are hidden, and the mint balance shows the funds.
4. Genuinely spent token: verify the "already spent" error still appears.

Follow-ups (out of scope): a manual "sweep mint to self-custody" entry point so stranded balances have a one-tap exit, and an own-wallet check on "already spent" errors after app restart.
