### PR TITLE
views: NWC: show in-flight wait on delete/regenerate

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2047,6 +2047,7 @@
     "views.Settings.NostrWalletConnect.connectionSecret": "Connection Secret",
     "views.Settings.NostrWalletConnect.connectionSecretDescription": "Scan this QR code or copy the connection secret in your Nostr app to link this connection.",
     "views.Settings.NostrWalletConnect.waitingForAppToConnect": "Waiting for app to connect...",
+    "views.Settings.NostrWalletConnect.waitingForInFlightRequest": "Waiting for an in-flight request to finish...",
     "views.Settings.NostrWalletConnect.noEventReceivedTimeoutDescription": "We didn't receive any event from your Nostr client, but you can still close this screen and use your connection. The connection will work once your Nostr client sends a request.",
     "views.Settings.NostrWalletConnect.connectionTimeout": "Connection Timeout",
     "views.Settings.NostrWalletConnect.keepWaiting": "Keep Waiting",

--- a/locales/en.json
+++ b/locales/en.json
@@ -2047,7 +2047,7 @@
     "views.Settings.NostrWalletConnect.connectionSecret": "Connection Secret",
     "views.Settings.NostrWalletConnect.connectionSecretDescription": "Scan this QR code or copy the connection secret in your Nostr app to link this connection.",
     "views.Settings.NostrWalletConnect.waitingForAppToConnect": "Waiting for app to connect...",
-    "views.Settings.NostrWalletConnect.waitingForInFlightRequest": "Waiting for an in-flight request to finish...",
+    "views.Settings.NostrWalletConnect.waitingToFinishPendingRequest": "Waiting to finish a pending request...",
     "views.Settings.NostrWalletConnect.noEventReceivedTimeoutDescription": "We didn't receive any event from your Nostr client, but you can still close this screen and use your connection. The connection will work once your Nostr client sends a request.",
     "views.Settings.NostrWalletConnect.connectionTimeout": "Connection Timeout",
     "views.Settings.NostrWalletConnect.keepWaiting": "Keep Waiting",

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1170,6 +1170,7 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
         await new Promise((resolve) => setImmediate(resolve));
         expect(deleted).toBe(false);
         expect(store.connections).toHaveLength(1);
+        expect(store.waitingForInFlightHandlers).toBe(true);
 
         const lateResponse = await (store as any).withGlobalHandler(
             connection.id,
@@ -1186,6 +1187,7 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
 
         expect(deleted).toBe(true);
         expect(store.connections).toHaveLength(0);
+        expect(store.waitingForInFlightHandlers).toBe(false);
     });
 
     it('defers relay release when delete awaited in-flight handlers', async () => {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -437,6 +437,7 @@ export default class NostrWalletConnectStore {
                 this.walletServiceKeys = null;
                 this.errorMessage = '';
                 this.waitingForConnection = false;
+                this.waitingForInFlightHandlers = false;
                 this.currentConnectionId = undefined;
                 this.connectionJustSucceeded = false;
                 this.lastConnectionAttempt = 0;
@@ -667,20 +668,16 @@ export default class NostrWalletConnectStore {
                     connectionId
                 );
                 this.makeInvoiceTimestampsByConnection.delete(connectionId);
-                const hasInFlightHandlers =
-                    !!this.inFlightHandlersByConnection.get(connectionId)?.size;
-                if (hasInFlightHandlers) {
+                let hadInFlight = false;
+                if (this.inFlightHandlersByConnection.get(connectionId)?.size) {
                     runInAction(() => {
                         this.waitingForInFlightHandlers = true;
                     });
-                }
-                let hadInFlight = false;
-                try {
-                    hadInFlight = await this.awaitInFlightHandlers(
-                        connectionId
-                    );
-                } finally {
-                    if (hasInFlightHandlers) {
+                    try {
+                        hadInFlight = await this.awaitInFlightHandlers(
+                            connectionId
+                        );
+                    } finally {
                         runInAction(() => {
                             this.waitingForInFlightHandlers = false;
                         });

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -147,6 +147,7 @@ export default class NostrWalletConnectStore {
         new Map();
     @observable private publishedRelays: Set<string> = new Set();
     @observable public waitingForConnection = false;
+    @observable public waitingForInFlightHandlers = false;
     @observable public currentConnectionId?: string;
     @observable public connectionJustSucceeded = false;
     @observable private walletServiceKeys: WalletServiceKeys | null = null;
@@ -666,9 +667,25 @@ export default class NostrWalletConnectStore {
                     connectionId
                 );
                 this.makeInvoiceTimestampsByConnection.delete(connectionId);
-                const hadInFlight = await this.awaitInFlightHandlers(
-                    connectionId
-                );
+                const hasInFlightHandlers =
+                    !!this.inFlightHandlersByConnection.get(connectionId)?.size;
+                if (hasInFlightHandlers) {
+                    runInAction(() => {
+                        this.waitingForInFlightHandlers = true;
+                    });
+                }
+                let hadInFlight = false;
+                try {
+                    hadInFlight = await this.awaitInFlightHandlers(
+                        connectionId
+                    );
+                } finally {
+                    if (hasInFlightHandlers) {
+                        runInAction(() => {
+                            this.waitingForInFlightHandlers = false;
+                        });
+                    }
+                }
                 await this.deleteClientKeys(connection.pubkey);
                 const { index: liveIndex } = this.getConnection({
                     connectionId

--- a/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
@@ -714,7 +714,7 @@ export default class NWCConnectionDetails extends React.Component<
                                         ]}
                                     >
                                         {localeString(
-                                            'views.Settings.NostrWalletConnect.waitingForInFlightRequest'
+                                            'views.Settings.NostrWalletConnect.waitingToFinishPendingRequest'
                                         )}
                                     </Text>
                                 </View>

--- a/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
@@ -322,7 +322,10 @@ export default class NWCConnectionDetails extends React.Component<
         const { navigation, NostrWalletConnectStore } = this.props;
         const { loading, regenerating, deleting, error, connection } =
             this.state;
-        const { loading: storeLoading } = NostrWalletConnectStore;
+        const { loading: storeLoading, waitingForInFlightHandlers } =
+            NostrWalletConnectStore;
+        const showInFlightWait =
+            waitingForInFlightHandlers && (deleting || regenerating);
 
         return (
             <Screen>
@@ -691,12 +694,31 @@ export default class NWCConnectionDetails extends React.Component<
                         </ScrollView>
 
                         <View style={styles.bottomContainer}>
+                            {showInFlightWait && (
+                                <View style={styles.inFlightWaitContainer}>
+                                    <LoadingIndicator size={24} />
+                                    <Text
+                                        style={[
+                                            styles.inFlightWaitText,
+                                            {
+                                                color: themeColor(
+                                                    'secondaryText'
+                                                )
+                                            }
+                                        ]}
+                                    >
+                                        {localeString(
+                                            'views.Settings.NostrWalletConnect.waitingForInFlightRequest'
+                                        )}
+                                    </Text>
+                                </View>
+                            )}
                             <Button
                                 title={localeString(
                                     'views.Settings.NostrWalletConnect.regenerateConnection'
                                 )}
                                 onPress={this.confirmRegenerateConnection}
-                                disabled={regenerating}
+                                disabled={regenerating || deleting}
                                 secondary={regenerating}
                                 noUppercase
                             />
@@ -708,7 +730,7 @@ export default class NWCConnectionDetails extends React.Component<
                                     this.deleteConnection(connection)
                                 }
                                 warning
-                                disabled={loading || deleting}
+                                disabled={loading || deleting || regenerating}
                                 secondary={deleting}
                                 noUppercase
                             />
@@ -766,5 +788,18 @@ const styles = StyleSheet.create({
         paddingHorizontal: 20,
         paddingVertical: 15,
         gap: 10
+    },
+    inFlightWaitContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 10,
+        paddingVertical: 4
+    },
+    inFlightWaitText: {
+        flexShrink: 1,
+        fontSize: 14,
+        fontFamily: 'PPNeueMontreal-Book',
+        textAlign: 'center'
     }
 });

--- a/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
@@ -56,6 +56,7 @@ export default class NWCConnectionDetails extends React.Component<
     NWCConnectionDetailsState
 > {
     private unsubscribeFocus?: () => void;
+    private isUnmounted = false;
     constructor(props: NWCConnectionDetailsProps) {
         super(props);
         this.state = {
@@ -169,6 +170,7 @@ export default class NWCConnectionDetails extends React.Component<
     };
 
     componentWillUnmount() {
+        this.isUnmounted = true;
         if (this.unsubscribeFocus) {
             this.unsubscribeFocus();
         }
@@ -297,17 +299,21 @@ export default class NWCConnectionDetails extends React.Component<
                     this.setState({ deleting: true, error: null });
                     NostrWalletConnectStore.deleteConnection(connection.id)
                         .then(() => {
-                            navigation.goBack();
+                            if (!this.isUnmounted) {
+                                navigation.goBack();
+                            }
                         })
                         .catch((error) => {
                             console.error(
                                 'Failed to delete connection:',
                                 error
                             );
-                            this.setState({
-                                error: 'Failed to delete connection',
-                                deleting: false
-                            });
+                            if (!this.isUnmounted) {
+                                this.setState({
+                                    error: 'Failed to delete connection',
+                                    deleting: false
+                                });
+                            }
                         });
                 }
             },


### PR DESCRIPTION
# Description

Relates to issue: **#4487**

Follow-up to #4443: `deleteConnection` correctly waits for in-flight NIP-47 handlers before removing a connection, but delete and regenerate in `NWCConnectionDetails` showed only a spinner during that window (up to ~125s behind a slow `pay_invoice`). Users may force-kill the app, which is exactly what the handler-await fix is meant to prevent.

This PR:
- Adds `waitingForInFlightHandlers` on `NostrWalletConnectStore`, set while `deleteConnection` awaits in-flight handlers
- Shows spinner + “Waiting to finish a pending request...” above the action buttons during delete or regenerate
- Disables both buttons while either operation is in progress

Regenerate is covered because it calls `deleteConnection` before `createConnection`.

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-31 at 17 20 30" src="https://github.com/user-attachments/assets/10ba1553-629d-4507-875c-d2366f8cfd5d" />



This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
