### PR TITLE
fix(nfc): add remaining URI schemes to NDEF_DISCOVERED filter

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -87,6 +87,14 @@
             <category android:name="android.intent.category.DEFAULT" />
             <data android:scheme="lightning" />
             <data android:scheme="LIGHTNING" />
+            <data android:scheme="bitcoin" />
+            <data android:scheme="BITCOIN" />
+            <data android:scheme="lnurl" />
+            <data android:scheme="lnurlw" />
+            <data android:scheme="lnurlc" />
+            <data android:scheme="lnurlp" />
+            <data android:scheme="cashu" />
+            <data android:scheme="lndconnect" />
         </intent-filter>
         <intent-filter>
             <action android:name="android.intent.action.SEND" />


### PR DESCRIPTION
# Description

Follow-up to #4103, which added `NDEF_DISCOVERED` intent filters for the `lightning:` scheme and explicitly deferred the remaining schemes.

Android dispatches NFC tags containing URI-type NDEF records by URI scheme. Zeus only registered `NDEF_DISCOVERED` for `text/plain` records and the `lightning:` scheme, so tags programmed with the other schemes Zeus handles, most notably `lnurlw://` used by Boltcards and other LNURL-withdraw cards, were dispatched to other apps and Zeus never appeared in Android's app chooser.

This adds the remaining payment URI schemes already registered for `ACTION_VIEW` (`bitcoin`, `BITCOIN`, `lnurl`, `lnurlw`, `lnurlc`, `lnurlp`, `cashu`, `lndconnect`) to the existing `NDEF_DISCOVERED` filter.

Addresses the Boltcard/LNURLw portion of #2129: Zeus now appears in the chooser (and opens directly if set as default) when tapping such a tag. Fully preventing other apps from opening while Zeus is foregrounded would additionally require claiming the NFC reader in foreground mode, which is out of scope here.

Testing so far: manifest-only change, verified against the intent filter dispatch rules. Device testing with a Boltcard/LNURLw tag is pending, hence draft.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding