### PR TITLE
ldk-node: bump to v0.7.0-zeus-rl-0.2.5 (rust-lightning v0.2.5 security fixes)

### DIFF
--- a/fetch-libraries-versions.json
+++ b/fetch-libraries-versions.json
@@ -5,9 +5,9 @@
         "iosSha256": "58320b9a3b6de5a92b25405f02ec4bb8e279c657bbf70817a8439fa7e5560168"
     },
     "ldk-node": {
-        "version": "v0.7.0-zeus-vss-enhanced.1",
-        "androidSha256": "30ad5e914488f9e6f3b38b71f74c5042640fcbc019be95269de7b88860de9cc5",
-        "iosSha256": "fe50c9796f91f121ed58bd2aa3970dc2c3048358b750ff5b8fafa3e6a8b50fce"
+        "version": "v0.7.0-zeus-rl-0.2.5",
+        "androidSha256": "322ffdab97fea34844b82d0aea756e28a30c06a3d0873c1ed4f94dab2bf5fe4f",
+        "iosSha256": "649c2c08ff6870220eb8c3871728c9791c40215040a0e9714963130dd0394d98"
     },
     "cdk": {
         "version": "0.17.3",


### PR DESCRIPTION
# Description

Bumps the LDK Node artifact to [v0.7.0-zeus-rl-0.2.5](https://github.com/ZeusLN/ldk-node/releases/tag/v0.7.0-zeus-rl-0.2.5), which re-pins the fork's rust-lightning dependency from a December 2025 snapshot of upstream main onto upstream's maintained 0.2 release branch head (= v0.2.5), with the same three Zeus patches rebased on top (LSPS7 client, cooperative close feerate floor bypass, BOLT11 route hints override).

The old pin was missing every upstream 0.2.1-0.2.5 fix, including both security batches (0.2.3 "Through the Loupe", 0.2.5 "The MegaScan Project"). Because our mobile artifacts build with panic = abort, the missing "no longer panics" fixes are hard app aborts for ZEUS users today. Highlights reachable in ZEUS:

- rust-lightning#4717: a crafted BOLT11 invoice (explicit payee pubkey + non-recovering signature) parses fine but aborts the app when paid. Reachable from paste/QR/LNURL.
- rust-lightning#4716: overflowing route-hint fee aggregates panic when no routing fee cap is set, which is our default when no fee limit is passed.
- rust-lightning#4715: pre-1970 LSPSDateTime from a counterparty LSPS message panics at parse time.
- rust-lightning#4850: onion message with an invalid reply path naming our node as introduction point panics.
- rust-lightning#4849: reorg changing on-chain HTLC claim batching panics during chain sync (crash-loop risk mid-force-close).

Plus the lower-severity fixes from those releases (RGS OOM bound, anchor reserve estimation, LSPS persistence wedge after a single KVStore failure, OutputSweeper future drop, unicode log/UI sanitization, etc.).

Fork PR with the full rebase details: ZeusLN/ldk-node#5

The uniffi FFI surface is unchanged; the committed Kotlin/Swift/TS bindings are untouched. Only the tag and the two artifact sha256s change.

This pull request is categorized as a:

- [x] Bug fix

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations

### Third Party Dependencies and Packages

- [x] Contributors will need to run `yarn` after this PR is merged in (re-fetches the ldk-node artifacts)

### Other:

Both release assets re-downloaded from GitHub and verified against the pinned sha256s. Android .so files confirmed 16KB page-size aligned and confirmed to embed the new rust-lightning revision. Device testing on LDK Node wallets (Android + iOS) still required before undrafting.