### PR TITLE
LNURL: surface successActions when LndHub-style backends omit payment hash or preimage

### DIFF
--- a/models/Payment.test.ts
+++ b/models/Payment.test.ts
@@ -103,3 +103,50 @@ describe('Payment.getAmount with partial HTLC success', () => {
         expect(payment.getAmount).toBe(50000);
     });
 });
+
+describe('Payment.resolvedPaymentHash', () => {
+    // BOLT11 spec reference vector; its payment_hash is
+    // 0001020304050607080900010203040506070809000102030405060708090102
+    const specInvoice =
+        'lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr';
+    const specHash =
+        '0001020304050607080900010203040506070809000102030405060708090102';
+
+    it('passes through a string payment_hash', () => {
+        const payment = new Payment({ payment_hash: specHash });
+        expect(payment.resolvedPaymentHash).toBe(specHash);
+    });
+
+    it('converts a Buffer-style payment_hash (LndHub)', () => {
+        const payment = new Payment({
+            payment_hash: { type: 'Buffer', data: [171, 205] }
+        });
+        expect(payment.resolvedPaymentHash).toBe('abcd');
+    });
+
+    it('derives the hash from the payment request when absent', () => {
+        const payment = new Payment({ payment_request: specInvoice });
+        expect(payment.resolvedPaymentHash).toBe(specHash);
+    });
+
+    it('derives the hash from the preimage when nothing else is available', () => {
+        const payment = new Payment({
+            payment_preimage: '01'.repeat(32)
+        });
+        expect(payment.resolvedPaymentHash).toBe(
+            '72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793'
+        );
+    });
+
+    it('ignores an all-zero preimage', () => {
+        const payment = new Payment({
+            payment_preimage: '00'.repeat(32)
+        });
+        expect(payment.resolvedPaymentHash).toBeUndefined();
+    });
+
+    it('returns undefined when the hash cannot be derived', () => {
+        const payment = new Payment({ value_sat: 1000 });
+        expect(payment.resolvedPaymentHash).toBeUndefined();
+    });
+});

--- a/models/Payment.ts
+++ b/models/Payment.ts
@@ -1,6 +1,7 @@
 import { computed } from 'mobx';
 import BigNumber from 'bignumber.js';
 import humanizeDuration from 'humanize-duration';
+import { sha256 } from 'js-sha256';
 
 import BaseModel from './BaseModel';
 import DateTimeUtils from '../utils/DateTimeUtils';
@@ -63,6 +64,28 @@ export default class Payment extends BaseModel {
             this.payment_hash = Base64Utils.bytesToHex(this.payment_hash.data);
             return this.payment_hash;
         }
+        return undefined;
+    }
+
+    // Some LndHub-style servers omit payment_hash from their responses;
+    // derive it from the payment request or preimage so hash-keyed lookups
+    // (e.g. LNURL successActions) still resolve. Kept separate from
+    // paymentHash so note keys (getNoteKey) stay stable.
+    @computed public get resolvedPaymentHash(): string | undefined {
+        if (this.paymentHash) return this.paymentHash;
+
+        const pay_req = this.getPaymentRequest;
+        if (pay_req) {
+            try {
+                const hash = Bolt11Utils.decode(pay_req).payment_hash;
+                if (hash) return hash;
+            } catch {}
+        }
+
+        if (!this.isIncomplete) {
+            return sha256(Base64Utils.hexToBytes(this.getPreimage));
+        }
+
         return undefined;
     }
 

--- a/stores/TransactionsStore.ts
+++ b/stores/TransactionsStore.ts
@@ -786,7 +786,7 @@ export default class TransactionsStore {
         const payment = new Payment(result);
         this.noteKey = payment.getNoteKey;
         this.payment_preimage = payment.getPreimage;
-        this.payment_hash = payment.paymentHash;
+        this.payment_hash = payment.resolvedPaymentHash;
         this.payment_fee = payment.getFee;
         this.isIncomplete = payment.isIncomplete;
 

--- a/views/Cashu/CashuPayment.tsx
+++ b/views/Cashu/CashuPayment.tsx
@@ -62,8 +62,8 @@ export default class CashuPayment extends React.Component<
     async componentDidMount() {
         const { navigation, LnurlPayStore, route } = this.props;
         const payment = route.params?.payment;
-        const lnurlpaytx = payment.paymentHash
-            ? await LnurlPayStore!.load(payment.paymentHash)
+        const lnurlpaytx = payment.resolvedPaymentHash
+            ? await LnurlPayStore!.load(payment.resolvedPaymentHash)
             : undefined;
         if (lnurlpaytx) {
             this.setState({ lnurlpaytx });

--- a/views/Cashu/CashuSendingLightning.tsx
+++ b/views/Cashu/CashuSendingLightning.tsx
@@ -418,9 +418,12 @@ export default class CashuSendingLightning extends React.Component<
                                     />
                                 )}
                             {!paymentError &&
-                                !!paymentPreimage &&
                                 payment_hash === LnurlPayStore.paymentHash &&
-                                LnurlPayStore.successAction && (
+                                LnurlPayStore.successAction &&
+                                // the preimage is only needed to decrypt
+                                // LUD-10 aes success actions
+                                (LnurlPayStore.successAction.tag !== 'aes' ||
+                                    !!paymentPreimage) && (
                                     <View style={{ width: '90%' }}>
                                         <LnurlPaySuccess
                                             color="white"
@@ -428,7 +431,7 @@ export default class CashuSendingLightning extends React.Component<
                                             successAction={
                                                 LnurlPayStore.successAction
                                             }
-                                            preimage={paymentPreimage}
+                                            preimage={paymentPreimage || ''}
                                             scrollable={true}
                                             maxHeight={windowSize.height * 0.15}
                                         />

--- a/views/Payment.tsx
+++ b/views/Payment.tsx
@@ -62,8 +62,8 @@ export default class PaymentView extends React.Component<
     async componentDidMount() {
         const { navigation, LnurlPayStore, route } = this.props;
         const payment = route.params?.payment;
-        const lnurlpaytx = payment.paymentHash
-            ? await LnurlPayStore!.load(payment.paymentHash)
+        const lnurlpaytx = payment.resolvedPaymentHash
+            ? await LnurlPayStore!.load(payment.resolvedPaymentHash)
             : undefined;
         if (lnurlpaytx) {
             this.setState({ lnurlpaytx });

--- a/views/SendingLightning.tsx
+++ b/views/SendingLightning.tsx
@@ -504,9 +504,12 @@ export default class SendingLightning extends React.Component<
                                 )}
                             {!!success &&
                                 !error &&
-                                !!payment_preimage &&
                                 payment_hash === LnurlPayStore.paymentHash &&
-                                LnurlPayStore.successAction && (
+                                LnurlPayStore.successAction &&
+                                // the preimage is only needed to decrypt
+                                // LUD-10 aes success actions
+                                (LnurlPayStore.successAction.tag !== 'aes' ||
+                                    !!payment_preimage) && (
                                     <View style={{ width: '90%' }}>
                                         <LnurlPaySuccess
                                             color="white"
@@ -514,7 +517,7 @@ export default class SendingLightning extends React.Component<
                                             successAction={
                                                 LnurlPayStore.successAction
                                             }
-                                            preimage={payment_preimage}
+                                            preimage={payment_preimage || ''}
                                             scrollable={true}
                                             maxHeight={windowSize.height * 0.15}
                                         />


### PR DESCRIPTION
# Description

Relates to issue: #1319

Follow-up hardening for the LndHub successAction display bug. The originally reported failure (Buffer-serialized `payment_hash`/`payment_preimage` being discarded) was fixed in v0.8.1/v0.8.2, but two narrow gaps remained for LndHub-style backends:

1. The payment success screen required a preimage before displaying any successAction, though per LUD-09/LUD-10 only `aes` actions need one (to decrypt the payload). BlueWallet-flavor LndHub servers return no preimage for internal (same-hub) payments, so `message` and `url` actions stayed hidden.
2. The successAction lookup is keyed by payment hash, and some LndHub-style servers omit `payment_hash` from their pay and transaction responses. There was no fallback derivation.

Changes:

- `models/Payment.ts`: new `resolvedPaymentHash` computed getter. Uses `payment_hash` when present (string or Buffer-style), otherwise decodes the payment request, otherwise hashes a non-zero preimage. Kept separate from `paymentHash` so note keys (`getNoteKey`, which falls back to the preimage) stay stable for existing users.
- `views/SendingLightning.tsx`: only require the preimage for `aes` successActions.
- `stores/TransactionsStore.ts` + `views/Payment.tsx`: use `resolvedPaymentHash` for the successAction match on the success screen and the `lnurlpay:` storage lookup in the payment details view.
- `models/Payment.test.ts`: unit tests covering all `resolvedPaymentHash` paths, including the BOLT11 spec reference vector for the decode fallback.

Draft pending device testing (Android + iOS, LndHub + LND regression pass).

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding