### PR TITLE
Receive: force LSP on when creating wrapped invoice

### DIFF
--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -186,6 +186,7 @@ export default class InvoicesStore {
         addressType,
         customPreimage,
         noLsp,
+        forceLsp,
         skipOnchain
     }: {
         memo: string;
@@ -199,6 +200,7 @@ export default class InvoicesStore {
         addressType?: string;
         customPreimage?: string;
         noLsp?: boolean;
+        forceLsp?: boolean;
         skipOnchain?: boolean;
     }) => {
         this.creatingInvoice = true;
@@ -213,7 +215,8 @@ export default class InvoicesStore {
             routeHintChannels,
             unified: true,
             customPreimage,
-            noLsp
+            noLsp,
+            forceLsp
         })
             .then((result) => {
                 if (!result?.rHash || !result?.paymentRequest) {
@@ -279,7 +282,8 @@ export default class InvoicesStore {
         routeHintChannels,
         unified,
         customPreimage,
-        noLsp
+        noLsp,
+        forceLsp
     }: {
         memo: string;
         value: string;
@@ -292,6 +296,7 @@ export default class InvoicesStore {
         unified?: boolean;
         customPreimage?: string;
         noLsp?: boolean;
+        forceLsp?: boolean;
     }) => {
         this.lspStore?.resetFee();
         this.payment_request = null;
@@ -372,7 +377,7 @@ export default class InvoicesStore {
 
         if (
             BackendUtils.supportsFlowLSP() &&
-            this.settingsStore.settings?.enableLSP &&
+            (this.settingsStore.settings?.enableLSP || forceLsp) &&
             value &&
             value !== '0' &&
             !noLsp
@@ -447,7 +452,7 @@ export default class InvoicesStore {
                 let jit_bolt11: string = '';
                 if (
                     BackendUtils.supportsFlowLSP() &&
-                    this.settingsStore.settings?.enableLSP &&
+                    (this.settingsStore.settings?.enableLSP || forceLsp) &&
                     value !== '0' &&
                     !noLsp
                 ) {

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -117,6 +117,7 @@ interface ReceiveProps {
             autoGenerateChange?: boolean;
             forceLn?: boolean; // when coming from the LN balance slider action
             forceOnChain?: boolean; // when coming from the on-chain balance slider action
+            forceLsp?: boolean; // when coming from Create a wrapped invoice in LSP settings
             account: string;
             addressType?: string;
             selectedIndex: number;
@@ -307,8 +308,10 @@ export default class Receive extends React.Component<
 
         const expirationIndex = expirationIndexFromSeconds(newExpirySeconds);
 
+        const forceLsp = !!route.params?.forceLsp;
+
         const lspIsActive =
-            settings?.enableLSP &&
+            (settings?.enableLSP || forceLsp) &&
             BackendUtils.supportsFlowLSP() &&
             !flowLspNotConfigured;
 
@@ -339,7 +342,7 @@ export default class Receive extends React.Component<
             routeHints,
             ampInvoice,
             blindedPaths,
-            enableLSP: settings?.enableLSP,
+            enableLSP: settings?.enableLSP || forceLsp,
             lspIsActive,
             flowLspNotConfigured
         });
@@ -2094,6 +2097,11 @@ export default class Receive extends React.Component<
                                                             <Switch
                                                                 value={
                                                                     enableLSP
+                                                                }
+                                                                disabled={
+                                                                    !!route
+                                                                        .params
+                                                                        ?.forceLsp
                                                                 }
                                                                 onValueChange={async () => {
                                                                     this.setState(

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -282,6 +282,7 @@ export default class Receive extends React.Component<
             InvoicesStore,
             SettingsStore,
             LightningAddressStore,
+            LSPStore,
             NodeInfoStore,
             route
         } = this.props;
@@ -346,6 +347,12 @@ export default class Receive extends React.Component<
             lspIsActive,
             flowLspNotConfigured
         });
+
+        // Wallet only fetches LSP info (and peers with the LSP) when the
+        // persisted setting is enabled, so a forced session fetches it here
+        if (forceLsp && lspIsActive && !LSPStore.info?.pubkey) {
+            LSPStore.getLSPInfo().catch(() => {});
+        }
 
         const { lnOnly, onChainOnly } = this.getReceiveModeFlags();
 
@@ -638,6 +645,7 @@ export default class Receive extends React.Component<
                     ? addressType || '1'
                     : undefined,
                 noLsp: !effectiveLspIsActive,
+                forceLsp: !!this.props.route.params?.forceLsp,
                 skipOnchain
             })
                 .then(
@@ -737,6 +745,7 @@ export default class Receive extends React.Component<
                             expirySeconds: '3600',
                             lnurl: lnurlParams,
                             noLsp: !lspIsActive,
+                            forceLsp: !!this.props.route.params?.forceLsp,
                             skipOnchain
                         })
                             .then(
@@ -2104,6 +2113,13 @@ export default class Receive extends React.Component<
                                                                         ?.forceLsp
                                                                 }
                                                                 onValueChange={async () => {
+                                                                    // never persist a change while the LSP is forced on
+                                                                    if (
+                                                                        route
+                                                                            .params
+                                                                            ?.forceLsp
+                                                                    )
+                                                                        return;
                                                                     this.setState(
                                                                         {
                                                                             enableLSP:
@@ -2914,6 +2930,9 @@ export default class Receive extends React.Component<
                                                                     ? customPreimage
                                                                     : undefined,
                                                             noLsp: !lspIsActive,
+                                                            forceLsp:
+                                                                !!route.params
+                                                                    ?.forceLsp,
                                                             skipOnchain
                                                         })
                                                             .then(

--- a/views/Settings/LSP.tsx
+++ b/views/Settings/LSP.tsx
@@ -356,7 +356,11 @@ export default class LSP extends React.Component<LSPProps, LSPState> {
                                     label: localeString(
                                         'views.Settings.LSP.createWrappedInvoice'
                                     ),
-                                    nav: 'Receive'
+                                    nav: 'Receive',
+                                    params: {
+                                        forceLsp: true,
+                                        selectedIndex: 1
+                                    }
                                 },
                                 {
                                     label: localeString(
@@ -379,7 +383,10 @@ export default class LSP extends React.Component<LSPProps, LSPState> {
                                     }}
                                     onPress={() => {
                                         if (item.nav)
-                                            navigation.navigate(item.nav);
+                                            navigation.navigate(
+                                                item.nav,
+                                                item.params
+                                            );
                                         if (item.url)
                                             UrlUtils.goToUrl(item.url);
                                     }}


### PR DESCRIPTION
# Description

|LSP JIT Settings|Receive view from 'create a wrapped invoice'|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-28 at 09 28 53" src="https://github.com/user-attachments/assets/5025c154-0eca-47cd-8e44-c3d0cc275bb9" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-28 at 09 28 58" src="https://github.com/user-attachments/assets/4354335a-e3ce-493a-8b90-42e8ed000160" />|

The "Create a wrapped invoice" item in LSP (Flow 2.0) settings navigated to the Receive view with no params, so the screen simply used the persisted `enableLSP` setting. If the user had the LSP toggled off, tapping "Create a wrapped invoice" landed them on a screen that would generate a plain, unwrapped invoice, contradicting the button they just tapped.

This PR:

- passes a new `forceLsp` route param (following the existing `forceLn`/`forceOnChain` convention) from the LSP settings entry, along with `selectedIndex: 1` so the user lands on the Lightning tab, since wrapped invoices are Lightning-specific
- makes Receive activate the LSP for the session when `forceLsp` is set, regardless of the persisted setting; the persisted `enableLSP` setting itself is not modified
- renders the LSP switch disabled (locked in the on position) when entering via this path

Because the override is state-only and flows through `lspIsActive`, downstream behavior follows automatically: the memo field hides, expiry locks to 1 hour, and the amount input's inbound-liquidity check uses the LSP path. The entry point is only reachable when the Flow LSP is configured (the list is gated on `flowLspNotConfigured` in `views/Settings/LSP.tsx`), so the forced-on state cannot conflict with an unconfigured LSP.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Test plan: with the LSP toggle off in LSP settings, tap "Create a wrapped invoice" and verify the Receive screen opens on the Lightning tab with the LSP switch on and locked, then generate an invoice and confirm it is wrapped (payee is the LSP, not the node). Also verify normal Receive entry still respects the persisted setting and the toggle remains interactive there.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
