### PR TITLE
Balance view: stop double counting unconfirmed on-chain funds

### DIFF
--- a/backends/CLNRest.ts
+++ b/backends/CLNRest.ts
@@ -813,6 +813,8 @@ export default class CLNRest {
     supportsOnchainBalance = () => true;
     supportsOnchainSends = () => true;
     supportsOnchainReceiving = () => true;
+    // listfunds cannot attribute unconfirmed outputs to self-transfers
+    supportsUnconfirmedTransactionOrigin = () => false;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;
     supportsChannelManagement = () => true;

--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -554,6 +554,7 @@ export default class EmbeddedLND extends LND {
     supportsOnchainBalance = () => true;
     supportsOnchainSends = () => true;
     supportsOnchainReceiving = () => true;
+    supportsUnconfirmedTransactionOrigin = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;
     supportsChannelManagement = () => true;

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -1012,6 +1012,7 @@ export default class LND {
     supportsOnchainBalance = () => true;
     supportsOnchainSends = () => true;
     supportsOnchainReceiving = () => true;
+    supportsUnconfirmedTransactionOrigin = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;
     supportsChannelManagement = () => true;

--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -2176,6 +2176,7 @@ export default class LdkNode {
     supportsOnchainBalance = () => true;
     supportsOnchainSends = () => true;
     supportsOnchainReceiving = () => true;
+    supportsUnconfirmedTransactionOrigin = () => true;
     supportsLightningSends = () => true;
     supportsKeysend = () => true;
     supportsChannelManagement = () => true;

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -874,6 +874,7 @@ export default class LightningNodeConnect {
     supportsOnchainBalance = () => true;
     supportsOnchainSends = () => this.permSendCoins;
     supportsOnchainReceiving = () => this.permNewAddress;
+    supportsUnconfirmedTransactionOrigin = () => true;
     supportsLightningSends = () => this.permSendLN;
     supportsKeysend = () => true;
     supportsChannelManagement = () => this.permOpenChannel;

--- a/backends/LndHub.ts
+++ b/backends/LndHub.ts
@@ -187,6 +187,7 @@ export default class LndHub extends LND {
     supportsMessageVerification = () => false;
     supportsLnurlAuth = () => true;
     supportsOnchainBalance = () => false;
+    supportsUnconfirmedTransactionOrigin = () => false;
     supportsOnchainSends = () => false;
     supportsOnchainReceiving = () =>
         !(

--- a/stores/BalanceStore.ts
+++ b/stores/BalanceStore.ts
@@ -3,6 +3,7 @@ import BigNumber from 'bignumber.js';
 
 import SettingsStore from './SettingsStore';
 import BackendUtils from './../utils/BackendUtils';
+import { getExternalUnconfirmedBalance } from './../utils/BalanceUtils';
 
 export default class BalanceStore {
     @observable public totalBlockchainBalance: number | string;
@@ -10,6 +11,11 @@ export default class BalanceStore {
     @observable public totalBlockchainBalanceAccounts: number | string;
     @observable public confirmedBlockchainBalance: number | string;
     @observable public unconfirmedBlockchainBalance: number | string;
+    // portion of unconfirmedBlockchainBalance that came from transactions
+    // the wallet did not create itself (external deposits). Change from the
+    // wallet's own spends (e.g. channel funding change) is excluded so it
+    // isn't shown as pending on top of a total that already includes it (#2167)
+    @observable public externalUnconfirmedBalance: number;
     @observable public loadingBlockchainBalance = false;
     @observable public loadingLightningBalance = false;
     @observable public error = false;
@@ -47,6 +53,7 @@ export default class BalanceStore {
     @action
     public resetBlockchainBalance = () => {
         this.unconfirmedBlockchainBalance = 0;
+        this.externalUnconfirmedBalance = 0;
         this.confirmedBlockchainBalance = 0;
         this.totalBlockchainBalance = 0;
         this.otherAccounts = {};
@@ -103,6 +110,28 @@ export default class BalanceStore {
                 data.total_balance || 0
             );
 
+            // where the backend can tell where unconfirmed funds came from,
+            // split out external deposits so the view can show them as
+            // pending on top of the total instead of counting them twice.
+            // Change from the wallet's own spends stays in the total (#2167)
+            let externalUnconfirmedBalance = 0;
+            if (
+                unconfirmedBlockchainBalance > 0 &&
+                BackendUtils.supportsUnconfirmedTransactionOrigin()
+            ) {
+                try {
+                    const txData = await BackendUtils.getTransactions();
+                    externalUnconfirmedBalance = getExternalUnconfirmedBalance(
+                        txData?.transactions || [],
+                        unconfirmedBlockchainBalance
+                    );
+                } catch {
+                    // if classification fails, treat unconfirmed funds as
+                    // the wallet's own: they stay in the total balance and
+                    // off the pending line
+                }
+            }
+
             runInAction(() => {
                 if (set) {
                     if (accounts && accounts.default && data.confirmed_balance)
@@ -111,6 +140,8 @@ export default class BalanceStore {
 
                     this.unconfirmedBlockchainBalance =
                         unconfirmedBlockchainBalance;
+                    this.externalUnconfirmedBalance =
+                        externalUnconfirmedBalance;
                     this.confirmedBlockchainBalance =
                         confirmedBlockchainBalance;
                     this.totalBlockchainBalance = totalBlockchainBalance;
@@ -121,6 +152,7 @@ export default class BalanceStore {
             });
             return {
                 unconfirmedBlockchainBalance,
+                externalUnconfirmedBalance,
                 confirmedBlockchainBalance,
                 totalBlockchainBalance,
                 accounts
@@ -174,6 +206,8 @@ export default class BalanceStore {
             this.otherAccounts = onChain?.accounts || [];
             this.unconfirmedBlockchainBalance =
                 onChain?.unconfirmedBlockchainBalance || 0;
+            this.externalUnconfirmedBalance =
+                onChain?.externalUnconfirmedBalance || 0;
             this.confirmedBlockchainBalance =
                 onChain?.confirmedBlockchainBalance || 0;
             this.totalBlockchainBalance = onChain?.totalBlockchainBalance || 0;

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -219,6 +219,8 @@ class BackendUtils {
     supportsOnchainBalance = () => this.call('supportsOnchainBalance');
     supportsOnchainSends = () => this.call('supportsOnchainSends');
     supportsOnchainReceiving = () => this.call('supportsOnchainReceiving');
+    supportsUnconfirmedTransactionOrigin = () =>
+        this.call('supportsUnconfirmedTransactionOrigin');
     supportsLightningSends = () => this.call('supportsLightningSends');
     supportsKeysend = () => this.call('supportsKeysend');
     supportsChannelManagement = () => this.call('supportsChannelManagement');

--- a/utils/BalanceUtils.test.ts
+++ b/utils/BalanceUtils.test.ts
@@ -1,0 +1,140 @@
+import { getExternalUnconfirmedBalance } from './BalanceUtils';
+
+describe('BalanceUtils', () => {
+    describe('getExternalUnconfirmedBalance', () => {
+        it('excludes change from our own channel funding transaction', () => {
+            // regtest repro from issue #2167: 1,000,000 sat wallet opens a
+            // 500,000 sat channel at a 166 sat fee, leaving 499,834 sats of
+            // unconfirmed change
+            const transactions = [
+                {
+                    amount: '-500166',
+                    total_fees: '166',
+                    num_confirmations: 0
+                }
+            ];
+            expect(getExternalUnconfirmedBalance(transactions, 499834)).toEqual(
+                0
+            );
+        });
+
+        it('counts an unconfirmed external deposit', () => {
+            const transactions = [
+                {
+                    amount: '50000',
+                    total_fees: '0',
+                    num_confirmations: 0
+                }
+            ];
+            expect(getExternalUnconfirmedBalance(transactions, 50000)).toEqual(
+                50000
+            );
+        });
+
+        it('separates external deposits from own change when mixed', () => {
+            const transactions = [
+                {
+                    amount: '-500166',
+                    total_fees: '166',
+                    num_confirmations: 0
+                },
+                {
+                    amount: '50000',
+                    total_fees: '0',
+                    num_confirmations: 0
+                }
+            ];
+            expect(getExternalUnconfirmedBalance(transactions, 549834)).toEqual(
+                50000
+            );
+        });
+
+        it('ignores confirmed transactions', () => {
+            const transactions = [
+                {
+                    amount: '50000',
+                    total_fees: '0',
+                    num_confirmations: 3
+                },
+                {
+                    amount: '25000',
+                    total_fees: '0',
+                    num_confirmations: 0,
+                    status: 'confirmed'
+                }
+            ];
+            expect(getExternalUnconfirmedBalance(transactions, 10000)).toEqual(
+                0
+            );
+        });
+
+        it('handles LDK Node shaped transactions', () => {
+            const transactions = [
+                {
+                    amount: '25000',
+                    total_fees: '0',
+                    num_confirmations: 0,
+                    status: 'pending'
+                },
+                {
+                    amount: '-30000',
+                    total_fees: '0',
+                    num_confirmations: 0,
+                    status: 'pending'
+                }
+            ];
+            expect(getExternalUnconfirmedBalance(transactions, 25000)).toEqual(
+                25000
+            );
+        });
+
+        it('handles numeric and Long-like amount fields', () => {
+            const longLike = {
+                toString: () => '40000'
+            };
+            const transactions = [
+                {
+                    amount: longLike,
+                    total_fees: 0,
+                    num_confirmations: 0
+                }
+            ];
+            expect(getExternalUnconfirmedBalance(transactions, 40000)).toEqual(
+                40000
+            );
+        });
+
+        it('clamps to the reported unconfirmed balance', () => {
+            const transactions = [
+                {
+                    amount: '60000',
+                    total_fees: '0',
+                    num_confirmations: 0
+                }
+            ];
+            expect(getExternalUnconfirmedBalance(transactions, 40000)).toEqual(
+                40000
+            );
+        });
+
+        it('returns 0 for empty or missing inputs', () => {
+            expect(getExternalUnconfirmedBalance([], 10000)).toEqual(0);
+            expect(
+                getExternalUnconfirmedBalance(undefined as any, 10000)
+            ).toEqual(0);
+            expect(getExternalUnconfirmedBalance([null], 10000)).toEqual(0);
+            expect(
+                getExternalUnconfirmedBalance(
+                    [{ amount: '50000', total_fees: '0' }],
+                    0
+                )
+            ).toEqual(0);
+            expect(
+                getExternalUnconfirmedBalance(
+                    [{ amount: '50000', total_fees: '0' }],
+                    -100
+                )
+            ).toEqual(0);
+        });
+    });
+});

--- a/utils/BalanceUtils.ts
+++ b/utils/BalanceUtils.ts
@@ -1,0 +1,40 @@
+import BigNumber from 'bignumber.js';
+
+// amounts may arrive as strings, numbers, or protobuf Longs
+// depending on the backend
+const toNumber = (value: any): number =>
+    value == null ? 0 : Number(value.toString());
+
+/**
+ * Sums the portion of the wallet's unconfirmed on-chain balance that came
+ * from transactions the wallet did not create itself (external deposits).
+ *
+ * Unconfirmed change from the wallet's own spends (e.g. channel funding
+ * change) is excluded: those funds never left the wallet, so they belong
+ * in the available balance rather than the pending balance. Own spends
+ * are identified by a negative net amount or a known transaction fee,
+ * since the wallet only knows the fee of transactions it authored.
+ *
+ * The result is clamped to [0, unconfirmedBalance].
+ */
+export function getExternalUnconfirmedBalance(
+    transactions: any[],
+    unconfirmedBalance: string | number
+): number {
+    const unconfirmed = toNumber(unconfirmedBalance);
+    if (!Array.isArray(transactions) || unconfirmed <= 0) return 0;
+
+    let external = new BigNumber(0);
+    for (const tx of transactions) {
+        if (!tx) continue;
+        const isConfirmed =
+            toNumber(tx.num_confirmations) > 0 || tx.status === 'confirmed';
+        if (isConfirmed) continue;
+
+        const amount = toNumber(tx.amount);
+        const fees = toNumber(tx.total_fees);
+        if (amount > 0 && fees <= 0) external = external.plus(amount);
+    }
+
+    return BigNumber.min(external, unconfirmed).toNumber();
+}

--- a/views/Wallet/BalancePane.tsx
+++ b/views/Wallet/BalancePane.tsx
@@ -181,7 +181,7 @@ export default class BalancePane extends React.PureComponent<
         } = this.state;
         const {
             totalBlockchainBalance,
-            unconfirmedBlockchainBalance,
+            externalUnconfirmedBalance,
             lightningBalance,
             pendingOpenBalance,
             pendingCloseBalance
@@ -195,11 +195,15 @@ export default class BalancePane extends React.PureComponent<
             .toNumber();
         const hasLightningPending = lightningPendingTotal > 0;
 
+        // the pending balance sits on top of the total balance: external
+        // unconfirmed deposits count toward pending only, while unconfirmed
+        // change from the wallet's own spends counts toward the total only
         const pendingUnconfirmedBalance = new BigNumber(lightningPendingTotal)
-            .plus(unconfirmedBlockchainBalance)
+            .plus(externalUnconfirmedBalance || 0)
             .toNumber()
             .toFixed(3);
         const combinedBalanceValue = new BigNumber(totalBlockchainBalance)
+            .minus(externalUnconfirmedBalance || 0)
             .plus(lightningBalance)
             .plus(settings?.ecash?.enableCashu ? cashuBalance : 0)
             .toNumber()
@@ -259,7 +263,7 @@ export default class BalancePane extends React.PureComponent<
         );
         const BalanceViewCombined = () => {
             const hasOnchainPending = Boolean(
-                Number(unconfirmedBlockchainBalance ?? 0) ||
+                Number(externalUnconfirmedBalance ?? 0) ||
                     Number(pendingOpenBalance ?? 0) ||
                     Number(pendingCloseBalance ?? 0)
             );


### PR DESCRIPTION
# Description

Fixes #2167

The combined balance view double counted unconfirmed on-chain funds: the big combined number includes them (`totalBlockchainBalance` = confirmed + unconfirmed) and the pending (clock) line summed them again on top of the pending channel balances. After a channel open, the funding transaction's change is unconfirmed while the channel's local balance is reported as `pending_open_balance`, so nearly the entire wallet was displayed twice. In the regtest repro from the issue (1,000,000 sats, 500,000 sat channel), the pending line showed 996,364 sats: 499,834 unconfirmed change + 496,530 pending channel balance.

This PR makes the pending balance strictly additive, per the model proposed in the issue: **total + pending = eventual balance**, with no overlap.

- Unconfirmed funds are classified by origin where the backend supports it (new `supportsUnconfirmedTransactionOrigin` capability: LND REST, embedded LND, LNC, LDK Node). A transaction the wallet authored has a negative net amount and/or a known fee; anything else that is unconfirmed and positive is an external deposit.
- Change from the wallet's own spends (e.g. channel funding change) stays in the total balance only. This matches lnd behavior, since own unconfirmed change is spendable.
- External unconfirmed deposits move to the pending line only.
- Backends that cannot attribute unconfirmed outputs (CLNRest) and any classification failure (e.g. LNC pairings without `GetTransactions` permission) treat all unconfirmed funds as the wallet's own. That is exactly right for the channel-open case and never double counts.

The classification lives in a new pure utility (`utils/BalanceUtils.ts`) with unit tests covering the issue's regtest repro, external deposits, mixed cases, LDK Node shaped transactions, protobuf Long fields, and clamping. The extra `getTransactions` call only happens when there is a nonzero unconfirmed balance.

Behavior after this change, using the issue's repro:

| State | Total | Pending line |
| --- | --- | --- |
| Before channel open | 1,000,000 | none |
| Funding tx unconfirmed (old) | 499,834 | 996,364 (wrong) |
| Funding tx unconfirmed (new) | 499,834 | 496,530 |
| After 1 conf | 499,834 + 496,530 LN | none |

Known follow-up (out of scope): on lnd, an unconfirmed sweep after a force close can still be counted in both the limbo balance and the unconfirmed on-chain balance. The LDK Node backend already skips confirmed sweeps; the lnd path deserves the same treatment in a separate PR.

Screenshots and device testing to follow; opening as draft.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
