### PR TITLE
models: decode percent-encoded memos for display

### DIFF
--- a/models/CashuPayment.ts
+++ b/models/CashuPayment.ts
@@ -5,6 +5,7 @@ import DateTimeUtils from '../utils/DateTimeUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { Proof } from './CashuToken';
 import Bolt11Utils from '../utils/Bolt11Utils';
+import { decodeMemo } from '../utils/MemoUtils';
 
 // Quote structure used in meltResponse
 export interface MeltQuote {
@@ -82,7 +83,7 @@ export default class CashuPayment extends Payment {
         const payReq = this.payment_request || this.bolt11;
         if (payReq) {
             try {
-                return Bolt11Utils.decode(payReq).description;
+                return decodeMemo(Bolt11Utils.decode(payReq).description);
             } catch {}
         }
         return undefined;

--- a/models/Invoice.test.ts
+++ b/models/Invoice.test.ts
@@ -119,6 +119,24 @@ describe('Invoice.isExpired / isExpiredNow', () => {
     });
 });
 
+describe('Invoice.getMemo', () => {
+    it('decodes percent-encoded memos from LNURL-pay services (#1717)', () => {
+        const invoice = new Invoice({ memo: 'Pay%20to%20Alice' });
+        expect(invoice.getMemo).toBe('Pay to Alice');
+    });
+
+    it('leaves memos with a literal % untouched', () => {
+        const invoice = new Invoice({ memo: '50% off' });
+        expect(invoice.getMemo).toBe('50% off');
+    });
+
+    it('still splits NameDesc memos after decoding', () => {
+        const invoice = new Invoice({ memo: 'Alice:  Pay%20me' });
+        expect(invoice.getMemo).toBe('Pay me');
+        expect(invoice.getNameDescReceiver).toBe('Alice');
+    });
+});
+
 describe('Invoice.determineFormattedOriginalTimeUntilExpiry', () => {
     it('humanizes the fallback expiry seconds', () => {
         const invoice = new Invoice({

--- a/models/Invoice.ts
+++ b/models/Invoice.ts
@@ -6,6 +6,7 @@ import Base64Utils from '../utils/Base64Utils';
 import DateTimeUtils from '../utils/DateTimeUtils';
 import Bolt11Utils, { DecodedBolt11 } from '../utils/Bolt11Utils';
 import { localeString } from '../utils/LocaleUtils';
+import { decodeMemo } from '../utils/MemoUtils';
 import { notesStore } from '../stores/Stores';
 
 interface HopHint {
@@ -175,6 +176,8 @@ export default class Invoice extends BaseModel {
         if (typeof source === 'string') memo = source;
         if (Array.isArray(source)) memo = source[0];
 
+        memo = decodeMemo(memo);
+
         // NameDesc
         if (memo?.includes(':  ')) {
             return memo.split(':  ')[1];
@@ -190,6 +193,8 @@ export default class Invoice extends BaseModel {
         let memo;
         if (typeof source === 'string') memo = source;
         if (Array.isArray(source)) memo = source[0];
+
+        memo = decodeMemo(memo);
 
         // NameDesc
         if (memo?.includes(':  ')) {

--- a/models/Payment.ts
+++ b/models/Payment.ts
@@ -8,6 +8,7 @@ import { getFeePercentage } from '../utils/AmountUtils';
 import { localeString } from '../utils/LocaleUtils';
 import Bolt11Utils from '../utils/Bolt11Utils';
 import Base64Utils from '../utils/Base64Utils';
+import { decodeMemo } from '../utils/MemoUtils';
 import { lnrpc } from '../proto/lightning';
 import { notesStore } from '../stores/Stores';
 
@@ -114,7 +115,9 @@ export default class Payment extends BaseModel {
     @computed public get getMemo(): string | undefined {
         if (this.getPaymentRequest) {
             try {
-                return Bolt11Utils.decode(this.getPaymentRequest).description;
+                return decodeMemo(
+                    Bolt11Utils.decode(this.getPaymentRequest).description
+                );
             } catch (e) {
                 console.log('Error decoding payment request:', e);
             }

--- a/utils/MemoUtils.test.ts
+++ b/utils/MemoUtils.test.ts
@@ -1,0 +1,38 @@
+import { decodeMemo } from './MemoUtils';
+
+describe('MemoUtils.decodeMemo', () => {
+    it('decodes percent-encoded spaces (#1717)', () => {
+        expect(decodeMemo('Pay%20to%20Alice')).toBe('Pay to Alice');
+    });
+
+    it('decodes other percent-encoded characters', () => {
+        expect(decodeMemo('caf%C3%A9%20%26%20bar')).toBe('café & bar');
+        expect(decodeMemo('100%25 legit')).toBe('100% legit');
+    });
+
+    it('leaves plain memos untouched', () => {
+        expect(decodeMemo('Pay to Alice')).toBe('Pay to Alice');
+        expect(decodeMemo('zeus pay: tip')).toBe('zeus pay: tip');
+    });
+
+    it('leaves memos with a bare % untouched', () => {
+        expect(decodeMemo('50% off')).toBe('50% off');
+        expect(decodeMemo('100%')).toBe('100%');
+    });
+
+    it('returns the original when decoding throws despite a valid-looking sequence', () => {
+        // %20 matches, but the bare "% o" makes decodeURIComponent throw
+        expect(decodeMemo('50% off%20today')).toBe('50% off%20today');
+        // %ff matches the pattern but is an invalid lone UTF-8 byte
+        expect(decodeMemo('bad%ffbyte')).toBe('bad%ffbyte');
+    });
+
+    it('does not treat + as a space', () => {
+        expect(decodeMemo('1+1%202')).toBe('1+1 2');
+    });
+
+    it('passes through empty and undefined values', () => {
+        expect(decodeMemo('')).toBe('');
+        expect(decodeMemo(undefined)).toBeUndefined();
+    });
+});

--- a/utils/MemoUtils.ts
+++ b/utils/MemoUtils.ts
@@ -1,0 +1,18 @@
+// Some LNURL-pay services store the percent-encoded comment/description
+// in the invoice memo (e.g. spaces arrive as %20), which Zeus would
+// then display verbatim. Decode such memos for display, leaving memos
+// that merely contain a literal % untouched.
+const percentEncodedSequence = /%[0-9A-Fa-f]{2}/;
+
+export function decodeMemo(memo: string): string;
+export function decodeMemo(memo?: string): string | undefined;
+export function decodeMemo(memo?: string): string | undefined {
+    if (!memo || !percentEncodedSequence.test(memo)) return memo;
+    try {
+        return decodeURIComponent(memo);
+    } catch {
+        // not actually percent-encoded (e.g. a bare % elsewhere in the
+        // memo) - show the original text rather than throwing
+        return memo;
+    }
+}

--- a/views/LnurlPay/Metadata.tsx
+++ b/views/LnurlPay/Metadata.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Text, Image, View } from 'react-native';
 import { Icon } from '@rneui/themed';
 
+import { decodeMemo } from '../../utils/MemoUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 
 interface LnurlPayMetadataProps {
@@ -20,9 +21,11 @@ export default class LnurlPayMetadata extends React.Component<LnurlPayMetadataPr
         } catch (err) {
             keypairs = [];
         }
-        const text: string = keypairs
-            .filter(([typ]: any) => typ === 'text/plain')
-            .map(([, content]: any) => content)[0];
+        const text: string = decodeMemo(
+            keypairs
+                .filter(([typ]: any) => typ === 'text/plain')
+                .map(([, content]: any) => content)[0]
+        );
 
         const image: string = keypairs
             .filter(([typ]: any) => typ.slice(0, 6) === 'image/')


### PR DESCRIPTION
# Description

Fixes #1717
Supersedes #4180

Some LNURL-pay services store the percent-encoded comment/description in the invoice memo and metadata, so a memo like `Pay to Alice` was rendered as `Pay%20to%20Alice` on the Invoice view, in the activity list, and on the LNURL pay screen.

This PR adds a `decodeMemo` util and applies it at the display layer:

- `utils/MemoUtils.ts`: runs a memo through `decodeURIComponent` only when it contains a valid percent-encoded sequence (`%XX`), and falls back to the original text if decoding throws, so memos with a bare `%` (e.g. `50% off`) are left untouched.
- Receiver side: applied in `Invoice.getMemo` / `Invoice.getNameDescReceiver` (decode happens before the NameDesc split), covering the Invoice view, activity list, search, and CSV export surfaces from the issue's screenshot.
- Sender side: applied in `Payment.getMemo`, `CashuPayment.getMemo`, and the `text/plain` metadata on the LNURL pay screen (`views/LnurlPay/Metadata.tsx`, taking over the fix from #4180, thanks @Wajid-0ne).

`decodeURIComponent` is used rather than `decodeURI` because the memo is an encoded component, not a full URI: `decodeURI` leaves reserved characters like `%2C` and `%26` encoded.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
