### PR TITLE
fix: display units for Cashu payment request expiry and CLTV expiry

### DIFF
--- a/views/Cashu/CashuPaymentRequest.tsx
+++ b/views/Cashu/CashuPaymentRequest.tsx
@@ -400,11 +400,14 @@ export default class CashuPaymentRequest extends React.Component<
 
         const isPayReqExpired = !!payReq && payReq.isExpiredNow();
 
+        const locale = SettingsStore.settings.locale;
+        if (payReq) payReq.determineFormattedOriginalTimeUntilExpiry(locale);
+
         const requestAmount =
             payReq && payReq.getRequestAmount
                 ? payReq.getRequestAmount
                 : undefined;
-        const expiry = payReq && payReq.expiry;
+        const expiry = payReq && payReq.formattedOriginalTimeUntilExpiry;
         const cltv_expiry = payReq && payReq.cltv_expiry;
         const destination = payReq && payReq.destination;
         const description = payReq && payReq.description;
@@ -824,7 +827,9 @@ export default class CashuPaymentRequest extends React.Component<
                                         keyValue={localeString(
                                             'views.PaymentRequest.cltvExpiry'
                                         )}
-                                        value={cltv_expiry}
+                                        value={`${cltv_expiry} ${localeString(
+                                            'general.blocks'
+                                        )}`}
                                     />
                                 )}
 


### PR DESCRIPTION
# Description

Relates to issue: **#2025**

Follow-up to #4223 / ee7561ebe, which fixed the Lightning `PaymentRequest` view. The Cashu payment request view was not covered by that fix: it still rendered the decoded invoice expiry as raw seconds (e.g. `3600`) and CLTV expiry as a bare number.

This PR mirrors the earlier fix in `CashuPaymentRequest`:
- expiry is now displayed as a localized, humanized duration via the `Invoice` model's existing `determineFormattedOriginalTimeUntilExpiry` formatter
- CLTV expiry now has the blocks unit appended

Display-only change; no payment logic touched. No new strings (reuses `views.PaymentRequest.expiry`, `views.PaymentRequest.cltvExpiry`, and `general.blocks`).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
