### PR TITLE
cashu: serialize full CDK transactions and surface CDK-recorded melts

### DIFF
--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -1636,8 +1636,10 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
         scope.launch {
             try {
-                val txDirection = direction?.let {
-                    if (it == "incoming") TransactionDirection.INCOMING else TransactionDirection.OUTGOING
+                val txDirection = when (direction) {
+                    "incoming" -> TransactionDirection.INCOMING
+                    "outgoing" -> TransactionDirection.OUTGOING
+                    else -> null
                 }
 
                 val transactions = db!!.listTransactions(
@@ -1649,13 +1651,27 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                 val result = JSONArray()
                 transactions.forEach { tx ->
                     val txJson = JSONObject().apply {
-                        put("id", tx.id.toString())
+                        put("id", tx.id.hex)
                         put("direction", if (tx.direction == TransactionDirection.INCOMING) "incoming" else "outgoing")
                         put("amount", tx.amount.value.toLong())
                         put("mint_url", tx.mintUrl.url)
                         put("timestamp", tx.timestamp)
-                        tx.fee?.let { put("fee", it.value.toLong()) }
+                        put("fee", tx.fee.value.toLong())
+                        put("unit", currencyUnitToString(tx.unit))
                         tx.memo?.let { put("memo", it) }
+                        tx.quoteId?.let { put("quote_id", it) }
+                        tx.paymentRequest?.let { put("payment_request", it) }
+                        tx.paymentProof?.let { put("payment_proof", it) }
+                        tx.paymentMethod?.let {
+                            put(
+                                "payment_method",
+                                when (it) {
+                                    is PaymentMethod.Bolt11 -> "bolt11"
+                                    is PaymentMethod.Bolt12 -> "bolt12"
+                                    is PaymentMethod.Custom -> it.method
+                                }
+                            )
+                        }
                     }
                     result.put(txJson)
                 }

--- a/cashu-cdk/types.ts
+++ b/cashu-cdk/types.ts
@@ -192,8 +192,14 @@ export interface CDKTransaction {
     fee?: number;
     mint_url: string;
     timestamp: number;
+    unit?: string;
     memo?: string;
-    state: string;
+    quote_id?: string;
+    payment_request?: string;
+    payment_proof?: string;
+    payment_method?: string;
+    // lifecycle status; absent until CDK 0.18 (all records are then completed)
+    state?: string;
 }
 
 // ============================================================================

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -1522,8 +1522,10 @@ class CashuDevKitModule: RCTEventEmitter {
         Task {
             do {
                 var txDirection: TransactionDirection? = nil
-                if let dir = direction {
-                    txDirection = dir == "incoming" ? .incoming : .outgoing
+                if direction == "incoming" {
+                    txDirection = .incoming
+                } else if direction == "outgoing" {
+                    txDirection = .outgoing
                 }
 
                 let transactions = try await db.listTransactions(
@@ -1539,10 +1541,30 @@ class CashuDevKitModule: RCTEventEmitter {
                         "amount": tx.amount.value,
                         "mint_url": tx.mintUrl.url,
                         "timestamp": tx.timestamp,
-                        "fee": tx.fee.value
+                        "fee": tx.fee.value,
+                        "unit": currencyUnitToString(tx.unit)
                     ]
                     if let memo = tx.memo {
                         result["memo"] = memo
+                    }
+                    if let quoteId = tx.quoteId {
+                        result["quote_id"] = quoteId
+                    }
+                    if let paymentRequest = tx.paymentRequest {
+                        result["payment_request"] = paymentRequest
+                    }
+                    if let paymentProof = tx.paymentProof {
+                        result["payment_proof"] = paymentProof
+                    }
+                    if let paymentMethod = tx.paymentMethod {
+                        switch paymentMethod {
+                        case .bolt11:
+                            result["payment_method"] = "bolt11"
+                        case .bolt12:
+                            result["payment_method"] = "bolt12"
+                        case .custom(let method):
+                            result["payment_method"] = method
+                        }
                     }
                     return result
                 }

--- a/models/CashuInvoice.test.ts
+++ b/models/CashuInvoice.test.ts
@@ -1,0 +1,57 @@
+jest.mock('../stores/Stores', () => ({}));
+
+import CashuInvoice from './CashuInvoice';
+import type { CDKTransaction } from '../cashu-cdk';
+
+const cdkReceive: CDKTransaction = {
+    id: 'b'.repeat(64),
+    direction: 'incoming',
+    amount: 5000,
+    fee: 1,
+    mint_url: 'https://mint.example.com',
+    timestamp: 1756200000,
+    unit: 'sat',
+    memo: 'zap',
+    quote_id: 'quote-2',
+    payment_request: 'lnbc50u1invoice'
+};
+
+describe('CashuInvoice.fromCDKTransaction', () => {
+    it('maps CDK transaction fields onto invoice getters', () => {
+        const invoice = CashuInvoice.fromCDKTransaction(cdkReceive);
+
+        expect(invoice.getAmount).toBe(5000);
+        expect(invoice.getFee).toBe(1);
+        expect(invoice.getTimestamp).toBe(1756200000);
+        expect(invoice.getMemo).toBe('zap');
+        expect(invoice.getPaymentRequest).toBe('lnbc50u1invoice');
+        expect(invoice.mintUrl).toBe('https://mint.example.com');
+        expect(invoice.key).toBe('b'.repeat(64));
+        expect(invoice.cdkQuoteId).toBe('quote-2');
+    });
+
+    it('treats records without a lifecycle state as paid (pre-0.18 CDK)', () => {
+        const invoice = CashuInvoice.fromCDKTransaction(cdkReceive);
+
+        expect(invoice.isPaid).toBe(true);
+        expect(invoice.isExpired).toBe(false);
+    });
+
+    it('treats a Pending lifecycle state as unpaid', () => {
+        const invoice = CashuInvoice.fromCDKTransaction({
+            ...cdkReceive,
+            state: 'Pending'
+        });
+
+        expect(invoice.isPaid).toBe(false);
+    });
+
+    it('defaults fee to 0 when absent', () => {
+        const invoice = CashuInvoice.fromCDKTransaction({
+            ...cdkReceive,
+            fee: undefined
+        });
+
+        expect(invoice.getFee).toBe(0);
+    });
+});

--- a/models/CashuInvoice.ts
+++ b/models/CashuInvoice.ts
@@ -2,6 +2,7 @@ import { observable, computed } from 'mobx';
 import humanizeDuration from 'humanize-duration';
 
 import BaseModel from './BaseModel';
+import type { CDKTransaction } from '../cashu-cdk';
 import DateTimeUtils from '../utils/DateTimeUtils';
 import Bolt11Utils from '../utils/Bolt11Utils';
 import { localeString } from '../utils/LocaleUtils';
@@ -31,22 +32,17 @@ export default class CashuInvoice extends BaseModel {
     public cdkAmount?: number;
     public cdkMemo?: string;
     public cdkFee?: number;
+    public cdkQuoteId?: string;
 
     /**
      * Create CashuInvoice from CDK transaction (incoming)
      */
-    static fromCDKTransaction(tx: {
-        id: string;
-        amount: number;
-        fee?: number;
-        mint_url: string;
-        timestamp: number;
-        memo?: string;
-        state: string;
-    }): CashuInvoice {
+    static fromCDKTransaction(tx: CDKTransaction): CashuInvoice {
+        // state is absent before CDK 0.18; every recorded transaction
+        // is completed until lifecycle states arrive
         const invoice = new CashuInvoice({
             quote: tx.id,
-            request: '',
+            request: tx.payment_request || '',
             state: tx.state === 'Pending' ? 'UNPAID' : 'PAID',
             paid: tx.state !== 'Pending' && tx.state !== 'Failed',
             mintUrl: tx.mint_url,
@@ -55,7 +51,8 @@ export default class CashuInvoice extends BaseModel {
             cdkTimestamp: tx.timestamp,
             cdkAmount: tx.amount,
             cdkMemo: tx.memo,
-            cdkFee: tx.fee || 0
+            cdkFee: tx.fee || 0,
+            cdkQuoteId: tx.quote_id
         });
         return invoice;
     }
@@ -93,6 +90,10 @@ export default class CashuInvoice extends BaseModel {
     @computed public get getAmount(): number {
         if (this.fromCDK) return this.cdkAmount || 0;
         return this.decoded?.satoshis ? this.decoded.satoshis : 0;
+    }
+
+    @computed public get getFee(): number {
+        return this.cdkFee || 0;
     }
 
     // return amount in satoshis

--- a/models/CashuPayment.test.ts
+++ b/models/CashuPayment.test.ts
@@ -1,0 +1,50 @@
+jest.mock('../stores/Stores', () => ({}));
+
+import CashuPayment from './CashuPayment';
+import type { CDKTransaction } from '../cashu-cdk';
+
+const cdkMelt: CDKTransaction = {
+    id: 'a'.repeat(64),
+    direction: 'outgoing',
+    amount: 21000,
+    fee: 4,
+    mint_url: 'https://mint.example.com',
+    timestamp: 1756200000,
+    unit: 'sat',
+    quote_id: 'quote-1',
+    payment_request: 'lnbc210u1invoice',
+    payment_proof: 'deadbeef',
+    payment_method: 'bolt11'
+};
+
+describe('CashuPayment.fromCDKTransaction', () => {
+    it('maps CDK melt fields onto payment getters', () => {
+        const payment = CashuPayment.fromCDKTransaction(cdkMelt);
+
+        expect(payment.getAmount).toBe(21000);
+        expect(payment.getFee).toBe('4');
+        expect(payment.getTimestamp).toBe(1756200000);
+        expect(payment.getPreimage).toBe('deadbeef');
+        expect(payment.getPaymentRequest).toBe('lnbc210u1invoice');
+        expect(payment.getMintUrl).toBe('https://mint.example.com');
+        expect(payment.fromCDK).toBe(true);
+        expect(payment.cdkTransactionId).toBe('a'.repeat(64));
+        expect(payment.cdkQuoteId).toBe('quote-1');
+    });
+
+    it('is neither failed nor in transit', () => {
+        const payment = CashuPayment.fromCDKTransaction(cdkMelt);
+
+        expect(payment.isFailed).toBe(false);
+        expect(payment.isInTransit).toBe(false);
+    });
+
+    it('defaults fee to 0 when absent', () => {
+        const payment = CashuPayment.fromCDKTransaction({
+            ...cdkMelt,
+            fee: undefined
+        });
+
+        expect(payment.getFee).toBe('0');
+    });
+});

--- a/models/CashuPayment.ts
+++ b/models/CashuPayment.ts
@@ -5,6 +5,7 @@ import DateTimeUtils from '../utils/DateTimeUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { Proof } from './CashuToken';
 import Bolt11Utils from '../utils/Bolt11Utils';
+import type { CDKTransaction } from '../cashu-cdk';
 
 // Quote structure used in meltResponse
 export interface MeltQuote {
@@ -33,8 +34,30 @@ export default class CashuPayment extends Payment {
     public mintUrl: string;
     public proofs: Proof[];
 
+    // CDK transaction fields (for melts recovered from CDK history)
+    public fromCDK?: boolean;
+    public cdkTransactionId?: string;
+    public cdkQuoteId?: string;
+
     constructor(data?: any) {
         super(data);
+    }
+
+    /**
+     * Create CashuPayment from CDK transaction (outgoing melt)
+     */
+    static fromCDKTransaction(tx: CDKTransaction): CashuPayment {
+        return new CashuPayment({
+            payment_request: tx.payment_request,
+            payment_preimage: tx.payment_proof,
+            amount: tx.amount,
+            fee: tx.fee || 0,
+            mintUrl: tx.mint_url,
+            timestamp: tx.timestamp,
+            fromCDK: true,
+            cdkTransactionId: tx.id,
+            cdkQuoteId: tx.quote_id
+        });
     }
 
     @computed public get model(): string {

--- a/stores/ActivityStore.ts
+++ b/stores/ActivityStore.ts
@@ -320,6 +320,8 @@ export default class ActivityStore {
             // CDK transaction history (completed)
             additions = additions.concat(this.cashuStore.cdkInvoices);
             additions = additions.concat(this.cashuStore.payments || []);
+            // CDK-recorded melts missing from local payment storage
+            additions = additions.concat(this.cashuStore.cdkPayments);
 
             // Include pending/unpaid Cashu invoices (from local storage)
             const pendingCashuInvoices = this.cashuStore.invoices?.filter(
@@ -364,6 +366,15 @@ export default class ActivityStore {
         if (BackendUtils.supportsOnchainSends())
             await this.transactionsStore.getTransactions();
         await this.invoicesStore.getInvoices();
+
+        if (
+            BackendUtils.supportsCashuWallet() &&
+            this.settingsStore.settings?.ecash?.enableCashu
+        ) {
+            // refresh CDK transaction history so activity reflects
+            // records written since the last explicit sync
+            await this.cashuStore.loadTransactions();
+        }
 
         await this.swapStore.fetchAndUpdateSwaps();
         const sortedActivity = await this.getSortedActivity();

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -53,6 +53,7 @@ import ModalStore from './ModalStore';
 import Base64Utils from '../utils/Base64Utils';
 import { BIP39_WORD_LIST } from '../utils/Bip39Utils';
 import CashuUtils, {
+    isCdkMeltTrackedLocally,
     MintPaymentStatus,
     MintProgressInfo,
     MultimintProgressCallback,
@@ -192,6 +193,8 @@ export default class CashuStore {
     @observable public sentTokens?: Array<CashuToken>;
     // CDK transactions loaded from history (CashuInvoice for incoming, CashuPayment for outgoing)
     @observable public cdkInvoices: Array<CashuInvoice> = [];
+    // CDK outgoing melts not represented in locally persisted payments
+    @observable public cdkPayments: Array<CashuPayment> = [];
     @observable public seedVersion?: string;
     @observable public seedPhrase?: Array<string>;
     @observable public seed?: Uint8Array;
@@ -627,6 +630,17 @@ export default class CashuStore {
                 this.cdkInvoices = cdkTransactions
                     .filter((tx) => tx.direction === 'incoming')
                     .map((tx) => CashuInvoice.fromCDKTransaction(tx));
+                // Outgoing melts CDK recorded but local storage missed
+                // (e.g. app killed between melt and persist). Token sends
+                // carry no quote_id and stay tracked via sentTokens.
+                this.cdkPayments = cdkTransactions
+                    .filter(
+                        (tx) =>
+                            tx.direction === 'outgoing' &&
+                            !!tx.quote_id &&
+                            !isCdkMeltTrackedLocally(tx, this.payments || [])
+                    )
+                    .map((tx) => CashuPayment.fromCDKTransaction(tx));
             });
         } catch (e) {
             console.error('CDK: Failed to load transactions:', e);

--- a/utils/CashuUtils.test.ts
+++ b/utils/CashuUtils.test.ts
@@ -9,10 +9,12 @@ jest.mock('../cashu-cdk', () => ({
 }));
 
 import CashuDevKit from '../cashu-cdk';
+import type { CDKTransaction } from '../cashu-cdk';
 import CashuUtils, {
     cashuTokenPrefixes,
     CashuSeedOrigin,
-    classifyCashuSeedOrigin
+    classifyCashuSeedOrigin,
+    isCdkMeltTrackedLocally
 } from './CashuUtils';
 
 const mockIsValidToken = CashuDevKit.isValidToken as jest.Mock;
@@ -406,5 +408,84 @@ describe('CashuUtils', () => {
                 CashuSeedOrigin.DerivedFromWalletSeed
             );
         });
+    });
+});
+
+describe('isCdkMeltTrackedLocally', () => {
+    const cdkMelt = (overrides: Partial<CDKTransaction> = {}): CDKTransaction =>
+        ({
+            id: 'a'.repeat(64),
+            direction: 'outgoing',
+            amount: 1000,
+            fee: 2,
+            mint_url: 'https://mint.example.com',
+            timestamp: 1756200000,
+            quote_id: 'quote-1',
+            payment_proof: 'preimage-1',
+            ...overrides
+        } as CDKTransaction);
+
+    it('returns false with no local payments', () => {
+        expect(isCdkMeltTrackedLocally(cdkMelt(), [])).toBe(false);
+    });
+
+    it('matches a local payment by melt quote id', () => {
+        const payments = [
+            {
+                amount: 999999,
+                meltResponse: { quote: { quote: 'quote-1' } }
+            }
+        ];
+        expect(isCdkMeltTrackedLocally(cdkMelt(), payments)).toBe(true);
+    });
+
+    it('falls back to preimage + amount when quote ids differ (MPP)', () => {
+        const payments = [
+            {
+                amount: 1000,
+                payment_preimage: 'preimage-1',
+                meltResponse: { quote: { quote: 'planner-quote' } }
+            }
+        ];
+        expect(
+            isCdkMeltTrackedLocally(
+                cdkMelt({ quote_id: 'mint-mpp-quote' }),
+                payments
+            )
+        ).toBe(true);
+    });
+
+    it('does not match on preimage alone when amounts differ', () => {
+        const payments = [
+            {
+                amount: 400,
+                payment_preimage: 'preimage-1',
+                meltResponse: { quote: { quote: 'planner-quote' } }
+            }
+        ];
+        expect(
+            isCdkMeltTrackedLocally(
+                cdkMelt({ quote_id: 'mint-mpp-quote' }),
+                payments
+            )
+        ).toBe(false);
+    });
+
+    it('matches by preimage when the local record has no amount', () => {
+        const payments = [{ payment_preimage: 'preimage-1' }];
+        expect(
+            isCdkMeltTrackedLocally(cdkMelt({ quote_id: undefined }), payments)
+        ).toBe(true);
+    });
+
+    it('returns false for an untracked melt', () => {
+        const payments = [
+            {
+                amount: 1000,
+                payment_preimage: 'other-preimage',
+                meltResponse: { quote: { quote: 'other-quote' } }
+            }
+        ];
+        expect(isCdkMeltTrackedLocally(cdkMelt(), payments)).toBe(false);
     });
 });

--- a/utils/CashuUtils.ts
+++ b/utils/CashuUtils.ts
@@ -1,4 +1,4 @@
-import CashuDevKit, { CDKToken } from '../cashu-cdk';
+import CashuDevKit, { CDKToken, CDKTransaction } from '../cashu-cdk';
 
 export enum MintPaymentStatus {
     IDLE = 'idle',
@@ -96,6 +96,40 @@ export const classifyCashuSeedOrigin = (
 
     return CashuSeedOrigin.Independent;
 };
+
+// Structural subset of a persisted CashuPayment; kept duck-typed so this
+// module does not import models (which would cycle back through stores)
+export interface LocalCashuPaymentRecord {
+    payment_preimage?: string;
+    amount?: number | string;
+    meltResponse?: { quote?: { quote?: string } };
+}
+
+/**
+ * True if an outgoing CDK melt transaction is already represented by a
+ * locally persisted CashuPayment. Matches on melt quote id, falling back
+ * to payment preimage + amount: MPP segments are recorded locally under
+ * the planner's quote id while CDK records the mint-side MPP quote id.
+ */
+export function isCdkMeltTrackedLocally(
+    tx: CDKTransaction,
+    payments: LocalCashuPaymentRecord[]
+): boolean {
+    return payments.some((p) => {
+        const localQuoteId = p.meltResponse?.quote?.quote;
+        if (tx.quote_id && localQuoteId && localQuoteId === tx.quote_id) {
+            return true;
+        }
+        if (
+            tx.payment_proof &&
+            p.payment_preimage === tx.payment_proof &&
+            (p.amount === undefined || Number(p.amount) === Number(tx.amount))
+        ) {
+            return true;
+        }
+        return false;
+    });
+}
 
 // Limits to mitigate resource exhaustion from malicious P2PK secret payloads
 const MAX_P2PK_SECRET_LENGTH = 2048;


### PR DESCRIPTION
# Description

Groundwork for adopting CDK 0.18's transaction lifecycle states (pending/completed/failed, upstream cashubtc/cdk#2267). This PR makes the existing `listTransactions` path trustworthy on CDK 0.17.4 so the 0.18 bump can plug status into a working pipeline.

**Bridge (Kotlin + Swift):**
- Serialize the full CDK `Transaction` record: `unit`, `quote_id`, `payment_request`, `payment_proof`, `payment_method` (previously dropped)
- Fix Android emitting `TransactionId(hex=...)` via `toString()` instead of the 64-char hex id iOS emits
- Emit `fee` unconditionally on both platforms (the binding field is non-nullable; Android emitted it conditionally)
- Strict direction parsing: only `"incoming"`/`"outgoing"` apply a filter, instead of any non-`"incoming"` string meaning outgoing

**App:**
- `loadTransactions` previously discarded all outgoing CDK transactions. Melts recorded by CDK but missed by local storage (e.g. app killed between melt resolution and persistence) were invisible. Outgoing melts now surface in the activity list via a new `cdkPayments` observable, deduplicated against locally persisted payments by melt quote id, with a preimage+amount fallback for MPP segments (local records carry the planner quote id; CDK records the mint-side MPP quote id). Token sends carry no `quote_id` and stay tracked via `sentTokens`.
- Activity list refreshes CDK transaction history on build, so records written since the last explicit sync appear
- `CashuInvoice.getFee`: the `cdkFee` field was stored but never displayed; ecash receive fees now render in the activity list
- `CDKTransaction.state` is now typed optional: the bridge never emitted it, so the previous mapping silently rendered every CDK record as PAID. Missing state is now explicitly treated as completed until 0.18 lands

No storage schema changes: `cdkPayments` is derived state, rebuilt from the CDK database on each load and never persisted.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
