### PR TITLE
fix(nwc): guard updateConnection against in-flight handler races

### DIFF
--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1260,6 +1260,127 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
         jest.clearAllTimers();
         jest.useRealTimers();
     });
+
+    it('lets an in-flight handler finish before updateConnection mutates budget', async () => {
+        const store = buildStore();
+        jest.spyOn(store as any, 'subscribeToConnection').mockResolvedValue(
+            undefined
+        );
+        const connection = seedConnection(store, {
+            maxAmountSats: 5000,
+            totalSpendSats: 42
+        });
+
+        let releaseHandler: (value: { result: { ok: boolean } }) => void = () =>
+            undefined;
+        const handlerDone = (store as any).withGlobalHandler(
+            connection.id,
+            () =>
+                new Promise((resolve) => {
+                    releaseHandler = resolve;
+                })
+        );
+
+        await Promise.resolve();
+
+        let updated = false;
+        const updateDone = store
+            .updateConnection(connection.id, { maxAmountSats: 0 })
+            .then((result) => {
+                updated = result.success;
+            });
+
+        await Promise.resolve();
+        expect(updated).toBe(false);
+        expect(connection.maxAmountSats).toBe(5000);
+
+        const lateResponse = await (store as any).withGlobalHandler(
+            connection.id,
+            async () => ({
+                result: { should: 'not-run' },
+                error: undefined
+            })
+        );
+        expect(lateResponse.error?.code).toBe('UNAUTHORIZED');
+
+        releaseHandler({ result: { ok: true } });
+        await handlerDone;
+        await updateDone;
+
+        expect(updated).toBe(true);
+        expect(connection.maxAmountSats).toBe(0);
+    });
+
+    it('defers relay release when updateConnection awaited in-flight handlers', async () => {
+        jest.useFakeTimers();
+        const store = buildStore();
+        jest.spyOn(store as any, 'subscribeToConnection').mockResolvedValue(
+            undefined
+        );
+        jest.spyOn(
+            store as any,
+            'unsubscribeFromConnection'
+        ).mockImplementation(() => undefined);
+        jest.spyOn(store as any, 'generateConnectionSecret').mockReturnValue({
+            connectionUrl: `nostr+walletconnect://${SERVICE_PUB}?relay=${encodeURIComponent(
+                NEW_RELAY
+            )}`,
+            connectionPrivateKey: OLD_PRIVKEY,
+            connectionPublicKey: OTHER_PUBKEY
+        });
+        jest.spyOn(store as any, 'storeClientKeys').mockResolvedValue(
+            undefined
+        );
+        jest.spyOn(store as any, 'deleteClientKeys').mockResolvedValue(
+            undefined
+        );
+        (store as any).nwcWalletServices.set(OLD_RELAY, { close: jest.fn() });
+        (store as any).nwcWalletServices.set(NEW_RELAY, {
+            connected: true,
+            close: jest.fn()
+        });
+        (store as any).publishedRelays.add(OLD_RELAY);
+        (store as any).publishedRelays.add(NEW_RELAY);
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+
+        let releaseHandler: (value: { result: { ok: boolean } }) => void = () =>
+            undefined;
+        const handlerDone = (store as any).withGlobalHandler(
+            connection.id,
+            () =>
+                new Promise((resolve) => {
+                    releaseHandler = resolve;
+                })
+        );
+
+        await Promise.resolve();
+
+        const releaseSpy = jest.spyOn(
+            store as any,
+            'releaseUnusedRelayService'
+        );
+        const updateDone = store.updateConnection(connection.id, {
+            relayUrl: NEW_RELAY
+        });
+
+        await Promise.resolve();
+        expect(releaseSpy).not.toHaveBeenCalled();
+
+        releaseHandler({ result: { ok: true } });
+        await handlerDone;
+        const result = await updateDone;
+        expect(result.success).toBe(true);
+
+        expect(releaseSpy).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(RELAY_RELEASE_GRACE_MS);
+        expect(releaseSpy).toHaveBeenCalledWith(OLD_RELAY);
+
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
 });
 
 function buildMakeInvoiceTestStore(invoices: Invoice[] = []) {

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -234,6 +234,7 @@ describe('NostrWalletConnectStore relay rotation', () => {
     it('leaves relayUrl unchanged when storing the new key fails so retry can rotate', async () => {
         const store = buildStore();
         const connection = seedConnection(store);
+        const unsubSpy = jest.spyOn(store as any, 'unsubscribeFromConnection');
         const consoleError = jest
             .spyOn(console, 'error')
             .mockImplementation(() => {});
@@ -251,6 +252,8 @@ describe('NostrWalletConnectStore relay rotation', () => {
             expect(result.nostrUrl).toBeUndefined();
             expect(connection.relayUrl).toBe(OLD_RELAY);
             expect(connection.pubkey).toBe(OLD_PUBKEY);
+            expect(unsubSpy).not.toHaveBeenCalled();
+            expect((store as any).subscribeToConnection).not.toHaveBeenCalled();
         } finally {
             consoleError.mockRestore();
         }

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -186,7 +186,7 @@ export default class NostrWalletConnectStore {
         number
     >();
     private makeInvoiceTimestampsByConnection = new Map<string, number[]>();
-    private pendingDeleteConnectionIds = new Set<string>();
+    private pendingConnectionMutationIds = new Set<string>();
     private inFlightHandlersByConnection = new Map<
         string,
         Set<Promise<unknown>>
@@ -653,7 +653,7 @@ export default class NostrWalletConnectStore {
                     )
                 );
             }
-            this.pendingDeleteConnectionIds.add(connectionId);
+            this.pendingConnectionMutationIds.add(connectionId);
             try {
                 const relayUrl = connection.relayUrl;
                 const hadActiveSubscription =
@@ -687,7 +687,7 @@ export default class NostrWalletConnectStore {
                 }
                 await this.saveConnections();
             } finally {
-                this.pendingDeleteConnectionIds.delete(connectionId);
+                this.pendingConnectionMutationIds.delete(connectionId);
             }
         } catch (error: any) {
             runInAction(() => {
@@ -767,107 +767,126 @@ export default class NostrWalletConnectStore {
                   }
                 | undefined;
 
-            if (relayUrlChanged) {
-                if (!this.walletServiceKeys?.privateKey) {
-                    await this.loadWalletServiceKeys();
+            this.pendingConnectionMutationIds.add(connectionId);
+            try {
+                const hadActiveSubscription =
+                    this.activeSubscriptions.has(connectionId);
+
+                if (relayUrlChanged) {
+                    this.unsubscribeFromConnection(connectionId);
                 }
 
-                rotatedSecret = this.generateConnectionSecret(newRelayUrl!);
-                await this.storeClientKeys(
-                    rotatedSecret.connectionPublicKey,
-                    rotatedSecret.connectionPrivateKey
+                const hadInFlight = await this.awaitInFlightHandlers(
+                    connectionId
                 );
 
-                this.unsubscribeFromConnection(connectionId);
-                if (!this.nwcWalletServices.has(newRelayUrl!)) {
-                    this.nwcWalletServices.set(
-                        newRelayUrl!,
-                        new NWCWalletService({
-                            relayUrls: [newRelayUrl!]
-                        })
+                if (relayUrlChanged) {
+                    if (!this.walletServiceKeys?.privateKey) {
+                        await this.loadWalletServiceKeys();
+                    }
+
+                    rotatedSecret = this.generateConnectionSecret(newRelayUrl!);
+                    await this.storeClientKeys(
+                        rotatedSecret.connectionPublicKey,
+                        rotatedSecret.connectionPrivateKey
                     );
-                }
-                if (!this.publishedRelays.has(newRelayUrl!)) {
-                    const nwcWalletService = this.nwcWalletServices.get(
-                        newRelayUrl!
-                    );
-                    if (
-                        nwcWalletService &&
-                        this.walletServiceKeys?.privateKey
-                    ) {
-                        try {
-                            await this.publishWalletServiceInfoWithRetry(
-                                nwcWalletService,
-                                newRelayUrl!
-                            );
-                            await new Promise((resolve) =>
-                                setTimeout(resolve, 500)
-                            );
-                        } catch (error) {
-                            console.warn(
-                                `NWC: Failed to publish wallet service info to relay ${newRelayUrl} before connection update:`,
-                                error
-                            );
+
+                    if (!this.nwcWalletServices.has(newRelayUrl!)) {
+                        this.nwcWalletServices.set(
+                            newRelayUrl!,
+                            new NWCWalletService({
+                                relayUrls: [newRelayUrl!]
+                            })
+                        );
+                    }
+                    if (!this.publishedRelays.has(newRelayUrl!)) {
+                        const nwcWalletService = this.nwcWalletServices.get(
+                            newRelayUrl!
+                        );
+                        if (
+                            nwcWalletService &&
+                            this.walletServiceKeys?.privateKey
+                        ) {
+                            try {
+                                await this.publishWalletServiceInfoWithRetry(
+                                    nwcWalletService,
+                                    newRelayUrl!
+                                );
+                                await new Promise((resolve) =>
+                                    setTimeout(resolve, 500)
+                                );
+                            } catch (error) {
+                                console.warn(
+                                    `NWC: Failed to publish wallet service info to relay ${newRelayUrl} before connection update:`,
+                                    error
+                                );
+                            }
                         }
                     }
                 }
-            }
 
-            runInAction(() => {
-                const oldBudgetRenewal = connection.budgetRenewal;
-                const newBudgetRenewal = updates.budgetRenewal;
-                const newMaxAmountSats = updates.maxAmountSats;
+                runInAction(() => {
+                    const oldBudgetRenewal = connection.budgetRenewal;
+                    const newBudgetRenewal = updates.budgetRenewal;
+                    const newMaxAmountSats = updates.maxAmountSats;
 
-                Object.assign(connection, updates);
-                if (rotatedSecret) {
-                    connection.pubkey = rotatedSecret.connectionPublicKey;
+                    Object.assign(connection, updates);
+                    if (rotatedSecret) {
+                        connection.pubkey = rotatedSecret.connectionPublicKey;
+                    }
+
+                    const hadBudget = connection.hasBudgetLimit;
+                    const hasBudget =
+                        newMaxAmountSats !== undefined && newMaxAmountSats > 0;
+                    const budgetRenewalChanged =
+                        newBudgetRenewal !== undefined &&
+                        newBudgetRenewal !== oldBudgetRenewal;
+
+                    if (!hadBudget && hasBudget) {
+                        connection.resetBudget();
+                    } else if (hadBudget && !hasBudget) {
+                        connection.lastBudgetReset = undefined;
+                        connection.totalSpendSats = 0;
+                    } else if (hasBudget && budgetRenewalChanged) {
+                        connection.resetBudget();
+                    }
+                    this.findAndUpdateConnection(connection);
+                });
+
+                if (relayUrlChanged) {
+                    if (hadInFlight || hadActiveSubscription) {
+                        this.scheduleReleaseUnusedRelayService(oldRelayUrl);
+                    } else {
+                        this.releaseUnusedRelayService(oldRelayUrl);
+                    }
                 }
 
-                const hadBudget = connection.hasBudgetLimit;
-                const hasBudget =
-                    newMaxAmountSats !== undefined && newMaxAmountSats > 0;
-                const budgetRenewalChanged =
-                    newBudgetRenewal !== undefined &&
-                    newBudgetRenewal !== oldBudgetRenewal;
+                if (relayUrlChanged && rotatedSecret) {
+                    // Rotation (new key stored + pubkey rebound) is already durable.
+                    // If subscribe/save fails here, still return the pairing URL so
+                    // the UI can show the QR; subscription recovers on restart.
+                    try {
+                        await this.subscribeToConnection(connection);
+                        await this.saveConnections();
+                    } catch (error) {
+                        console.warn(
+                            'NWC: Relay change rotation persisted but subscribe/save failed; returning pairing URL anyway:',
+                            error
+                        );
+                    }
+                    await this.deleteClientKeys(oldPubkey);
 
-                if (!hadBudget && hasBudget) {
-                    connection.resetBudget();
-                } else if (hadBudget && !hasBudget) {
-                    connection.lastBudgetReset = undefined;
-                    connection.totalSpendSats = 0;
-                } else if (hasBudget && budgetRenewalChanged) {
-                    connection.resetBudget();
+                    return {
+                        nostrUrl: rotatedSecret.connectionUrl,
+                        success: true
+                    };
                 }
-                this.findAndUpdateConnection(connection);
-            });
 
-            if (relayUrlChanged) {
-                this.releaseUnusedRelayService(oldRelayUrl);
+                await this.subscribeToConnection(connection);
+                return { success: true };
+            } finally {
+                this.pendingConnectionMutationIds.delete(connectionId);
             }
-
-            if (relayUrlChanged && rotatedSecret) {
-                // Rotation (new key stored + pubkey rebound) is already durable.
-                // If subscribe/save fails here, still return the pairing URL so
-                // the UI can show the QR; subscription recovers on restart.
-                try {
-                    await this.subscribeToConnection(connection);
-                    await this.saveConnections();
-                } catch (error) {
-                    console.warn(
-                        'NWC: Relay change rotation persisted but subscribe/save failed; returning pairing URL anyway:',
-                        error
-                    );
-                }
-                await this.deleteClientKeys(oldPubkey);
-
-                return {
-                    nostrUrl: rotatedSecret.connectionUrl,
-                    success: true
-                };
-            }
-
-            await this.subscribeToConnection(connection);
-            return { success: true };
         } catch (error: any) {
             console.error('Failed to update NWC connection:', error);
             runInAction(() => {
@@ -1721,7 +1740,7 @@ export default class NostrWalletConnectStore {
                 this.unsubscribeFromConnection(connectionId);
                 return this.unauthorizedConnectionResponse<T>();
             }
-            if (this.pendingDeleteConnectionIds.has(connectionId)) {
+            if (this.pendingConnectionMutationIds.has(connectionId)) {
                 return this.unauthorizedConnectionResponse<T>();
             }
             if (connection.isExpired) {
@@ -1734,7 +1753,10 @@ export default class NostrWalletConnectStore {
                 ) as T;
             }
             const marked = await this.markConnectionUsed(connectionId);
-            if (!marked || this.pendingDeleteConnectionIds.has(connectionId)) {
+            if (
+                !marked ||
+                this.pendingConnectionMutationIds.has(connectionId)
+            ) {
                 return this.unauthorizedConnectionResponse<T>();
             }
             return await handler();

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -756,8 +756,8 @@ export default class NostrWalletConnectStore {
                 newRelayUrl && newRelayUrl !== oldRelayUrl
             );
 
-            // Fallible rotation work must finish before any connection mutation
-            // so a failed attempt leaves relayUrl unchanged and retries still
+            // Fallible rotation work runs before unsubscribe so a failed attempt
+            // leaves relayUrl and the live subscription unchanged; retries still
             // detect the change and return a new pairing URL.
             let rotatedSecret:
                 | {
@@ -771,10 +771,6 @@ export default class NostrWalletConnectStore {
             try {
                 const hadActiveSubscription =
                     this.activeSubscriptions.has(connectionId);
-
-                if (relayUrlChanged) {
-                    this.unsubscribeFromConnection(connectionId);
-                }
 
                 const hadInFlight = await this.awaitInFlightHandlers(
                     connectionId
@@ -823,6 +819,8 @@ export default class NostrWalletConnectStore {
                             }
                         }
                     }
+
+                    this.unsubscribeFromConnection(connectionId);
                 }
 
                 runInAction(() => {


### PR DESCRIPTION
# Description

Relates to issue: **#4486**

PR #4443 fixed the race between `deleteConnection` and in-flight NIP-47 handlers, but the same window existed in `updateConnection` — relay changes could tear down the old relay while the SDK was still flushing a response, and budget/permission/expiry edits could interleave with a mid-settle `pay_invoice`.
This applies the same mutation guard pattern to `updateConnection`:
- Rename `pendingDeleteConnectionIds` → `pendingConnectionMutationIds` and use it for both delete and update, so `withGlobalHandler` rejects new requests during either operation
- `awaitInFlightHandlers()` before applying connection mutations (budget, permissions, relay rotation, etc.)
- On relay change, unsubscribe first, then drain handlers, then mutate
- Defer old-relay release via `scheduleReleaseUnusedRelayService` when handlers were in flight or the connection had been subscribed (same rule as delete)


No behavior change for the common case where no request is in flight.


This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
