### PR TITLE
refactor: deduplicate FAILURE_REASON locale-key maps (#4490)

### DIFF
--- a/utils/ErrorUtils.ts
+++ b/utils/ErrorUtils.ts
@@ -1,3 +1,13 @@
+export const FAILURE_REASON_LOCALE_KEYS: Record<string, string> = {
+    FAILURE_REASON_TIMEOUT: 'error.failureReasonTimeout',
+    FAILURE_REASON_NO_ROUTE: 'error.failureReasonNoRoute',
+    FAILURE_REASON_ERROR: 'error.failureReasonError',
+    FAILURE_REASON_INCORRECT_PAYMENT_DETAILS:
+        'error.failureReasonIncorrectPaymentDetails',
+    FAILURE_REASON_INSUFFICIENT_BALANCE:
+        'error.failureReasonInsufficientBalance'
+};
+
 const userFriendlyErrors: any = {
     'Error: SOCKS: Connection refused': 'error.connectionRefused',
     'Error: SOCKS: Host unreachable': 'error.hostUnreachable',
@@ -11,14 +21,8 @@ const userFriendlyErrors: any = {
         'error.invalidMacaroon',
     'ReactNativeBlobUtil failed to encode response data to BASE64 string.':
         'error.invalidResponse',
-    FAILURE_REASON_TIMEOUT: 'error.failureReasonTimeout',
-    FAILURE_REASON_NO_ROUTE: 'error.failureReasonNoRoute',
-    FAILURE_REASON_ERROR: 'error.failureReasonError',
-    FAILURE_REASON_INCORRECT_PAYMENT_DETAILS:
-        'error.failureReasonIncorrectPaymentDetails',
+    ...FAILURE_REASON_LOCALE_KEYS,
     'Payment details incorrect': 'error.failureReasonIncorrectPaymentDetails',
-    FAILURE_REASON_INSUFFICIENT_BALANCE:
-        'error.failureReasonInsufficientBalance',
     // LDK Node payment failure reasons
     recipientRejected: 'error.ldk.recipientRejected',
     retriesExhausted: 'error.ldk.retriesExhausted',

--- a/utils/NostrConnectUtils.ts
+++ b/utils/NostrConnectUtils.ts
@@ -24,6 +24,7 @@ import CashuInvoice from '../models/CashuInvoice';
 import { lnrpc } from '../proto/lightning';
 
 import Base64Utils from './Base64Utils';
+import { FAILURE_REASON_LOCALE_KEYS } from './ErrorUtils';
 import { localeString } from './LocaleUtils';
 import dateTimeUtils from './DateTimeUtils';
 import Bolt11Utils from './Bolt11Utils';
@@ -1107,16 +1108,7 @@ export default class NostrConnectUtils {
             typeof reason === 'number'
                 ? lnrpc.PaymentFailureReason[reason]
                 : String(reason);
-        const keys: Record<string, string> = {
-            FAILURE_REASON_TIMEOUT: 'error.failureReasonTimeout',
-            FAILURE_REASON_NO_ROUTE: 'error.failureReasonNoRoute',
-            FAILURE_REASON_ERROR: 'error.failureReasonError',
-            FAILURE_REASON_INCORRECT_PAYMENT_DETAILS:
-                'error.failureReasonIncorrectPaymentDetails',
-            FAILURE_REASON_INSUFFICIENT_BALANCE:
-                'error.failureReasonInsufficientBalance'
-        };
-        return keys[name] || 'error.paymentFailed';
+        return FAILURE_REASON_LOCALE_KEYS[name] || 'error.paymentFailed';
     }
 
     static findPaymentForInvoice<T extends Payment>(


### PR DESCRIPTION
# Description

Relates to issue: #4490

Deduplicates the identical `FAILURE_REASON_*` → locale-key maps that lived in both `ErrorUtils.ts` (`userFriendlyErrors`) and `NostrConnectUtils.paymentFailureReasonLocaleKey()`.

- Extracts a single exported `FAILURE_REASON_LOCALE_KEYS` map in `utils/ErrorUtils.ts`.
- Spreads it into `userFriendlyErrors` (preserves the existing `'Payment details incorrect'` alias and all other keys).
- Updates `paymentFailureReasonLocaleKey` to look up the shared map (keeps numeric-enum normalization and `'error.paymentFailed'` fallback).

No behavior change. Prevents future drift when failure reasons or locale keys are added/renamed.


This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
