### PR TITLE
Receive: generate imported account addresses under the account's key scope

### DIFF
--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -82,7 +82,10 @@ import {
     verifyMessageWithAddr as verifyMsgWithAddr
 } from '../lndmobile/wallet';
 
-import { toLnrpcAddressTypeNum } from '../utils/LndUtils';
+import {
+    toLnrpcAddressTypeNum,
+    toWalletrpcAddressTypeNum
+} from '../utils/LndUtils';
 
 export default class EmbeddedLND extends LND {
     openChannelListener: any;
@@ -132,7 +135,12 @@ export default class EmbeddedLND extends LND {
             data?.account
         );
     getNewChangeAddress = async (data: any) =>
-        await newChangeAddress(data.type, data.account);
+        // NextAddr takes walletrpc.AddressType numbering, which differs
+        // from lnrpc numbering; protobufjs would encode a name string as 0
+        await newChangeAddress(
+            toWalletrpcAddressTypeNum(data.type) as any,
+            data.account
+        );
     openChannelSync = async (data: OpenChannelRequest) =>
         await openChannelSync(
             data.node_pubkey_string,

--- a/backends/EmbeddedLND.ts
+++ b/backends/EmbeddedLND.ts
@@ -575,6 +575,7 @@ export default class EmbeddedLND extends LND {
     supportsChannelCoinControl = () => this.supports('v0.17.0');
     supportsHopPicking = () => this.supports('v0.11.0');
     supportsAccounts = () => true;
+    supportsAccountImportRescan = () => true;
     supportsRouting = () => false;
     supportsNodeInfo = () => true;
     supportsWithdrawalRequests = () => false;

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -392,11 +392,12 @@ export default class LND {
         );
 
     getNewAddress = (data: any) => {
-        const params: any = { ...data };
-        const type = toLnrpcAddressType(params.type);
-        if (type !== undefined) params.type = type;
-        else delete params.type;
-        return this.getRequest('/v1/newaddress', params);
+        const { type, ...rest } = data;
+        const lnrpcType = toLnrpcAddressType(type);
+        return this.getRequest(
+            '/v1/newaddress',
+            lnrpcType === undefined ? rest : { ...rest, type: lnrpcType }
+        );
     };
     getNewChangeAddress = (data: any) =>
         this.postRequest('/v2/wallet/address/next', data);

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -1026,6 +1026,9 @@ export default class LND {
     supportsChannelCoinControl = () => this.supports('v0.17.0');
     supportsHopPicking = () => this.supports('v0.11.0');
     supportsAccounts = () => this.supports('v0.13.0');
+    // ImportAccountRequest.birthday_height and the rescan RPC are Zeus
+    // lnd-fork extensions; upstream lnd has neither
+    supportsAccountImportRescan = () => false;
     supportsRouting = () => true;
     supportsNodeInfo = () => true;
     supportsWithdrawalRequests = () => false;

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -19,20 +19,14 @@ import {
     deriveExpectedPaymentHash
 } from '../utils/LncPayUtils';
 import { localeString } from '../utils/LocaleUtils';
-import { toLnrpcAddressType } from '../utils/LndUtils';
+import {
+    toLnrpcAddressType,
+    toWalletrpcAddressTypeName
+} from '../utils/LndUtils';
 import VersionUtils from '../utils/VersionUtils';
 
 import { Hash as sha256Hash } from 'fast-sha256';
 import BigNumber from 'bignumber.js';
-
-const NEXT_ADDR_MAP: any = {
-    WITNESS_PUBKEY_HASH: 0,
-    NESTED_PUBKEY_HASH: 1,
-    UNUSED_WITNESS_PUBKEY_HASH: 2,
-    UNUSED_NESTED_PUBKEY_HASH: 3,
-    TAPROOT_PUBKEY: 4,
-    UNUSED_TAPROOT_PUBKEY: 5
-};
 
 export default class LightningNodeConnect {
     lnc: any;
@@ -233,7 +227,9 @@ export default class LightningNodeConnect {
     getNewChangeAddress = async (data: any) =>
         await this.lnc.lnd.walletKit
             .nextAddr({
-                type: NEXT_ADDR_MAP[data.type],
+                // NextAddr takes walletrpc.AddressType, whose names and
+                // numbering differ from lnrpc.AddressType
+                type: toWalletrpcAddressTypeName(data.type),
                 account: data.account || 'default',
                 change: true
             })

--- a/backends/LightningNodeConnect.ts
+++ b/backends/LightningNodeConnect.ts
@@ -886,6 +886,7 @@ export default class LightningNodeConnect {
         this.permNewAddress && this.supports('v0.17.0');
     supportsHopPicking = () => this.permOpenChannel;
     supportsAccounts = () => this.permImportAccount;
+    supportsAccountImportRescan = () => false;
     supportsRouting = () => this.permForwardingHistory;
     supportsNodeInfo = () => true;
     supportsWithdrawalRequests = () => false;

--- a/stores/InvoicesStore.test.ts
+++ b/stores/InvoicesStore.test.ts
@@ -6,6 +6,7 @@ jest.mock('../utils/BackendUtils', () => ({
     default: {
         decodePaymentRequest: jest.fn(),
         getNewAddress: jest.fn(),
+        getNewChangeAddress: jest.fn(),
         isLNDBased: jest.fn(() => false)
     }
 }));
@@ -114,6 +115,14 @@ describe('InvoicesStore.getNewAddress', () => {
         });
     });
 
+    it('leaves the caller-supplied request object untouched', async () => {
+        const store = newStore();
+        const params = { account: 'SeedSigner', type: '0' };
+        await store.getNewAddress(params);
+
+        expect(params).toEqual({ account: 'SeedSigner', type: '0' });
+    });
+
     it('surfaces backend errors instead of leaving a stale address', async () => {
         (BackendUtils.getNewAddress as jest.Mock).mockRejectedValue(
             new Error('account not found')
@@ -124,5 +133,27 @@ describe('InvoicesStore.getNewAddress', () => {
 
         expect(store.onChainAddress).toBeNull();
         expect(store.error_msg).toContain('account not found');
+    });
+});
+
+describe('InvoicesStore.getNewChangeAddress', () => {
+    it('sets change without mutating the caller-supplied request object', async () => {
+        (BackendUtils.getNewChangeAddress as jest.Mock).mockResolvedValue({
+            addr: 'bcrt1qchange'
+        });
+
+        const store = newStore();
+        const params = { account: 'SeedSigner', type: 'TAPROOT_PUBKEY' };
+        await store.getNewChangeAddress(params);
+
+        expect(BackendUtils.getNewChangeAddress).toHaveBeenCalledWith({
+            account: 'SeedSigner',
+            type: 'TAPROOT_PUBKEY',
+            change: true
+        });
+        expect(params).toEqual({
+            account: 'SeedSigner',
+            type: 'TAPROOT_PUBKEY'
+        });
     });
 });

--- a/stores/InvoicesStore.test.ts
+++ b/stores/InvoicesStore.test.ts
@@ -5,6 +5,7 @@ jest.mock('../utils/BackendUtils', () => ({
     __esModule: true,
     default: {
         decodePaymentRequest: jest.fn(),
+        getNewAddress: jest.fn(),
         isLNDBased: jest.fn(() => false)
     }
 }));
@@ -59,5 +60,69 @@ describe('InvoicesStore.getPayReq', () => {
 
         expect(store.pay_req).toBeNull();
         expect(store.getPayReqError).toBe('decode failed');
+    });
+});
+
+// ZEUS-2223 / ZEUS-2932: imported accounts live under a single key scope;
+// lnd rejects address requests whose type doesn't match it
+describe('InvoicesStore.getNewAddress', () => {
+    beforeEach(() => {
+        (BackendUtils.getNewAddress as jest.Mock).mockResolvedValue({
+            address: 'bcrt1qtest'
+        });
+    });
+
+    it('honors an account-derived walletrpc address type for non-default accounts', async () => {
+        const store = newStore();
+        await store.getNewAddress({
+            account: 'SeedSigner',
+            type: 'TAPROOT_PUBKEY'
+        });
+
+        expect(BackendUtils.getNewAddress).toHaveBeenCalledWith({
+            account: 'SeedSigner',
+            type: 'TAPROOT_PUBKEY'
+        });
+    });
+
+    it('normalizes walletrpc numeric address types from the embedded proto decode', async () => {
+        const store = newStore();
+        await store.getNewAddress({ account: 'SeedSigner', type: 4 });
+
+        expect(BackendUtils.getNewAddress).toHaveBeenCalledWith({
+            account: 'SeedSigner',
+            type: 'TAPROOT_PUBKEY'
+        });
+    });
+
+    it('drops non-account address types (like the settings preference) for non-default accounts', async () => {
+        const store = newStore();
+        await store.getNewAddress({ account: 'SeedSigner', type: '0' });
+
+        expect(BackendUtils.getNewAddress).toHaveBeenCalledWith({
+            account: 'SeedSigner'
+        });
+    });
+
+    it('leaves the requested type untouched for the default account', async () => {
+        const store = newStore();
+        await store.getNewAddress({ account: 'default', type: '0' });
+
+        expect(BackendUtils.getNewAddress).toHaveBeenCalledWith({
+            account: 'default',
+            type: '0'
+        });
+    });
+
+    it('surfaces backend errors instead of leaving a stale address', async () => {
+        (BackendUtils.getNewAddress as jest.Mock).mockRejectedValue(
+            new Error('account not found')
+        );
+
+        const store = newStore();
+        await store.getNewAddress({ account: 'SeedSigner' });
+
+        expect(store.onChainAddress).toBeNull();
+        expect(store.error_msg).toContain('account not found');
     });
 });

--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -12,6 +12,7 @@ import ChannelInfo from '../models/ChannelInfo';
 import SettingsStore from './SettingsStore';
 import LSPStore from './LSPStore';
 import BackendUtils from '../utils/BackendUtils';
+import { toWalletrpcAddressTypeName } from '../utils/LndUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { errorToUserFriendly } from '../utils/ErrorUtils';
 import LdkNodeInjection from '../ldknode/LdkNodeInjection';
@@ -184,6 +185,7 @@ export default class InvoicesStore {
         routeHints,
         routeHintChannels,
         addressType,
+        account,
         customPreimage,
         noLsp,
         forceLsp,
@@ -198,6 +200,7 @@ export default class InvoicesStore {
         routeHints?: boolean;
         routeHintChannels?: Channel[];
         addressType?: string;
+        account?: string;
         customPreimage?: string;
         noLsp?: boolean;
         forceLsp?: boolean;
@@ -234,11 +237,15 @@ export default class InvoicesStore {
                 }
                 const { rHash, paymentRequest } = result;
                 if (BackendUtils.supportsOnchainReceiving() && !skipOnchain) {
-                    return this.getNewAddress(
-                        addressType
-                            ? { type: addressType, unified: true }
-                            : { unified: true }
-                    )
+                    // ZEUS-2223: the on-chain leg must come from the
+                    // requested account; falling back to the default
+                    // account would silently receive into the node's own
+                    // wallet instead of e.g. an imported watch-only account
+                    const addressRequest: any = { unified: true };
+                    if (addressType) addressRequest.type = addressType;
+                    if (account && account !== 'default')
+                        addressRequest.account = account;
+                    return this.getNewAddress(addressRequest)
                         .then((onChainAddress: string) => {
                             runInAction(() => {
                                 this.onChainAddress = onChainAddress;
@@ -619,10 +626,16 @@ export default class InvoicesStore {
             this.creatingInvoice = true;
             this.error_msg = null;
         }
-        // ZEUS-2396
-        // https://github.com/ZeusLN/zeus/issues/2396
+        // ZEUS-2223 / ZEUS-2932: imported accounts exist under a single key
+        // scope, and lnd requires the request's address type to match it;
+        // it never infers the scope from the account name. Honor an
+        // account-derived (walletrpc) address type; drop anything else (like
+        // the user's preferred type from settings, see ZEUS-2396) so lnd's
+        // default applies instead of a mismatched scope.
         if (params.account && params.account !== 'default') {
-            delete params.type;
+            const accountType = toWalletrpcAddressTypeName(params.type);
+            if (accountType) params.type = accountType;
+            else delete params.type;
         }
         this.onChainAddress = null;
         return BackendUtils.getNewAddress(params)

--- a/stores/InvoicesStore.ts
+++ b/stores/InvoicesStore.ts
@@ -629,16 +629,18 @@ export default class InvoicesStore {
         // ZEUS-2223 / ZEUS-2932: imported accounts exist under a single key
         // scope, and lnd requires the request's address type to match it;
         // it never infers the scope from the account name. Honor an
-        // account-derived (walletrpc) address type; drop anything else (like
+        // account-derived (walletrpc) address type; omit anything else (like
         // the user's preferred type from settings, see ZEUS-2396) so lnd's
         // default applies instead of a mismatched scope.
-        if (params.account && params.account !== 'default') {
-            const accountType = toWalletrpcAddressTypeName(params.type);
-            if (accountType) params.type = accountType;
-            else delete params.type;
-        }
+        const { type, ...rest } = params;
+        const resolvedType =
+            rest.account && rest.account !== 'default'
+                ? toWalletrpcAddressTypeName(type)
+                : type;
+        const request =
+            resolvedType === undefined ? rest : { ...rest, type: resolvedType };
         this.onChainAddress = null;
-        return BackendUtils.getNewAddress(params)
+        return BackendUtils.getNewAddress(request)
             .then((data: any) => {
                 const address =
                     data.address ||
@@ -646,8 +648,8 @@ export default class InvoicesStore {
                     data.p2tr ||
                     (data[0] && data[0].address);
                 runInAction(() => {
-                    if (!params.unified) this.onChainAddress = address;
-                    if (!params.unified) this.creatingInvoice = false;
+                    if (!request.unified) this.onChainAddress = address;
+                    if (!request.unified) this.creatingInvoice = false;
                 });
                 return address;
             })
@@ -671,15 +673,15 @@ export default class InvoicesStore {
             this.error_msg = null;
         }
 
-        params.change = true;
+        const request = { ...params, change: true };
 
         this.onChainAddress = null;
-        return BackendUtils.getNewChangeAddress(params)
+        return BackendUtils.getNewChangeAddress(request)
             .then((data: any) => {
                 const address = data.addr;
                 runInAction(() => {
-                    if (!params.unified) this.onChainAddress = address;
-                    if (!params.unified) this.creatingInvoice = false;
+                    if (!request.unified) this.onChainAddress = address;
+                    if (!request.unified) this.creatingInvoice = false;
                 });
                 return address;
             })

--- a/stores/UTXOsStore.test.ts
+++ b/stores/UTXOsStore.test.ts
@@ -1,0 +1,155 @@
+jest.mock('../stores/Stores', () => ({}));
+jest.mock('react-native-blob-util', () => ({}));
+jest.mock('../ldknode/LdkNodeInjection', () => ({}));
+jest.mock('../storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: jest.fn(() => Promise.resolve(null)),
+        setItem: jest.fn(() => Promise.resolve())
+    }
+}));
+jest.mock('../utils/BackendUtils', () => ({
+    __esModule: true,
+    default: {
+        importAccount: jest.fn(),
+        listAccounts: jest.fn(),
+        getBlockchainBalance: jest.fn(),
+        getNewAddress: jest.fn(),
+        getNewChangeAddress: jest.fn(),
+        rescan: jest.fn(),
+        supportsAccountImportRescan: jest.fn(() => false)
+    }
+}));
+
+import UTXOsStore from './UTXOsStore';
+import BackendUtils from '../utils/BackendUtils';
+
+const newStore = () => new UTXOsStore({} as any, {} as any);
+
+const dryRunResponse = {
+    account: {
+        name: 'SeedSigner',
+        address_type: 'TAPROOT_PUBKEY'
+    },
+    dry_run_external_addrs: ['bcrt1p-ext'],
+    dry_run_internal_addrs: ['bcrt1p-int']
+};
+
+// birthday_height and the rescan RPC only exist on the Zeus lnd fork
+// (embedded); litd's proto JSON unmarshaler rejects requests carrying
+// unknown fields and BackendUtils.call returns false for missing RPCs
+describe('UTXOsStore.importAccount', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (BackendUtils.supportsAccountImportRescan as jest.Mock).mockReturnValue(
+            false
+        );
+        (BackendUtils.importAccount as jest.Mock).mockResolvedValue(
+            dryRunResponse
+        );
+        (BackendUtils.listAccounts as jest.Mock).mockResolvedValue({
+            accounts: []
+        });
+        (BackendUtils.getNewAddress as jest.Mock).mockResolvedValue({
+            address: 'bcrt1p-recv'
+        });
+        (BackendUtils.getNewChangeAddress as jest.Mock).mockResolvedValue({
+            addr: 'bcrt1p-change'
+        });
+        (BackendUtils.rescan as jest.Mock).mockResolvedValue({});
+    });
+
+    const dryRunData = () => ({
+        name: 'SeedSigner',
+        extended_public_key: 'tpubDDfvzhdVV4u',
+        birthday_height: 800000,
+        addresses_to_generate: 2,
+        dry_run: true
+    });
+
+    it('strips addresses_to_generate from every import request', async () => {
+        await newStore().importAccount(dryRunData());
+
+        const request = (BackendUtils.importAccount as jest.Mock).mock
+            .calls[0][0];
+        expect('addresses_to_generate' in request).toBe(false);
+    });
+
+    it('keeps birthday_height when the backend supports the fork import extensions', async () => {
+        (BackendUtils.supportsAccountImportRescan as jest.Mock).mockReturnValue(
+            true
+        );
+
+        await newStore().importAccount(dryRunData());
+
+        const request = (BackendUtils.importAccount as jest.Mock).mock
+            .calls[0][0];
+        expect(request.birthday_height).toBe(800000);
+    });
+
+    it('re-attaches the dry-run birthday to the real import on the fork backend', async () => {
+        (BackendUtils.supportsAccountImportRescan as jest.Mock).mockReturnValue(
+            true
+        );
+
+        const store = newStore();
+        await store.importAccount(dryRunData());
+        // the real import from ImportingAccount doesn't resend the birthday
+        await store.importAccount({
+            name: 'SeedSigner',
+            extended_public_key: 'tpubDDfvzhdVV4u',
+            dry_run: false
+        });
+
+        const request = (BackendUtils.importAccount as jest.Mock).mock
+            .calls[1][0];
+        expect(request.birthday_height).toBe(800000);
+        expect(BackendUtils.rescan).toHaveBeenCalledWith({
+            start_height: 800000
+        });
+        expect(store.success).toBe(true);
+    });
+
+    it('strips birthday_height and skips the rescan on backends without the fork extensions', async () => {
+        const store = newStore();
+        await store.importAccount(dryRunData());
+        await store.importAccount({
+            name: 'SeedSigner',
+            extended_public_key: 'tpubDDfvzhdVV4u',
+            dry_run: false
+        });
+
+        for (const call of (BackendUtils.importAccount as jest.Mock).mock
+            .calls) {
+            expect('birthday_height' in call[0]).toBe(false);
+        }
+        // pre-generation still runs off the captured start_height
+        expect(BackendUtils.getNewAddress).toHaveBeenCalledTimes(2);
+        // rescan is fork-only; calling it would throw false.then into the
+        // catch and report the successful import as failed
+        expect(BackendUtils.rescan).not.toHaveBeenCalled();
+        expect(store.success).toBe(true);
+        expect(store.errorMsg).toBe('');
+        expect(store.accountToImport).not.toBeNull();
+        expect(BackendUtils.listAccounts).toHaveBeenCalled();
+    });
+
+    it('does not mutate the caller-supplied data object', async () => {
+        const data = dryRunData();
+        const snapshot = JSON.parse(JSON.stringify(data));
+
+        const store = newStore();
+        await store.importAccount(data);
+        // real import re-attaches the birthday internally, not on `data`
+        const realData = {
+            name: 'SeedSigner',
+            extended_public_key: 'tpubDDfvzhdVV4u',
+            dry_run: false
+        };
+        const realSnapshot = JSON.parse(JSON.stringify(realData));
+        await store.importAccount(realData);
+
+        expect(data).toEqual(snapshot);
+        expect(realData).toEqual(realSnapshot);
+    });
+});

--- a/stores/UTXOsStore.ts
+++ b/stores/UTXOsStore.ts
@@ -246,9 +246,20 @@ export default class UTXOsStore {
             data.birthday_height = this.start_height;
         }
 
-        console.log('importAccount req', data);
+        // birthday_height and addresses_to_generate drive the Zeus-side
+        // rescan and address pre-generation above; they aren't part of
+        // lnd's ImportAccountRequest. Embedded (protobufjs) and REST
+        // silently drop unknown fields but LNC's proto JSON unmarshaler
+        // rejects the whole request over them.
+        const {
+            birthday_height: _birthdayHeight,
+            addresses_to_generate: _addressesToGenerate,
+            ...importRequest
+        } = data;
 
-        return BackendUtils.importAccount(data)
+        console.log('importAccount req', importRequest);
+
+        return BackendUtils.importAccount(importRequest)
             .then(async (response: any) => {
                 if (!data.dry_run) {
                     if (this.start_height) {

--- a/stores/UTXOsStore.ts
+++ b/stores/UTXOsStore.ts
@@ -5,11 +5,10 @@ import SettingsStore from './SettingsStore';
 import SyncStore from './SyncStore';
 
 import BackendUtils from '../utils/BackendUtils';
+import { toWalletrpcAddressTypeName } from '../utils/LndUtils';
 
 import Account from '../models/Account';
 import Utxo from '../models/Utxo';
-
-import { walletrpc } from '../proto/lightning';
 
 export const LEGACY_HIDDEN_ACCOUNTS_KEY = 'hidden-accounts';
 export const HIDDEN_ACCOUNTS_KEY = 'zeus-hidden-accounts';
@@ -201,6 +200,29 @@ export default class UTXOsStore {
             });
     };
 
+    // Resolves an imported account's address type (as the walletrpc enum
+    // name) so address requests can match the account's key scope; lnd
+    // rejects requests whose type doesn't match it (ZEUS-2223 / ZEUS-2932).
+    public getAccountAddressType = async (
+        name: string
+    ): Promise<string | undefined> => {
+        const cached = this.accounts.find(
+            (account: any) => account.name === name
+        );
+        const cachedType = toWalletrpcAddressTypeName(cached?.address_type);
+        if (cachedType) return cachedType;
+        try {
+            const data = await BackendUtils.listAccounts();
+            const match = (data?.accounts || []).find(
+                (account: any) => account.name === name
+            );
+            return toWalletrpcAddressTypeName(match?.address_type);
+        } catch (e) {
+            console.error('error resolving account address type', e);
+            return undefined;
+        }
+    };
+
     @action
     public importAccount = (data: any) => {
         this.errorMsg = '';
@@ -235,9 +257,9 @@ export default class UTXOsStore {
                             this.addresses_to_generate_progress = i + 1;
                             await BackendUtils.getNewAddress({
                                 account: this.accountToImport.account.name,
-                                type: walletrpc.AddressType[
+                                type: toWalletrpcAddressTypeName(
                                     this.accountToImport.account.address_type
-                                ]
+                                )
                             }).then((response: any) => {
                                 console.log(
                                     `generated address ${i}`,
@@ -246,9 +268,9 @@ export default class UTXOsStore {
                             });
                             await BackendUtils.getNewChangeAddress({
                                 account: this.accountToImport.account.name,
-                                type: walletrpc.AddressType[
+                                type: toWalletrpcAddressTypeName(
                                     this.accountToImport.account.address_type
-                                ],
+                                ),
                                 change: true
                             }).then((response: any) => {
                                 console.log(

--- a/stores/UTXOsStore.ts
+++ b/stores/UTXOsStore.ts
@@ -257,8 +257,6 @@ export default class UTXOsStore {
             ...importRequest
         } = data;
 
-        console.log('importAccount req', importRequest);
-
         return BackendUtils.importAccount(importRequest)
             .then(async (response: any) => {
                 if (!data.dry_run) {

--- a/stores/UTXOsStore.ts
+++ b/stores/UTXOsStore.ts
@@ -301,6 +301,9 @@ export default class UTXOsStore {
                         this.error = false;
                         this.success = true;
                     });
+                    // refresh so the new account shows up on the balance
+                    // pane without a manual pull-to-refresh
+                    this.listAccounts();
                     return;
                 } else {
                     runInAction(() => {

--- a/stores/UTXOsStore.ts
+++ b/stores/UTXOsStore.ts
@@ -242,20 +242,25 @@ export default class UTXOsStore {
             this.addresses_to_generate = data.addresses_to_generate || 50;
         }
 
-        if (this.start_height && !data.birthday_height) {
-            data.birthday_height = this.start_height;
-        }
+        // the dry run captures the birthday into start_height; the real
+        // import from ImportingAccount doesn't resend it
+        const birthday_height = data.birthday_height || this.start_height;
 
-        // birthday_height and addresses_to_generate drive the Zeus-side
-        // rescan and address pre-generation above; they aren't part of
-        // lnd's ImportAccountRequest. Embedded (protobufjs) and REST
-        // silently drop unknown fields but LNC's proto JSON unmarshaler
+        // addresses_to_generate only drives the Zeus-side address
+        // pre-generation above; no backend knows it. birthday_height is a
+        // Zeus lnd-fork extension (walletrpc ImportAccountRequest field 6)
+        // the embedded node uses to move the wallet birthday back to the
+        // account's; upstream lnd stops at dry_run = 5, and while REST
+        // silently drops unknown fields, LNC's proto JSON unmarshaler
         // rejects the whole request over them.
         const {
             birthday_height: _birthdayHeight,
             addresses_to_generate: _addressesToGenerate,
             ...importRequest
         } = data;
+        if (birthday_height && BackendUtils.supportsAccountImportRescan()) {
+            importRequest.birthday_height = birthday_height;
+        }
 
         return BackendUtils.importAccount(importRequest)
             .then(async (response: any) => {
@@ -289,20 +294,26 @@ export default class UTXOsStore {
                             });
                         }
 
-                        console.log(
-                            'Starting rescan at height',
-                            this.start_height
-                        );
+                        // rescan is a Zeus lnd-fork RPC; on backends
+                        // without it BackendUtils.call returns false and
+                        // the .then would throw into the outer catch,
+                        // reporting a successful import as failed
+                        if (BackendUtils.supportsAccountImportRescan()) {
+                            console.log(
+                                'Starting rescan at height',
+                                this.start_height
+                            );
 
-                        BackendUtils.rescan({
-                            start_height: this.start_height
-                        })
-                            .then((response: any) => {
-                                console.log('rescan resp', response);
+                            BackendUtils.rescan({
+                                start_height: this.start_height
                             })
-                            .catch((err: Error) => {
-                                console.log('rescan err', err);
-                            });
+                                .then((response: any) => {
+                                    console.log('rescan resp', response);
+                                })
+                                .catch((err: Error) => {
+                                    console.log('rescan err', err);
+                                });
+                        }
                     }
 
                     runInAction(() => {

--- a/utils/BackendUtils.ts
+++ b/utils/BackendUtils.ts
@@ -233,6 +233,8 @@ class BackendUtils {
     supportsChannelCoinControl = () => this.call('supportsChannelCoinControl');
     supportsHopPicking = () => this.call('supportsHopPicking');
     supportsAccounts = () => this.call('supportsAccounts');
+    supportsAccountImportRescan = () =>
+        this.call('supportsAccountImportRescan');
     supportsRouting = () => this.call('supportsRouting');
     supportsForwardingHistory = () => this.call('supportsForwardingHistory');
     supportsNodeInfo = () => this.call('supportsNodeInfo');

--- a/utils/LndUtils.test.ts
+++ b/utils/LndUtils.test.ts
@@ -1,4 +1,9 @@
-import { toLnrpcAddressType, toLnrpcAddressTypeNum } from './LndUtils';
+import {
+    toLnrpcAddressType,
+    toLnrpcAddressTypeNum,
+    toWalletrpcAddressTypeName,
+    toWalletrpcAddressTypeNum
+} from './LndUtils';
 
 describe('LndUtils', () => {
     describe('toLnrpcAddressType', () => {
@@ -98,6 +103,83 @@ describe('LndUtils', () => {
             expect(toLnrpcAddressTypeNum(0)).toEqual(0);
             expect(toLnrpcAddressTypeNum(1)).toEqual(1);
             expect(toLnrpcAddressTypeNum(4)).toEqual(4);
+        });
+    });
+
+    describe('toWalletrpcAddressTypeName', () => {
+        it('normalizes walletrpc numeric values from the embedded proto decode', () => {
+            // walletrpc.AddressType numbering differs from lnrpc:
+            // UNKNOWN=0, WITNESS_PUBKEY_HASH=1, NESTED_WITNESS_PUBKEY_HASH=2,
+            // HYBRID_NESTED_WITNESS_PUBKEY_HASH=3, TAPROOT_PUBKEY=4
+            expect(toWalletrpcAddressTypeName(1)).toEqual(
+                'WITNESS_PUBKEY_HASH'
+            );
+            expect(toWalletrpcAddressTypeName(2)).toEqual(
+                'NESTED_WITNESS_PUBKEY_HASH'
+            );
+            expect(toWalletrpcAddressTypeName(3)).toEqual(
+                'HYBRID_NESTED_WITNESS_PUBKEY_HASH'
+            );
+            expect(toWalletrpcAddressTypeName(4)).toEqual('TAPROOT_PUBKEY');
+            expect(toWalletrpcAddressTypeName('1')).toEqual(
+                'WITNESS_PUBKEY_HASH'
+            );
+            expect(toWalletrpcAddressTypeName('4')).toEqual('TAPROOT_PUBKEY');
+        });
+
+        it('passes walletrpc enum names from REST/LNC ListAccounts through unchanged', () => {
+            expect(toWalletrpcAddressTypeName('WITNESS_PUBKEY_HASH')).toEqual(
+                'WITNESS_PUBKEY_HASH'
+            );
+            expect(
+                toWalletrpcAddressTypeName('NESTED_WITNESS_PUBKEY_HASH')
+            ).toEqual('NESTED_WITNESS_PUBKEY_HASH');
+            expect(
+                toWalletrpcAddressTypeName('HYBRID_NESTED_WITNESS_PUBKEY_HASH')
+            ).toEqual('HYBRID_NESTED_WITNESS_PUBKEY_HASH');
+            expect(toWalletrpcAddressTypeName('TAPROOT_PUBKEY')).toEqual(
+                'TAPROOT_PUBKEY'
+            );
+        });
+
+        it('maps the lnrpc nested name to its walletrpc equivalent', () => {
+            expect(toWalletrpcAddressTypeName('NESTED_PUBKEY_HASH')).toEqual(
+                'NESTED_WITNESS_PUBKEY_HASH'
+            );
+        });
+
+        it('returns undefined for UNKNOWN, null, undefined and unrecognized values', () => {
+            expect(toWalletrpcAddressTypeName(0)).toBeUndefined();
+            expect(toWalletrpcAddressTypeName('0')).toBeUndefined();
+            expect(toWalletrpcAddressTypeName('UNKNOWN')).toBeUndefined();
+            expect(toWalletrpcAddressTypeName(undefined)).toBeUndefined();
+            expect(toWalletrpcAddressTypeName(null)).toBeUndefined();
+            expect(toWalletrpcAddressTypeName('SOMETHING_NEW')).toBeUndefined();
+        });
+    });
+
+    describe('toWalletrpcAddressTypeNum', () => {
+        it('returns walletrpc numeric values for walletrpc names', () => {
+            expect(toWalletrpcAddressTypeNum('WITNESS_PUBKEY_HASH')).toEqual(1);
+            expect(
+                toWalletrpcAddressTypeNum('NESTED_WITNESS_PUBKEY_HASH')
+            ).toEqual(2);
+            expect(
+                toWalletrpcAddressTypeNum('HYBRID_NESTED_WITNESS_PUBKEY_HASH')
+            ).toEqual(3);
+            expect(toWalletrpcAddressTypeNum('TAPROOT_PUBKEY')).toEqual(4);
+        });
+
+        it('passes walletrpc numeric values through', () => {
+            expect(toWalletrpcAddressTypeNum(1)).toEqual(1);
+            expect(toWalletrpcAddressTypeNum(4)).toEqual(4);
+        });
+
+        it('returns undefined for UNKNOWN, null and unrecognized values', () => {
+            expect(toWalletrpcAddressTypeNum(0)).toBeUndefined();
+            expect(toWalletrpcAddressTypeNum(undefined)).toBeUndefined();
+            expect(toWalletrpcAddressTypeNum(null)).toBeUndefined();
+            expect(toWalletrpcAddressTypeNum('SOMETHING_NEW')).toBeUndefined();
         });
     });
 });

--- a/utils/LndUtils.ts
+++ b/utils/LndUtils.ts
@@ -53,3 +53,45 @@ export const toLnrpcAddressTypeNum = (
     const num = Number(name);
     return Number.isInteger(num) ? num : undefined;
 };
+
+// walletrpc.AddressType helpers, for values that live in the walletrpc enum
+// space: ListAccounts / ListAddresses responses and NextAddr requests.
+// walletrpc numbering differs from lnrpc numbering (WITNESS_PUBKEY_HASH is 1
+// in walletrpc but 0 in lnrpc), and REST/LNC decode enums to their names
+// while the embedded proto decode yields raw numbers, so account address
+// types must be normalized through here, never fed to the lnrpc helpers
+// above directly.
+const WALLETRPC_ADDRESS_TYPE_NAMES: { [key: string]: string } = {
+    '1': 'WITNESS_PUBKEY_HASH',
+    '2': 'NESTED_WITNESS_PUBKEY_HASH',
+    '3': 'HYBRID_NESTED_WITNESS_PUBKEY_HASH',
+    '4': 'TAPROOT_PUBKEY',
+    WITNESS_PUBKEY_HASH: 'WITNESS_PUBKEY_HASH',
+    NESTED_WITNESS_PUBKEY_HASH: 'NESTED_WITNESS_PUBKEY_HASH',
+    HYBRID_NESTED_WITNESS_PUBKEY_HASH: 'HYBRID_NESTED_WITNESS_PUBKEY_HASH',
+    TAPROOT_PUBKEY: 'TAPROOT_PUBKEY',
+    // lnrpc's name for nested segwit, accepted for convenience
+    NESTED_PUBKEY_HASH: 'NESTED_WITNESS_PUBKEY_HASH'
+};
+
+export const toWalletrpcAddressTypeName = (
+    value: string | number | undefined | null
+): string | undefined => {
+    if (value == null) return undefined;
+    return WALLETRPC_ADDRESS_TYPE_NAMES[String(value)];
+};
+
+const WALLETRPC_ADDRESS_TYPE_NUMS: { [key: string]: number } = {
+    WITNESS_PUBKEY_HASH: 1,
+    NESTED_WITNESS_PUBKEY_HASH: 2,
+    HYBRID_NESTED_WITNESS_PUBKEY_HASH: 3,
+    TAPROOT_PUBKEY: 4
+};
+
+export const toWalletrpcAddressTypeNum = (
+    value: string | number | undefined | null
+): number | undefined => {
+    const name = toWalletrpcAddressTypeName(value);
+    if (name == null) return undefined;
+    return WALLETRPC_ADDRESS_TYPE_NUMS[name];
+};

--- a/views/OnChainAddresses.tsx
+++ b/views/OnChainAddresses.tsx
@@ -566,6 +566,8 @@ export default class OnChainAddresses extends React.Component<
                         // @ts-ignore:next-line
                         onChangeText={this.updateSearch}
                         value={searchText}
+                        autoCorrect={false}
+                        autoCapitalize="none"
                         inputStyle={{
                             color: themeColor('text')
                         }}

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -907,11 +907,6 @@ export default class Receive extends React.Component<
         }
     };
 
-    getNewAddress = (params: any) => {
-        const { InvoicesStore } = this.props;
-        InvoicesStore.getNewAddress(params);
-    };
-
     updateExpirationIndex = (expirationIndex: number) => {
         if (expirationIndex === 0) {
             this.setState({

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -69,9 +69,11 @@ import LightningAddressStore from '../stores/LightningAddressStore';
 import LSPStore from '../stores/LSPStore';
 import UnitsStore from '../stores/UnitsStore';
 import BalanceStore from '../stores/BalanceStore';
+import UTXOsStore from '../stores/UTXOsStore';
 
 import { localeString } from '../utils/LocaleUtils';
 import BackendUtils from '../utils/BackendUtils';
+import { toWalletrpcAddressTypeName } from '../utils/LndUtils';
 import { scanNfcTag } from '../utils/NFCUtils';
 import { themeColor } from '../utils/ThemeUtils';
 import { SATS_PER_BTC } from '../utils/UnitsUtils';
@@ -107,6 +109,7 @@ interface ReceiveProps {
     LSPStore: LSPStore;
     LightningAddressStore: LightningAddressStore;
     BalanceStore: BalanceStore;
+    UTXOsStore: UTXOsStore;
     route: Route<
         'Receive',
         {
@@ -149,6 +152,9 @@ interface ReceiveState {
     ampInvoice: boolean;
     routeHints: boolean;
     account: string;
+    // walletrpc address type name matching the non-default account's key
+    // scope, resolved from ListAccounts (undefined until resolved)
+    accountAddressType?: string;
     blindedPaths: boolean;
     nfcSupported: boolean;
     // POS
@@ -189,7 +195,8 @@ const LSP_MIN_CHANNEL_OPEN_FEE_SATS = 1000;
     'NodeInfoStore',
     'LightningAddressStore',
     'LSPStore',
-    'BalanceStore'
+    'BalanceStore',
+    'UTXOsStore'
 )
 @observer
 export default class Receive extends React.Component<
@@ -385,6 +392,17 @@ export default class Receive extends React.Component<
 
         const addressType = this.getAddressType();
 
+        // Non-default accounts exist under a single key scope; address
+        // requests must carry the matching type or lnd rejects them with
+        // "account not found" (ZEUS-2223 / ZEUS-2932)
+        let accountAddressType: string | undefined;
+        if (account && account !== 'default') {
+            accountAddressType =
+                toWalletrpcAddressTypeName(route.params?.addressType) ||
+                (await this.props.UTXOsStore.getAccountAddressType(account));
+            if (accountAddressType) this.setState({ accountAddressType });
+        }
+
         // POS
         const memo = route.params?.memo ?? this.state.memo;
         const { orderId, orderTotal, orderTip, exchangeRate, rate } =
@@ -462,10 +480,12 @@ export default class Receive extends React.Component<
             );
         }
 
+        const onChainType =
+            account && account !== 'default' ? accountAddressType : addressType;
         if (autoGenerateChange) {
-            this.autoGenerateChange(account, addressType);
+            this.autoGenerateChange(account, onChainType);
         } else if (autoGenerateOnChain) {
-            this.autoGenerateOnChainAddress(account, addressType);
+            this.autoGenerateOnChainAddress(account, onChainType);
         }
 
         this.setState({
@@ -646,7 +666,8 @@ export default class Receive extends React.Component<
                     : undefined,
                 noLsp: !effectiveLspIsActive,
                 forceLsp: !!this.props.route.params?.forceLsp,
-                skipOnchain
+                skipOnchain,
+                ...this.getUnifiedAccountParams()
             })
                 .then(
                     ({
@@ -678,36 +699,45 @@ export default class Receive extends React.Component<
         });
     };
 
-    autoGenerateOnChainAddress = (account?: string, address_type?: string) => {
-        const { InvoicesStore } = this.props;
-        const { getNewAddress } = InvoicesStore;
+    // For non-default accounts the on-chain leg of a unified invoice must
+    // come from that account, with its own address type (ZEUS-2223)
+    private getUnifiedAccountParams = () => {
+        const { account, accountAddressType } = this.state;
+        return account !== 'default'
+            ? { account, addressType: accountAddressType }
+            : {};
+    };
 
-        let request: any = {
-            type: address_type || this.state.addressType
-        };
-
-        if (account) {
+    // For non-default accounts, only an account-derived address type may be
+    // sent; the picker/settings default can point at the wrong key scope
+    private buildAddressRequest = (account?: string, address_type?: string) => {
+        const request: any = {};
+        if (account && account !== 'default') {
             request.account = account;
+            if (address_type) request.type = address_type;
+        } else {
+            request.type = address_type || this.state.addressType;
+            if (account) request.account = account;
         }
+        return request;
+    };
 
-        getNewAddress(request).then((onChainAddress: string) => {
-            this.subscribeInvoice(undefined, onChainAddress);
-        });
+    autoGenerateOnChainAddress = (account?: string, address_type?: string) => {
+        const { getNewAddress } = this.props.InvoicesStore;
+
+        getNewAddress(this.buildAddressRequest(account, address_type)).then(
+            (onChainAddress: string) => {
+                this.subscribeInvoice(undefined, onChainAddress);
+            }
+        );
     };
 
     autoGenerateChange = (account?: string, address_type?: string) => {
-        const { InvoicesStore } = this.props;
-        const { getNewChangeAddress } = InvoicesStore;
+        const { getNewChangeAddress } = this.props.InvoicesStore;
 
-        let request: any = {
-            type: address_type || this.state.addressType
-        };
-
-        if (account) {
-            request.account = account;
-        }
-
-        getNewChangeAddress(request).then((onChainAddress: string) => {
+        getNewChangeAddress(
+            this.buildAddressRequest(account, address_type)
+        ).then((onChainAddress: string) => {
             this.subscribeInvoice(undefined, onChainAddress);
         });
     };
@@ -746,7 +776,8 @@ export default class Receive extends React.Component<
                             lnurl: lnurlParams,
                             noLsp: !lspIsActive,
                             forceLsp: !!this.props.route.params?.forceLsp,
-                            skipOnchain
+                            skipOnchain,
+                            ...this.getUnifiedAccountParams()
                         })
                             .then(
                                 ({
@@ -914,7 +945,7 @@ export default class Receive extends React.Component<
         const { InvoicesStore } = this.props;
         const { onChainAddress, payment_request, getNewAddress } =
             InvoicesStore;
-        const { addressType, account } = this.state;
+        const { addressType, account, accountAddressType } = this.state;
 
         this.setState({
             selectedIndex
@@ -928,10 +959,12 @@ export default class Receive extends React.Component<
             !onChainAddress &&
             BackendUtils.supportsOnchainReceiving()
         ) {
-            await getNewAddress({
-                type: addressType,
-                account: account !== 'default' ? account : 'default'
-            });
+            await getNewAddress(
+                this.buildAddressRequest(
+                    account,
+                    account !== 'default' ? accountAddressType : addressType
+                )
+            );
         }
     };
 
@@ -2933,7 +2966,8 @@ export default class Receive extends React.Component<
                                                             forceLsp:
                                                                 !!route.params
                                                                     ?.forceLsp,
-                                                            skipOnchain
+                                                            skipOnchain,
+                                                            ...this.getUnifiedAccountParams()
                                                         })
                                                             .then(
                                                                 ({

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -318,10 +318,15 @@ export default class Receive extends React.Component<
 
         const forceLsp = !!route.params?.forceLsp;
 
+        const { lnOnly, onChainOnly } = this.getReceiveModeFlags();
+
+        // In on-chain-only mode the lightning leg is never displayed, so
+        // the LSP must not wrap it (or surface fee UI for it)
         const lspIsActive =
             (settings?.enableLSP || forceLsp) &&
             BackendUtils.supportsFlowLSP() &&
-            !flowLspNotConfigured;
+            !flowLspNotConfigured &&
+            !onChainOnly;
 
         // Calculate invoice options once to avoid duplication
         const routeHints =
@@ -360,8 +365,6 @@ export default class Receive extends React.Component<
         if (forceLsp && lspIsActive && !LSPStore.info?.pubkey) {
             LSPStore.getLSPInfo().catch(() => {});
         }
-
-        const { lnOnly, onChainOnly } = this.getReceiveModeFlags();
 
         reset();
 
@@ -1397,12 +1400,15 @@ export default class Receive extends React.Component<
 
         const enablePrinter: boolean = settings?.pos?.enablePrinter || false;
 
+        // Advanced settings only affect the lightning invoice, which is
+        // never displayed in on-chain-only mode
         const showAdvancedSettingsToggle =
-            (BackendUtils.supportsCustomPreimages() &&
+            !onChainOnly &&
+            ((BackendUtils.supportsCustomPreimages() &&
                 showCustomPreimageField) ||
-            (BackendUtils.isLNDBased() && !lspIsActive) ||
-            (BackendUtils.supportsAMP() && !lspIsActive) ||
-            (BackendUtils.supportsBolt11BlindedRoutes() && !lspIsActive);
+                (BackendUtils.isLNDBased() && !lspIsActive) ||
+                (BackendUtils.supportsAMP() && !lspIsActive) ||
+                (BackendUtils.supportsBolt11BlindedRoutes() && !lspIsActive));
 
         const baseModalHeight = 300;
         const itemHeight = ADDRESS_TYPES.length <= 2 ? 25 : 50;
@@ -2084,7 +2090,8 @@ export default class Receive extends React.Component<
                                     !loading &&
                                     route.params?.selectedIndex !== 2 && (
                                         <>
-                                            {BackendUtils.supportsFlowLSP() &&
+                                            {!onChainOnly &&
+                                                BackendUtils.supportsFlowLSP() &&
                                                 !flowLspNotConfigured && (
                                                     <View
                                                         style={{
@@ -2329,155 +2336,126 @@ export default class Receive extends React.Component<
                                                 </TouchableOpacity>
                                             )}
 
-                                            {BackendUtils.supportsSettingInvoiceExpiration() && (
-                                                <Accordion
-                                                    headerLayout="form"
-                                                    key={`receive-expiration-${lspIsActive}`}
-                                                    id="receive-expiration"
-                                                    title={localeString(
-                                                        'views.Receive.expiration'
-                                                    )}
-                                                    disabled={lspIsActive}
-                                                    renderHeader={(isOpen) => (
-                                                        <Row
-                                                            justify="space-between"
-                                                            style={{
-                                                                alignItems:
-                                                                    'center'
-                                                            }}
-                                                        >
-                                                            <View
+                                            {!onChainOnly &&
+                                                BackendUtils.supportsSettingInvoiceExpiration() && (
+                                                    <Accordion
+                                                        headerLayout="form"
+                                                        key={`receive-expiration-${lspIsActive}`}
+                                                        id="receive-expiration"
+                                                        title={localeString(
+                                                            'views.Receive.expiration'
+                                                        )}
+                                                        disabled={lspIsActive}
+                                                        renderHeader={(
+                                                            isOpen
+                                                        ) => (
+                                                            <Row
+                                                                justify="space-between"
                                                                 style={{
-                                                                    flex: 1
+                                                                    alignItems:
+                                                                        'center'
                                                                 }}
                                                             >
-                                                                <Row
-                                                                    justify="space-between"
+                                                                <View
                                                                     style={{
-                                                                        alignItems:
-                                                                            'center'
+                                                                        flex: 1
                                                                     }}
                                                                 >
-                                                                    <View
+                                                                    <Row
+                                                                        justify="space-between"
                                                                         style={{
-                                                                            flex: 1
+                                                                            alignItems:
+                                                                                'center'
                                                                         }}
                                                                     >
-                                                                        <KeyValue
-                                                                            keyValue={localeString(
-                                                                                'views.Receive.expiration'
-                                                                            )}
-                                                                        />
-                                                                    </View>
-
-                                                                    {!isOpen && (
-                                                                        <Text
+                                                                        <View
                                                                             style={{
-                                                                                ...styles.secondaryText,
-                                                                                color: themeColor(
-                                                                                    'secondaryText'
-                                                                                ),
-                                                                                textAlign:
-                                                                                    'center',
-                                                                                fontSize: 14
+                                                                                flex: 1
                                                                             }}
                                                                         >
-                                                                            {this.getFormattedDuration()}
-                                                                        </Text>
-                                                                    )}
-                                                                </Row>
-                                                            </View>
+                                                                            <KeyValue
+                                                                                keyValue={localeString(
+                                                                                    'views.Receive.expiration'
+                                                                                )}
+                                                                            />
+                                                                        </View>
 
-                                                            {lspIsActive ? (
-                                                                <LockIcon
-                                                                    fill={themeColor(
-                                                                        'secondaryText'
-                                                                    )}
-                                                                    width="20"
-                                                                    height="20"
-                                                                />
-                                                            ) : isOpen ? (
-                                                                <CaretDown
-                                                                    fill={themeColor(
-                                                                        'text'
-                                                                    )}
-                                                                    width="20"
-                                                                    height="20"
-                                                                />
-                                                            ) : (
-                                                                <CaretRight
-                                                                    fill={themeColor(
-                                                                        'text'
-                                                                    )}
-                                                                    width="20"
-                                                                    height="20"
-                                                                />
-                                                            )}
-                                                        </Row>
-                                                    )}
-                                                >
-                                                    <>
-                                                        <Row
-                                                            style={{
-                                                                width: '100%'
-                                                            }}
-                                                        >
-                                                            <TextInput
-                                                                keyboardType="numeric"
-                                                                value={expiry}
+                                                                        {!isOpen && (
+                                                                            <Text
+                                                                                style={{
+                                                                                    ...styles.secondaryText,
+                                                                                    color: themeColor(
+                                                                                        'secondaryText'
+                                                                                    ),
+                                                                                    textAlign:
+                                                                                        'center',
+                                                                                    fontSize: 14
+                                                                                }}
+                                                                            >
+                                                                                {this.getFormattedDuration()}
+                                                                            </Text>
+                                                                        )}
+                                                                    </Row>
+                                                                </View>
+
+                                                                {lspIsActive ? (
+                                                                    <LockIcon
+                                                                        fill={themeColor(
+                                                                            'secondaryText'
+                                                                        )}
+                                                                        width="20"
+                                                                        height="20"
+                                                                    />
+                                                                ) : isOpen ? (
+                                                                    <CaretDown
+                                                                        fill={themeColor(
+                                                                            'text'
+                                                                        )}
+                                                                        width="20"
+                                                                        height="20"
+                                                                    />
+                                                                ) : (
+                                                                    <CaretRight
+                                                                        fill={themeColor(
+                                                                            'text'
+                                                                        )}
+                                                                        width="20"
+                                                                        height="20"
+                                                                    />
+                                                                )}
+                                                            </Row>
+                                                        )}
+                                                    >
+                                                        <>
+                                                            <Row
                                                                 style={{
-                                                                    width: '58%'
-                                                                }}
-                                                                onChangeText={(
-                                                                    text: string
-                                                                ) => {
-                                                                    const digits =
-                                                                        text.replace(
-                                                                            /[^0-9]/g,
-                                                                            ''
-                                                                        );
-                                                                    const expirySeconds =
-                                                                        expirySecondsFromInput(
-                                                                            digits,
-                                                                            timePeriod as TimePeriod
-                                                                        );
-                                                                    this.setState(
-                                                                        {
-                                                                            expiry: digits,
-                                                                            expirySeconds,
-                                                                            expirationIndex:
-                                                                                expirationIndexFromSeconds(
-                                                                                    expirySeconds
-                                                                                )
-                                                                        }
-                                                                    );
-                                                                }}
-                                                            />
-                                                            <Spacer width={4} />
-                                                            <View
-                                                                style={{
-                                                                    flex: 1
+                                                                    width: '100%'
                                                                 }}
                                                             >
-                                                                <DropdownSetting
-                                                                    selectedValue={
-                                                                        timePeriod
+                                                                <TextInput
+                                                                    keyboardType="numeric"
+                                                                    value={
+                                                                        expiry
                                                                     }
-                                                                    values={
-                                                                        TIME_PERIOD_KEYS
-                                                                    }
-                                                                    onValueChange={async (
-                                                                        value: string
+                                                                    style={{
+                                                                        width: '58%'
+                                                                    }}
+                                                                    onChangeText={(
+                                                                        text: string
                                                                     ) => {
+                                                                        const digits =
+                                                                            text.replace(
+                                                                                /[^0-9]/g,
+                                                                                ''
+                                                                            );
                                                                         const expirySeconds =
                                                                             expirySecondsFromInput(
-                                                                                expiry,
-                                                                                value as TimePeriod
+                                                                                digits,
+                                                                                timePeriod as TimePeriod
                                                                             );
                                                                         this.setState(
                                                                             {
-                                                                                timePeriod:
-                                                                                    value,
+                                                                                expiry: digits,
                                                                                 expirySeconds,
                                                                                 expirationIndex:
                                                                                     expirationIndexFromSeconds(
@@ -2487,50 +2465,86 @@ export default class Receive extends React.Component<
                                                                         );
                                                                     }}
                                                                 />
-                                                            </View>
-                                                        </Row>
+                                                                <Spacer
+                                                                    width={4}
+                                                                />
+                                                                <View
+                                                                    style={{
+                                                                        flex: 1
+                                                                    }}
+                                                                >
+                                                                    <DropdownSetting
+                                                                        selectedValue={
+                                                                            timePeriod
+                                                                        }
+                                                                        values={
+                                                                            TIME_PERIOD_KEYS
+                                                                        }
+                                                                        onValueChange={async (
+                                                                            value: string
+                                                                        ) => {
+                                                                            const expirySeconds =
+                                                                                expirySecondsFromInput(
+                                                                                    expiry,
+                                                                                    value as TimePeriod
+                                                                                );
+                                                                            this.setState(
+                                                                                {
+                                                                                    timePeriod:
+                                                                                        value,
+                                                                                    expirySeconds,
+                                                                                    expirationIndex:
+                                                                                        expirationIndexFromSeconds(
+                                                                                            expirySeconds
+                                                                                        )
+                                                                                }
+                                                                            );
+                                                                        }}
+                                                                    />
+                                                                </View>
+                                                            </Row>
 
-                                                        <ButtonGroup
-                                                            onPress={
-                                                                this
-                                                                    .updateExpirationIndex
-                                                            }
-                                                            selectedIndex={
-                                                                expirationIndex
-                                                            }
-                                                            buttons={
-                                                                expirationButtons
-                                                            }
-                                                            selectedButtonStyle={{
-                                                                backgroundColor:
-                                                                    themeColor(
-                                                                        'highlight'
-                                                                    ),
-                                                                borderRadius: 12
-                                                            }}
-                                                            containerStyle={{
-                                                                backgroundColor:
-                                                                    themeColor(
+                                                            <ButtonGroup
+                                                                onPress={
+                                                                    this
+                                                                        .updateExpirationIndex
+                                                                }
+                                                                selectedIndex={
+                                                                    expirationIndex
+                                                                }
+                                                                buttons={
+                                                                    expirationButtons
+                                                                }
+                                                                selectedButtonStyle={{
+                                                                    backgroundColor:
+                                                                        themeColor(
+                                                                            'highlight'
+                                                                        ),
+                                                                    borderRadius: 12
+                                                                }}
+                                                                containerStyle={{
+                                                                    backgroundColor:
+                                                                        themeColor(
+                                                                            'secondary'
+                                                                        ),
+                                                                    borderRadius: 12,
+                                                                    borderWidth: 0,
+                                                                    height: 30,
+                                                                    marginBottom:
+                                                                        Platform.OS ===
+                                                                        'ios'
+                                                                            ? 16
+                                                                            : 0
+                                                                }}
+                                                                innerBorderStyle={{
+                                                                    color: themeColor(
                                                                         'secondary'
-                                                                    ),
-                                                                borderRadius: 12,
-                                                                borderWidth: 0,
-                                                                height: 30,
-                                                                marginBottom:
-                                                                    Platform.OS ===
-                                                                    'ios'
-                                                                        ? 16
-                                                                        : 0
-                                                            }}
-                                                            innerBorderStyle={{
-                                                                color: themeColor(
-                                                                    'secondary'
-                                                                )
-                                                            }}
-                                                        />
-                                                    </>
-                                                </Accordion>
-                                            )}
+                                                                    )
+                                                                }}
+                                                            />
+                                                        </>
+                                                    </Accordion>
+                                                )}
 
                                             {showAdvancedSettingsToggle && (
                                                 <Accordion

--- a/views/Receive.tsx
+++ b/views/Receive.tsx
@@ -1061,7 +1061,12 @@ export default class Receive extends React.Component<
         const showCustomPreimageField =
             settings?.invoices?.showCustomPreimageField;
 
-        const skipOnchain = this.getSkipOnchain();
+        // The defaultInvoiceType preference must not suppress the on-chain
+        // leg while the user is looking at the on-chain pane: in forced
+        // on-chain mode (account receive, on-chain slider action) there are
+        // no tabs whose switch would trigger generation later, leaving the
+        // pane permanently blank
+        const skipOnchain = this.getSkipOnchain() && selectedIndex !== 2;
 
         const { lnOnly, onChainOnly } = this.getReceiveModeFlags();
 

--- a/views/Tools/Accounts/ImportAccount.tsx
+++ b/views/Tools/Accounts/ImportAccount.tsx
@@ -6,7 +6,6 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { inject, observer } from 'mobx-react';
 import { Route } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -177,67 +176,67 @@ export default class ImportAccount extends React.Component<
         if (!understood) {
             return (
                 <Screen>
-                    <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
-                        <ScrollView showsVerticalScrollIndicator={false}>
-                            <View style={{ marginHorizontal: 10 }}>
-                                <ErrorMessage
-                                    message={localeString(
-                                        'general.warning'
-                                    ).toUpperCase()}
-                                />
-                            </View>
-                            <Text
-                                style={{
-                                    ...styles.warningText,
-                                    color: themeColor('text')
-                                }}
-                            >
-                                {localeString(
-                                    'views.ImportAccount.Warning.text1'
-                                )}
-                            </Text>
-                            <Text
-                                style={{
-                                    ...styles.warningText,
-                                    color: themeColor('text')
-                                }}
-                            >
-                                {localeString(
-                                    'views.ImportAccount.Warning.text2'
-                                )}
-                            </Text>
-                            <Text
-                                style={{
-                                    ...styles.warningText,
-                                    color: themeColor('text')
-                                }}
-                            >
-                                {localeString(
-                                    'views.ImportAccount.Warning.text3'
-                                ).replace('Zeus', 'ZEUS')}
-                            </Text>
-                            {implementation !== 'embedded-lnd' && (
-                                <Text
-                                    style={{
-                                        ...styles.warningText,
-                                        color: themeColor('text')
-                                    }}
-                                >
-                                    {localeString(
-                                        'views.ImportAccount.note'
-                                    ).replace('Zeus', 'ZEUS')}
-                                </Text>
-                            )}
-                        </ScrollView>
-                        <View style={{ paddingVertical: 10 }}>
-                            <Button
-                                onPress={() =>
-                                    this.setState({ understood: true })
-                                }
-                                title={localeString('general.iUnderstand')}
+                    <Header
+                        leftComponent="Back"
+                        centerComponent={{
+                            text: localeString('views.ImportAccount.title'),
+                            style: { color: themeColor('text') }
+                        }}
+                        navigation={navigation}
+                    />
+                    <ScrollView showsVerticalScrollIndicator={false}>
+                        <View style={{ marginHorizontal: 10 }}>
+                            <ErrorMessage
+                                message={localeString(
+                                    'general.warning'
+                                ).toUpperCase()}
                             />
                         </View>
-                    </SafeAreaView>
+                        <Text
+                            style={{
+                                ...styles.warningText,
+                                color: themeColor('text')
+                            }}
+                        >
+                            {localeString('views.ImportAccount.Warning.text1')}
+                        </Text>
+                        <Text
+                            style={{
+                                ...styles.warningText,
+                                color: themeColor('text')
+                            }}
+                        >
+                            {localeString('views.ImportAccount.Warning.text2')}
+                        </Text>
+                        <Text
+                            style={{
+                                ...styles.warningText,
+                                color: themeColor('text')
+                            }}
+                        >
+                            {localeString(
+                                'views.ImportAccount.Warning.text3'
+                            ).replace('Zeus', 'ZEUS')}
+                        </Text>
+                        {implementation !== 'embedded-lnd' && (
+                            <Text
+                                style={{
+                                    ...styles.warningText,
+                                    color: themeColor('text')
+                                }}
+                            >
+                                {localeString(
+                                    'views.ImportAccount.note'
+                                ).replace('Zeus', 'ZEUS')}
+                            </Text>
+                        )}
+                    </ScrollView>
+                    <View style={{ bottom: 10 }}>
+                        <Button
+                            onPress={() => this.setState({ understood: true })}
+                            title={localeString('general.iUnderstand')}
+                        />
+                    </View>
                 </Screen>
             );
         }

--- a/views/Tools/Accounts/ImportAccount.tsx
+++ b/views/Tools/Accounts/ImportAccount.tsx
@@ -156,8 +156,28 @@ export default class ImportAccount extends React.Component<
             addresses_to_generate,
             understood
         } = this.state;
-        const { errorMsg } = UTXOsStore;
+        const { errorMsg, importingAccount } = UTXOsStore;
         const { implementation } = SettingsStore;
+
+        const trimmedName = name.trim();
+        const trimmedExtendedPublicKey = extended_public_key.trim();
+        const trimmedMasterKeyFingerprint = master_key_fingerprint.trim();
+
+        // the fingerprint is optional, but when one is supplied it has to be
+        // exactly four bytes - reverseMfpBytes drops any trailing nibble, so
+        // a malformed value would be imported as a silently wrong fingerprint
+        const masterKeyFingerprintInvalid =
+            !!trimmedMasterKeyFingerprint &&
+            !/^[0-9a-fA-F]{8}$/.test(trimmedMasterKeyFingerprint);
+
+        // lnd needs both a name and a key to import an account, and a zero
+        // birthday height would kick off a rescan from the genesis block
+        const importDisabled =
+            importingAccount ||
+            !trimmedName ||
+            !trimmedExtendedPublicKey ||
+            masterKeyFingerprintInvalid ||
+            (existing_account && block_height < 1);
 
         const ScanBadge = () => (
             <TouchableOpacity
@@ -318,6 +338,7 @@ export default class ImportAccount extends React.Component<
                                         master_key_fingerprint: text
                                     })
                                 }
+                                error={masterKeyFingerprintInvalid}
                             />
                         </>
                         <DropdownSetting
@@ -455,20 +476,22 @@ export default class ImportAccount extends React.Component<
                         title={localeString(
                             'views.ImportAccount.importAccount'
                         )}
+                        disabled={importDisabled}
                         onPress={() =>
                             this.props.UTXOsStore.importAccount({
-                                name,
-                                extended_public_key,
+                                name: trimmedName,
+                                extended_public_key: trimmedExtendedPublicKey,
                                 address_type: address_type
                                     ? Number(address_type)
                                     : undefined,
-                                master_key_fingerprint: master_key_fingerprint
-                                    ? Base64Utils.hexToBase64(
-                                          Base64Utils.reverseMfpBytes(
-                                              master_key_fingerprint
+                                master_key_fingerprint:
+                                    trimmedMasterKeyFingerprint
+                                        ? Base64Utils.hexToBase64(
+                                              Base64Utils.reverseMfpBytes(
+                                                  trimmedMasterKeyFingerprint
+                                              )
                                           )
-                                      )
-                                    : undefined,
+                                        : undefined,
                                 dry_run: true,
                                 birthday_height: existing_account
                                     ? block_height

--- a/views/Tools/Accounts/ImportAccount.tsx
+++ b/views/Tools/Accounts/ImportAccount.tsx
@@ -318,6 +318,8 @@ export default class ImportAccount extends React.Component<
                             numberOfLines={4}
                             multiline
                             style={{ paddingBottom: 10 }}
+                            autoCapitalize="none"
+                            autoCorrect={false}
                         />
                         <>
                             <Text
@@ -339,6 +341,8 @@ export default class ImportAccount extends React.Component<
                                     })
                                 }
                                 error={masterKeyFingerprintInvalid}
+                                autoCapitalize="none"
+                                autoCorrect={false}
                             />
                         </>
                         <DropdownSetting


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-2223**, **ZEUS-2932**

Fixes #2223
Fixes #2932

Full root cause analysis: https://github.com/ZeusLN/zeus/issues/2223#issuecomment-5465433173

Receiving to imported (watch-only) accounts was broken in two ways:

1. **"account not found" for taproot and nested segwit imports.** lnd never infers an account's key scope from its name: `NewAddress`/`NextAddr` default to `WITNESS_PUBKEY_HASH` (BIP84) when no type is given, and btcwallet rejects the request when the account lives under another scope. The ZEUS-2396 workaround of stripping the address type from account requests therefore only ever worked for BIP84 (zpub) imports; taproot (BIP86) and nested segwit (BIP49) accounts could not receive at all. It also discarded the correct address type that the OnChainAddresses view already passes.
2. **Unified invoices silently used the default account.** `createUnifiedInvoice` and the Create Invoice button never passed the account, so the on-chain leg of the invoice came from the node's own hot wallet while the Receive screen labeled the address with the imported account's name. This is the unrecognized segwit address in the ZEUS-2223 screenshots, and funds sent to it landed in the embedded node's wallet instead of the user's airgapped wallet.

Changes:

- `utils/LndUtils`: new `toWalletrpcAddressTypeName` / `toWalletrpcAddressTypeNum` helpers. walletrpc.AddressType names and numbering differ from lnrpc.AddressType (walletrpc `WITNESS_PUBKEY_HASH=1` vs lnrpc `0`), REST/LNC decode enum names while the embedded proto decode yields raw numbers, so account address types need explicit normalization for each RPC's enum space.
- `stores/InvoicesStore`: `getNewAddress` honors account-derived walletrpc address types and only strips types that don't come from the account (the settings preference that motivated ZEUS-2396). `createUnifiedInvoice` accepts an `account` so the on-chain leg comes from the requested account, never silently from `default`.
- `stores/UTXOsStore`: new `getAccountAddressType` resolves an account's type from ListAccounts (cache first). The post-import address pre-generation now normalizes types through the walletrpc helpers instead of `walletrpc.AddressType[...]` lookups that sent walletrpc numbers into lnrpc `NewAddress` on REST.
- `views/Receive`: resolves the account's address type on mount and threads it through auto-generated receive/change addresses, tab-switch generation, and all `createUnifiedInvoice` call sites. Non-default account requests never fall back to the picker/settings address type.
- `backends/EmbeddedLND` + `backends/LightningNodeConnect`: `NextAddr` change-address types are now converted into walletrpc enum space. The embedded path previously fed enum-name strings into the protobuf encoder (coerced to NaN, serialized as 0/UNKNOWN); LNC used a map with lnrpc numbering, so a nested segwit request became walletrpc `WITNESS_PUBKEY_HASH`.

Behavior notes:

- BIP84 (zpub) imported accounts behave exactly as before.
- If an account's type cannot be resolved (e.g. ListAccounts unavailable), the request is sent without a type, which matches today's behavior and surfaces lnd's error rather than showing an address from the wrong wallet.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

New tests: walletrpc conversion helpers in `utils/LndUtils.test.ts`; account address-type handling in `stores/InvoicesStore.test.ts` (honors account-derived types, normalizes embedded numeric types, drops settings-preference types, default account untouched, errors surfaced).

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND

Remote
- [x] LND (REST)
- [x] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Testing performed (iOS Simulator, embedded LND mainnet): imported the taproot xpub from the ZEUS-2223 report (verified against an independent local BIP86 derivation, which also matches the reporter's screenshots) plus the BIP84 and BIP49 spec test vector zpub/ypub with the existing-account toggle and birthday height. Verified: swipe-receive generates the exact expected address for all three scopes with no "account not found" errors; unified invoice creation from the account context puts the account's next address in the BIP21 URI; the 50+50 import pre-generation completes for all scopes, with receive and change lists matching the derivations (including nested segwit change, which previously hit the protobuf enum trap); the OnChainAddresses regenerate path works; default-account receive is unchanged. No platform-specific code is touched. 

Additional testing (Polar regtest, iOS Simulator): over LND (REST) and Lightning Node Connect (litd via Polar, admin session, default mailbox), imported regtest accounts derived from the BIP39 spec mnemonic (verified against independent local derivations): taproot tpub over LNC and BIP84 vpub over REST, both with birthday height and address pre-generation. Swipe-receive matched the exact expected next index on both backends, the LNC change list matched the derivation (exercising the rewritten NextAddr mapping), and an end-to-end receive worked over REST: coins sent from another Polar node to a Zeus-generated watch-only account address, mined, and reflected in the account balance. The LNC testing also surfaced a pre-existing bug fixed in this PR: existing-account imports over LNC always failed because Zeus-side fields (addresses_to_generate, birthday_height) were sent to litd's proto JSON unmarshaler, which rejects unknown fields.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding


