### PR TITLE
ui: Receive: animate gradient border on channel-open fee card

### DIFF
--- a/components/AnimatedGradientBorder.tsx
+++ b/components/AnimatedGradientBorder.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from 'react';
+import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+import Animated, {
+    cancelAnimation,
+    Easing,
+    useAnimatedStyle,
+    useReducedMotion,
+    useSharedValue,
+    withRepeat,
+    withTiming
+} from 'react-native-reanimated';
+
+import LinearGradient from './LinearGradient';
+
+interface AnimatedGradientBorderProps {
+    // when false, renders a plain hairline-bordered card instead
+    active: boolean;
+    colors: string[];
+    backgroundColor: string;
+    borderRadius?: number;
+    borderWidth?: number;
+    inactiveBorderWidth?: number;
+    duration?: number;
+    style?: StyleProp<ViewStyle>;
+    contentStyle?: StyleProp<ViewStyle>;
+    children?: React.ReactNode;
+}
+
+export default function AnimatedGradientBorder({
+    active,
+    colors,
+    backgroundColor,
+    borderRadius = 10,
+    borderWidth = 2,
+    inactiveBorderWidth = 0.5,
+    duration = 3000,
+    style,
+    contentStyle,
+    children
+}: AnimatedGradientBorderProps) {
+    const reducedMotion = useReducedMotion();
+    const [layout, setLayout] = useState<{
+        width: number;
+        height: number;
+    } | null>(null);
+    const rotation = useSharedValue(0);
+
+    const animate = active && !reducedMotion;
+
+    useEffect(() => {
+        if (animate) {
+            rotation.value = 0;
+            rotation.value = withRepeat(
+                withTiming(360, { duration, easing: Easing.linear }),
+                -1
+            );
+        } else {
+            cancelAnimation(rotation);
+            rotation.value = 0;
+        }
+        return () => cancelAnimation(rotation);
+    }, [animate, duration]);
+
+    const spinStyle = useAnimatedStyle(() => ({
+        transform: [{ rotate: `${rotation.value}deg` }]
+    }));
+
+    if (!active) {
+        return (
+            <View
+                style={[
+                    {
+                        backgroundColor,
+                        borderRadius,
+                        borderWidth: inactiveBorderWidth
+                    },
+                    style,
+                    contentStyle
+                ]}
+            >
+                {children}
+            </View>
+        );
+    }
+
+    // the spinning gradient square must cover the card at every angle,
+    // so it is sized to the card's diagonal
+    const diagonal = layout
+        ? Math.ceil(Math.hypot(layout.width, layout.height))
+        : 0;
+
+    return (
+        <View
+            style={[
+                style,
+                {
+                    borderRadius,
+                    overflow: 'hidden',
+                    padding: borderWidth
+                }
+            ]}
+            onLayout={(e) => {
+                const { width, height } = e.nativeEvent.layout;
+                setLayout({ width, height });
+            }}
+        >
+            {layout && animate ? (
+                <Animated.View
+                    style={[
+                        {
+                            position: 'absolute',
+                            width: diagonal,
+                            height: diagonal,
+                            top: (layout.height - diagonal) / 2,
+                            left: (layout.width - diagonal) / 2
+                        },
+                        spinStyle
+                    ]}
+                >
+                    <LinearGradient
+                        colors={colors}
+                        start={{ x: 0, y: 0 }}
+                        end={{ x: 1, y: 1 }}
+                        style={{ flex: 1 }}
+                    />
+                </Animated.View>
+            ) : (
+                <View
+                    style={[
+                        StyleSheet.absoluteFill,
+                        { backgroundColor: colors[0] }
+                    ]}
+                />
+            )}
+            <View
+                style={[
+                    {
+                        backgroundColor,
+                        borderRadius: Math.max(borderRadius - borderWidth, 0)
+                    },
+                    contentStyle
+                ]}
+            >
+                {children}
+            </View>
+        </View>
+    );
+}

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -31,6 +31,7 @@ const ZPayIconWhite = require('../assets/images/pay_z_white.png');
 
 import Amount from '../components/Amount';
 import AmountInput, { getSatAmount } from '../components/AmountInput';
+import AnimatedGradientBorder from '../components/AnimatedGradientBorder';
 import Button from '../components/Button';
 import CollapsedQR from '../components/CollapsedQR';
 import DropdownSetting from '../components/DropdownSetting';
@@ -1617,21 +1618,24 @@ export default class Receive extends React.Component<
                                                 )
                                             }
                                         >
-                                            <View
+                                            <AnimatedGradientBorder
+                                                active={!!requiresChannelSetup}
+                                                colors={[
+                                                    themeColor('highlight'),
+                                                    themeColor('secondary'),
+                                                    themeColor('highlight')
+                                                ]}
+                                                backgroundColor={themeColor(
+                                                    'secondary'
+                                                )}
+                                                borderRadius={10}
+                                                borderWidth={2}
                                                 style={{
-                                                    backgroundColor:
-                                                        themeColor('secondary'),
-                                                    borderColor:
-                                                        requiresChannelSetup
-                                                            ? themeColor(
-                                                                  'highlight'
-                                                              )
-                                                            : undefined,
-                                                    borderRadius: 10,
                                                     top: 10,
-                                                    margin: 10,
-                                                    padding: 15,
-                                                    borderWidth: 0.5
+                                                    margin: 10
+                                                }}
+                                                contentStyle={{
+                                                    padding: 15
                                                 }}
                                             >
                                                 <Text
@@ -1698,7 +1702,7 @@ export default class Receive extends React.Component<
                                                         'general.tapToLearnMore'
                                                     )}
                                                 </Text>
-                                            </View>
+                                            </AnimatedGradientBorder>
                                         </TouchableOpacity>
                                     )}
                                 {haveInvoice &&


### PR DESCRIPTION
# Description

https://github.com/user-attachments/assets/63fd6035-9ec8-40e0-882a-c9632fc71a74

Follow-up to #4197. The static highlight border and amount color on the LSP channel-open fee card are still being missed: users create wrapped invoices without realizing a channel open fee will be deducted from the amount received.

This PR adds a reusable `AnimatedGradientBorder` component and applies it to the fee explainer card on the Receive screen when the quoted LSP fee indicates a channel open. The highlight color now sweeps continuously around the card border as an animated gradient.

Implementation notes:

* No new dependencies: composes the existing SVG-backed `components/LinearGradient.tsx` with `react-native-reanimated`.
* The animation is a UI-thread transform (an oversized gradient square, sized to the card diagonal, rotating behind the content and clipped by the card's rounded border). No per-frame JS re-renders.
* Respects the OS reduce motion accessibility setting: falls back to a static 2px highlight border, which is still more prominent than the previous 0.5px hairline.
* When no channel open is required (`active={false}`), the card renders exactly as before. The routing-fee and zero-fee wrapped invoice cards are unchanged.

Screenshots/video will be added after device testing (draft until then).

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
