### PR TITLE
Currency: add custom BTCPay Server fiat rates source

### DIFF
--- a/components/CurrencyList.tsx
+++ b/components/CurrencyList.tsx
@@ -6,7 +6,8 @@ import { inject, observer } from 'mobx-react';
 import SettingsStore, {
     CURRENCY_KEYS,
     DEFAULT_FIAT,
-    DEFAULT_FIAT_RATES_SOURCE
+    DEFAULT_FIAT_RATES_SOURCE,
+    isCurrencySupportedBySource
 } from '../stores/SettingsStore';
 import UnitsStore from '../stores/UnitsStore';
 import FiatStore from '../stores/FiatStore';
@@ -275,7 +276,7 @@ export default class CurrencyList extends React.Component<
 
         const currencies = [...this.state.currencies]
             .sort((a, b) => a.key.localeCompare(b.key))
-            .filter((c) => c.supportedSources?.includes(fiatRatesSource));
+            .filter((c) => isCurrencySupportedBySource(c, fiatRatesSource));
 
         const favoriteCurrencyItems = currencies.filter((c) =>
             favoriteCurrencies.includes(c.value)

--- a/locales/en.json
+++ b/locales/en.json
@@ -1193,6 +1193,8 @@
     "views.Settings.Currency.currencies": "Currencies",
     "views.Settings.Currency.otherCurrencies": "Other currencies",
     "views.Settings.Currency.source": "Source",
+    "views.Settings.Currency.btcPayServerHost": "BTCPay Server URL",
+    "views.Settings.Currency.btcPayServerStoreId": "BTCPay Server store ID",
     "views.Settings.Currency.selectCurrency": "Select Currency",
     "views.Settings.SelectCurrency.title": "Select Currency",
     "views.Settings.Theme.title": "Theme",

--- a/stores/FiatStore.ts
+++ b/stores/FiatStore.ts
@@ -701,9 +701,16 @@ export default class FiatStore {
             if (settings.fiatRatesSource.toLowerCase() === 'zeus') {
                 this.fiatRates = await this.getFiatRatesFromZeus();
             } else if (settings.fiat != null) {
-                const rate = await this.getSelectedFiatRateFromYadio(
-                    settings.fiat
-                );
+                const rate =
+                    settings.fiatRatesSource === 'BTCPayServer'
+                        ? await this.getSelectedFiatRateFromBTCPay(
+                              settings.btcPayServerHost || '',
+                              settings.btcPayServerStoreId || '',
+                              settings.fiat
+                          )
+                        : await this.getSelectedFiatRateFromYadio(
+                              settings.fiat
+                          );
 
                 runInAction(() => {
                     if (this.fiatRates) {
@@ -752,6 +759,46 @@ export default class FiatStore {
             }
         } catch (error) {
             console.error('Error fetching fiat rates from yadio', error);
+        }
+
+        return undefined;
+    };
+
+    private getSelectedFiatRateFromBTCPay = async (
+        host: string,
+        storeId: string,
+        code: string
+    ) => {
+        if (!host.trim() || !storeId.trim()) return undefined;
+
+        try {
+            const baseUrl = host.trim().replace(/\/+$/, '');
+            const response = await ReactNativeBlobUtil.fetch(
+                'GET',
+                `${baseUrl}/api/rates?storeId=${encodeURIComponent(
+                    storeId.trim()
+                )}&currencyPairs=BTC_${code}`
+            );
+            const status = response.info().status;
+            if (status == 200) {
+                const rates = response.json();
+                const entry =
+                    Array.isArray(rates) &&
+                    rates.find((r: any) => r.code === code);
+                if (entry && entry.rate != null) {
+                    return {
+                        cryptoCode: 'BTC',
+                        code,
+                        rate: entry.rate,
+                        currencyPair: `BTC_${code}`
+                    };
+                }
+            }
+        } catch (error) {
+            console.error(
+                'Error fetching fiat rates from BTCPay Server',
+                error
+            );
         }
 
         return undefined;

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -200,7 +200,9 @@ export interface Settings {
     authenticationAttempts?: number;
     fiatEnabled?: boolean;
     fiat?: string;
-    fiatRatesSource: 'Zeus' | 'Yadio';
+    fiatRatesSource: 'Zeus' | 'Yadio' | 'BTCPayServer';
+    btcPayServerHost?: string;
+    btcPayServerStoreId?: string;
     locale?: string;
     privacy: PrivacySettings;
     display: DisplaySettings;
@@ -266,8 +268,17 @@ interface NetworkingSettings {
 
 export const FIAT_RATES_SOURCE_KEYS = [
     { key: 'ZEUS', value: 'Zeus' },
-    { key: 'Yadio', value: 'Yadio' }
+    { key: 'Yadio', value: 'Yadio' },
+    { key: 'BTCPay Server', value: 'BTCPayServer' }
 ];
+
+// A user's own BTCPay Server decides its own currency coverage, so every
+// currency is selectable there; unsupported ones simply return no rate.
+export const isCurrencySupportedBySource = (
+    currency: { supportedSources?: Array<string> } | undefined,
+    source: string
+): boolean =>
+    source === 'BTCPayServer' || !!currency?.supportedSources?.includes(source);
 
 export const BLOCK_EXPLORER_KEYS = [
     { key: 'mempool.space', value: 'mempool.space' },
@@ -1551,6 +1562,8 @@ export default class SettingsStore {
         fiatEnabled: true,
         fiat: DEFAULT_FIAT,
         fiatRatesSource: DEFAULT_FIAT_RATES_SOURCE,
+        btcPayServerHost: '',
+        btcPayServerStoreId: '',
         // embedded node
         automaticDisasterRecoveryBackup: true,
         expressGraphSync: false,

--- a/views/Settings/Currency.tsx
+++ b/views/Settings/Currency.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import { Icon, ListItem } from '@rneui/themed';
 import { inject, observer } from 'mobx-react';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -11,15 +11,19 @@ import SettingsStore, {
     CURRENCY_KEYS,
     DEFAULT_FIAT,
     DEFAULT_FIAT_RATES_SOURCE,
-    FIAT_RATES_SOURCE_KEYS
+    FIAT_RATES_SOURCE_KEYS,
+    isCurrencySupportedBySource
 } from '../../stores/SettingsStore';
 
 import UnitsStore from '../../stores/UnitsStore';
 
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
+import UrlUtils from '../../utils/UrlUtils';
 import DropdownSetting from '../../components/DropdownSetting';
 import Switch from '../../components/Switch';
+import Text from '../../components/Text';
+import TextInput from '../../components/TextInput';
 
 interface CurrencyProps {
     navigation: NativeStackNavigationProp<any, any>;
@@ -31,6 +35,8 @@ interface CurrencyState {
     fiatEnabled: boolean | undefined;
     selectedCurrency: string | undefined;
     fiatRatesSource: string;
+    btcPayServerHost: string;
+    btcPayServerStoreId: string;
 }
 
 @inject('SettingsStore', 'UnitsStore')
@@ -44,7 +50,42 @@ export default class Currency extends React.Component<
         selectedCurrency: this.props.SettingsStore.settings.fiat || '',
         fiatRatesSource:
             this.props.SettingsStore.settings.fiatRatesSource ??
-            DEFAULT_FIAT_RATES_SOURCE
+            DEFAULT_FIAT_RATES_SOURCE,
+        btcPayServerHost:
+            this.props.SettingsStore.settings.btcPayServerHost || '',
+        btcPayServerStoreId:
+            this.props.SettingsStore.settings.btcPayServerStoreId || ''
+    };
+
+    componentWillUnmount() {
+        // 'BTCPay Server' with incomplete config can never return a rate,
+        // so leaving it selected would misrepresent the source actually in
+        // use. Revert the dropdown on the way out.
+        const { settings, updateSettings }: any = this.props.SettingsStore;
+        if (
+            settings.fiatRatesSource === 'BTCPayServer' &&
+            (!(settings.btcPayServerHost || '').trim() ||
+                !(settings.btcPayServerStoreId || '').trim())
+        ) {
+            const updates: any = {
+                fiatRatesSource: DEFAULT_FIAT_RATES_SOURCE
+            };
+            if (
+                !isCurrencySupportedBySource(
+                    CURRENCY_KEYS.find((c) => c.value === settings.fiat),
+                    DEFAULT_FIAT_RATES_SOURCE
+                )
+            ) {
+                updates.fiat = DEFAULT_FIAT;
+            }
+            updateSettings(updates);
+        }
+    }
+
+    // Requires a full http(s) URL, matching the other custom server settings
+    isValidHost = (text: string): boolean => {
+        const trimmed = text.trim();
+        return trimmed === '' || UrlUtils.isValidUrl(trimmed);
     };
 
     async componentDidUpdate(
@@ -66,8 +107,16 @@ export default class Currency extends React.Component<
 
     render() {
         const { navigation, SettingsStore, UnitsStore } = this.props;
-        const { fiatEnabled, selectedCurrency, fiatRatesSource } = this.state;
+        const {
+            fiatEnabled,
+            selectedCurrency,
+            fiatRatesSource,
+            btcPayServerHost,
+            btcPayServerStoreId
+        } = this.state;
         const { updateSettings }: any = SettingsStore;
+
+        const btcPayServerHostError = !this.isValidHost(btcPayServerHost);
 
         return (
             <Screen>
@@ -83,129 +132,232 @@ export default class Currency extends React.Component<
                         }}
                         navigation={navigation}
                     />
-                    <ListItem
-                        containerStyle={{
-                            borderBottomWidth: 0,
-                            backgroundColor: 'transparent'
-                        }}
-                    >
-                        <ListItem.Title
-                            style={{
-                                color: themeColor('secondaryText'),
-                                fontFamily: 'PPNeueMontreal-Book'
+                    <ScrollView keyboardShouldPersistTaps="handled">
+                        <ListItem
+                            containerStyle={{
+                                borderBottomWidth: 0,
+                                backgroundColor: 'transparent'
                             }}
                         >
-                            {localeString('general.enabled')}
-                        </ListItem.Title>
-                        <View
-                            style={{
-                                flex: 1,
-                                flexDirection: 'row',
-                                justifyContent: 'flex-end'
-                            }}
-                        >
-                            <Switch
-                                value={fiatEnabled}
-                                onValueChange={async () => {
-                                    const newFiatEnabled = !fiatEnabled;
-                                    this.setState({
-                                        fiatEnabled: newFiatEnabled
-                                    });
-                                    await updateSettings({
-                                        fiatEnabled: newFiatEnabled
-                                    });
-                                    if (!newFiatEnabled) {
-                                        if (UnitsStore.units === 'fiat') {
-                                            UnitsStore.resetUnits();
-                                        }
-                                    }
+                            <ListItem.Title
+                                style={{
+                                    color: themeColor('secondaryText'),
+                                    fontFamily: 'PPNeueMontreal-Book'
                                 }}
-                            />
-                        </View>
-                    </ListItem>
-                    {fiatEnabled && (
-                        <>
-                            <View style={{ marginHorizontal: 16 }}>
-                                <DropdownSetting
-                                    title={
-                                        localeString(
-                                            'views.Settings.Currency.source'
-                                        ) + ':'
-                                    }
-                                    selectedValue={fiatRatesSource}
-                                    onValueChange={async (value: string) => {
+                            >
+                                {localeString('general.enabled')}
+                            </ListItem.Title>
+                            <View
+                                style={{
+                                    flex: 1,
+                                    flexDirection: 'row',
+                                    justifyContent: 'flex-end'
+                                }}
+                            >
+                                <Switch
+                                    value={fiatEnabled}
+                                    onValueChange={async () => {
+                                        const newFiatEnabled = !fiatEnabled;
                                         this.setState({
-                                            fiatRatesSource: value
+                                            fiatEnabled: newFiatEnabled
                                         });
-                                        const newSettings: any = {
-                                            fiatRatesSource: value
-                                        };
-                                        if (
-                                            !CURRENCY_KEYS.find(
-                                                (c) =>
-                                                    c.value === selectedCurrency
-                                            )?.supportedSources.includes(value)
-                                        ) {
-                                            newSettings.fiat = DEFAULT_FIAT;
-                                            this.setState({
-                                                selectedCurrency: DEFAULT_FIAT
-                                            });
+                                        await updateSettings({
+                                            fiatEnabled: newFiatEnabled
+                                        });
+                                        if (!newFiatEnabled) {
+                                            if (UnitsStore.units === 'fiat') {
+                                                UnitsStore.resetUnits();
+                                            }
                                         }
-                                        await updateSettings(newSettings);
                                     }}
-                                    values={FIAT_RATES_SOURCE_KEYS}
                                 />
                             </View>
-                            <ListItem
-                                containerStyle={{
-                                    backgroundColor: 'transparent'
-                                }}
-                                onPress={() => this.navigateToSelectCurrency()}
-                            >
-                                <ListItem.Content>
-                                    <ListItem.Title
-                                        style={{
-                                            color: themeColor('secondaryText'),
-                                            fontFamily: 'PPNeueMontreal-Book'
+                        </ListItem>
+                        {fiatEnabled && (
+                            <>
+                                <View style={{ marginHorizontal: 16 }}>
+                                    <DropdownSetting
+                                        title={
+                                            localeString(
+                                                'views.Settings.Currency.source'
+                                            ) + ':'
+                                        }
+                                        selectedValue={fiatRatesSource}
+                                        onValueChange={async (
+                                            value: string
+                                        ) => {
+                                            this.setState({
+                                                fiatRatesSource: value
+                                            });
+                                            const newSettings: any = {
+                                                fiatRatesSource: value
+                                            };
+                                            if (
+                                                !isCurrencySupportedBySource(
+                                                    CURRENCY_KEYS.find(
+                                                        (c) =>
+                                                            c.value ===
+                                                            selectedCurrency
+                                                    ),
+                                                    value
+                                                )
+                                            ) {
+                                                newSettings.fiat = DEFAULT_FIAT;
+                                                this.setState({
+                                                    selectedCurrency:
+                                                        DEFAULT_FIAT
+                                                });
+                                            }
+                                            await updateSettings(newSettings);
                                         }}
-                                    >
-                                        {localeString(
-                                            'views.Settings.Currency.selectCurrency'
-                                        ) + ` (${selectedCurrency})`}
-                                    </ListItem.Title>
-                                </ListItem.Content>
-                                <Icon
-                                    name="keyboard-arrow-right"
-                                    color={themeColor('secondaryText')}
-                                />
-                            </ListItem>
-                            <ListItem
-                                containerStyle={{
-                                    backgroundColor: 'transparent'
-                                }}
-                                onPress={() =>
-                                    navigation.navigate('CurrencyConverter')
-                                }
-                            >
-                                <ListItem.Content>
-                                    <ListItem.Title
-                                        style={{
-                                            color: themeColor('secondaryText'),
-                                            fontFamily: 'PPNeueMontreal-Book'
-                                        }}
-                                    >
-                                        {localeString(
-                                            'views.Settings.CurrencyConverter.title'
-                                        )}
-                                    </ListItem.Title>
-                                </ListItem.Content>
-                                <Icon
-                                    name="keyboard-arrow-right"
-                                    color={themeColor('secondaryText')}
-                                />
-                            </ListItem>
-                        </>
-                    )}
+                                        values={FIAT_RATES_SOURCE_KEYS}
+                                    />
+                                    {fiatRatesSource === 'BTCPayServer' && (
+                                        <>
+                                            <Text
+                                                style={{
+                                                    color: themeColor(
+                                                        'secondaryText'
+                                                    ),
+                                                    fontFamily:
+                                                        'PPNeueMontreal-Book'
+                                                }}
+                                            >
+                                                {localeString(
+                                                    'views.Settings.Currency.btcPayServerHost'
+                                                )}
+                                            </Text>
+                                            <TextInput
+                                                value={btcPayServerHost}
+                                                placeholder="https://btcpay.mynode.local"
+                                                error={btcPayServerHostError}
+                                                autoCapitalize="none"
+                                                autoCorrect={false}
+                                                onChangeText={async (
+                                                    text: string
+                                                ) => {
+                                                    this.setState({
+                                                        btcPayServerHost: text
+                                                    });
+
+                                                    if (!this.isValidHost(text))
+                                                        return;
+
+                                                    await updateSettings({
+                                                        btcPayServerHost: text
+                                                    });
+                                                }}
+                                            />
+                                            {btcPayServerHostError && (
+                                                <Text
+                                                    style={{
+                                                        color: themeColor(
+                                                            'error'
+                                                        ),
+                                                        fontFamily:
+                                                            'PPNeueMontreal-Book',
+                                                        fontSize: 12,
+                                                        marginTop: 4
+                                                    }}
+                                                >
+                                                    {localeString(
+                                                        'views.Settings.Privacy.invalidCustomUrl'
+                                                    )}
+                                                </Text>
+                                            )}
+                                            <Text
+                                                style={{
+                                                    color: themeColor(
+                                                        'secondaryText'
+                                                    ),
+                                                    fontFamily:
+                                                        'PPNeueMontreal-Book'
+                                                }}
+                                            >
+                                                {localeString(
+                                                    'views.Settings.Currency.btcPayServerStoreId'
+                                                )}
+                                            </Text>
+                                            <TextInput
+                                                value={btcPayServerStoreId}
+                                                autoCapitalize="none"
+                                                autoCorrect={false}
+                                                onChangeText={async (
+                                                    text: string
+                                                ) => {
+                                                    this.setState({
+                                                        btcPayServerStoreId:
+                                                            text
+                                                    });
+
+                                                    await updateSettings({
+                                                        btcPayServerStoreId:
+                                                            text
+                                                    });
+                                                }}
+                                            />
+                                        </>
+                                    )}
+                                </View>
+                                <ListItem
+                                    containerStyle={{
+                                        backgroundColor: 'transparent'
+                                    }}
+                                    onPress={() =>
+                                        this.navigateToSelectCurrency()
+                                    }
+                                >
+                                    <ListItem.Content>
+                                        <ListItem.Title
+                                            style={{
+                                                color: themeColor(
+                                                    'secondaryText'
+                                                ),
+                                                fontFamily:
+                                                    'PPNeueMontreal-Book'
+                                            }}
+                                        >
+                                            {localeString(
+                                                'views.Settings.Currency.selectCurrency'
+                                            ) + ` (${selectedCurrency})`}
+                                        </ListItem.Title>
+                                    </ListItem.Content>
+                                    <Icon
+                                        name="keyboard-arrow-right"
+                                        color={themeColor('secondaryText')}
+                                    />
+                                </ListItem>
+                                <ListItem
+                                    containerStyle={{
+                                        backgroundColor: 'transparent'
+                                    }}
+                                    onPress={() =>
+                                        navigation.navigate('CurrencyConverter')
+                                    }
+                                >
+                                    <ListItem.Content>
+                                        <ListItem.Title
+                                            style={{
+                                                color: themeColor(
+                                                    'secondaryText'
+                                                ),
+                                                fontFamily:
+                                                    'PPNeueMontreal-Book'
+                                            }}
+                                        >
+                                            {localeString(
+                                                'views.Settings.CurrencyConverter.title'
+                                            )}
+                                        </ListItem.Title>
+                                    </ListItem.Content>
+                                    <Icon
+                                        name="keyboard-arrow-right"
+                                        color={themeColor('secondaryText')}
+                                    />
+                                </ListItem>
+                            </>
+                        )}
+                    </ScrollView>
                 </View>
             </Screen>
         );

--- a/views/Settings/SelectCurrency.tsx
+++ b/views/Settings/SelectCurrency.tsx
@@ -12,7 +12,8 @@ import SettingsStore, {
     CURRENCY_KEYS,
     CURRENCY_CODES_KEY,
     DEFAULT_FIAT,
-    DEFAULT_FIAT_RATES_SOURCE
+    DEFAULT_FIAT_RATES_SOURCE,
+    isCurrencySupportedBySource
 } from '../../stores/SettingsStore';
 import UnitsStore from '../../stores/UnitsStore';
 
@@ -223,7 +224,7 @@ export default class SelectCurrency extends React.Component<
 
         const currencies = [...this.state.currencies]
             .sort((a, b) => a.key.localeCompare(b.key))
-            .filter((c) => c.supportedSources?.includes(fiatRatesSource));
+            .filter((c) => isCurrencySupportedBySource(c, fiatRatesSource));
 
         const favoriteCurrencyItems = currencies.filter((c) =>
             favoriteCurrencies.includes(c.value)


### PR DESCRIPTION
# Description

Relates to issue: **#237**

Adds the ability to query your own BTCPay Server instance for fiat rates.

A new **BTCPay Server** option is added to the fiat rates source dropdown in Currency settings. When selected, two fields appear: the BTCPay Server URL and the store ID. ZEUS then fetches the rate for the selected currency from `<host>/api/rates?storeId=<id>&currencyPairs=BTC_<code>`, which is the same endpoint format the default ZEUS source (pay.zeusln.app) already uses, so any BTCPay Server instance with a store that has rates configured will work out of the box.

Behavior notes:
- The rate fetch mirrors the Yadio path: only the selected currency's rate is fetched and merged into the rates list.
- All currencies are selectable when using a custom server, since coverage depends on the server's configured rate providers; pairs the server can't provide simply return no rate. This is implemented via a shared `isCurrencySupportedBySource` helper used by the Currency settings, Select Currency, and Currency List views.
- The server URL field requires a full http(s) URL, matching the custom block explorer and custom mempool instance fields. If the configuration is left incomplete when leaving the Currency settings view, the rates source reverts to the default so the dropdown never misrepresents the source actually in use.

Storage note: this is additive only. Two new optional keys (`btcPayServerHost`, `btcPayServerStoreId`) are added to the settings blob and one new value to `fiatRatesSource`. No defaults change for existing users and no migration is needed; all readers tolerate the fields being absent.

Verified against a live BTCPay instance that `GET /api/rates?storeId=<id>&currencyPairs=BTC_EUR` returns `[{"name":"Euro","cryptoCode":"BTC","currencyPair":"BTC_EUR","code":"EUR","rate":...}]`, the exact shape the parser consumes.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
