### PR TITLE
crypto: source sync random bytes from the OS CSPRNG

### DIFF
--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -2,7 +2,6 @@ import { action, observable, reaction, runInAction } from 'mobx';
 import BigNumber from 'bignumber.js';
 // leave as is, do not do tree-shaking
 import { chain } from 'lodash';
-import { randomBytes } from 'react-native-randombytes';
 
 import Channel from '../models/Channel';
 import ClosedChannel from '../models/ClosedChannel';
@@ -19,6 +18,7 @@ import SettingsStore from './SettingsStore';
 import BackendUtils from '../utils/BackendUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
+import { randomBytes } from '../utils/RandomUtils';
 
 interface ChannelInfoIndex {
     [key: string]: ChannelInfo;

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -1,7 +1,6 @@
 const bitcoin = require('bitcoinjs-lib');
 
 import { action, observable, runInAction } from 'mobx';
-import { randomBytes } from 'react-native-randombytes';
 import { sha256 } from 'js-sha256';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 
@@ -17,6 +16,7 @@ import Base64Utils from '../utils/Base64Utils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { checkGraphSyncBeforePayment } from '../utils/GraphSyncUtils';
+import { randomBytes } from '../utils/RandomUtils';
 import UrlUtils from '../utils/UrlUtils';
 import { RATING_MODAL_TRIGGER_DELAY } from '../utils/RatingUtils';
 

--- a/typings/react-native-randombytes/index.d.ts
+++ b/typings/react-native-randombytes/index.d.ts
@@ -1,4 +1,0 @@
-declare module 'react-native-randombytes' {
-    const randomBytes: any;
-    export { randomBytes };
-}

--- a/utils/RandomUtils.test.ts
+++ b/utils/RandomUtils.test.ts
@@ -1,0 +1,23 @@
+import { randomBytes } from './RandomUtils';
+
+describe('RandomUtils', () => {
+    describe('randomBytes', () => {
+        it('returns a Buffer of the requested length', () => {
+            const bytes = randomBytes(32);
+            expect(Buffer.isBuffer(bytes)).toBe(true);
+            expect(bytes.length).toBe(32);
+            expect(randomBytes(0).length).toBe(0);
+        });
+
+        it('returns fresh values on every call', () => {
+            const a = randomBytes(32);
+            const b = randomBytes(32);
+            expect(a.equals(b)).toBe(false);
+        });
+
+        it('does not return all-zero output', () => {
+            const bytes = randomBytes(64);
+            expect(bytes.some((byte) => byte !== 0)).toBe(true);
+        });
+    });
+});

--- a/utils/RandomUtils.ts
+++ b/utils/RandomUtils.ts
@@ -1,0 +1,12 @@
+// react-native-get-random-values (loaded first thing in index.js) installs a
+// synchronous WebCrypto getRandomValues backed by the OS CSPRNG. tsconfig
+// carries no DOM lib, so declare the shape we rely on.
+declare const crypto: {
+    getRandomValues: <T extends ArrayBufferView>(array: T) => T;
+};
+
+// Drop-in replacement for react-native-randombytes' synchronous randomBytes,
+// which draws from SJCL's userspace PRNG in JS rather than the OS generator.
+export function randomBytes(size: number): Buffer {
+    return Buffer.from(crypto.getRandomValues(new Uint8Array(size)));
+}


### PR DESCRIPTION
# Description

Relates to issue: **#4505** (first task of the epic; scoped while investigating #1085)

`react-native-randombytes`' synchronous `randomBytes` never calls the native module. It draws from SJCL's userspace PRNG running in JS, seeded once from native entropy at module init; only the async callback form reaches the OS CSPRNG. We were using the sync form in two funds-adjacent spots:

- keysend preimages (`stores/TransactionsStore.ts`)
- `pending_chan_id`s for PSBT-shim channel opens (`stores/ChannelsStore.ts`, 4 sites)

This PR adds `utils/RandomUtils.randomBytes`, a drop-in synchronous replacement backed by the `getRandomValues` polyfill from `react-native-get-random-values` (native, OS CSPRNG, already loaded first thing in `index.js`), and switches both stores to it. Call sites are unchanged apart from the import. The now-unused local typings for `react-native-randombytes` are removed; the package itself stays because it still backs the `react-native-crypto` shim's `randomBytes` for dependency code (its removal is a later task in #4505).

Note on local verification: the four checks are clean for the files this PR touches. My local run also surfaces pre-existing failures in nostr-related suites caused by a local node_modules skew against master's `@nostr/tools` alias; this PR does not touch dependencies, so CI reflects master's state.

Device tests pending.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Flows to exercise on device: keysend send (preimage/payment_hash still accepted by the receiver) and channel open with a non-default account or multiple channels (PSBT funding shim).

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
