### PR TITLE
Complete lookupPayment across capable backends and use it for the NWC pending refresh

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -815,6 +815,8 @@ export default class CLNRest {
     supportsOnchainReceiving = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;
+    // follow-up: /v1/listpays accepts payment_hash and could support this
+    supportsPaymentLookup = () => false;
     supportsChannelManagement = () => true;
     supportsCircularRebalancing = () => true;
     supportsForceClose = () => false;

--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -403,6 +403,39 @@ export default class CLNRest {
             };
         });
 
+    // targeted lookup via listpays' payment_hash filter. listpays returns
+    // one entry per retry group, so prefer a settled attempt, then a
+    // pending one, over stale failed groups from earlier retries. The
+    // status is mapped to LND's enum strings so trackPaymentToTerminal
+    // and the NWC reconcile helpers read it uniformly.
+    lookupPayment = (data: { payment_hash: string }) =>
+        this.postRequest('/v1/listpays', {
+            payment_hash: data.payment_hash
+        }).then((response: any) => {
+            const pays = response?.pays || [];
+            if (pays.length === 0) return null;
+            const pay =
+                pays.find((p: any) => p.status === 'complete') ||
+                pays.find((p: any) => p.status === 'pending') ||
+                pays[pays.length - 1];
+            return {
+                payment_hash: pay.payment_hash,
+                status:
+                    pay.status === 'complete'
+                        ? 'SUCCEEDED'
+                        : pay.status === 'failed'
+                        ? 'FAILED'
+                        : 'IN_FLIGHT',
+                destination: pay.destination,
+                created_at: pay.created_at?.toString(),
+                bolt11: pay.bolt11,
+                bolt12: pay.bolt12,
+                amount_msat: pay.amount_msat,
+                amount_sent_msat: pay.amount_sent_msat,
+                preimage: pay.preimage
+            };
+        });
+
     getNewAddress = (data: any) => {
         let addresstype: string | undefined;
 
@@ -515,7 +548,10 @@ export default class CLNRest {
             forcedTimeout((timeoutSeconds + 1) * 1000, {
                 payment_error: localeString(
                     'views.SendingLightning.paymentTimedOut'
-                )
+                ),
+                // outcome unknown on the node: lets the caller track the
+                // payment to a terminal state instead of reporting failure
+                payment_timed_out: true
             }),
             call
         ]);
@@ -815,8 +851,7 @@ export default class CLNRest {
     supportsOnchainReceiving = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;
-    // follow-up: /v1/listpays accepts payment_hash and could support this
-    supportsPaymentLookup = () => false;
+    supportsPaymentLookup = () => true;
     supportsChannelManagement = () => true;
     supportsCircularRebalancing = () => true;
     supportsForceClose = () => false;

--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -261,6 +261,20 @@ export default class EmbeddedLND extends LND {
             cltv_limit: data.cltv_limit,
             amp: data.amp
         });
+    // override LND's REST implementation with an on-device lookup
+    lookupPayment = async (data: { payment_hash: string }) => {
+        const response = await listPayments({
+            maxPayments: 50,
+            reversed: true
+        });
+        return (
+            response?.payments?.find(
+                (payment: any) =>
+                    payment.payment_hash?.toLowerCase() ===
+                    data.payment_hash.toLowerCase()
+            ) ?? null
+        );
+    };
     closeChannel = async (urlParams?: Array<string>) => {
         const fundingTxId = (urlParams && urlParams[0]) || '';
         const outputIndex =

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -535,6 +535,16 @@ export default class LND {
             return response;
         };
 
+        // payment_timed_out marks the outcome as unknown on the node (the
+        // client gave up, not the payment), so the caller can track the
+        // payment to its terminal state instead of reporting failure
+        const timedOutResponse = () => ({
+            payment_error: localeString(
+                'views.SendingLightning.paymentTimedOut'
+            ),
+            payment_timed_out: true
+        });
+
         // The request timeout must exceed the forcedTimeout below, or the
         // generic transport rejection wins the race and the user sees a
         // retryable-looking error instead of the payment-timed-out shape
@@ -547,19 +557,32 @@ export default class LND {
                     allow_self_payment: true
                 },
                 (timeoutSeconds + 5) * 1000
-            );
+            ).catch((err: any) => {
+                // safety net if the transport deadline ever fires first:
+                // a client-side timeout is outcome-unknown, not a failure
+                if (err?.message === 'Request timeout')
+                    return timedOutResponse();
+                throw err;
+            });
 
         const result: any = await Promise.race([
-            forcedTimeout((timeoutSeconds + 1) * 1000, {
-                payment_error: localeString(
-                    'views.SendingLightning.paymentTimedOut'
-                )
-            }),
+            forcedTimeout((timeoutSeconds + 1) * 1000, timedOutResponse()),
             call()
         ]);
 
         return result;
     };
+    // scans the newest payments because LND REST has no non-streaming
+    // per-payment lookup (TrackPaymentV2 streams until terminal)
+    lookupPayment = (data: { payment_hash: string }) =>
+        this.getPayments({ maxPayments: 50, reversed: true }).then(
+            (response: any) =>
+                response?.payments?.find(
+                    (payment: any) =>
+                        payment.payment_hash?.toLowerCase() ===
+                        data.payment_hash.toLowerCase()
+                ) ?? null
+        );
     closeChannel = (urlParams?: Array<string>) => {
         let requestString = `/v1/channels/${urlParams && urlParams[0]}/${
             urlParams && urlParams[1]
@@ -1014,6 +1037,7 @@ export default class LND {
     supportsOnchainReceiving = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;
+    supportsPaymentLookup = () => true;
     supportsChannelManagement = () => true;
     supportsCircularRebalancing = () => true;
     supportsForceClose = () => true;

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -2178,6 +2178,9 @@ export default class LdkNode {
     supportsOnchainReceiving = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;
+    // follow-up: awaitPaymentCompletion already polls listPayments; a
+    // lookup by hash could resolve payments its timeout leaves pending
+    supportsPaymentLookup = () => false;
     supportsChannelManagement = () => true;
     supportsCircularRebalancing = () => false;
     supportsForceClose = () => true;

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -1465,6 +1465,23 @@ export default class LdkNode {
     };
 
     /**
+     * Targeted lookup by payment hash. listPayments is in-memory, so the
+     * filter is a local operation. Resolves payments awaitPaymentCompletion's
+     * timeout leaves pending.
+     */
+    lookupPayment = async (data: { payment_hash: string }): Promise<any> => {
+        const target = data.payment_hash.toLowerCase();
+        const payments = await LdkNodeInjection.payments.listPayments();
+        const payment = payments.find(
+            (p) =>
+                p.direction === 'outbound' &&
+                p.kind.type !== 'onchain' &&
+                (p.kind.hash || '').toLowerCase() === target
+        );
+        return payment ? this.formatPayment(payment) : null;
+    };
+
+    /**
      * List all payments (raw)
      */
     listPayments = async (): Promise<PaymentDetails[]> => {
@@ -2178,9 +2195,7 @@ export default class LdkNode {
     supportsOnchainReceiving = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;
-    // follow-up: awaitPaymentCompletion already polls listPayments; a
-    // lookup by hash could resolve payments its timeout leaves pending
-    supportsPaymentLookup = () => false;
+    supportsPaymentLookup = () => true;
     supportsChannelManagement = () => true;
     supportsCircularRebalancing = () => false;
     supportsForceClose = () => true;

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -221,6 +221,17 @@ export default class LightningNodeConnect {
                     params?.reversed !== undefined ? params.reversed : true
             })
             .then((data: lnrpc.ListPaymentsResponse) => snakeize(data));
+    // scans the newest payments; trackPaymentV2 over LNC is a stream and
+    // would need view-level event plumbing
+    lookupPayment = async (data: { payment_hash: string }) =>
+        await this.getPayments({ maxPayments: 50, reversed: true }).then(
+            (response: any) =>
+                response?.payments?.find(
+                    (payment: any) =>
+                        payment.payment_hash?.toLowerCase() ===
+                        data.payment_hash.toLowerCase()
+                ) ?? null
+        );
     getNewAddress = async (data: any) =>
         await this.lnc.lnd.lightning
             .newAddress({
@@ -386,7 +397,11 @@ export default class LightningNodeConnect {
                         resolve({
                             payment_error: localeString(
                                 'views.SendingLightning.paymentTimedOut'
-                            )
+                            ),
+                            // outcome unknown on the node: lets the caller
+                            // track the payment to a terminal state
+                            // instead of reporting failure
+                            payment_timed_out: true
                         })
                     ),
                 timeoutMs
@@ -876,6 +891,7 @@ export default class LightningNodeConnect {
     supportsOnchainReceiving = () => this.permNewAddress;
     supportsLightningSends = () => this.permSendLN;
     supportsKeysend = () => true;
+    supportsPaymentLookup = () => true;
     supportsChannelManagement = () => this.permOpenChannel;
     supportsCircularRebalancing = () => true;
     supportsForceClose = () => true;

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -206,6 +206,9 @@ export default class LndHub extends LND {
     };
     supportsWatchtowerClient = () => false;
     supportsKeysend = () => false;
+    // the inherited lookupPayment would scan LndHub's /gettxs-shaped
+    // getPayments response, which has no payment_hash/status fields
+    supportsPaymentLookup = () => false;
     supportsChannelManagement = () => false;
     supportsCircularRebalancing = () => false;
     supportsForceClose = () => false;

--- a/backends/NostrWalletConnect.ts
+++ b/backends/NostrWalletConnect.ts
@@ -79,6 +79,40 @@ export default class NostrWalletConnect {
         await this.nwc.lookupInvoice({
             payment_hash: Base64Utils.hexToBase64(data.r_hash)
         });
+    // NIP-47 lookup_invoice resolves either direction by payment_hash;
+    // the raw client is used because the webln wrapper discards state and
+    // amounts. Mapped to an LND-shaped payment, with msat amounts
+    // converted to sats for parity with the webln-mapped getPayments list.
+    lookupPayment = async (data: { payment_hash: string }) => {
+        let tx: any;
+        try {
+            tx = await this.nwc.client.lookupInvoice({
+                payment_hash: data.payment_hash
+            });
+        } catch (error: any) {
+            // the wallet answered: it has no record of this payment
+            if (error?.code === 'NOT_FOUND') return null;
+            throw error;
+        }
+        if (!tx) return null;
+        // state predates some wallets; settled_at is the spec's original
+        // settlement signal
+        const state = tx.state || (tx.settled_at ? 'settled' : 'pending');
+        return {
+            payment_hash: tx.payment_hash,
+            payment_preimage: tx.preimage,
+            invoice: tx.invoice,
+            creation_date: tx.created_at?.toString(),
+            amount: Math.floor((tx.amount || 0) / 1000),
+            fees_paid: tx.fees_paid ? Math.floor(tx.fees_paid / 1000) : 0,
+            status:
+                state === 'settled'
+                    ? 'SUCCEEDED'
+                    : state === 'failed'
+                    ? 'FAILED'
+                    : 'IN_FLIGHT'
+        };
+    };
 
     supportsPeers = () => false;
     supportsMessageSigning = () => false;
@@ -89,7 +123,7 @@ export default class NostrWalletConnect {
     supportsOnchainReceiving = () => false;
     supportsLightningSends = () => true;
     supportsKeysend = () => false;
-    supportsPaymentLookup = () => false;
+    supportsPaymentLookup = () => true;
     supportsChannelManagement = () => false;
     supportsCircularRebalancing = () => false;
     supportsForceClose = () => false;

--- a/backends/NostrWalletConnect.ts
+++ b/backends/NostrWalletConnect.ts
@@ -89,6 +89,7 @@ export default class NostrWalletConnect {
     supportsOnchainReceiving = () => false;
     supportsLightningSends = () => true;
     supportsKeysend = () => false;
+    supportsPaymentLookup = () => false;
     supportsChannelManagement = () => false;
     supportsCircularRebalancing = () => false;
     supportsForceClose = () => false;

--- a/lndmobile/index.ts
+++ b/lndmobile/index.ts
@@ -386,7 +386,10 @@ export const sendPaymentV2Sync = async (
         forcedTimeout((timeout_seconds + 1) * 1000, {
             payment_error: localeString(
                 'views.SendingLightning.paymentTimedOut'
-            )
+            ),
+            // outcome unknown on the node: lets the caller track the
+            // payment to a terminal state instead of reporting failure
+            payment_timed_out: true
         }),
         call()
     ]);

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -9,7 +9,9 @@ jest.mock('../utils/BackendUtils', () => ({
     default: {
         supportsNodeInfo: () => false,
         supportsCashuWallet: () => false,
-        supportsMessageSigning: jest.fn(() => true)
+        supportsMessageSigning: jest.fn(() => true),
+        supportsPaymentLookup: jest.fn(() => false),
+        lookupPayment: jest.fn()
     }
 }));
 
@@ -2019,6 +2021,164 @@ describe('NostrWalletConnectStore timeout-failed pay_invoice reconcile', () => {
             connection.isUnresolvedPayInvoiceActivity(connection.activity[0])
         ).toBe(true);
         expect(connection.pendingSpendSats).toBe(10000);
+    });
+});
+
+describe('NostrWalletConnectStore targeted pending payment lookup', () => {
+    const invoice = 'lnbc1targeted-lookup';
+    const paymentHash = hex64('d');
+
+    const seedPending = (
+        store: NostrWalletConnectStore,
+        activityOverrides: Record<string, unknown> = {}
+    ) =>
+        seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'pending',
+                    satAmount: 10000,
+                    paymentHash,
+                    createdAt: new Date(Date.now() - 60_000),
+                    ...activityOverrides
+                }
+            ]
+        });
+
+    const mockEmptyPaymentsStore = (store: NostrWalletConnectStore) => {
+        (store as any).paymentsStore = {
+            payments: [],
+            getPayments: jest.fn(async () => [])
+        };
+        return (store as any).paymentsStore;
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (BackendUtils.supportsPaymentLookup as jest.Mock).mockImplementation(
+            () => true
+        );
+    });
+
+    afterEach(() => {
+        (BackendUtils.supportsPaymentLookup as jest.Mock).mockImplementation(
+            () => false
+        );
+        (BackendUtils.lookupPayment as jest.Mock).mockReset();
+    });
+
+    it('settles a pending pay_invoice via lookupPayment without fetching the payment list', async () => {
+        const store = buildPayInvoiceTestStore();
+        (BackendUtils.lookupPayment as jest.Mock).mockResolvedValue({
+            payment_hash: paymentHash,
+            status: 'SUCCEEDED',
+            value_sat: 10000,
+            fee_sat: '50',
+            payment_preimage: hex64('9')
+        });
+        const paymentsStore = mockEmptyPaymentsStore(store);
+        const connection = seedPending(store);
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(BackendUtils.lookupPayment).toHaveBeenCalledWith({
+            payment_hash: paymentHash
+        });
+        expect(paymentsStore.getPayments).not.toHaveBeenCalled();
+        expect(connection.activity[0].status).toBe('success');
+        expect(connection.activity[0].isBudgetDebited).toBe(true);
+        expect(connection.totalSpendSats).toBe(10050);
+    });
+
+    it('falls back to the payment list scan when the backend has no lookup', async () => {
+        const store = buildPayInvoiceTestStore();
+        (BackendUtils.supportsPaymentLookup as jest.Mock).mockImplementation(
+            () => false
+        );
+        const paymentsStore = mockEmptyPaymentsStore(store);
+        const connection = seedPending(store);
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(BackendUtils.lookupPayment).not.toHaveBeenCalled();
+        expect(paymentsStore.getPayments).toHaveBeenCalled();
+        expect(connection.activity[0].status).toBe('pending');
+    });
+
+    it('falls back to the payment list scan when a pending activity lacks a payment hash', async () => {
+        const store = buildPayInvoiceTestStore();
+        const paymentsStore = mockEmptyPaymentsStore(store);
+        const connection = seedPending(store, { paymentHash: undefined });
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(BackendUtils.lookupPayment).not.toHaveBeenCalled();
+        expect(paymentsStore.getPayments).toHaveBeenCalled();
+    });
+
+    it('falls back to the payment list scan when a lookup fails', async () => {
+        const store = buildPayInvoiceTestStore();
+        (BackendUtils.lookupPayment as jest.Mock).mockRejectedValue(
+            new Error('node unreachable')
+        );
+        const paymentsStore = mockEmptyPaymentsStore(store);
+        const connection = seedPending(store);
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(paymentsStore.getPayments).toHaveBeenCalled();
+        expect(connection.activity[0].status).toBe('pending');
+    });
+
+    it('leaves a recent pending hold untouched when the node has no record', async () => {
+        const store = buildPayInvoiceTestStore();
+        (BackendUtils.lookupPayment as jest.Mock).mockResolvedValue(null);
+        const paymentsStore = mockEmptyPaymentsStore(store);
+        const connection = seedPending(store);
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(paymentsStore.getPayments).not.toHaveBeenCalled();
+        expect(connection.activity[0].status).toBe('pending');
+        expect(connection.pendingSpendSats).toBe(10000);
+    });
+
+    it('looks up each unique hash once for duplicate pending activities', async () => {
+        const store = buildPayInvoiceTestStore();
+        (BackendUtils.lookupPayment as jest.Mock).mockResolvedValue(null);
+        mockEmptyPaymentsStore(store);
+        const connection = seedPayInvoiceConnection(store, {
+            maxAmountSats: 10000,
+            totalSpendSats: 0,
+            activity: [
+                {
+                    id: invoice,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'pending',
+                    satAmount: 5000,
+                    paymentHash,
+                    createdAt: new Date(Date.now() - 60_000)
+                },
+                {
+                    id: `${invoice}-retry`,
+                    type: 'pay_invoice',
+                    payment_source: 'lightning',
+                    status: 'pending',
+                    satAmount: 5000,
+                    paymentHash,
+                    createdAt: new Date(Date.now() - 60_000)
+                }
+            ]
+        });
+
+        await (store as any).reconcilePendingPayInvoiceActivities(connection);
+
+        expect(BackendUtils.lookupPayment).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -3000,9 +3000,54 @@ export default class NostrWalletConnectStore {
             return cached;
         }
 
+        const lookedUp = await this.lookupPendingPaymentsByHash(
+            lightningPending
+        );
+        if (lookedUp) {
+            this.lastPendingPaymentStatusFetchByConnection.set(
+                connectionId,
+                now
+            );
+            return lookedUp;
+        }
+
         await this.paymentsStore.getPayments();
         this.lastPendingPaymentStatusFetchByConnection.set(connectionId, now);
         return this.paymentsStore.payments || [];
+    }
+
+    /**
+     * Targeted per-hash lookups for the pending pay_invoice refresh: the
+     * by-hash question is answered by lookupPayment instead of fetching
+     * and scanning the payment list, so cost scales with the request
+     * rather than with payment history (issue #4286). Returns undefined
+     * when the backend has no lookup, a pending activity lacks a payment
+     * hash (matching it needs the list's payment_request strings), or a
+     * lookup fails; callers fall back to the list scan. Null lookup
+     * results are dropped: the node has no record of that payment, which
+     * downstream absence handling (stale-hold abandonment) already covers.
+     */
+    private async lookupPendingPaymentsByHash(
+        lightningPending: ConnectionActivity[]
+    ): Promise<Payment[] | undefined> {
+        if (!BackendUtils.supportsPaymentLookup()) return undefined;
+
+        const hashes = lightningPending.map((activity) => activity.paymentHash);
+        if (hashes.some((hash) => !hash)) return undefined;
+
+        const uniqueHashes = [...new Set(hashes as string[])];
+        try {
+            const results = await Promise.all(
+                uniqueHashes.map((payment_hash) =>
+                    BackendUtils.lookupPayment({ payment_hash })
+                )
+            );
+            return results
+                .filter((raw) => !!raw)
+                .map((raw) => new Payment(raw));
+        } catch {
+            return undefined;
+        }
     }
 
     private findLightningInvoiceInStore(invoice: Invoice): Invoice | undefined {

--- a/stores/TransactionsStore.test.ts
+++ b/stores/TransactionsStore.test.ts
@@ -1,0 +1,272 @@
+jest.mock('../stores/Stores', () => ({}));
+jest.mock('react-native-blob-util', () => ({}));
+jest.mock('bitcoinjs-lib', () => ({}));
+jest.mock('react-native-randombytes', () => ({
+    randomBytes: (n: number) => require('crypto').randomBytes(n)
+}));
+jest.mock('./SettingsStore', () => ({}));
+jest.mock('./NodeInfoStore', () => ({}));
+jest.mock('./ChannelsStore', () => ({}));
+jest.mock('./BalanceStore', () => ({}));
+jest.mock('./ModalStore', () => ({}));
+jest.mock('../utils/BackendUtils', () => ({
+    __esModule: true,
+    default: {
+        payLightningInvoice: jest.fn(),
+        sendKeysend: jest.fn(),
+        lookupPayment: jest.fn(),
+        supportsPaymentLookup: jest.fn(() => true),
+        isLNDBased: jest.fn(() => true)
+    }
+}));
+jest.mock('../utils/Bolt11Utils', () => ({
+    __esModule: true,
+    default: {
+        decode: jest.fn(() => ({ payment_hash: 'ab'.repeat(32) }))
+    }
+}));
+jest.mock('../utils/GraphSyncUtils', () => ({
+    checkGraphSyncBeforePayment: jest.fn(() => true)
+}));
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (s: string) => s
+}));
+jest.mock('../utils/ErrorUtils', () => ({
+    errorToUserFriendly: (error: any) =>
+        typeof error === 'string' ? error : error?.message
+}));
+jest.mock('../utils/UrlUtils', () => ({
+    __esModule: true,
+    default: {}
+}));
+jest.mock('../utils/RatingUtils', () => ({
+    RATING_MODAL_TRIGGER_DELAY: 1000
+}));
+
+import TransactionsStore, {
+    PAYMENT_TRACK_POLL_MS,
+    PAYMENT_TRACK_MAX_FAILURES
+} from './TransactionsStore';
+import BackendUtils from '../utils/BackendUtils';
+
+// 64-char hex: normalizePaymentHash rejects anything that isn't a real hash
+const HASH = 'ab'.repeat(32);
+
+const newStore = () =>
+    new TransactionsStore(
+        { implementation: 'lnd', enableTor: false, settings: {} } as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        { checkAndTriggerRatingModal: jest.fn() } as any
+    );
+
+const flush = () => jest.advanceTimersByTimeAsync(0);
+const advancePoll = () => jest.advanceTimersByTimeAsync(PAYMENT_TRACK_POLL_MS);
+
+describe('TransactionsStore payment tracking (issue #4317)', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.clearAllMocks();
+        (BackendUtils.supportsPaymentLookup as jest.Mock).mockReturnValue(true);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('holds the guard on an IN_FLIGHT result and tracks to SUCCEEDED', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+        // the first lookup fires immediately when tracking starts; the
+        // terminal result lands on the second poll
+        (BackendUtils.lookupPayment as jest.Mock)
+            .mockResolvedValueOnce({ status: 'IN_FLIGHT', payment_hash: HASH })
+            .mockResolvedValueOnce({ status: 'IN_FLIGHT', payment_hash: HASH })
+            .mockResolvedValueOnce({
+                status: 'SUCCEEDED',
+                payment_hash: HASH,
+                payment_preimage: 'deadbeef'
+            });
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+
+        // stream ended non-terminal: guard must stay armed
+        expect(store.paymentInFlight).toBe(true);
+        expect(store.status).toBe('IN_FLIGHT');
+
+        await advancePoll();
+        expect(store.paymentInFlight).toBe(true);
+
+        await advancePoll();
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.status).toBe('SUCCEEDED');
+        expect(store.error).toBe(false);
+    });
+
+    it('treats a client-side timeout as unknown and surfaces the tracked FAILED outcome', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockResolvedValue({
+            payment_error: 'views.SendingLightning.paymentTimedOut',
+            payment_timed_out: true
+        });
+        // hold the first lookup open so the ambiguous state is observable
+        let resolveLookup: (value: any) => void = () => {};
+        (BackendUtils.lookupPayment as jest.Mock).mockReturnValue(
+            new Promise((resolve) => {
+                resolveLookup = resolve;
+            })
+        );
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+
+        // outcome unknown: no error yet, guard held, in-transit UI
+        expect(store.paymentInFlight).toBe(true);
+        expect(store.error).toBe(false);
+        expect(store.status).toBe('IN_FLIGHT');
+
+        resolveLookup({
+            status: 'FAILED',
+            failure_reason: 'FAILURE_REASON_TIMEOUT',
+            payment_hash: HASH
+        });
+        await flush();
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.error).toBe(true);
+        expect(store.status).toBe('FAILED');
+    });
+
+    it('replaces a transport error with success when the payment settled anyway', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockRejectedValue(
+            new Error('connection closed')
+        );
+        (BackendUtils.lookupPayment as jest.Mock).mockResolvedValue({
+            status: 'SUCCEEDED',
+            payment_hash: HASH,
+            payment_preimage: 'deadbeef'
+        });
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.status).toBe('SUCCEEDED');
+        expect(store.error).toBe(false);
+    });
+
+    it('releases the guard when the node has no record of the payment', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockRejectedValue(
+            new Error('invoice is invalid')
+        );
+        (BackendUtils.lookupPayment as jest.Mock).mockResolvedValue(null);
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.error).toBe(true);
+        expect(store.error_msg).toBe('invoice is invalid');
+    });
+
+    it('gives up after consecutive failed lookups and releases the guard', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+        (BackendUtils.lookupPayment as jest.Mock).mockRejectedValue(
+            new Error('node unreachable')
+        );
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+        expect(store.paymentInFlight).toBe(true);
+
+        for (let i = 0; i < PAYMENT_TRACK_MAX_FAILURES; i++) {
+            await advancePoll();
+        }
+        expect(store.paymentInFlight).toBe(false);
+        expect(BackendUtils.lookupPayment).toHaveBeenCalledTimes(
+            PAYMENT_TRACK_MAX_FAILURES
+        );
+    });
+
+    it('keeps the pre-tracking behavior on backends without payment lookup', async () => {
+        (BackendUtils.supportsPaymentLookup as jest.Mock).mockReturnValue(
+            false
+        );
+        (BackendUtils.payLightningInvoice as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.status).toBe('IN_FLIGHT');
+        expect(BackendUtils.lookupPayment).not.toHaveBeenCalled();
+    });
+
+    it('ignores a second send while a tracked payment is unresolved', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+        (BackendUtils.lookupPayment as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+        expect(store.paymentInFlight).toBe(true);
+
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+        expect(BackendUtils.payLightningInvoice).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets an unscoped handlePayment (Rebalance view path) stop tracking and clear the guard', async () => {
+        (BackendUtils.payLightningInvoice as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+        (BackendUtils.lookupPayment as jest.Mock).mockResolvedValue({
+            status: 'IN_FLIGHT',
+            payment_hash: HASH
+        });
+
+        const store = newStore();
+        store.sendPayment({ payment_request: 'lnbc1fake' });
+        await flush();
+        expect(store.paymentInFlight).toBe(true);
+
+        store.handlePayment({
+            status: 'SUCCEEDED',
+            payment_hash: HASH,
+            payment_preimage: 'deadbeef'
+        });
+        expect(store.paymentInFlight).toBe(false);
+        expect(store.status).toBe('SUCCEEDED');
+
+        // the orphaned tracking loop must exit without resurrecting state
+        const calls = (BackendUtils.lookupPayment as jest.Mock).mock.calls
+            .length;
+        await advancePoll();
+        await advancePoll();
+        expect(
+            (BackendUtils.lookupPayment as jest.Mock).mock.calls.length
+        ).toBeLessThanOrEqual(calls + 1);
+        expect(store.paymentInFlight).toBe(false);
+    });
+});

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -17,6 +17,8 @@ import Base64Utils from '../utils/Base64Utils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { checkGraphSyncBeforePayment } from '../utils/GraphSyncUtils';
+import { deriveExpectedPaymentHash } from '../utils/LncPayUtils';
+import { sleep } from '../utils/SleepUtils';
 import UrlUtils from '../utils/UrlUtils';
 import { RATING_MODAL_TRIGGER_DELAY } from '../utils/RatingUtils';
 
@@ -29,6 +31,16 @@ import ModalStore from './ModalStore';
 const keySendPreimageType = '5482373484';
 const keySendMessageType = '34349334';
 const preimageByteLength = 32;
+
+// how often to poll lookupPayment while a payment's outcome is unknown
+export const PAYMENT_TRACK_POLL_MS = 5000;
+// ceiling on how long tracking may hold the send guard: a stuck HTLC can
+// pend until CLTV expiry (hours), and holding the guard that long would
+// lock the user out of all sends
+export const PAYMENT_TRACK_MAX_MS = 10 * 60 * 1000;
+// consecutive failed lookups tolerated before giving up and releasing the
+// guard the way the timed backstop used to
+export const PAYMENT_TRACK_MAX_FAILURES = 3;
 
 export interface SendPaymentReq {
     payment_request?: string;
@@ -91,6 +103,11 @@ export default class TransactionsStore {
     // NWC payment finishing while a user payment is still in flight)
     // can't disarm each other's guard
     private inFlightOwnerSeq: number | null = null;
+    // payment hash (hex) of the guard-owning payment, when known; lets an
+    // ambiguous outcome be tracked to a terminal state via lookupPayment
+    private inFlightPaymentHash: string | null = null;
+    // sequence currently being tracked to a terminal state (null when none)
+    private trackingSeq: number | null = null;
 
     settingsStore: SettingsStore;
     nodeInfoStore: NodeInfoStore;
@@ -117,6 +134,7 @@ export default class TransactionsStore {
         this.loading = false;
         this.paymentInFlight = false;
         this.inFlightOwnerSeq = null;
+        this.inFlightPaymentHash = null;
         this.error = false;
         this.error_msg = null;
         this.transactions = [];
@@ -604,6 +622,7 @@ export default class TransactionsStore {
         if (!background) {
             this.paymentInFlight = true;
             this.inFlightOwnerSeq = seq;
+            this.inFlightPaymentHash = null;
         }
         this.paymentStartTime = Date.now();
         this.paymentDuration = null;
@@ -691,14 +710,28 @@ export default class TransactionsStore {
             data.timeout_seconds = Number(timeout_seconds) || 60;
         }
 
+        // Record the dispatched payment's hash (lowercase hex) so an
+        // ambiguous outcome can be tracked to a terminal state. Undefined
+        // for AMP payments, which settle under per-attempt hashes and stay
+        // on the timed backstop.
+        if (!background) {
+            this.inFlightPaymentHash =
+                deriveExpectedPaymentHash({
+                    payment_hash: data.payment_hash,
+                    payment_request,
+                    amp
+                }) || null;
+        }
+
         // Backstop for the in-flight guard: if the completion callback is
         // lost (e.g. a dropped LNC stream, or a hung request on a backend
         // that gets no timeout_seconds), the flag would otherwise stay set
-        // and block all sends until the next reconnect. Clear it once the
-        // payment's timeout plus a grace period has elapsed.
+        // and block all sends until the next reconnect. Once the payment's
+        // timeout plus a grace period has elapsed, try to observe the
+        // payment's actual terminal state before releasing the flag.
         if (!background) {
             const backstopMs = ((data.timeout_seconds ?? 300) + 60) * 1000;
-            setTimeout(() => this.clearPaymentInFlight(seq), backstopMs);
+            setTimeout(() => this.backstopPaymentInFlight(seq), backstopMs);
         }
 
         const payFunc =
@@ -727,6 +760,107 @@ export default class TransactionsStore {
         if (seq !== undefined && this.inFlightOwnerSeq !== seq) return;
         this.paymentInFlight = false;
         this.inFlightOwnerSeq = null;
+        this.inFlightPaymentHash = null;
+    };
+
+    // true when payment `seq` still owns the guard and its terminal state
+    // can be observed via lookupPayment on the active backend
+    private canTrackPayment = (seq: number) =>
+        this.inFlightOwnerSeq === seq &&
+        !!this.inFlightPaymentHash &&
+        !!BackendUtils.supportsPaymentLookup();
+
+    // Fires when the backstop timer elapses without a completion callback
+    // having cleared the guard (dropped LNC stream, hung request). Rather
+    // than blindly releasing the guard while an HTLC may still settle, try
+    // to track the payment to its terminal state first.
+    private backstopPaymentInFlight = (seq: number) => {
+        if (this.inFlightOwnerSeq !== seq) return;
+        if (this.trackingSeq === seq) return; // tracking owns the release
+        if (this.canTrackPayment(seq)) {
+            this.trackPaymentToTerminal(seq);
+        } else {
+            this.clearPaymentInFlight(seq);
+        }
+    };
+
+    // Polls lookupPayment until the guard-owning payment reaches SUCCEEDED
+    // or FAILED, then surfaces the real outcome through handlePayment
+    // (which also releases the guard). This closes the double-pay window
+    // left by releasing the guard on timers while HTLCs are still pending:
+    // a keysend retry generates a fresh preimage, so node-side same-hash
+    // dedup can't protect against it (issue #4317). Exits released: on a
+    // terminal state, when the payment provably never reached the node,
+    // after PAYMENT_TRACK_MAX_FAILURES unobservable polls, or at the
+    // PAYMENT_TRACK_MAX_MS ceiling.
+    private trackPaymentToTerminal = async (seq: number) => {
+        if (this.trackingSeq === seq) return;
+        const payment_hash = this.inFlightPaymentHash;
+        if (!payment_hash) return;
+        this.trackingSeq = seq;
+        const deadline = Date.now() + PAYMENT_TRACK_MAX_MS;
+        let failures = 0;
+        try {
+            while (this.inFlightOwnerSeq === seq && Date.now() < deadline) {
+                let payment: any = null;
+                let lookupFailed = false;
+                try {
+                    payment = await BackendUtils.lookupPayment({
+                        payment_hash
+                    });
+                } catch (e) {
+                    lookupFailed = true;
+                }
+                if (this.inFlightOwnerSeq !== seq) return;
+
+                // embedded-lnd statuses are numeric protobuf enums
+                const status =
+                    typeof payment?.status === 'number'
+                        ? lnrpc.Payment.PaymentStatus[payment.status]
+                        : payment?.status;
+
+                if (status === 'SUCCEEDED' || status === 'FAILED') {
+                    // clear any transport error shown while the outcome
+                    // was unknown; handlePayment re-derives error state
+                    // from the payment's actual terminal result
+                    this.clearPaymentError();
+                    this.handlePayment(payment, seq);
+                    return;
+                }
+
+                if (payment) {
+                    failures = 0;
+                    if (status === 'IN_FLIGHT') {
+                        // outcome is pending, not failed: don't leave a
+                        // stale timeout/transport error on screen
+                        this.markPaymentInTransit();
+                    }
+                } else if (!lookupFailed) {
+                    // the node answered and has no record of the payment:
+                    // the dispatch never reached it, nothing can settle
+                    return;
+                } else if (++failures >= PAYMENT_TRACK_MAX_FAILURES) {
+                    return;
+                }
+                await sleep(PAYMENT_TRACK_POLL_MS);
+            }
+        } finally {
+            this.trackingSeq = null;
+            this.clearPaymentInFlight(seq);
+        }
+    };
+
+    @action
+    private clearPaymentError = () => {
+        this.error = false;
+        this.error_msg = null;
+        this.payment_error = null;
+    };
+
+    @action
+    private markPaymentInTransit = () => {
+        this.clearPaymentError();
+        this.status = 'IN_FLIGHT';
     };
 
     public sendPaymentSilently = async ({
@@ -780,6 +914,31 @@ export default class TransactionsStore {
     @action
     public handlePayment = (result: any, seq?: number) => {
         this.loading = false;
+
+        const implementation = this.settingsStore.implementation;
+
+        // TODO modify enum settings for embedded LND
+        const status =
+            implementation === 'embedded-lnd'
+                ? lnrpc.Payment.PaymentStatus[result.status]
+                : result.status;
+
+        // A non-terminal result (the send stream ended while HTLCs are
+        // still pending) or a client-side timeout (outcome unknown on the
+        // node) must not release the double-submission guard: a keysend
+        // retry generates a fresh preimage and can double-pay if the
+        // original HTLC later settles. Hold the guard and track the
+        // payment to its terminal state instead (issue #4317).
+        if (
+            seq !== undefined &&
+            (status === 'IN_FLIGHT' || result.payment_timed_out) &&
+            this.canTrackPayment(seq)
+        ) {
+            this.status = 'IN_FLIGHT';
+            this.trackPaymentToTerminal(seq);
+            return;
+        }
+
         this.clearPaymentInFlight(seq);
         this.payment_route = result.payment_route;
 
@@ -789,14 +948,6 @@ export default class TransactionsStore {
         this.payment_hash = payment.paymentHash;
         this.payment_fee = payment.getFee;
         this.isIncomplete = payment.isIncomplete;
-
-        const implementation = this.settingsStore.implementation;
-
-        // TODO modify enum settings for embedded LND
-        const status =
-            implementation === 'embedded-lnd'
-                ? lnrpc.Payment.PaymentStatus[result.status]
-                : result.status;
 
         const isKeysend =
             result?.htlcs?.[0]?.route?.hops?.[0]?.custom_records?.[
@@ -854,7 +1005,17 @@ export default class TransactionsStore {
     public handlePaymentError = (err: Error, seq?: number) => {
         this.error = true;
         this.loading = false;
-        this.clearPaymentInFlight(seq);
+        // A rejected dispatch (dropped connection, Tor timeout) doesn't
+        // prove the payment failed on the node: the request may have gone
+        // through before transport was lost. Surface the error, but verify
+        // via lookup before releasing the double-submission guard; if the
+        // payment turns out to be pending or terminal after all, the
+        // tracker replaces this error with the real outcome.
+        if (seq !== undefined && this.canTrackPayment(seq)) {
+            this.trackPaymentToTerminal(seq);
+        } else {
+            this.clearPaymentInFlight(seq);
+        }
         this.error_msg =
             errorToUserFriendly(err) || localeString('error.sendingPayment');
     };

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -95,6 +95,7 @@ class BackendUtils {
     getInvoices = (...args: any[]) => this.call('getInvoices', args);
     createInvoice = (...args: any[]) => this.call('createInvoice', args);
     getPayments = (...args: any[]) => this.call('getPayments', args);
+    lookupPayment = (...args: any[]) => this.call('lookupPayment', args);
     getNewAddress = (...args: any[]) => this.call('getNewAddress', args);
     getNewChangeAddress = (...args: any[]) =>
         this.call('getNewChangeAddress', args);
@@ -221,6 +222,7 @@ class BackendUtils {
     supportsOnchainReceiving = () => this.call('supportsOnchainReceiving');
     supportsLightningSends = () => this.call('supportsLightningSends');
     supportsKeysend = () => this.call('supportsKeysend');
+    supportsPaymentLookup = () => this.call('supportsPaymentLookup');
     supportsChannelManagement = () => this.call('supportsChannelManagement');
     supportsCircularRebalancing = () =>
         this.call('supportsCircularRebalancing');


### PR DESCRIPTION
# Description

Fixes issue: **#4286**

**Stacked on #4492** (its commit is included here; the second commit is this PR's diff). Review only `862ad96cc` until #4492 merges, after which this rebases to a single commit.

#4492 introduced `lookupPayment` / `supportsPaymentLookup` but only implemented the LND-family backends, which have no targeted per-payment query and scan their newest 50 payments. This PR completes #4286's proposal:

- **`CLNRest.lookupPayment`**: `/v1/listpays` with its `payment_hash` filter, a true targeted query. `listpays` returns one entry per retry group, so a settled attempt is preferred, then a pending one, over stale failed groups. Status is mapped to LND's enum strings (`complete` to `SUCCEEDED`, `failed` to `FAILED`, else `IN_FLIGHT`) so `trackPaymentToTerminal` and the NWC reconcile helpers read it uniformly; the remaining fields keep CLN's native names, which `models/Payment` already handles. CLN's `payWithTimeout` forced-timeout shape also gains the `payment_timed_out: true` marker from #4492, so a client-side timeout on `xpay`/`pay`/keysend is now tracked to its terminal state instead of surfacing as a failure while CLN may still be retrying inside `retry_for`.
- **`LdkNode.lookupPayment`**: filters the in-memory `listPayments()` result by hash (outbound, non-onchain) and reuses `formatPayment`, which already emits LND-shaped statuses. This also gives the send-guard tracker a real observation path for payments `awaitPaymentCompletion`'s timeout leaves pending, the follow-up noted in #4492.
- **`NostrWalletConnect.lookupPayment`**: NIP-47 `lookup_invoice` via the SDK's raw client (the webln wrapper discards `state` and amounts), which resolves either direction by `payment_hash`. `NOT_FOUND` maps to the `null` no-record contract; msat amounts are converted to sats for parity with the webln-mapped `getPayments` list; wallets that predate `state` fall back to `settled_at`.
- **NWC service**: `getPaymentsForPendingPayInvoiceRefresh` now answers the by-hash question through `lookupPayment` (one call per unique pending hash) instead of fetching and scanning the full payment list, so `lookup_invoice`, `list_transactions`, and budget reconciliation scale with the request rather than with payment history. The existing per-connection min-age and refresh-interval gates are unchanged. The list scan remains the fallback for backends without lookup (LndHub), pending activities without a recorded payment hash (matching needs the list's payment_request strings), and failed lookups. A `null` lookup result is authoritative absence, handled by the existing stale-hold abandonment.

All seven backends now resolve #4286's capability table: four precise lookups (CLN, LDK Node, NWC, plus the LNC/LND/embedded scans from #4492), and one genuine impossibility (LndHub, explicit `false`).

Six new unit tests cover the targeted refresh: settle-without-list-fetch, the three fallback paths (no capability, missing hash, lookup failure), authoritative-absence handling, and per-hash dedup.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

Device tests pending: CLN (xpay timeout tracked to terminal, NWC service lookup_invoice on a pending payment), LDK Node (timeout then settle), NWC backend (pay via remote wallet with dropped transport), and an LndHub regression pass on the scan fallback.
