### PR TITLE
ZEUS-2365: flag failed CLN payments as failed

### DIFF
--- a/models/Payment.test.ts
+++ b/models/Payment.test.ts
@@ -103,3 +103,57 @@ describe('Payment.getAmount with partial HTLC success', () => {
         expect(payment.getAmount).toBe(50000);
     });
 });
+
+describe('Payment.isFailed', () => {
+    it('flags Core Lightning failed payments via sendpays status', () => {
+        // shaped like a canceled hold-invoice payment from the CLNRest
+        // sql getPayments query: no htlcs, no failure_reason
+        const payment = new Payment({
+            payment_hash: 'abc123',
+            status: 'failed',
+            destination: '03abcdef',
+            created_at: 1724688000,
+            amount_sent_msat: null,
+            amount_msat: 0,
+            preimage: null
+        });
+
+        expect(payment.isFailed).toBe(true);
+    });
+
+    it('does not flag completed Core Lightning payments', () => {
+        const payment = new Payment({
+            payment_hash: 'abc123',
+            status: 'complete',
+            amount_sent_msat: 100500,
+            amount_msat: 100000,
+            preimage:
+                'a44ef01c2a2c11c9209232f6cc8e2bd25733fbc99b1b1e0d90b465c1b2c95a92'
+        });
+
+        expect(payment.isFailed).toBe(false);
+    });
+
+    it('does not flag pending Core Lightning payments', () => {
+        const payment = new Payment({
+            payment_hash: 'abc123',
+            status: 'pending',
+            amount_msat: 0,
+            preimage: null
+        });
+
+        expect(payment.isFailed).toBe(false);
+    });
+
+    it('still flags LND payments via failure_reason', () => {
+        const payment = new Payment({
+            payment_hash: 'abc123',
+            status: 'FAILED',
+            failure_reason: 'FAILURE_REASON_INCORRECT_PAYMENT_DETAILS',
+            value_sat: 50000,
+            htlcs: [{ status: 'FAILED', route: { total_amt: 50000 } }]
+        });
+
+        expect(payment.isFailed).toBe(true);
+    });
+});

--- a/models/Payment.ts
+++ b/models/Payment.ts
@@ -187,6 +187,9 @@ export default class Payment extends BaseModel {
                 lnrpc.PaymentFailureReason.FAILURE_REASON_NONE
         )
             isFailed = true;
+        // Core Lightning sendpays status; CLN payments carry no htlcs
+        // or failure_reason for the checks above
+        if (this.status === 'failed') isFailed = true;
         return isFailed;
     }
 


### PR DESCRIPTION
# Description

Follow-up investigation of ZEUS-2365 (CLN and LND show different values for canceled HOLD invoices). The original amount discrepancy no longer reproduces: since the partial-HTLC amount work, fully failed LND payments display 0, matching the 0 that the CLNRest sql `getPayments` query returns for failed sendpays. What remains is a presentation inconsistency on the failure flag itself:

* LND failed payments carry `failure_reason` and FAILED htlcs, so `Payment.isFailed` is true: they are hidden from the activity feed by the default failed filter, and labeled "Failed payment" when the filter is enabled.
* CLN payments come out of the CLNRest sql query with no `htlcs` and no `failure_reason`, so `isFailed` was always false. A canceled hold-invoice payment showed up in the default activity feed as an ordinary sent payment of 0 sats.

This PR makes `Payment.isFailed` also check the Core Lightning sendpays `status` field (`'failed'`), so failed CLN payments are hidden and labeled consistently with LND. Regression tests cover the CLN failed/complete/pending shapes and the existing LND `failure_reason` path.

Note: the sql query's `min(sp.status)` aggregation is safe here since any group containing a complete part reads `'complete'` ('complete' sorts before 'failed' and 'pending').

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
