### PR TITLE
Offer channel migration export when the embedded node won't start

### DIFF
--- a/utils/ChannelMigrationUtils.test.ts
+++ b/utils/ChannelMigrationUtils.test.ts
@@ -73,6 +73,7 @@ jest.mock('react-native', () => ({
 }));
 
 import {
+    graphDataExists,
     validateChannelBackupFile,
     importChannelDb
 } from './ChannelMigrationUtils';
@@ -83,6 +84,62 @@ describe('ChannelMigrationUtils', () => {
         mockExists.mockResolvedValue(true);
         mockStat.mockResolvedValue({ size: 1024 });
         mockReadDir.mockResolvedValue([]);
+    });
+
+    describe('graphDataExists', () => {
+        it('returns false when the graph directory does not exist', async () => {
+            mockExists.mockResolvedValue(false);
+
+            expect(await graphDataExists('lnd', false)).toBe(false);
+            expect(mockExists).toHaveBeenCalledWith(
+                expect.stringContaining('lnd/data/graph/mainnet')
+            );
+            expect(mockReadDir).not.toHaveBeenCalled();
+        });
+
+        it('returns false when the graph directory is empty', async () => {
+            mockReadDir.mockResolvedValue([]);
+
+            expect(await graphDataExists('lnd', false)).toBe(false);
+        });
+
+        it('returns true when the graph directory has entries', async () => {
+            mockReadDir.mockResolvedValue([
+                { path: '/graph/mainnet/channel.db', isFile: () => true }
+            ]);
+
+            expect(await graphDataExists('lnd', false)).toBe(true);
+        });
+
+        it('uses the testnet path when isTestnet is true', async () => {
+            mockReadDir.mockResolvedValue([
+                { path: '/graph/testnet/channel.db', isFile: () => true }
+            ]);
+
+            expect(await graphDataExists('lnd', true)).toBe(true);
+            expect(mockExists).toHaveBeenCalledWith(
+                expect.stringContaining('lnd/data/graph/testnet')
+            );
+        });
+
+        it('respects a custom lndDir', async () => {
+            await graphDataExists('lnd2', false);
+
+            expect(mockExists).toHaveBeenCalledWith(
+                expect.stringContaining('lnd2/data/graph/mainnet')
+            );
+        });
+
+        it('returns false when the filesystem check throws', async () => {
+            const consoleError = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+            mockReadDir.mockRejectedValue(new Error('EACCES'));
+
+            expect(await graphDataExists('lnd', false)).toBe(false);
+
+            consoleError.mockRestore();
+        });
     });
 
     describe('validateChannelBackupFile', () => {

--- a/utils/ChannelMigrationUtils.ts
+++ b/utils/ChannelMigrationUtils.ts
@@ -29,6 +29,25 @@ const getGraphDir = (lndDir: string, isTestnet: boolean): string => {
     return `${rootPath}/${lndDir}/data/graph/${network}`;
 };
 
+/**
+ * Checks whether channel data exists on disk, so export can be offered
+ * even when the node isn't running.
+ */
+export const channelDataExists = async (
+    lndDir: string,
+    isTestnet: boolean
+): Promise<boolean> => {
+    try {
+        const graphDir = getGraphDir(lndDir, isTestnet);
+        if (!(await RNFS.exists(graphDir))) return false;
+        const entries = await RNFS.readDir(graphDir);
+        return entries.length > 0;
+    } catch (e) {
+        console.error('Failed to check for channel data on disk:', e);
+        return false;
+    }
+};
+
 const stopLndSafely = async (): Promise<void> => {
     try {
         await stopLnd();
@@ -770,8 +789,8 @@ export const exportChannelDb = async (
 };
 
 /**
- * Prompts the user to export channel backup — either to Olympus (SQLite only)
- * or as a local zip file.
+ * Prompts the user to export channel backup — either to Olympus (SQLite
+ * only, requires a running node) or as a local zip file.
  */
 export const handleExportChannels = ({
     isSqlite,
@@ -779,6 +798,7 @@ export const handleExportChannels = ({
     isTestnet,
     pubkey,
     seedPhrase,
+    canUploadToOlympus,
     setStatus
 }: {
     isSqlite: boolean;
@@ -786,13 +806,16 @@ export const handleExportChannels = ({
     isTestnet: boolean;
     pubkey: string;
     seedPhrase: string;
+    // Olympus upload signs auth challenges with the node key,
+    // so it's only available while the node is running
+    canUploadToOlympus: boolean;
     setStatus: (msg: string | null) => void;
 }) => {
     const warningText =
         `${localeString('views.Tools.migration.export.text1')}\n\n` +
         `⚠️ ${localeString('views.Tools.migration.export.text2')}`;
 
-    if (isSqlite) {
+    if (isSqlite && canUploadToOlympus) {
         Alert.alert(
             localeString('views.Tools.migration.export.title'),
             warningText,

--- a/utils/ChannelMigrationUtils.ts
+++ b/utils/ChannelMigrationUtils.ts
@@ -30,10 +30,12 @@ const getGraphDir = (lndDir: string, isTestnet: boolean): string => {
 };
 
 /**
- * Checks whether channel data exists on disk, so export can be offered
- * even when the node isn't running.
+ * Checks whether graph data exists on disk, so export can be offered
+ * even when the node isn't running. Note this can't distinguish
+ * whether the node ever had channels: lnd creates the graph DB files
+ * on first start.
  */
-export const channelDataExists = async (
+export const graphDataExists = async (
     lndDir: string,
     isTestnet: boolean
 ): Promise<boolean> => {
@@ -43,7 +45,7 @@ export const channelDataExists = async (
         const entries = await RNFS.readDir(graphDir);
         return entries.length > 0;
     } catch (e) {
-        console.error('Failed to check for channel data on disk:', e);
+        console.error('Failed to check for graph data on disk:', e);
         return false;
     }
 };

--- a/views/Settings/Seed.tsx
+++ b/views/Settings/Seed.tsx
@@ -254,9 +254,12 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
         handleExportChannels({
             isSqlite: SettingsStore.isSqlite ?? true,
             lndDir: SettingsStore.lndDir || 'lnd',
-            isTestnet: NodeInfoStore.nodeInfo.isTestNet,
+            // nodeInfo is empty when the node isn't running, so read the
+            // network from the persisted wallet config instead
+            isTestnet: SettingsStore.embeddedLndNetwork === 'Testnet',
             pubkey: NodeInfoStore.nodeInfo.identity_pubkey,
-            seedPhrase: SettingsStore.seedPhrase.join(' '),
+            seedPhrase: (SettingsStore.seedPhrase || []).join(' '),
+            canUploadToOlympus: !!NodeInfoStore.nodeInfo.identity_pubkey,
             setStatus: (msg: string | null) =>
                 this.setState({
                     isChannelExporting: msg !== null,

--- a/views/Settings/Seed.tsx
+++ b/views/Settings/Seed.tsx
@@ -43,7 +43,10 @@ import {
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { IS_BACKED_UP_KEY } from '../../utils/MigrationUtils';
-import { handleExportChannels } from '../../utils/ChannelMigrationUtils';
+import {
+    graphDataExists,
+    handleExportChannels
+} from '../../utils/ChannelMigrationUtils';
 
 import Storage from '../../storage';
 
@@ -79,6 +82,7 @@ interface SeedState {
     isChannelExporting: boolean;
     channelExportMessage: string;
     revealResetKey: number;
+    graphDataOnDisk: boolean;
 }
 
 const MnemonicWord = ({ index, word }: { index: any; word: any }) => {
@@ -138,7 +142,8 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
         isDeleteModalVisible: false,
         isChannelExporting: false,
         channelExportMessage: '',
-        revealResetKey: 0
+        revealResetKey: 0,
+        graphDataOnDisk: false
     };
 
     private appStateSubscription: NativeEventSubscription | undefined;
@@ -153,6 +158,8 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
             'change',
             this.handleAppStateChange
         );
+
+        this.checkGraphDataOnDisk();
     }
 
     componentWillUnmount() {
@@ -167,6 +174,19 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                 revealResetKey: prevState.revealResetKey + 1
             }));
         }
+    };
+
+    // Fallback for offering channel export when the node isn't running
+    // and channels can't be queried
+    checkGraphDataOnDisk = async () => {
+        const { SettingsStore } = this.props;
+        if (SettingsStore.implementation !== 'embedded-lnd') return;
+
+        const graphDataOnDisk = await graphDataExists(
+            SettingsStore.lndDir || 'lnd',
+            SettingsStore.embeddedLndNetwork === 'Testnet'
+        );
+        this.setState({ graphDataOnDisk });
     };
 
     renderDeleteModal = () => {
@@ -269,7 +289,13 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
     };
 
     render() {
-        const { navigation, SettingsStore, ChannelsStore, route } = this.props;
+        const {
+            navigation,
+            SettingsStore,
+            NodeInfoStore,
+            ChannelsStore,
+            route
+        } = this.props;
         const {
             understood,
             showModal,
@@ -304,6 +330,14 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
             ChannelsStore.channels.length > 0 ||
             ChannelsStore.pendingChannels.length > 0 ||
             ChannelsStore.closedChannels.length > 0;
+
+        // If the node is up, trust its channel list; if it won't start,
+        // fall back to graph data found on disk so migration remains
+        // reachable before disaster recovery
+        const nodeConnected = !!NodeInfoStore.nodeInfo.identity_pubkey;
+        const canExportChannels = nodeConnected
+            ? hasChannels
+            : this.state.graphDataOnDisk;
 
         const DangerouslyCopySeed = () => (
             <TouchableOpacity
@@ -668,7 +702,7 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                                     } else if (
                                         SettingsStore.implementation ===
                                             'embedded-lnd' &&
-                                        hasChannels
+                                        canExportChannels
                                     ) {
                                         Alert.alert(
                                             localeString(
@@ -729,7 +763,7 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                             />
                             {!isRefundRescueKey &&
                                 !isViewingInactiveWalletSeed &&
-                                hasChannels &&
+                                canExportChannels &&
                                 SettingsStore.implementation ==
                                     'embedded-lnd' && (
                                     <Button

--- a/views/Tools/index.tsx
+++ b/views/Tools/index.tsx
@@ -36,7 +36,10 @@ import {
 } from '../../utils/DataClearUtils';
 import { restartApp } from '../../utils/RestartUtils';
 import { themeColor } from '../../utils/ThemeUtils';
-import { handleExportChannels } from '../../utils/ChannelMigrationUtils';
+import {
+    channelDataExists,
+    handleExportChannels
+} from '../../utils/ChannelMigrationUtils';
 
 import SettingsStore from '../../stores/SettingsStore';
 import NodeInfoStore from '../../stores/NodeInfoStore';
@@ -59,6 +62,7 @@ interface ToolsState {
     isChannelExporting: boolean;
     channelExportMessage: string;
     isClearingData: boolean;
+    channelDataOnDisk: boolean;
 }
 
 @inject('SettingsStore', 'NodeInfoStore', 'SyncStore', 'ChannelsStore')
@@ -72,7 +76,8 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
         this.state = {
             isChannelExporting: false,
             channelExportMessage: '',
-            isClearingData: false
+            isClearingData: false,
+            channelDataOnDisk: false
         };
     }
 
@@ -85,7 +90,22 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
         if (route.params?.showClearDataModal) {
             this.handleClearStorage();
         }
+
+        this.checkChannelDataOnDisk();
     }
+
+    // Fallback for offering channel export when the node isn't running
+    // and channels can't be queried
+    checkChannelDataOnDisk = async () => {
+        const { SettingsStore } = this.props;
+        if (SettingsStore.implementation !== 'embedded-lnd') return;
+
+        const channelDataOnDisk = await channelDataExists(
+            SettingsStore.lndDir || 'lnd',
+            SettingsStore.embeddedLndNetwork === 'Testnet'
+        );
+        this.setState({ channelDataOnDisk });
+    };
 
     componentWillUnmount() {
         if (this.focusListener) {
@@ -94,7 +114,10 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
         this.releaseWipeGuard?.();
     }
 
-    handleFocus = () => this.props.SettingsStore.getSettings();
+    handleFocus = () => {
+        this.props.SettingsStore.getSettings();
+        this.checkChannelDataOnDisk();
+    };
 
     handleClearStorage = () => {
         Alert.alert(
@@ -146,9 +169,12 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
         handleExportChannels({
             isSqlite: SettingsStore.isSqlite ?? true,
             lndDir: SettingsStore.lndDir || 'lnd',
-            isTestnet: NodeInfoStore.nodeInfo.isTestNet,
+            // nodeInfo is empty when the node isn't running, so read the
+            // network from the persisted wallet config instead
+            isTestnet: SettingsStore.embeddedLndNetwork === 'Testnet',
             pubkey: NodeInfoStore.nodeInfo.identity_pubkey,
-            seedPhrase: SettingsStore.seedPhrase.join(' '),
+            seedPhrase: (SettingsStore.seedPhrase || []).join(' '),
+            canUploadToOlympus: !!NodeInfoStore.nodeInfo.identity_pubkey,
             setStatus: (msg: string | null) =>
                 this.setState({
                     isChannelExporting: msg !== null,
@@ -158,12 +184,21 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
     };
 
     render() {
-        const { navigation, SettingsStore, ChannelsStore } = this.props;
+        const { navigation, SettingsStore, NodeInfoStore, ChannelsStore } =
+            this.props;
         const { settings, isChannelMigrating, implementation } = SettingsStore;
         const hasChannels =
             ChannelsStore.channels.length > 0 ||
             ChannelsStore.pendingChannels.length > 0 ||
             ChannelsStore.closedChannels.length > 0;
+
+        // If the node is up, trust its channel list; if it won't start,
+        // fall back to channel data found on disk so migration remains
+        // reachable before disaster recovery
+        const nodeConnected = !!NodeInfoStore.nodeInfo.identity_pubkey;
+        const canExportChannels = nodeConnected
+            ? hasChannels
+            : this.state.channelDataOnDisk;
 
         const selectedNode: any =
             (settings &&
@@ -754,7 +789,7 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
 
                     {implementation === 'embedded-lnd' &&
                         !isChannelMigrating &&
-                        hasChannels && (
+                        canExportChannels && (
                             <View
                                 style={{
                                     backgroundColor: themeColor('secondary'),

--- a/views/Tools/index.tsx
+++ b/views/Tools/index.tsx
@@ -37,7 +37,7 @@ import {
 import { restartApp } from '../../utils/RestartUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import {
-    channelDataExists,
+    graphDataExists,
     handleExportChannels
 } from '../../utils/ChannelMigrationUtils';
 
@@ -62,7 +62,7 @@ interface ToolsState {
     isChannelExporting: boolean;
     channelExportMessage: string;
     isClearingData: boolean;
-    channelDataOnDisk: boolean;
+    graphDataOnDisk: boolean;
 }
 
 @inject('SettingsStore', 'NodeInfoStore', 'SyncStore', 'ChannelsStore')
@@ -77,7 +77,7 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
             isChannelExporting: false,
             channelExportMessage: '',
             isClearingData: false,
-            channelDataOnDisk: false
+            graphDataOnDisk: false
         };
     }
 
@@ -91,20 +91,20 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
             this.handleClearStorage();
         }
 
-        this.checkChannelDataOnDisk();
+        this.checkGraphDataOnDisk();
     }
 
     // Fallback for offering channel export when the node isn't running
     // and channels can't be queried
-    checkChannelDataOnDisk = async () => {
+    checkGraphDataOnDisk = async () => {
         const { SettingsStore } = this.props;
         if (SettingsStore.implementation !== 'embedded-lnd') return;
 
-        const channelDataOnDisk = await channelDataExists(
+        const graphDataOnDisk = await graphDataExists(
             SettingsStore.lndDir || 'lnd',
             SettingsStore.embeddedLndNetwork === 'Testnet'
         );
-        this.setState({ channelDataOnDisk });
+        this.setState({ graphDataOnDisk });
     };
 
     componentWillUnmount() {
@@ -116,7 +116,7 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
 
     handleFocus = () => {
         this.props.SettingsStore.getSettings();
-        this.checkChannelDataOnDisk();
+        this.checkGraphDataOnDisk();
     };
 
     handleClearStorage = () => {
@@ -198,7 +198,7 @@ export default class Tools extends React.Component<ToolsProps, ToolsState> {
         const nodeConnected = !!NodeInfoStore.nodeInfo.identity_pubkey;
         const canExportChannels = nodeConnected
             ? hasChannels
-            : this.state.channelDataOnDisk;
+            : this.state.graphDataOnDisk;
 
         const selectedNode: any =
             (settings &&


### PR DESCRIPTION
# Description

A user on embedded LND reported that the "Export Channels to other device" option was missing from Tools. Their node fails to start, and they wanted to migrate to another device before resorting to disaster recovery.

The option was gated on `hasChannels`, which is computed from `ChannelsStore` and only populates from a running node. A dead node means channels never load, so the migration feature was unreachable in exactly the scenario it was built for. The local zip export doesn't need a running node at all: it stops LND (tolerating already-stopped) and zips the on-disk graph directory.

Changes:

- **Tools**: when the node is connected (`nodeInfo.identity_pubkey` present), keep trusting the node's channel list, preserving the intent of the `hasChannels` gate from v13.0.0. When it isn't, fall back to checking for channel data on disk (`channelDataExists` helper in `ChannelMigrationUtils`), so export stays reachable with a dead node.
- **Network source**: `isTestnet` now comes from the persisted `embeddedLndNetwork` wallet config instead of `nodeInfo.isTestNet`, which is empty when the node is down and would silently fall back to the mainnet directory for testnet wallets.
- **Olympus upload**: only offered while the node is running, since it signs auth challenges with the node key via `BackendUtils.signMessage`. With a dead node the local zip export is offered alone.
- Applied the same `isTestnet`/Olympus changes to the identical caller in `views/Settings/Seed.tsx` for consistency, plus a defensive default on `seedPhrase`.

Draft until device tests: (1) embedded wallet with channels, node prevented from starting, verify export appears and local zip completes; (2) node running, verify Olympus + local options unchanged; (3) fresh embedded wallet with no channel history, verify option stays hidden while the node is up; (4) testnet wallet with node down, verify the testnet graph dir is exported.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding