### PR TITLE
Track in-flight payments to a terminal state before releasing the send guard

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -815,6 +815,8 @@ export default class CLNRest {
     supportsOnchainReceiving = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;
+    // follow-up: /v1/listpays accepts payment_hash and could support this
+    supportsPaymentLookup = () => false;
     supportsChannelManagement = () => true;
     supportsCircularRebalancing = () => true;
     supportsForceClose = () => false;

--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -125,6 +125,7 @@ export default class EmbeddedLND extends LND {
     getPayments = async (params?: {
         maxPayments?: number;
         reversed?: boolean;
+        creationDateStart?: number;
     }) => await listPayments(params);
     getNewAddress = async (data: any) =>
         await newAddress(
@@ -261,12 +262,22 @@ export default class EmbeddedLND extends LND {
             cltv_limit: data.cltv_limit,
             amp: data.amp
         });
-    // override LND's REST implementation with an on-device lookup
-    lookupPayment = async (data: { payment_hash: string }) => {
-        const response = await listPayments({
-            maxPayments: 50,
-            reversed: true
-        });
+    // override LND's REST implementation with an on-device lookup; a
+    // creation_date_start bound anchors the page at the dispatch time so
+    // newer payments (e.g. the NWC service's) can't evict the target
+    lookupPayment = async (data: {
+        payment_hash: string;
+        creation_date_start?: number;
+    }) => {
+        const response = await listPayments(
+            data.creation_date_start
+                ? {
+                      maxPayments: 50,
+                      reversed: false,
+                      creationDateStart: data.creation_date_start
+                  }
+                : { maxPayments: 50, reversed: true }
+        );
         return (
             response?.payments?.find(
                 (payment: any) =>

--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -261,6 +261,20 @@ export default class EmbeddedLND extends LND {
             cltv_limit: data.cltv_limit,
             amp: data.amp
         });
+    // override LND's REST implementation with an on-device lookup
+    lookupPayment = async (data: { payment_hash: string }) => {
+        const response = await listPayments({
+            maxPayments: 50,
+            reversed: true
+        });
+        return (
+            response?.payments?.find(
+                (payment: any) =>
+                    payment.payment_hash?.toLowerCase() ===
+                    data.payment_hash.toLowerCase()
+            ) ?? null
+        );
+    };
     closeChannel = async (urlParams?: Array<string>) => {
         const fundingTxId = (urlParams && urlParams[0]) || '';
         const outputIndex =

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -535,6 +535,16 @@ export default class LND {
             return response;
         };
 
+        // payment_timed_out marks the outcome as unknown on the node (the
+        // client gave up, not the payment), so the caller can track the
+        // payment to its terminal state instead of reporting failure
+        const timedOutResponse = () => ({
+            payment_error: localeString(
+                'views.SendingLightning.paymentTimedOut'
+            ),
+            payment_timed_out: true
+        });
+
         // The request timeout must exceed the forcedTimeout below, or the
         // generic transport rejection wins the race and the user sees a
         // retryable-looking error instead of the payment-timed-out shape
@@ -547,19 +557,32 @@ export default class LND {
                     allow_self_payment: true
                 },
                 (timeoutSeconds + 5) * 1000
-            );
+            ).catch((err: any) => {
+                // safety net if the transport deadline ever fires first:
+                // a client-side timeout is outcome-unknown, not a failure
+                if (err?.message === 'Request timeout')
+                    return timedOutResponse();
+                throw err;
+            });
 
         const result: any = await Promise.race([
-            forcedTimeout((timeoutSeconds + 1) * 1000, {
-                payment_error: localeString(
-                    'views.SendingLightning.paymentTimedOut'
-                )
-            }),
+            forcedTimeout((timeoutSeconds + 1) * 1000, timedOutResponse()),
             call()
         ]);
 
         return result;
     };
+    // scans the newest payments because LND REST has no non-streaming
+    // per-payment lookup (TrackPaymentV2 streams until terminal)
+    lookupPayment = (data: { payment_hash: string }) =>
+        this.getPayments({ maxPayments: 50, reversed: true }).then(
+            (response: any) =>
+                response?.payments?.find(
+                    (payment: any) =>
+                        payment.payment_hash?.toLowerCase() ===
+                        data.payment_hash.toLowerCase()
+                ) ?? null
+        );
     closeChannel = (urlParams?: Array<string>) => {
         let requestString = `/v1/channels/${urlParams && urlParams[0]}/${
             urlParams && urlParams[1]
@@ -1014,6 +1037,7 @@ export default class LND {
     supportsOnchainReceiving = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;
+    supportsPaymentLookup = () => true;
     supportsChannelManagement = () => true;
     supportsCircularRebalancing = () => true;
     supportsForceClose = () => true;

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -378,7 +378,11 @@ export default class LND {
             route_hints: data.route_hints
         });
     getPayments = (
-        params: { maxPayments?: number; reversed?: boolean } = {
+        params: {
+            maxPayments?: number;
+            reversed?: boolean;
+            creationDateStart?: number;
+        } = {
             maxPayments: 500,
             reversed: true
         }
@@ -388,6 +392,10 @@ export default class LND {
                 params?.maxPayments ? `&max_payments=${params.maxPayments}` : ''
             }&reversed=${
                 params?.reversed !== undefined ? params.reversed : true
+            }${
+                params?.creationDateStart
+                    ? `&creation_date_start=${params.creationDateStart}`
+                    : ''
             }`
         );
 
@@ -572,10 +580,24 @@ export default class LND {
 
         return result;
     };
-    // scans the newest payments because LND REST has no non-streaming
-    // per-payment lookup (TrackPaymentV2 streams until terminal)
-    lookupPayment = (data: { payment_hash: string }) =>
-        this.getPayments({ maxPayments: 50, reversed: true }).then(
+    // scans a payments page because LND REST has no non-streaming
+    // per-payment lookup (TrackPaymentV2 streams until terminal). With a
+    // creation_date_start bound the page is anchored at the dispatch time
+    // (ascending), so newer payments from other clients can't evict the
+    // target; without one, fall back to the newest page.
+    lookupPayment = (data: {
+        payment_hash: string;
+        creation_date_start?: number;
+    }) =>
+        this.getPayments(
+            data.creation_date_start
+                ? {
+                      maxPayments: 50,
+                      reversed: false,
+                      creationDateStart: data.creation_date_start
+                  }
+                : { maxPayments: 50, reversed: true }
+        ).then(
             (response: any) =>
                 response?.payments?.find(
                     (payment: any) =>

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -2178,6 +2178,9 @@ export default class LdkNode {
     supportsOnchainReceiving = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;
+    // follow-up: awaitPaymentCompletion already polls listPayments; a
+    // lookup by hash could resolve payments its timeout leaves pending
+    supportsPaymentLookup = () => false;
     supportsChannelManagement = () => true;
     supportsCircularRebalancing = () => false;
     supportsForceClose = () => true;

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -221,6 +221,17 @@ export default class LightningNodeConnect {
                     params?.reversed !== undefined ? params.reversed : true
             })
             .then((data: lnrpc.ListPaymentsResponse) => snakeize(data));
+    // scans the newest payments; trackPaymentV2 over LNC is a stream and
+    // would need view-level event plumbing
+    lookupPayment = async (data: { payment_hash: string }) =>
+        await this.getPayments({ maxPayments: 50, reversed: true }).then(
+            (response: any) =>
+                response?.payments?.find(
+                    (payment: any) =>
+                        payment.payment_hash?.toLowerCase() ===
+                        data.payment_hash.toLowerCase()
+                ) ?? null
+        );
     getNewAddress = async (data: any) =>
         await this.lnc.lnd.lightning
             .newAddress({
@@ -386,7 +397,11 @@ export default class LightningNodeConnect {
                         resolve({
                             payment_error: localeString(
                                 'views.SendingLightning.paymentTimedOut'
-                            )
+                            ),
+                            // outcome unknown on the node: lets the caller
+                            // track the payment to a terminal state
+                            // instead of reporting failure
+                            payment_timed_out: true
                         })
                     ),
                 timeoutMs
@@ -876,6 +891,7 @@ export default class LightningNodeConnect {
     supportsOnchainReceiving = () => this.permNewAddress;
     supportsLightningSends = () => this.permSendLN;
     supportsKeysend = () => true;
+    supportsPaymentLookup = () => true;
     supportsChannelManagement = () => this.permOpenChannel;
     supportsCircularRebalancing = () => true;
     supportsForceClose = () => true;

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -206,6 +206,7 @@ export default class LightningNodeConnect {
         params: {
             maxPayments?: number;
             reversed?: boolean;
+            creationDateStart?: number;
         } = {
             maxPayments: 500,
             reversed: true
@@ -218,13 +219,30 @@ export default class LightningNodeConnect {
                     max_payments: params.maxPayments
                 }),
                 reversed:
-                    params?.reversed !== undefined ? params.reversed : true
+                    params?.reversed !== undefined ? params.reversed : true,
+                ...(params?.creationDateStart && {
+                    creation_date_start: params.creationDateStart
+                })
             })
             .then((data: lnrpc.ListPaymentsResponse) => snakeize(data));
-    // scans the newest payments; trackPaymentV2 over LNC is a stream and
-    // would need view-level event plumbing
-    lookupPayment = async (data: { payment_hash: string }) =>
-        await this.getPayments({ maxPayments: 50, reversed: true }).then(
+    // scans a payments page; trackPaymentV2 over LNC is a stream and would
+    // need view-level event plumbing. With a creation_date_start bound the
+    // page is anchored at the dispatch time (ascending), so newer payments
+    // from other clients can't evict the target; without one, fall back to
+    // the newest page.
+    lookupPayment = async (data: {
+        payment_hash: string;
+        creation_date_start?: number;
+    }) =>
+        await this.getPayments(
+            data.creation_date_start
+                ? {
+                      maxPayments: 50,
+                      reversed: false,
+                      creationDateStart: data.creation_date_start
+                  }
+                : { maxPayments: 50, reversed: true }
+        ).then(
             (response: any) =>
                 response?.payments?.find(
                     (payment: any) =>

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -206,6 +206,9 @@ export default class LndHub extends LND {
     };
     supportsWatchtowerClient = () => false;
     supportsKeysend = () => false;
+    // the inherited lookupPayment would scan LndHub's /gettxs-shaped
+    // getPayments response, which has no payment_hash/status fields
+    supportsPaymentLookup = () => false;
     supportsChannelManagement = () => false;
     supportsCircularRebalancing = () => false;
     supportsForceClose = () => false;

--- a/backends/NostrWalletConnect.ts
+++ b/backends/NostrWalletConnect.ts
@@ -89,6 +89,7 @@ export default class NostrWalletConnect {
     supportsOnchainReceiving = () => false;
     supportsLightningSends = () => true;
     supportsKeysend = () => false;
+    supportsPaymentLookup = () => false;
     supportsChannelManagement = () => false;
     supportsCircularRebalancing = () => false;
     supportsForceClose = () => false;

--- a/lndmobile/LndMobileInjection.ts
+++ b/lndmobile/LndMobileInjection.ts
@@ -254,6 +254,7 @@ export interface ILndMobileInjections {
         listPayments: (params?: {
             maxPayments?: number;
             reversed?: boolean;
+            creationDateStart?: number;
         }) => Promise<lnrpc.ListPaymentsResponse>;
         subscribeChannelGraph: () => Promise<string>;
         sendKeysendPaymentV2: ({

--- a/lndmobile/index.ts
+++ b/lndmobile/index.ts
@@ -631,6 +631,7 @@ export const listPeers = async (): Promise<lnrpc.ListPeersResponse> => {
 export const listPayments = async (params?: {
     maxPayments?: number;
     reversed?: boolean;
+    creationDateStart?: number;
 }): Promise<lnrpc.ListPaymentsResponse> => {
     const response = await sendCommand<
         lnrpc.IListPaymentsRequest,
@@ -643,7 +644,10 @@ export const listPayments = async (params?: {
         options: {
             include_incomplete: true,
             max_payments: Long.fromValue(params?.maxPayments ?? 1000),
-            ...(params?.reversed && { reversed: params.reversed })
+            ...(params?.reversed && { reversed: params.reversed }),
+            ...(params?.creationDateStart && {
+                creation_date_start: Long.fromValue(params.creationDateStart)
+            })
         }
     });
     return response;

--- a/lndmobile/index.ts
+++ b/lndmobile/index.ts
@@ -386,7 +386,10 @@ export const sendPaymentV2Sync = async (
         forcedTimeout((timeout_seconds + 1) * 1000, {
             payment_error: localeString(
                 'views.SendingLightning.paymentTimedOut'
-            )
+            ),
+            // outcome unknown on the node: lets the caller track the
+            // payment to a terminal state instead of reporting failure
+            payment_timed_out: true
         }),
         call()
     ]);

--- a/stores/TransactionsStore.test.ts
+++ b/stores/TransactionsStore.test.ts
@@ -1,0 +1,272 @@
+jest.mock('../stores/Stores', () => ({}));
+jest.mock('react-native-blob-util', () => ({}));
+jest.mock('bitcoinjs-lib', () => ({}));
+jest.mock('react-native-randombytes', () => ({
+    randomBytes: (n: number) => require('crypto').randomBytes(n)
+}));
+jest.mock('./SettingsStore', () => ({}));
+jest.mock('./NodeInfoStore', () => ({}));
+jest.mock('./ChannelsStore', () => ({}));
+jest.mock('./BalanceStore', () => ({}));
+jest.mock('./ModalStore', () => ({}));
+jest.mock('../utils/BackendUtils', () => ({
+    __esModule: true,
+    default: {
+        payLightningInvoice: jest.fn(),
+        sendKeysend: jest.fn(),
+        lookupPayment: jest.fn(),
+        supportsPaymentLookup: jest.fn(() => true),
+        isLNDBased: jest.fn(() => true)
+    }
+}));
+jest.mock('../utils/Bolt11Utils', () => ({
+    __esModule: true,
+    default: {
+        decode: jest.fn(() => ({ payment_hash: 'ab'.repeat(32) }))
+    }
+}));
+jest.mock('../utils/GraphSyncUtils', () => ({
+    checkGraphSyncBeforePayment: jest.fn(() => true)
+}));
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (s: string) => s
+}));
+jest.mock('../utils/ErrorUtils', () => ({
+    errorToUserFriendly: (error: any) =>
+        typeof error === 'string' ? error : error?.message
+}));
+jest.mock('../utils/UrlUtils', () => ({
+    __esModule: true,
+    default: {}
+}));
+jest.mock('../utils/RatingUtils', () => ({
+    RATING_MODAL_TRIGGER_DELAY: 1000
+}));
+
+import TransactionsStore, {
+    PAYMENT_TRACK_POLL_MS,
+    PAYMENT_TRACK_MAX_FAILURES
+} from './TransactionsStore';
+import BackendUtils from '../utils/BackendUtils';
+
+// 64-char hex: normalizePaymentHash rejects anything that isn't a real hash
+const HASH = 'ab'.repeat(32);
+
+const newStore = () =>
+    new TransactionsStore(
+        { implementation: 'lnd', enableTor: false, settings: {} } as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        { checkAndTriggerRatingModal: jest.fn() } as any
+    );
+
+const flush = () => jest.advanceTimersByTimeAsync(0);
+const advancePoll = () => jest.advanceTimersByTimeAsync(PAYMENT_TRACK_POLL_MS);
+
+describe('TransactionsStore payment tracking (issue #4317)', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.clearAllMocks();
+        (BackendUtils.supportsPaymentLookup as jest.Mock).mockReturnValue(true);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('holds the guard on an IN_FLIGHT result and tracks to SUCCEEDED', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+        // the first lookup fires immediately when tracking starts; the
+        // terminal result lands on the second poll
+        (BackendUtils.lookupPayment as jest.Mock)
+            .mockResolvedValueOnce({ status: 'IN_FLIGHT', payment_hash: HASH })
+            .mockResolvedValueOnce({ status: 'IN_FLIGHT', payment_hash: HASH })
+            .mockResolvedValueOnce({
+                status: 'SUCCEEDED',
+                payment_hash: HASH,
+                payment_preimage: 'deadbeef'
+            });
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+
+        // stream ended non-terminal: guard must stay armed
+        expect(store.paymentInFlight).toBe(true);
+        expect(store.status).toBe('IN_FLIGHT');
+
+        await advancePoll();
+        expect(store.paymentInFlight).toBe(true);
+
+        await advancePoll();
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.status).toBe('SUCCEEDED');
+        expect(store.error).toBe(false);
+    });
+
+    it('treats a client-side timeout as unknown and surfaces the tracked FAILED outcome', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockResolvedValue({
+            payment_error: 'views.SendingLightning.paymentTimedOut',
+            payment_timed_out: true
+        });
+        // hold the first lookup open so the ambiguous state is observable
+        let resolveLookup: (value: any) => void = () => {};
+        (BackendUtils.lookupPayment as jest.Mock).mockReturnValue(
+            new Promise((resolve) => {
+                resolveLookup = resolve;
+            })
+        );
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+
+        // outcome unknown: no error yet, guard held, in-transit UI
+        expect(store.paymentInFlight).toBe(true);
+        expect(store.error).toBe(false);
+        expect(store.status).toBe('IN_FLIGHT');
+
+        resolveLookup({
+            status: 'FAILED',
+            failure_reason: 'FAILURE_REASON_TIMEOUT',
+            payment_hash: HASH
+        });
+        await flush();
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.error).toBe(true);
+        expect(store.status).toBe('FAILED');
+    });
+
+    it('replaces a transport error with success when the payment settled anyway', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockRejectedValue(
+            new Error('connection closed')
+        );
+        (BackendUtils.lookupPayment as jest.Mock).mockResolvedValue({
+            status: 'SUCCEEDED',
+            payment_hash: HASH,
+            payment_preimage: 'deadbeef'
+        });
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.status).toBe('SUCCEEDED');
+        expect(store.error).toBe(false);
+    });
+
+    it('releases the guard when the node has no record of the payment', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockRejectedValue(
+            new Error('invoice is invalid')
+        );
+        (BackendUtils.lookupPayment as jest.Mock).mockResolvedValue(null);
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.error).toBe(true);
+        expect(store.error_msg).toBe('invoice is invalid');
+    });
+
+    it('gives up after consecutive failed lookups and releases the guard', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+        (BackendUtils.lookupPayment as jest.Mock).mockRejectedValue(
+            new Error('node unreachable')
+        );
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+        expect(store.paymentInFlight).toBe(true);
+
+        for (let i = 0; i < PAYMENT_TRACK_MAX_FAILURES; i++) {
+            await advancePoll();
+        }
+        expect(store.paymentInFlight).toBe(false);
+        expect(BackendUtils.lookupPayment).toHaveBeenCalledTimes(
+            PAYMENT_TRACK_MAX_FAILURES
+        );
+    });
+
+    it('keeps the pre-tracking behavior on backends without payment lookup', async () => {
+        (BackendUtils.supportsPaymentLookup as jest.Mock).mockReturnValue(
+            false
+        );
+        (BackendUtils.payLightningInvoice as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.status).toBe('IN_FLIGHT');
+        expect(BackendUtils.lookupPayment).not.toHaveBeenCalled();
+    });
+
+    it('ignores a second send while a tracked payment is unresolved', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+        (BackendUtils.lookupPayment as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+        expect(store.paymentInFlight).toBe(true);
+
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+        expect(BackendUtils.payLightningInvoice).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets an unscoped handlePayment (Rebalance view path) stop tracking and clear the guard', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+        (BackendUtils.lookupPayment as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+        expect(store.paymentInFlight).toBe(true);
+
+        store.handlePayment({
+            status: 'SUCCEEDED',
+            payment_hash: HASH,
+            payment_preimage: 'deadbeef'
+        });
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.status).toBe('SUCCEEDED');
+
+        // the orphaned tracking loop must exit without resurrecting state
+        const calls = (BackendUtils.lookupPayment as jest.Mock).mock.calls
+            .length;
+        await advancePoll();
+        await advancePoll();
+        expect(
+            (BackendUtils.lookupPayment as jest.Mock).mock.calls.length
+        ).toBeLessThanOrEqual(calls + 1);
+        expect(store.paymentInFlight).toBe(false);
+    });
+});

--- a/stores/TransactionsStore.test.ts
+++ b/stores/TransactionsStore.test.ts
@@ -45,7 +45,8 @@ jest.mock('../utils/RatingUtils', () => ({
 
 import TransactionsStore, {
     PAYMENT_TRACK_POLL_MS,
-    PAYMENT_TRACK_MAX_FAILURES
+    PAYMENT_TRACK_MAX_FAILURES,
+    PAYMENT_TRACK_MAX_NOT_FOUND
 } from './TransactionsStore';
 import BackendUtils from '../utils/BackendUtils';
 
@@ -160,7 +161,7 @@ describe('TransactionsStore payment tracking (issue #4317)', () => {
         expect(store.error).toBe(false);
     });
 
-    it('releases the guard when the node has no record of the payment', async () => {
+    it('releases the guard after repeated no-record answers from the node', async () => {
         (BackendUtils.payLightningInvoice as jest.Mock).mockRejectedValue(
             new Error('invoice is invalid')
         );
@@ -170,9 +171,57 @@ describe('TransactionsStore payment tracking (issue #4317)', () => {
         store.sendPayment({ payment_request: 'lnbc1fake' });
         await flush();
 
-        expect(store.paymentInFlight).toBe(false);
+        // the error surfaces immediately, but one no-record answer isn't
+        // proof the dispatch never reached the node (the request may still
+        // be in transit), so the guard stays held
         expect(store.error).toBe(true);
         expect(store.error_msg).toBe('invoice is invalid');
+        expect(store.paymentInFlight).toBe(true);
+
+        for (let i = 0; i < PAYMENT_TRACK_MAX_NOT_FOUND - 1; i++) {
+            await advancePoll();
+        }
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.error).toBe(true);
+        expect(BackendUtils.lookupPayment).toHaveBeenCalledTimes(
+            PAYMENT_TRACK_MAX_NOT_FOUND
+        );
+        // lookups are bounded to payments created around dispatch, so a
+        // busy node's newer payments can't evict ours from the page
+        expect(BackendUtils.lookupPayment).toHaveBeenCalledWith({
+            payment_hash: HASH,
+            creation_date_start: expect.any(Number)
+        });
+    });
+
+    it('keeps tracking when a no-record answer precedes the payment appearing', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockRejectedValue(
+            new Error('connection closed')
+        );
+        // the dispatch request was still in transit when the first lookup
+        // answered; the payment then appears and settles
+        (BackendUtils.lookupPayment as jest.Mock)
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ status: 'IN_FLIGHT', payment_hash: HASH })
+            .mockResolvedValueOnce({
+                status: 'SUCCEEDED',
+                payment_hash: HASH,
+                payment_preimage: 'deadbeef'
+            });
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+        expect(store.paymentInFlight).toBe(true);
+
+        await advancePoll();
+        expect(store.paymentInFlight).toBe(true);
+        expect(store.status).toBe('IN_FLIGHT');
+
+        await advancePoll();
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.status).toBe('SUCCEEDED');
+        expect(store.error).toBe(false);
     });
 
     it('gives up after consecutive failed lookups and releases the guard', async () => {

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -41,6 +41,14 @@ export const PAYMENT_TRACK_MAX_MS = 10 * 60 * 1000;
 // consecutive failed lookups tolerated before giving up and releasing the
 // guard the way the timed backstop used to
 export const PAYMENT_TRACK_MAX_FAILURES = 3;
+// consecutive "node answered, no record" results required before concluding
+// the dispatch never reached the node: a single lookup can miss a payment
+// whose dispatch request is still in transit (e.g. a slow Tor circuit)
+export const PAYMENT_TRACK_MAX_NOT_FOUND = 3;
+// how far before the recorded dispatch time lookupPayment's
+// creation_date_start filter reaches, to absorb clock skew between the
+// device and the node
+export const PAYMENT_LOOKUP_CREATION_SLACK_MS = 10 * 60 * 1000;
 
 export interface SendPaymentReq {
     payment_request?: string;
@@ -106,6 +114,9 @@ export default class TransactionsStore {
     // payment hash (hex) of the guard-owning payment, when known; lets an
     // ambiguous outcome be tracked to a terminal state via lookupPayment
     private inFlightPaymentHash: string | null = null;
+    // when the guard-owning payment was dispatched (ms); bounds lookupPayment
+    // scans so a busy node's newer payments can't evict ours from the page
+    private inFlightDispatchTime: number | null = null;
     // sequence currently being tracked to a terminal state (null when none)
     private trackingSeq: number | null = null;
 
@@ -135,6 +146,7 @@ export default class TransactionsStore {
         this.paymentInFlight = false;
         this.inFlightOwnerSeq = null;
         this.inFlightPaymentHash = null;
+        this.inFlightDispatchTime = null;
         this.error = false;
         this.error_msg = null;
         this.transactions = [];
@@ -623,6 +635,7 @@ export default class TransactionsStore {
             this.paymentInFlight = true;
             this.inFlightOwnerSeq = seq;
             this.inFlightPaymentHash = null;
+            this.inFlightDispatchTime = Date.now();
         }
         this.paymentStartTime = Date.now();
         this.paymentDuration = null;
@@ -761,6 +774,7 @@ export default class TransactionsStore {
         this.paymentInFlight = false;
         this.inFlightOwnerSeq = null;
         this.inFlightPaymentHash = null;
+        this.inFlightDispatchTime = null;
     };
 
     // true when payment `seq` still owns the guard and its terminal state
@@ -797,16 +811,32 @@ export default class TransactionsStore {
         if (this.trackingSeq === seq) return;
         const payment_hash = this.inFlightPaymentHash;
         if (!payment_hash) return;
+        // bound the scan to payments created around dispatch, so a not-found
+        // answer means "no record" rather than "evicted from the newest page
+        // by other clients' payments" (the guard only serializes this app's
+        // sends, not a shared node's)
+        const creation_date_start = this.inFlightDispatchTime
+            ? Math.max(
+                  0,
+                  Math.floor(
+                      (this.inFlightDispatchTime -
+                          PAYMENT_LOOKUP_CREATION_SLACK_MS) /
+                          1000
+                  )
+              )
+            : undefined;
         this.trackingSeq = seq;
         const deadline = Date.now() + PAYMENT_TRACK_MAX_MS;
         let failures = 0;
+        let notFound = 0;
         try {
             while (this.inFlightOwnerSeq === seq && Date.now() < deadline) {
                 let payment: any = null;
                 let lookupFailed = false;
                 try {
                     payment = await BackendUtils.lookupPayment({
-                        payment_hash
+                        payment_hash,
+                        creation_date_start
                     });
                 } catch (e) {
                     lookupFailed = true;
@@ -830,15 +860,21 @@ export default class TransactionsStore {
 
                 if (payment) {
                     failures = 0;
+                    notFound = 0;
                     if (status === 'IN_FLIGHT') {
                         // outcome is pending, not failed: don't leave a
                         // stale timeout/transport error on screen
                         this.markPaymentInTransit();
                     }
                 } else if (!lookupFailed) {
-                    // the node answered and has no record of the payment:
-                    // the dispatch never reached it, nothing can settle
-                    return;
+                    // the node answered and has no record of the payment.
+                    // One such answer isn't proof the dispatch never reached
+                    // it: the send request may still be in transit (a slow
+                    // Tor circuit can deliver it after a fresh-connection
+                    // lookup returns). Only conclude never-dispatched after
+                    // repeated no-record answers with no sighting between.
+                    failures = 0;
+                    if (++notFound >= PAYMENT_TRACK_MAX_NOT_FOUND) return;
                 } else if (++failures >= PAYMENT_TRACK_MAX_FAILURES) {
                     return;
                 }

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -17,6 +17,8 @@ import Base64Utils from '../utils/Base64Utils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { checkGraphSyncBeforePayment } from '../utils/GraphSyncUtils';
+import { deriveExpectedPaymentHash } from '../utils/LncPayUtils';
+import { sleep } from '../utils/SleepUtils';
 import UrlUtils from '../utils/UrlUtils';
 import { RATING_MODAL_TRIGGER_DELAY } from '../utils/RatingUtils';
 
@@ -29,6 +31,16 @@ import ModalStore from './ModalStore';
 const keySendPreimageType = '5482373484';
 const keySendMessageType = '34349334';
 const preimageByteLength = 32;
+
+// how often to poll lookupPayment while a payment's outcome is unknown
+export const PAYMENT_TRACK_POLL_MS = 5000;
+// ceiling on how long tracking may hold the send guard: a stuck HTLC can
+// pend until CLTV expiry (hours), and holding the guard that long would
+// lock the user out of all sends
+export const PAYMENT_TRACK_MAX_MS = 10 * 60 * 1000;
+// consecutive failed lookups tolerated before giving up and releasing the
+// guard the way the timed backstop used to
+export const PAYMENT_TRACK_MAX_FAILURES = 3;
 
 export interface SendPaymentReq {
     payment_request?: string;
@@ -91,6 +103,11 @@ export default class TransactionsStore {
     // NWC payment finishing while a user payment is still in flight)
     // can't disarm each other's guard
     private inFlightOwnerSeq: number | null = null;
+    // payment hash (hex) of the guard-owning payment, when known; lets an
+    // ambiguous outcome be tracked to a terminal state via lookupPayment
+    private inFlightPaymentHash: string | null = null;
+    // sequence currently being tracked to a terminal state (null when none)
+    private trackingSeq: number | null = null;
 
     settingsStore: SettingsStore;
     nodeInfoStore: NodeInfoStore;
@@ -117,6 +134,7 @@ export default class TransactionsStore {
         this.loading = false;
         this.paymentInFlight = false;
         this.inFlightOwnerSeq = null;
+        this.inFlightPaymentHash = null;
         this.error = false;
         this.error_msg = null;
         this.transactions = [];
@@ -604,6 +622,7 @@ export default class TransactionsStore {
         if (!background) {
             this.paymentInFlight = true;
             this.inFlightOwnerSeq = seq;
+            this.inFlightPaymentHash = null;
         }
         this.paymentStartTime = Date.now();
         this.paymentDuration = null;
@@ -691,14 +710,28 @@ export default class TransactionsStore {
             data.timeout_seconds = Number(timeout_seconds) || 60;
         }
 
+        // Record the dispatched payment's hash (lowercase hex) so an
+        // ambiguous outcome can be tracked to a terminal state. Undefined
+        // for AMP payments, which settle under per-attempt hashes and stay
+        // on the timed backstop.
+        if (!background) {
+            this.inFlightPaymentHash =
+                deriveExpectedPaymentHash({
+                    payment_hash: data.payment_hash,
+                    payment_request,
+                    amp
+                }) || null;
+        }
+
         // Backstop for the in-flight guard: if the completion callback is
         // lost (e.g. a dropped LNC stream, or a hung request on a backend
         // that gets no timeout_seconds), the flag would otherwise stay set
-        // and block all sends until the next reconnect. Clear it once the
-        // payment's timeout plus a grace period has elapsed.
+        // and block all sends until the next reconnect. Once the payment's
+        // timeout plus a grace period has elapsed, try to observe the
+        // payment's actual terminal state before releasing the flag.
         if (!background) {
             const backstopMs = ((data.timeout_seconds ?? 300) + 60) * 1000;
-            setTimeout(() => this.clearPaymentInFlight(seq), backstopMs);
+            setTimeout(() => this.backstopPaymentInFlight(seq), backstopMs);
         }
 
         const payFunc =
@@ -727,6 +760,107 @@ export default class TransactionsStore {
         if (seq !== undefined && this.inFlightOwnerSeq !== seq) return;
         this.paymentInFlight = false;
         this.inFlightOwnerSeq = null;
+        this.inFlightPaymentHash = null;
+    };
+
+    // true when payment `seq` still owns the guard and its terminal state
+    // can be observed via lookupPayment on the active backend
+    private canTrackPayment = (seq: number) =>
+        this.inFlightOwnerSeq === seq &&
+        !!this.inFlightPaymentHash &&
+        !!BackendUtils.supportsPaymentLookup();
+
+    // Fires when the backstop timer elapses without a completion callback
+    // having cleared the guard (dropped LNC stream, hung request). Rather
+    // than blindly releasing the guard while an HTLC may still settle, try
+    // to track the payment to its terminal state first.
+    private backstopPaymentInFlight = (seq: number) => {
+        if (this.inFlightOwnerSeq !== seq) return;
+        if (this.trackingSeq === seq) return; // tracking owns the release
+        if (this.canTrackPayment(seq)) {
+            this.trackPaymentToTerminal(seq);
+        } else {
+            this.clearPaymentInFlight(seq);
+        }
+    };
+
+    // Polls lookupPayment until the guard-owning payment reaches SUCCEEDED
+    // or FAILED, then surfaces the real outcome through handlePayment
+    // (which also releases the guard). This closes the double-pay window
+    // left by releasing the guard on timers while HTLCs are still pending:
+    // a keysend retry generates a fresh preimage, so node-side same-hash
+    // dedup can't protect against it (issue #4317). Exits released: on a
+    // terminal state, when the payment provably never reached the node,
+    // after PAYMENT_TRACK_MAX_FAILURES unobservable polls, or at the
+    // PAYMENT_TRACK_MAX_MS ceiling.
+    private trackPaymentToTerminal = async (seq: number) => {
+        if (this.trackingSeq === seq) return;
+        const payment_hash = this.inFlightPaymentHash;
+        if (!payment_hash) return;
+        this.trackingSeq = seq;
+        const deadline = Date.now() + PAYMENT_TRACK_MAX_MS;
+        let failures = 0;
+        try {
+            while (this.inFlightOwnerSeq === seq && Date.now() < deadline) {
+                let payment: any = null;
+                let lookupFailed = false;
+                try {
+                    payment = await BackendUtils.lookupPayment({
+                        payment_hash
+                    });
+                } catch (e) {
+                    lookupFailed = true;
+                }
+                if (this.inFlightOwnerSeq !== seq) return;
+
+                // embedded-lnd statuses are numeric protobuf enums
+                const status =
+                    typeof payment?.status === 'number'
+                        ? lnrpc.Payment.PaymentStatus[payment.status]
+                        : payment?.status;
+
+                if (status === 'SUCCEEDED' || status === 'FAILED') {
+                    // clear any transport error shown while the outcome
+                    // was unknown; handlePayment re-derives error state
+                    // from the payment's actual terminal result
+                    this.clearPaymentError();
+                    this.handlePayment(payment, seq);
+                    return;
+                }
+
+                if (payment) {
+                    failures = 0;
+                    if (status === 'IN_FLIGHT') {
+                        // outcome is pending, not failed: don't leave a
+                        // stale timeout/transport error on screen
+                        this.markPaymentInTransit();
+                    }
+                } else if (!lookupFailed) {
+                    // the node answered and has no record of the payment:
+                    // the dispatch never reached it, nothing can settle
+                    return;
+                } else if (++failures >= PAYMENT_TRACK_MAX_FAILURES) {
+                    return;
+                }
+                await sleep(PAYMENT_TRACK_POLL_MS);
+            }
+        } finally {
+            this.trackingSeq = null;
+            this.clearPaymentInFlight(seq);
+        }
+    };
+
+    @action
+    private clearPaymentError = () => {
+        this.error = false;
+        this.error_msg = null;
+        this.payment_error = null;
+    };
+
+    @action
+    private markPaymentInTransit = () => {
+        this.clearPaymentError();
+        this.status = 'IN_FLIGHT';
     };
 
     public sendPaymentSilently = async ({
@@ -780,6 +914,31 @@ export default class TransactionsStore {
     @action
     public handlePayment = (result: any, seq?: number) => {
         this.loading = false;
+
+        const implementation = this.settingsStore.implementation;
+
+        // TODO modify enum settings for embedded LND
+        const status =
+            implementation === 'embedded-lnd'
+                ? lnrpc.Payment.PaymentStatus[result.status]
+                : result.status;
+
+        // A non-terminal result (the send stream ended while HTLCs are
+        // still pending) or a client-side timeout (outcome unknown on the
+        // node) must not release the double-submission guard: a keysend
+        // retry generates a fresh preimage and can double-pay if the
+        // original HTLC later settles. Hold the guard and track the
+        // payment to its terminal state instead (issue #4317).
+        if (
+            seq !== undefined &&
+            (status === 'IN_FLIGHT' || result.payment_timed_out) &&
+            this.canTrackPayment(seq)
+        ) {
+            this.status = 'IN_FLIGHT';
+            this.trackPaymentToTerminal(seq);
+            return;
+        }
+
         this.clearPaymentInFlight(seq);
         this.payment_route = result.payment_route;
 
@@ -789,14 +948,6 @@ export default class TransactionsStore {
         this.payment_hash = payment.paymentHash;
         this.payment_fee = payment.getFee;
         this.isIncomplete = payment.isIncomplete;
-
-        const implementation = this.settingsStore.implementation;
-
-        // TODO modify enum settings for embedded LND
-        const status =
-            implementation === 'embedded-lnd'
-                ? lnrpc.Payment.PaymentStatus[result.status]
-                : result.status;
 
         const isKeysend =
             result?.htlcs?.[0]?.route?.hops?.[0]?.custom_records?.[
@@ -854,7 +1005,17 @@ export default class TransactionsStore {
     public handlePaymentError = (err: Error, seq?: number) => {
         this.error = true;
         this.loading = false;
-        this.clearPaymentInFlight(seq);
+        // A rejected dispatch (dropped connection, Tor timeout) doesn't
+        // prove the payment failed on the node: the request may have gone
+        // through before transport was lost. Surface the error, but verify
+        // via lookup before releasing the double-submission guard; if the
+        // payment turns out to be pending or terminal after all, the
+        // tracker replaces this error with the real outcome.
+        if (seq !== undefined && this.canTrackPayment(seq)) {
+            this.trackPaymentToTerminal(seq);
+        } else {
+            this.clearPaymentInFlight(seq);
+        }
         this.error_msg =
             errorToUserFriendly(err) || localeString('error.sendingPayment');
     };

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -95,6 +95,7 @@ class BackendUtils {
     getInvoices = (...args: any[]) => this.call('getInvoices', args);
     createInvoice = (...args: any[]) => this.call('createInvoice', args);
     getPayments = (...args: any[]) => this.call('getPayments', args);
+    lookupPayment = (...args: any[]) => this.call('lookupPayment', args);
     getNewAddress = (...args: any[]) => this.call('getNewAddress', args);
     getNewChangeAddress = (...args: any[]) =>
         this.call('getNewChangeAddress', args);
@@ -221,6 +222,7 @@ class BackendUtils {
     supportsOnchainReceiving = () => this.call('supportsOnchainReceiving');
     supportsLightningSends = () => this.call('supportsLightningSends');
     supportsKeysend = () => this.call('supportsKeysend');
+    supportsPaymentLookup = () => this.call('supportsPaymentLookup');
     supportsChannelManagement = () => this.call('supportsChannelManagement');
     supportsCircularRebalancing = () =>
         this.call('supportsCircularRebalancing');


### PR DESCRIPTION
# Description

Relates to issue: **#4317** (fixes)
Fixes issue: **#2577** (a held payment was indistinguishable from a failed one, so users retried and double-paid; client-side timeouts now surface the in-transit screen and are tracked to their real outcome)
Fixes issue: **#2467** (LNC payment showed a failure with a retry button while it had actually settled, and the retry double-paid; the LNC stream-death timeout marker plus lookup tracking here holds the send guard and resolves the payment to its real outcome)
Relates to issue: **#1865** (hold invoice payments on embedded LND stuck on "sending": the timeout marker plus tracking here surfaces the in-transit screen and follows the payment to its real outcome)

PR #4301 added a `paymentInFlight` guard against accidental double-submission, but the guard was released by `handlePayment` on non-terminal (`IN_FLIGHT`) results, by `handlePaymentError` on client-side timeouts and transport errors, and by a blind timed backstop. In all three cases an HTLC may still settle after release, and a keysend retry generates a fresh preimage, so node-side same-hash dedup cannot prevent a double-pay.

This PR holds the guard through ambiguity and actively tracks the payment to a terminal state, as proposed in the issue:

- **New `lookupPayment({ payment_hash })` backend method** on `lnd` (REST), `embedded-lnd`, and `lightning-node-connect`, gated by a new `supportsPaymentLookup` flag. All three scan the newest 50 payments (`include_incomplete`), since LND REST's only per-payment query (`TrackPaymentV2`) is a stream. `LndHub` explicitly overrides the flag to `false` (inheritance hazard); `cln-rest`, `ldk-node`, and `nostr-wallet-connect` are explicit `false` with follow-up notes (CLN's `/v1/listpays` accepts `payment_hash` and could support this later).
- **`TransactionsStore.trackPaymentToTerminal`**: polls `lookupPayment` every 5s until `SUCCEEDED`/`FAILED`, then surfaces the real outcome through `handlePayment` (which releases the guard and flips the SendingLightning screen to the true success/failure state). Exits with the guard released: on a terminal state, when the node answers that it has no record of the payment (dispatch never reached it), after 3 consecutive unobservable lookups, or at a 10-minute ceiling (a stuck HTLC can pend until CLTV expiry; holding the guard that long would lock the user out of all sends).
- **Client-side timeouts are now outcome-unknown, not failures**: the forced-timeout shapes in `LND.payLightningInvoice`, lndmobile's `sendPaymentV2Sync`, and LNC's stream-death resolution gain a `payment_timed_out: true` marker; `restReq`'s `Request timeout` rejection is normalized to the same shape as a safety net (with master's +5s transport headroom the forced timeout normally wins the race). On lookup-capable backends these now show the in-transit screen and get tracked instead of showing "Payment timed out" while the node may still be paying. The `payment_error` string is unchanged, so existing consumers (donation flow, NWC service string-match) behave as before.
- **Rejected dispatches are verified before release**: `handlePaymentError` still surfaces the error immediately, but on lookup-capable backends it verifies against the node before releasing the guard. If the payment turns out to be pending, the UI flips to in-transit; if it settled anyway (e.g. Tor connection dropped after the request went through), it flips to the real success outcome. Genuine pre-dispatch errors release after a single lookup round-trip.
- **The timed backstop remains** for lost completion callbacks and non-lookup backends, but where lookup is available it now attempts observation instead of blindly clearing. Together with the marker on LNC's stream-death shape, this gives LNC dropped-stream payments a real terminal observation path for the guard.
- AMP payments settle under per-attempt hashes, so they remain untrackable and keep the timed backstop. The tracked hash is derived with `deriveExpectedPaymentHash` from `utils/LncPayUtils.ts`, reusing the correlation logic that landed with the LNC payment fix rather than duplicating it.

Review questions:
1. Is the 10-minute tracking ceiling the right balance between double-pay protection and not locking the user out of unrelated sends? (The old backstop was `timeout_seconds + 60s`.)
2. While a tracked payment is unresolved, other sends are silently ignored by the guard, same as before but potentially for longer; the in-transit screen is showing during this time. The disabled-state work in #4404 complements this.

Lays groundwork for #4286 (first-class `lookupPayment` for the NWC service's payment scans).

New unit test suite `stores/TransactionsStore.test.ts` (8 tests) covers: guard held on `IN_FLIGHT` and tracked to `SUCCEEDED`, timeout marker tracked to `FAILED`, transport error replaced by tracked success, release when the node has no record, give-up after consecutive failed lookups, unchanged behavior on non-lookup backends, second send ignored while tracking, and the unscoped LNC view path stopping the tracker.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

Device tests pending: LND REST (clearnet + Tor, keysend + invoice, forced timeout), embedded LND, and LNC dropped-stream scenarios.




