### PR TITLE
Wallet: halt fetchData when LNC or NWC connection fails

### DIFF
--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1185,32 +1185,39 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             if (connecting) {
                 error = await connect();
             }
-            if (!error) {
-                try {
-                    await BackendUtils.checkPerms();
-                    await NodeInfoStore.getNodeInfo();
-                    if (BackendUtils.supportsAccounts())
-                        await UTXOsStore.listAccounts();
-                    await BalanceStore.getCombinedBalance();
-                    if (BackendUtils.supportsChannelManagement())
-                        await ChannelsStore.getChannels();
-                } catch (connectionError) {
-                    console.log('LNC connection failed:', connectionError);
-                    return;
-                }
+            if (error) {
+                setConnectingStatus(false);
+                return;
+            }
+            try {
+                await BackendUtils.checkPerms();
+                await NodeInfoStore.getNodeInfo();
+                if (BackendUtils.supportsAccounts())
+                    await UTXOsStore.listAccounts();
+                await BalanceStore.getCombinedBalance();
+                if (BackendUtils.supportsChannelManagement())
+                    await ChannelsStore.getChannels();
+            } catch (connectionError) {
+                console.log('LNC connection failed:', connectionError);
+                NodeInfoStore.handleGetNodeInfoError();
+                setConnectingStatus(false);
+                return;
             }
         } else if (implementation === 'nostr-wallet-connect') {
             let error;
             if (connecting) {
                 error = await connectNWC();
             }
-            if (!error) {
-                try {
-                    await BalanceStore.getLightningBalance(true);
-                } catch (connectionError) {
-                    console.log('NWC connection failed:', connectionError);
-                    return;
-                }
+            if (error) {
+                setConnectingStatus(false);
+                return;
+            }
+            try {
+                await BalanceStore.getLightningBalance(true);
+            } catch (connectionError) {
+                console.log('NWC connection failed:', connectionError);
+                setConnectingStatus(false);
+                return;
             }
         } else if (implementation === 'ldk-node') {
             try {
@@ -1262,6 +1269,9 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
         if (
             lightningAddress.enabled &&
             !NodeInfoStore.testnet &&
+            // all ZEUS Pay calls authenticate with the node pubkey; without
+            // it (connection failure) they can only fail server-side
+            NodeInfoStore.nodeInfo?.identity_pubkey &&
             BackendUtils.supportsLightningAddress()
         ) {
             if (connecting) {

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -1199,8 +1199,10 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                     await ChannelsStore.getChannels();
             } catch (connectionError) {
                 console.log('LNC connection failed:', connectionError);
-                NodeInfoStore.handleGetNodeInfoError();
-                setConnectingStatus(false);
+                // getNodeInfo() is the only call above that can reject, and it
+                // already sets the node info error state itself - under a
+                // staleness check this call site does not have
+                if (connecting) setConnectingStatus(false);
                 return;
             }
         } else if (implementation === 'nostr-wallet-connect') {
@@ -1216,7 +1218,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                 await BalanceStore.getLightningBalance(true);
             } catch (connectionError) {
                 console.log('NWC connection failed:', connectionError);
-                setConnectingStatus(false);
+                if (connecting) setConnectingStatus(false);
                 return;
             }
         } else if (implementation === 'ldk-node') {


### PR DESCRIPTION
# Description

Fixes the "Lightning address error: Pubkey not defined" error thrown on failed connections.

Root cause: in `Wallet.tsx` `fetchData`, the `lightning-node-connect` and `nostr-wallet-connect` branches do not bail out when `connect()` reports an error. Every other backend branch returns early on connection failure, but these two only skip their own data fetching (`if (!error)`) and then fall through to the post-connection work. With `NodeInfoStore.nodeInfo` empty, the ZEUS Pay status call posts `pubkey: undefined` to the server, which responds with `Pubkey not defined`; `LightningAddressStore.status()` stores that as its error state and re-throws. The dead connection also triggered pointless follow-up work (LSP info fetch, swaps fetch) before the connecting status was finally cleared.

Changes:
- LNC and NWC branches now return early when `connect()` reports an error, clearing the connecting status first so the error screen (driven by `SettingsStore.error`, which `connect()`/`connectNWC()` already set) is shown, matching the LND (REST) branch's failure handling.
- Their post-connect fetch `catch` blocks now also clear the connecting status before returning, instead of stranding the connecting spinner.
- The Lightning address block is additionally guarded on `NodeInfoStore.nodeInfo?.identity_pubkey`: every ZEUS Pay call authenticates with the node pubkey, so without it the calls can only fail server-side.

Only the LNC path can currently reach the Lightning address block on a failed connection (`supportsLightningAddress()` is false for NWC), but the NWC branch had the same fall-through defect, so both are fixed.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding