### PR TITLE
LNC: move streaming call listeners into the backend

### DIFF
--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -37,6 +37,7 @@ const NEXT_ADDR_MAP: any = {
 export default class LightningNodeConnect {
     lnc: any;
     listener: any;
+    customMessagesListener: EmitterSubscription | null = null;
 
     permOpenChannel: boolean;
     permSendCoins: boolean;
@@ -162,8 +163,31 @@ export default class LightningNodeConnect {
                 data: Base64Utils.hexToBase64(data.data)
             })
             .then((data: lnrpc.SendCustomMessageResponse) => snakeize(data));
-    subscribeCustomMessages = () =>
-        this.lnc.lnd.lightning.subscribeCustomMessages({});
+    // same callback signature as the LND REST backend so callers like
+    // LSPStore can subscribe without implementation branching
+    subscribeCustomMessages = (onResponse: any, onError: any) => {
+        const streamingCall = this.lnc.lnd.lightning.subscribeCustomMessages(
+            {}
+        );
+
+        const { LncModule } = NativeModules;
+        const eventEmitter = new NativeEventEmitter(LncModule);
+        // events for this call arrive under the RPC method name, so a
+        // re-subscription reuses the same event name; drop the previous
+        // listener so messages are not handled twice
+        this.customMessagesListener?.remove();
+        this.customMessagesListener = eventEmitter.addListener(
+            streamingCall,
+            (event: any) => {
+                if (!event.result || event.result === 'EOF') return;
+                try {
+                    onResponse({ result: JSON.parse(event.result) });
+                } catch (error) {
+                    onError(error);
+                }
+            }
+        );
+    };
     getMyNodeInfo = async () =>
         await this.lnc.lnd.lightning
             .getInfo({})
@@ -409,7 +433,7 @@ export default class LightningNodeConnect {
             );
         });
     };
-    closeChannel = async (urlParams?: Array<string>) => {
+    closeChannel = (urlParams?: Array<string>) => {
         let params: any = {
             channel_point: {
                 funding_txid_str: urlParams && urlParams[0],
@@ -426,7 +450,42 @@ export default class LightningNodeConnect {
             params.delivery_address = urlParams[4];
         }
 
-        return this.lnc.lnd.lightning.closeChannel(params);
+        // closeChannel is a streaming RPC: the call returns the event name
+        // and updates arrive on a channel shared by every concurrent close.
+        // CloseStatusUpdate carries no request identifiers, so events cannot
+        // be correlated to a specific close; ZEUS only drives one close at a
+        // time from the UI. Resolve on the first terminal update so callers
+        // get the same promise contract as the other backends.
+        const streamingCall = this.lnc.lnd.lightning.closeChannel(params);
+
+        const { LncModule } = NativeModules;
+        const eventEmitter = new NativeEventEmitter(LncModule);
+        return new Promise((resolve, reject) => {
+            const listener = eventEmitter.addListener(
+                streamingCall,
+                (event: any) => {
+                    if (!event.result || event.result === 'EOF') return;
+                    let result;
+                    try {
+                        result = JSON.parse(event.result);
+                    } catch (e) {
+                        result = event.result;
+                    }
+                    listener.remove();
+                    if (result?.chan_close?.success || result?.close_pending) {
+                        resolve(result);
+                    } else {
+                        reject(
+                            new Error(
+                                typeof result === 'string'
+                                    ? result
+                                    : JSON.stringify(result)
+                            )
+                        );
+                    }
+                }
+            );
+        });
     };
     abandonChannel = async (
         urlParams?: Array<string | boolean | undefined>
@@ -695,6 +754,25 @@ export default class LightningNodeConnect {
     subscribeInvoices = () => this.lnc.lnd.lightning.subscribeInvoices();
     subscribeTransactions = () =>
         this.lnc.lnd.lightning.subscribeTransactions();
+    watchActivityUpdates = (
+        onTransaction: () => void,
+        onInvoice: () => void
+    ): (() => void) => {
+        const { LncModule } = NativeModules;
+        const eventEmitter = new NativeEventEmitter(LncModule);
+        const transactionsListener = eventEmitter.addListener(
+            this.subscribeTransactions(),
+            onTransaction
+        );
+        const invoicesListener = eventEmitter.addListener(
+            this.subscribeInvoices(),
+            onInvoice
+        );
+        return () => {
+            transactionsListener.remove();
+            invoicesListener.remove();
+        };
+    };
     watchInvoicePaid = (
         { rHash }: { rHash: string; value?: string | number },
         onPaid: (payload: {

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -698,7 +698,17 @@ export default class ChannelsStore {
         }
 
         if (implementation === 'lightning-node-connect') {
-            return BackendUtils.closeChannel(urlParams);
+            // the LNC backend resolves once the close stream reports
+            // close_pending or success, so no forced timeout is needed
+            return await BackendUtils.closeChannel(urlParams)
+                .then(() => {
+                    this.handleChannelClose();
+                    return true;
+                })
+                .catch((error: Error) => {
+                    this.handleChannelCloseError(error);
+                    return true;
+                });
         } else {
             let settled = false;
             return await Promise.race([

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -152,6 +152,9 @@ class BackendUtils {
         this.call('subscribeInvoices', args);
     subscribeTransactions = (...args: any[]) =>
         this.call('subscribeTransactions', args);
+    // returns an unsubscribe function
+    watchActivityUpdates = (...args: any[]) =>
+        this.call('watchActivityUpdates', args);
     initChanAcceptor = (...args: any[]) => this.call('initChanAcceptor', args);
     rescan = (...args: any[]) => this.call('rescan', args);
 

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react';
 import {
     FlatList,
-    NativeModules,
-    NativeEventEmitter,
     Text,
     TouchableOpacity,
     View,
-    StyleSheet,
-    EmitterSubscription
+    StyleSheet
 } from 'react-native';
 import { Button, Icon, ListItem } from '@rneui/themed';
 import { inject, observer } from 'mobx-react';
@@ -464,8 +461,7 @@ export default class Activity extends React.PureComponent<
     ActivityProps,
     ActivityState
 > {
-    private transactionListener: EmitterSubscription;
-    private invoicesListener: EmitterSubscription;
+    private unsubscribeActivityUpdates?: () => void;
     private focusListener?: () => void;
 
     state = {
@@ -514,23 +510,15 @@ export default class Activity extends React.PureComponent<
     }
 
     componentWillUnmount() {
-        if (this.transactionListener) this.transactionListener.remove();
-        if (this.invoicesListener) this.invoicesListener.remove();
+        if (this.unsubscribeActivityUpdates) this.unsubscribeActivityUpdates();
         if (this.focusListener) this.focusListener();
     }
 
     subscribeEvents = () => {
         const { ActivityStore, SettingsStore } = this.props;
-        const { LncModule } = NativeModules;
         const locale = SettingsStore.settings.locale;
-        const eventEmitter = new NativeEventEmitter(LncModule);
-        this.transactionListener = eventEmitter.addListener(
-            BackendUtils.subscribeTransactions(),
-            () => ActivityStore.updateTransactions(locale)
-        );
-
-        this.invoicesListener = eventEmitter.addListener(
-            BackendUtils.subscribeInvoices(),
+        this.unsubscribeActivityUpdates = BackendUtils.watchActivityUpdates(
+            () => ActivityStore.updateTransactions(locale),
             () => ActivityStore.updateInvoices(locale)
         );
     };

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -1,12 +1,5 @@
 import * as React from 'react';
-import {
-    NativeModules,
-    NativeEventEmitter,
-    ScrollView,
-    StyleSheet,
-    TouchableOpacity,
-    View
-} from 'react-native';
+import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { Button as ElementButton, Divider } from '@rneui/themed';
 import { inject, observer } from 'mobx-react';
@@ -99,7 +92,6 @@ export default class ChannelView extends React.Component<
     ChannelProps,
     ChannelState
 > {
-    listener: any;
     constructor(props: ChannelProps) {
         super(props);
         const { route, ChannelsStore, LSPStore, NodeInfoStore } = props;
@@ -236,8 +228,7 @@ export default class ChannelView extends React.Component<
         forceClose?: boolean | null,
         deliveryAddress?: string | null
     ) => {
-        const { ChannelsStore, SettingsStore, navigation } = this.props;
-        const { implementation } = SettingsStore;
+        const { ChannelsStore, navigation } = this.props;
 
         let funding_txid_str, output_index;
         if (channelPoint) {
@@ -246,7 +237,7 @@ export default class ChannelView extends React.Component<
             output_index = outputIndex;
         }
 
-        const streamingCall = await ChannelsStore.closeChannel(
+        await ChannelsStore.closeChannel(
             funding_txid_str && output_index
                 ? { funding_txid_str, output_index }
                 : undefined,
@@ -256,52 +247,13 @@ export default class ChannelView extends React.Component<
             deliveryAddress ? deliveryAddress : undefined
         );
 
-        if (implementation === 'lightning-node-connect') {
-            this.subscribeChannelClose(streamingCall);
-        } else {
-            if (!ChannelsStore.closeChannelErr) navigation.popTo('Wallet');
-        }
+        if (!ChannelsStore.closeChannelErr) navigation.popTo('Wallet');
     };
 
     handleOnNavigateBack = (satPerByte: string) => {
         this.setState({
             satPerByte
         });
-    };
-
-    subscribeChannelClose = (streamingCall: string) => {
-        const { handleChannelClose, handleChannelCloseError } =
-            this.props.ChannelsStore;
-        const { LncModule } = NativeModules;
-        const eventEmitter = new NativeEventEmitter(LncModule);
-        this.listener = eventEmitter.addListener(
-            streamingCall,
-            (event: any) => {
-                if (event.result && event.result !== 'EOF') {
-                    let result;
-                    try {
-                        result = JSON.parse(event.result);
-                    } catch (e) {
-                        try {
-                            result = JSON.parse(event);
-                        } catch (e2) {
-                            result = event.result || event;
-                        }
-                    }
-                    if (
-                        result &&
-                        (result?.chan_close?.success || result?.close_pending)
-                    ) {
-                        handleChannelClose();
-                        this.listener = null;
-                        this.props.navigation.popTo('Wallet');
-                    } else {
-                        handleChannelCloseError(new Error(result));
-                        this.listener = null;
-                    }
-                }
-            }
-        );
     };
 
     render() {

--- a/views/LSPS1/index.tsx
+++ b/views/LSPS1/index.tsx
@@ -1,13 +1,6 @@
 import * as React from 'react';
 import { inject, observer } from 'mobx-react';
-import {
-    NativeEventEmitter,
-    NativeModules,
-    View,
-    StyleSheet,
-    ScrollView,
-    TouchableOpacity
-} from 'react-native';
+import { View, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
 import { ButtonGroup, Icon } from '@rneui/themed';
 import Slider from '@react-native-community/slider';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -68,7 +61,6 @@ interface LSPS1State {
 @inject('LSPStore', 'ChannelsStore', 'SettingsStore', 'NodeInfoStore')
 @observer
 export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
-    listener: any;
     private scrollViewRef = React.createRef<ScrollView>();
     private lastSavedOrderId: string | null = null;
     constructor(props: LSPS1Props) {
@@ -144,10 +136,6 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
         }
     };
     componentWillUnmount() {
-        if (this.listener) {
-            this.listener.remove();
-            this.listener = null;
-        }
         this.props.LSPStore.resetLSPS1Data();
     }
 
@@ -243,42 +231,20 @@ export default class LSPS1 extends React.Component<LSPS1Props, LSPS1State> {
     };
 
     subscribeToCustomMessages() {
-        if (
-            this.props.SettingsStore.implementation === 'lightning-node-connect'
-        ) {
-            const { LncModule } = NativeModules;
-            const eventName = BackendUtils.subscribeCustomMessages();
-            const eventEmitter = new NativeEventEmitter(LncModule);
-            this.listener = eventEmitter.addListener(
-                eventName,
-                (event: any) => {
-                    if (event.result) {
-                        try {
-                            const result = JSON.parse(event.result);
-                            this.props.LSPStore.handleCustomMessages(result);
-                        } catch (error) {
-                            console.error(error);
-                        }
-                    }
-                }
-            );
-            return;
-        } else {
-            return new Promise((resolve, reject) => {
-                this.props.LSPStore.subscribeCustomMessages()
-                    .then((response) => {
-                        console.log('Subscribed to custom messages:', response);
-                        resolve({});
-                    })
-                    .catch((error) => {
-                        console.error(
-                            'Error subscribing to custom messages:',
-                            error
-                        );
-                        reject();
-                    });
-            });
-        }
+        return new Promise((resolve, reject) => {
+            this.props.LSPStore.subscribeCustomMessages()
+                .then((response) => {
+                    console.log('Subscribed to custom messages:', response);
+                    resolve({});
+                })
+                .catch((error) => {
+                    console.error(
+                        'Error subscribing to custom messages:',
+                        error
+                    );
+                    reject();
+                });
+        });
     }
 
     connectPeer = async () => {

--- a/views/Tools/Rebalance.tsx
+++ b/views/Tools/Rebalance.tsx
@@ -4,10 +4,7 @@ import {
     StyleSheet,
     TouchableOpacity,
     View,
-    Alert,
-    NativeModules,
-    NativeEventEmitter,
-    EmitterSubscription
+    Alert
 } from 'react-native';
 import { inject, observer } from 'mobx-react';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -52,8 +49,7 @@ const REBALANCE_CONSTANTS = {
     CIRCULAR_LAYER_NAME: 'circular-rebalance',
     BALANCE_PRECISION: 3,
     MSAT_MULTIPLIER: 1000,
-    DEFAULT_CLN_CLTV_EXPIRY: 144,
-    TIMEOUT_BUFFER_MS: 5000
+    DEFAULT_CLN_CLTV_EXPIRY: 144
 } as const;
 
 const calculateProjectedBalance = (
@@ -173,8 +169,6 @@ export default class Rebalance extends React.Component<
     RebalanceProps,
     RebalanceState
 > {
-    private listener: EmitterSubscription | null = null;
-    private paymentTimeoutId: ReturnType<typeof setTimeout> | null = null;
     private navigationUnsubscribe: (() => void) | null = null;
 
     constructor(props: RebalanceProps) {
@@ -200,8 +194,6 @@ export default class Rebalance extends React.Component<
 
     componentDidMount() {
         const { ChannelsStore, navigation } = this.props;
-
-        this.cleanupPaymentListener();
 
         if (!ChannelsStore.channels || ChannelsStore.channels.length === 0) {
             ChannelsStore.getChannels();
@@ -248,8 +240,6 @@ export default class Rebalance extends React.Component<
     };
 
     componentWillUnmount() {
-        this.cleanupPaymentListener();
-
         if (this.navigationUnsubscribe) {
             this.navigationUnsubscribe();
         }
@@ -633,18 +623,10 @@ export default class Rebalance extends React.Component<
                 case 'cln-rest':
                     return this.executeClnRestRebalance(invoiceData);
 
-                case 'lightning-node-connect':
-                    const result = await this.executeLndRebalance(invoiceData);
-
-                    // If result is a string (subscription ID), subscribe to payment updates
-                    if (typeof result === 'string') {
-                        return (await this.subscribePayment(
-                            result
-                        )) as PaymentResult;
-                    }
-                    return result;
-
                 default:
+                    // the LNC backend resolves payLightningInvoice with the
+                    // terminal payment result, so it takes the same path as
+                    // the other lnd-based backends here
                     return this.executeLndRebalance(invoiceData);
             }
         } catch (error: any) {
@@ -1169,7 +1151,6 @@ export default class Rebalance extends React.Component<
             );
             this.props.TransactionsStore.loading = false;
             this.handleRebalanceError(error);
-            this.cleanupPaymentListener();
         }
     };
 
@@ -1509,94 +1490,6 @@ export default class Rebalance extends React.Component<
             />
         </View>
     );
-
-    subscribePayment = (streamingCall: string) => {
-        const { handlePayment, handlePaymentError } =
-            this.props.TransactionsStore;
-        const { LncModule } = NativeModules;
-        const eventEmitter = new NativeEventEmitter(LncModule);
-
-        this.cleanupPaymentListener();
-
-        return new Promise((resolve, reject) => {
-            this.listener = eventEmitter.addListener(
-                streamingCall,
-                (event: { result?: string }) => {
-                    if (event.result && event.result !== 'EOF') {
-                        try {
-                            const result =
-                                typeof event.result === 'string'
-                                    ? JSON.parse(event.result)
-                                    : event.result;
-
-                            // Process final payment status
-                            if (result && result.status !== 'IN_FLIGHT') {
-                                handlePayment(result);
-
-                                this.cleanupPaymentListener();
-
-                                if (result.status === PaymentStatus.SUCCEEDED) {
-                                    const formattedResult = {
-                                        payment_hash: result.payment_hash,
-                                        payment_preimage:
-                                            result.payment_preimage,
-                                        value_sat: result.value_sat,
-                                        fee_sat: result.fee_sat,
-                                        status: PaymentStatus.COMPLETE,
-                                        creation_date: result.creation_date,
-                                        htlcs: result.htlcs
-                                    };
-                                    resolve(formattedResult);
-                                } else {
-                                    reject(
-                                        new Error(
-                                            result.failure_reason ||
-                                                localeString(
-                                                    'error.paymentFailed'
-                                                )
-                                        )
-                                    );
-                                }
-                            }
-                        } catch (error: any) {
-                            console.error(
-                                'Error parsing payment update:',
-                                error
-                            );
-                            handlePaymentError(error);
-                            this.cleanupPaymentListener();
-                            reject(error);
-                        }
-                    }
-                }
-            );
-
-            // Timeout to prevent hanging forever
-            const timeoutMs = Number(this.state.timeoutSeconds) * 1000;
-            this.paymentTimeoutId = setTimeout(() => {
-                if (this.listener) {
-                    const timeoutError = new Error(
-                        'Payment timed out waiting for final status'
-                    );
-                    handlePaymentError(timeoutError);
-                    this.cleanupPaymentListener();
-                    reject(timeoutError);
-                }
-            }, timeoutMs + REBALANCE_CONSTANTS.TIMEOUT_BUFFER_MS);
-        });
-    };
-
-    private cleanupPaymentListener = () => {
-        if (this.listener) {
-            this.listener.remove();
-            this.listener = null;
-        }
-
-        if (this.paymentTimeoutId) {
-            clearTimeout(this.paymentTimeoutId);
-            this.paymentTimeoutId = null;
-        }
-    };
 
     // Navigation and result handling
     private createRebalanceResult = (


### PR DESCRIPTION
# Description

Relates to issue: **#2144**

Moves the remaining LNC streaming call listeners out of views and into `backends/LightningNodeConnect.ts`, following the `openChannelStream` pattern. After this PR, no file outside the backend imports `LncModule` or builds a `NativeEventEmitter` for LNC calls.

**`closeChannel`** now wraps its stream in a promise that resolves on `close_pending` / `chan_close.success` and rejects otherwise. `ChannelsStore.closeChannel` routes the result through `handleChannelClose` / `handleChannelCloseError` like the other backends, and the Channel view's `subscribeChannelClose` and its implementation branch are gone. This also fixes three bugs in the old view listener: it was nulled without calling `remove()` (leaked and could fire after navigation), it had no unmount cleanup, and its error path did `new Error(result)` on an object, surfacing "[object Object]" to the user. Note: `CloseStatusUpdate` carries no request identifiers, so events on the shared stream cannot be correlated to a specific close request; ZEUS only drives one close at a time from the UI, and the wrapper resolves on the first terminal event, matching the previous behavior.

**`subscribeCustomMessages`** now takes the same `(onResponse, onError)` callback signature as the LND REST backend and manages its own listener (removing the previous one on re-subscribe, since LNC event names are just the RPC method name). The LSPS1 view's LNC-only branch is replaced by the `LSPStore.subscribeCustomMessages` path used for the other backends. Behavior note: LNC now gets the store's 7 second no-response timeout like LND REST does, where before it would wait indefinitely.

**`watchActivityUpdates`** is a new backend method returning an unsubscribe function for the transaction/invoice refresh events the Activity view uses, mirroring `watchInvoicePaid` / `watchOnchainReceived`.

**Rebalance**: the view-side `subscribePayment` and its `typeof result === 'string'` branch have been dead since the LNC backend started resolving `payLightningInvoice` with the terminal payment result; deleted in a separate commit.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Device tests pending: LNC cooperative and force close, LSPS1 flow over LNC custom messages, Activity refresh over LNC, LNC rebalance. Will undraft after they pass.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
