### PR TITLE
backends: don't show read-only badge when LNC connection fails

### DIFF
--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -38,15 +38,17 @@ export default class LightningNodeConnect {
     lnc: any;
     listener: any;
 
-    permOpenChannel: boolean;
-    permSendCoins: boolean;
-    permSendLN: boolean;
-    permNewAddress: boolean;
-    permImportAccount: boolean;
-    permForwardingHistory: boolean;
-    // Default true so NWC subscribe-before-checkPerms (app resume) does
-    // not drop sign_message. checkPerms currently forces all perms true
-    // (ZEUS-3642); restore hasPerms there before relying on this flag.
+    // Default true: checkPerms currently forces all perms true (ZEUS-3642),
+    // and it only runs after a successful connect, so uninitialized perms
+    // would misreport a failed connection as a read-only wallet (and NWC
+    // subscribe-before-checkPerms on app resume would drop sign_message).
+    // Restore hasPerms in checkPerms before relying on these flags.
+    permOpenChannel: boolean = true;
+    permSendCoins: boolean = true;
+    permSendLN: boolean = true;
+    permNewAddress: boolean = true;
+    permImportAccount: boolean = true;
+    permForwardingHistory: boolean = true;
     permSignMessage: boolean = true;
 
     initLNC = async () => {


### PR DESCRIPTION
# Description

The wallet header's read-only badge (`components/WalletHeader.tsx`) renders whenever `supportsLightningSends()` is falsy. On LNC that flag returns `permSendLN`, which stayed `undefined` until `checkPerms()` ran, and `checkPerms()` only runs after a successful connect in `views/Wallet/Wallet.tsx`. On a fresh launch where the LNC connection fails, the header misreported the connectivity failure as a read-only wallet, pointing users at the wrong explanation at exactly the moment they are trying to diagnose the failure.

Since `checkPerms()` currently hardcodes every perm to true anyway (ZEUS-3642), this initializes the perm fields to true so perm-derived `supports*` flags are stable from construction, matching the existing `permSignMessage` default. If/when real `hasPerms` checks are restored for ZEUS-3642, badge gating should also consider connection state so a failed perms check is not rendered as read-only.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding