### PR TITLE
VerifyOnChain: show estimated total fee before broadcast (LND family)

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -812,6 +812,7 @@ export default class CLNRest {
     supportsLnurlAuth = () => true;
     supportsOnchainBalance = () => true;
     supportsOnchainSends = () => true;
+    supportsOnchainFeeEstimation = () => false;
     supportsOnchainReceiving = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;

--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -63,7 +63,8 @@ const {
     newAddress,
     newChangeAddress,
     getTransactions,
-    sendCoins
+    sendCoins,
+    estimateFee
 } = lndMobile.onchain;
 
 const {
@@ -102,6 +103,12 @@ export default class EmbeddedLND extends LND {
             data.spend_unconfirmed,
             data.send_all,
             data.outpoints
+        );
+    estimateOnchainFee = async (data: any) =>
+        await estimateFee(
+            data.addr_to_amount,
+            data.target_conf,
+            data.spend_unconfirmed
         );
     sendCustomMessage = async (data: any) =>
         await sendCustomMessage(data.peer, data.type, data.data);
@@ -553,6 +560,7 @@ export default class EmbeddedLND extends LND {
     supportsLnurlAuth = () => true;
     supportsOnchainBalance = () => true;
     supportsOnchainSends = () => true;
+    supportsOnchainFeeEstimation = () => true;
     supportsOnchainReceiving = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -300,6 +300,16 @@ export default class LND {
             send_all: data.send_all,
             outpoints: data.outpoints
         });
+    estimateOnchainFee = (data: any) => {
+        const params: any = {
+            target_conf: data.target_conf,
+            spend_unconfirmed: data.spend_unconfirmed
+        };
+        Object.keys(data.addr_to_amount).forEach((addr: string) => {
+            params[`AddrToAmount[${addr}]`] = data.addr_to_amount[addr];
+        });
+        return this.getRequest('/v1/transactions/fee', params);
+    };
     sendCustomMessage = (data: any) =>
         this.postRequest('/v1/custommessage', {
             peer: Base64Utils.hexToBase64(data.peer),
@@ -1011,6 +1021,7 @@ export default class LND {
     supportsLnurlAuth = () => true;
     supportsOnchainBalance = () => true;
     supportsOnchainSends = () => true;
+    supportsOnchainFeeEstimation = () => true;
     supportsOnchainReceiving = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -2175,6 +2175,7 @@ export default class LdkNode {
     supportsLnurlAuth = () => true;
     supportsOnchainBalance = () => true;
     supportsOnchainSends = () => true;
+    supportsOnchainFeeEstimation = () => false;
     supportsOnchainReceiving = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -154,6 +154,14 @@ export default class LightningNodeConnect {
                 outpoints: data.outpoints
             })
             .then((data: lnrpc.SendCoinsResponse) => snakeize(data));
+    estimateOnchainFee = async (data: any) =>
+        await this.lnc.lnd.lightning
+            .estimateFee({
+                AddrToAmount: data.addr_to_amount,
+                target_conf: data.target_conf,
+                spend_unconfirmed: data.spend_unconfirmed
+            })
+            .then((data: lnrpc.EstimateFeeResponse) => snakeize(data));
     sendCustomMessage = async (data: any) =>
         await this.lnc.lnd.lightning
             .sendCustomMessage({
@@ -873,6 +881,7 @@ export default class LightningNodeConnect {
     supportsLnurlAuth = () => true;
     supportsOnchainBalance = () => true;
     supportsOnchainSends = () => this.permSendCoins;
+    supportsOnchainFeeEstimation = () => this.permSendCoins;
     supportsOnchainReceiving = () => this.permNewAddress;
     supportsLightningSends = () => this.permSendLN;
     supportsKeysend = () => true;

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -188,6 +188,7 @@ export default class LndHub extends LND {
     supportsLnurlAuth = () => true;
     supportsOnchainBalance = () => false;
     supportsOnchainSends = () => false;
+    supportsOnchainFeeEstimation = () => false;
     supportsOnchainReceiving = () =>
         !(
             settingsStore?.lndhubUrl?.includes('lnbank/api/lndhub') ||

--- a/backends/NostrWalletConnect.ts
+++ b/backends/NostrWalletConnect.ts
@@ -86,6 +86,7 @@ export default class NostrWalletConnect {
     supportsLnurlAuth = () => false;
     supportsOnchainBalance = () => false;
     supportsOnchainSends = () => false;
+    supportsOnchainFeeEstimation = () => false;
     supportsOnchainReceiving = () => false;
     supportsLightningSends = () => true;
     supportsKeysend = () => false;

--- a/components/KeyValue.tsx
+++ b/components/KeyValue.tsx
@@ -241,9 +241,20 @@ export default class KeyValue extends React.Component<KeyValueProps> {
         const KeyValueRow = () => (
             <Row justify="space-between">
                 <View style={rtl ? styles.rtlValue : styles.key}>
-                    <Text style={{ color: themeColor('secondaryText') }}>
-                        {rtl ? Value : Key}
-                    </Text>
+                    {infoModalText ? (
+                        // the touchable is a native view; nesting it inline
+                        // in Text gets it clipped to a too-narrow measured
+                        // frame on iOS, cutting off the info glyph
+                        rtl ? (
+                            Value
+                        ) : (
+                            Key
+                        )
+                    ) : (
+                        <Text style={{ color: themeColor('secondaryText') }}>
+                            {rtl ? Value : Key}
+                        </Text>
+                    )}
                 </View>
                 <View style={rtl ? styles.rtlKey : styles.value}>
                     {rtl ? Key : Value}

--- a/lndmobile/LndMobileInjection.ts
+++ b/lndmobile/LndMobileInjection.ts
@@ -64,6 +64,7 @@ import {
     updateChannelPolicy
 } from './channel';
 import {
+    estimateFee,
     getTransactions,
     newAddress,
     newChangeAddress,
@@ -370,6 +371,11 @@ export interface ILndMobileInjections {
         }) => Promise<lnrpc.PolicyUpdateResponse>;
     };
     onchain: {
+        estimateFee: (
+            addr_to_amount: { [address: string]: string },
+            target_conf?: number,
+            spend_unconfirmed?: boolean
+        ) => Promise<lnrpc.EstimateFeeResponse>;
         getTransactions: (data?: any) => Promise<lnrpc.TransactionDetails>;
         newAddress: (
             type: lnrpc.AddressType,
@@ -711,6 +717,7 @@ export default {
         updateChannelPolicy
     },
     onchain: {
+        estimateFee,
         getTransactions,
         newAddress,
         newChangeAddress,

--- a/lndmobile/onchain.ts
+++ b/lndmobile/onchain.ts
@@ -96,6 +96,35 @@ export const walletBalance = async ({
 /**
  * @throws
  */
+export const estimateFee = async (
+    addr_to_amount: { [address: string]: string },
+    target_conf?: number,
+    spend_unconfirmed?: boolean
+): Promise<lnrpc.EstimateFeeResponse> => {
+    const AddrToAmount: { [address: string]: Long } = {};
+    Object.keys(addr_to_amount).forEach((address: string) => {
+        AddrToAmount[address] = Long.fromValue(Number(addr_to_amount[address]));
+    });
+    const response = await sendCommand<
+        lnrpc.IEstimateFeeRequest,
+        lnrpc.EstimateFeeRequest,
+        lnrpc.EstimateFeeResponse
+    >({
+        request: lnrpc.EstimateFeeRequest,
+        response: lnrpc.EstimateFeeResponse,
+        method: 'EstimateFee',
+        options: {
+            AddrToAmount,
+            target_conf,
+            spend_unconfirmed
+        }
+    });
+    return response;
+};
+
+/**
+ * @throws
+ */
 export const sendCoins = async (
     address: string,
     sat: number,

--- a/locales/en.json
+++ b/locales/en.json
@@ -970,6 +970,7 @@
     "views.SendingOnChain.txid": "TXID",
     "views.SendingOnChain.goToBlockExplorer": "Go to block explorer",
     "views.VerifyOnChain.title": "Verify Transaction",
+    "views.VerifyOnChain.feeEstimateInfo": "An estimate of the total fee for this transaction, based on your chosen fee rate and a test run of coin selection in your wallet. The estimate assumes the largest possible transaction size, so the final fee may be slightly lower.",
     "views.NostrContacts.nostrContacts": "Nostr Contacts",
     "views.NostrContacts.lookUpContacts": "Look up Contacts",
     "views.NostrContacts.importAllContacts": "Import all Contacts",

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -85,6 +85,8 @@ class BackendUtils {
     getLightningBalance = (...args: any[]) =>
         this.call('getLightningBalance', args);
     sendCoins = (...args: any[]) => this.call('sendCoins', args);
+    estimateOnchainFee = (...args: any[]) =>
+        this.call('estimateOnchainFee', args);
     sendCustomMessage = (...args: any[]) =>
         this.call('sendCustomMessage', args);
     subscribeCustomMessages = (...args: any[]) =>
@@ -218,6 +220,8 @@ class BackendUtils {
     supportsLnurlAuth = () => this.call('supportsLnurlAuth');
     supportsOnchainBalance = () => this.call('supportsOnchainBalance');
     supportsOnchainSends = () => this.call('supportsOnchainSends');
+    supportsOnchainFeeEstimation = () =>
+        this.call('supportsOnchainFeeEstimation');
     supportsOnchainReceiving = () => this.call('supportsOnchainReceiving');
     supportsLightningSends = () => this.call('supportsLightningSends');
     supportsKeysend = () => this.call('supportsKeysend');

--- a/views/VerifyOnChain.tsx
+++ b/views/VerifyOnChain.tsx
@@ -10,10 +10,12 @@ import Screen from '../components/Screen';
 import Header from '../components/Header';
 import KeyValue from '../components/KeyValue';
 import Amount from '../components/Amount';
+import LoadingIndicator from '../components/LoadingIndicator';
 import SwipeButton from '../components/SwipeButton';
 import Button from '../components/Button';
 import Text from '../components/Text';
 
+import BackendUtils from '../utils/BackendUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
 
@@ -45,6 +47,8 @@ interface VerifyOnChainProps {
 interface VerifyOnChainState {
     bitcoinUnits: 'sats' | 'BTC';
     slideToPayThreshold: number;
+    estimatedFee: number | null;
+    loadingFeeEstimate: boolean;
 }
 
 @inject('TransactionsStore', 'SettingsStore', 'UnitsStore')
@@ -52,7 +56,9 @@ interface VerifyOnChainState {
 export default class VerifyOnChain extends React.Component<VerifyOnChainProps> {
     state: VerifyOnChainState = {
         bitcoinUnits: 'sats',
-        slideToPayThreshold: 10000
+        slideToPayThreshold: 10000,
+        estimatedFee: null,
+        loadingFeeEstimate: false
     };
 
     async componentDidMount() {
@@ -61,7 +67,72 @@ export default class VerifyOnChain extends React.Component<VerifyOnChainProps> {
         this.setState({
             slideToPayThreshold: settings?.payments?.slideToPayThreshold
         });
+        this.fetchFeeEstimate();
     }
+
+    fetchFeeEstimate = async () => {
+        const { route } = this.props;
+        const {
+            destination,
+            fee,
+            satAmount,
+            amount,
+            utxos,
+            account,
+            additionalOutputs,
+            fundMax
+        } = route?.params || {};
+
+        if (!BackendUtils.supportsOnchainFeeEstimation()) return;
+        // the dry-run coin selection behind the estimate can't be
+        // constrained to manually selected UTXOs, a non-default account,
+        // or a send-max spend, so an estimate would mislead there
+        if (fundMax) return;
+        if (Array.isArray(utxos) && utxos.length > 0) return;
+        if (account && account !== 'default') return;
+
+        const userRate = Number(fee);
+        const primaryAmount = Number(satAmount || amount || 0);
+        if (!destination || !(primaryAmount > 0) || !(userRate > 0)) return;
+
+        const addr_to_amount: { [address: string]: string } = {
+            [destination]: primaryAmount.toString()
+        };
+        if (Array.isArray(additionalOutputs)) {
+            for (const output of additionalOutputs) {
+                const outputAmount = Number(
+                    output?.satAmount || output?.amount || 0
+                );
+                if (!output?.address || !(outputAmount > 0)) return;
+                addr_to_amount[output.address] = (
+                    Number(addr_to_amount[output.address] || 0) + outputAmount
+                ).toString();
+            }
+        }
+
+        this.setState({ loadingFeeEstimate: true });
+        try {
+            const result = await BackendUtils.estimateOnchainFee({
+                addr_to_amount,
+                target_conf: 6,
+                spend_unconfirmed: true
+            });
+            const feeSat = Number(String(result?.fee_sat ?? ''));
+            const nodeRate = Number(String(result?.sat_per_vbyte ?? ''));
+            if (feeSat > 0 && nodeRate > 0) {
+                // the node derives its own rate from target_conf, so
+                // rescale its total by vsize to match the user's rate
+                this.setState({
+                    estimatedFee: Math.ceil((feeSat / nodeRate) * userRate),
+                    loadingFeeEstimate: false
+                });
+            } else {
+                this.setState({ loadingFeeEstimate: false });
+            }
+        } catch (e) {
+            this.setState({ loadingFeeEstimate: false });
+        }
+    };
 
     toggleBitcoinUnits = () => {
         const { UnitsStore } = this.props;
@@ -337,7 +408,12 @@ export default class VerifyOnChain extends React.Component<VerifyOnChainProps> {
         const { navigation, route } = this.props;
         const { destination, fee, satAmount, amount, account, fundMax } =
             route?.params;
-        const { slideToPayThreshold } = this.state;
+        const {
+            bitcoinUnits,
+            slideToPayThreshold,
+            estimatedFee,
+            loadingFeeEstimate
+        } = this.state;
 
         const totalAmount = this.getTotalAmount();
         const shouldUseSwipeButton = totalAmount >= slideToPayThreshold;
@@ -370,6 +446,48 @@ export default class VerifyOnChain extends React.Component<VerifyOnChainProps> {
                         keyValue={localeString('views.Send.feeSatsVbyte')}
                         value={fee}
                     />
+
+                    {loadingFeeEstimate && (
+                        <View style={{ marginTop: 10 }}>
+                            <LoadingIndicator size={30} />
+                        </View>
+                    )}
+
+                    {estimatedFee !== null && (
+                        <>
+                            <TouchableOpacity onPress={this.toggleBitcoinUnits}>
+                                <KeyValue
+                                    keyValue={localeString(
+                                        'views.PaymentRequest.feeEstimate'
+                                    )}
+                                    value={
+                                        <Amount
+                                            fixedUnits={bitcoinUnits}
+                                            sats={estimatedFee}
+                                        />
+                                    }
+                                    infoModalText={localeString(
+                                        'views.VerifyOnChain.feeEstimateInfo'
+                                    )}
+                                    disableCopy
+                                />
+                            </TouchableOpacity>
+                            <TouchableOpacity onPress={this.toggleBitcoinUnits}>
+                                <KeyValue
+                                    keyValue={localeString(
+                                        'general.totalAmount'
+                                    )}
+                                    value={
+                                        <Amount
+                                            fixedUnits={bitcoinUnits}
+                                            sats={totalAmount + estimatedFee}
+                                        />
+                                    }
+                                    disableCopy
+                                />
+                            </TouchableOpacity>
+                        </>
+                    )}
 
                     {this.renderInputs()}
 


### PR DESCRIPTION
|A|B|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-28 at 21 46 07" src="https://github.com/user-attachments/assets/a9de738e-8eab-4d0d-93a5-9060df8e38bc" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-28 at 21 32 08" src="https://github.com/user-attachments/assets/fe117dd5-4eaf-44dd-bd8c-dec1ebea7daa" />|

# Description

Relates to issue: **#4456**

Shows an estimated total fee on the on-chain confirmation screen (`VerifyOnChain`) before the user commits to a broadcast, for the three LND-family backends. Until now the confirmation screen only showed the raw sat/vB rate, making on-chain the only payment method where the user never sees an absolute fee before sending.

## How it works

- New `estimateOnchainFee` backend call + `supportsOnchainFeeEstimation` capability flag, dispatched through `BackendUtils`
- Backed by `lnrpc.Lightning.EstimateFee`, which runs a dry-run `CreateSimpleTx` against the wallet's real UTXOs and returns `fee_sat` + `sat_per_vbyte`. It does not lease UTXOs
  - **LND (REST)**: `GET /v1/transactions/fee` with `AddrToAmount[<addr>]=<amt>` map query params (grpc-gateway map syntax)
  - **Embedded LND**: new `estimateFee` wrapper in `lndmobile/onchain.ts` (the `EstimateFee` binding is already present in the shipped Lndmobile binaries)
  - **Lightning Node Connect**: `lnc.lnd.lightning.estimateFee`, gated on the same perm as `permSendCoins`
- The RPC derives its rate from `target_conf` internally rather than accepting the user's sat/vB, so the view rescales by vsize: `estimated fee = (fee_sat / sat_per_vbyte) * user rate`, rounded up
- `VerifyOnChain` renders "Fee Estimate" and "Total Amount" rows (existing locale strings, no new translations) under the fee-rate row, with a loading indicator while the estimate is in flight. The rows unit-toggle (sats/BTC/fiat) like the amount rows

## Scope / safety

- Explicit `supportsOnchainFeeEstimation = () => false` on CLN, LDK Node, LndHub, and NWC (avoids the call-returns-false trap and the extends-LND inheritance leak on LndHub); behavior on those backends is unchanged. CLN support via `fundpsbt`/`txdiscard` is possible as a follow-up; LDK Node is blocked on FFI binding work
- The estimate is skipped (row hidden, no call made) for send-max spends, manually selected UTXOs, and non-default accounts, since this version of `EstimateFeeRequest` can't constrain the dry-run coin selection to match those transactions; a wrong number right before confirming would be worse than none. Follow-up: local vsize computation for the coin-control case
- Any estimate failure hides the rows silently; the send path itself is untouched

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS (iPhone 17 Pro simulator)

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST) (mutinynet)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
