### PR TITLE
Embedded LND: route node traffic through in-app Tor SOCKS proxy

### DIFF
--- a/android/app/src/main/java/com/zeus/LndMobile.java
+++ b/android/app/src/main/java/com/zeus/LndMobile.java
@@ -369,8 +369,7 @@ class LndMobile extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void startLnd(String args, String lndDir, Boolean isTorEnabled, Boolean isTestnet, Promise promise) {
-    // TODO args is only used on iOS right now
+  public void startLnd(String args, String lndDir, Boolean isTestnet, Promise promise) {
     int req = new Random().nextInt();
     requests.put(req, promise);
 
@@ -386,21 +385,14 @@ class LndMobile extends ReactContextBaseJavaModule {
       params = "--lnddir=" + getReactApplicationContext().getFilesDir().getPath() + "/" + lndDir;
     }
 
-    if (isTorEnabled) {
-      // int listenPort = ZeusTorUtils.getListenPort(isTestnet);
-      // String controlSocket = "unix://" + getReactApplicationContext().getDir(TorService.class.getSimpleName(), Context.MODE_PRIVATE).getAbsolutePath() + "/data/ControlSocket";
-      // params += " --tor.active --tor.control=" + controlSocket;
-      // params += " --tor.v3 --listen=localhost:" + listenPort;
-    } else {
-      // If Tor isn't active, make sure we aren't
-      // listening at all
-      params += " --nolisten";
-     
-      
-    }
-     // Enable watchtower client
-     params += " --wtclient.active";
-     
+    // Never listen for inbound p2p connections on mobile. Tor args
+    // (tor.active, tor.socks) are composed on the JS side and arrive
+    // via `args`.
+    params += " --nolisten";
+
+    // Enable watchtower client
+    params += " --wtclient.active";
+
     bundle.putString(
       "args",
       params + " " + args

--- a/ios/LndMobile/Lnd.swift
+++ b/ios/LndMobile/Lnd.swift
@@ -194,13 +194,15 @@ open class Lnd {
     return flags
   }
 
-  func startLnd(_ args: String, lndDir: String, isTorEnabled: Bool, isTestnet: Bool, lndStartedCallback: @escaping Callback) -> Void {
+  func startLnd(_ args: String, lndDir: String, isTestnet: Bool, lndStartedCallback: @escaping Callback) -> Void {
     let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
     let lndPath = applicationSupport.appendingPathComponent(lndDir, isDirectory: true)
 
-    var lndArgs = "--nolisten --lnddir=\"\(lndPath.path)\" --wtclient.active" + args
-    if (isTorEnabled) {
-      lndArgs += " --tor.active"
+    // Tor args (tor.active, tor.socks) are composed on the JS side
+    // and arrive via `args`.
+    var lndArgs = "--nolisten --lnddir=\"\(lndPath.path)\" --wtclient.active"
+    if (!args.isEmpty) {
+      lndArgs += " " + args
     }
 
     let started: Callback = {(data: Data?, error: Error?) in {

--- a/ios/LndMobile/LndMobile.m
+++ b/ios/LndMobile/LndMobile.m
@@ -16,7 +16,6 @@ RCT_EXTERN_METHOD(
 RCT_EXTERN_METHOD(
   startLnd: (NSString *)args
   lndDir: (NSString *)lndDir
-  isTorEnabled: (BOOL)isTorEnabled
   isTestnet: (BOOL)isTestnet
   resolver: (RCTPromiseResolveBlock)resolve
   rejecter: (RCTPromiseRejectBlock)reject

--- a/ios/LndMobile/LndMobile.swift
+++ b/ios/LndMobile/LndMobile.swift
@@ -120,9 +120,9 @@ class LndMobile: RCTEventEmitter {
     resolve(Lnd.shared.checkStatus())
   }
 
-  @objc(startLnd:lndDir:isTorEnabled:isTestnet:resolver:rejecter:)
-  func startLnd(_ args: String, lndDir: String, isTorEnabled: Bool, isTestnet: Bool, resolve: @escaping RCTPromiseResolveBlock, rejecter reject:@escaping RCTPromiseRejectBlock) {
-    Lnd.shared.startLnd(args, lndDir: lndDir, isTorEnabled: isTorEnabled, isTestnet: isTestnet) { (data, error) in
+  @objc(startLnd:lndDir:isTestnet:resolver:rejecter:)
+  func startLnd(_ args: String, lndDir: String, isTestnet: Bool, resolve: @escaping RCTPromiseResolveBlock, rejecter reject:@escaping RCTPromiseRejectBlock) {
+    Lnd.shared.startLnd(args, lndDir: lndDir, isTestnet: isTestnet) { (data, error) in
       if let e = error {
         reject("error", e.localizedDescription, e)
         return

--- a/lndmobile/LndMobile.d.ts
+++ b/lndmobile/LndMobile.d.ts
@@ -10,7 +10,6 @@ export interface ILndMobile {
     startLnd(
         args: string,
         lndDir: string,
-        isTorEnabled?: boolean,
         isTestnet?: boolean
     ): Promise<{ data: string }>;
     stopLnd(): Promise<{ data: string }>;

--- a/lndmobile/LndMobileInjection.ts
+++ b/lndmobile/LndMobileInjection.ts
@@ -144,12 +144,10 @@ export interface ILndMobileInjections {
         startLnd: ({
             args,
             lndDir,
-            isTorEnabled,
             isTestnet
         }: {
             args: string;
             lndDir: string;
-            isTorEnabled?: boolean;
             isTestnet?: boolean;
         }) => Promise<string>;
         stopLnd: () => Promise<string>;

--- a/lndmobile/index.ts
+++ b/lndmobile/index.ts
@@ -82,20 +82,13 @@ export const stopLnd = async (): Promise<{ data: string }> => {
 export const startLnd = async ({
     args,
     lndDir,
-    isTorEnabled = false,
     isTestnet = false
 }: {
     args?: string;
     lndDir: string;
-    isTorEnabled: boolean;
     isTestnet: boolean;
 }): Promise<{ data: string }> => {
-    return await LndMobile.startLnd(
-        args || '',
-        lndDir,
-        isTorEnabled,
-        isTestnet
-    );
+    return await LndMobile.startLnd(args || '', lndDir, isTestnet);
 };
 
 /**

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1878,7 +1878,14 @@ export default class SettingsStore {
             this.dismissCustodialWarning = node.dismissCustodialWarning;
             this.implementation = node.implementation || 'lnd';
             this.certVerification = node.certVerification || false;
-            this.enableTor = node.enableTor;
+            // embeddedTor torifies the embedded node's own traffic; extend it
+            // to enableTor so ancillary HTTP calls (channel backups, sync
+            // block-tip checks, migration) don't leak clearnet alongside a
+            // torified node. Remote nodes keep their per-node toggle.
+            this.enableTor =
+                node.enableTor ||
+                (node.implementation === 'embedded-lnd' &&
+                    !!settings.embeddedTor);
             // LNC
             this.pairingPhrase = node.pairingPhrase;
             this.mailboxServer = node.mailboxServer;

--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -16,6 +16,7 @@ import Base64Utils from './Base64Utils';
 import { localeString } from './LocaleUtils';
 import { retry, sleep } from './SleepUtils';
 import { importChannelDb } from './ChannelMigrationUtils';
+import { ensureTorStarted, SOCKS_PORT } from './TorUtils';
 
 import lndMobile from '../lndmobile/LndMobileInjection';
 import {
@@ -599,6 +600,21 @@ export async function startLnd({
         }
     }
 
+    // When the node should run over Tor, the SOCKS proxy must be
+    // listening before LND starts: with tor.active, LND routes all
+    // peer dials and DNS lookups through it. Hard-fail if Tor won't
+    // bootstrap rather than silently starting over clearnet.
+    let args = '';
+    if (isTorEnabled) {
+        try {
+            await ensureTorStarted();
+        } catch (e) {
+            log.e('Failed to start Tor for embedded LND', [e]);
+            throw new Error(localeString('error.torBootstrap'));
+        }
+        args = `--tor.active --tor.socks=127.0.0.1:${SOCKS_PORT}`;
+    }
+
     // Mark as started only on proper start-up, not on wallet creation
     if (walletPassword) {
         settingsStore.embeddedLndStarted = true;
@@ -606,8 +622,8 @@ export async function startLnd({
 
     await startLndWithRetry({
         startLnd,
+        args,
         lndDir,
-        isTorEnabled,
         isTestnet,
         walletPassword,
         unlockWallet
@@ -627,8 +643,8 @@ export async function startLnd({
  */
 async function startLndWithRetry({
     startLnd,
+    args,
     lndDir,
-    isTorEnabled,
     isTestnet,
     walletPassword,
     unlockWallet
@@ -636,16 +652,15 @@ async function startLndWithRetry({
     startLnd: (opts: {
         args: string;
         lndDir: string;
-        isTorEnabled: boolean;
         isTestnet: boolean;
     }) => Promise<unknown>;
+    args: string;
     lndDir: string;
-    isTorEnabled: boolean;
     isTestnet: boolean;
     walletPassword: string;
     unlockWallet: (password: string) => Promise<void>;
 }) {
-    const startArgs = { args: '', lndDir, isTorEnabled, isTestnet };
+    const startArgs = { args, lndDir, isTestnet };
 
     try {
         await startLnd(startArgs);
@@ -722,13 +737,11 @@ async function retryStartLnd({
     startLnd: (opts: {
         args: string;
         lndDir: string;
-        isTorEnabled: boolean;
         isTestnet: boolean;
     }) => Promise<unknown>;
     startArgs: {
         args: string;
         lndDir: string;
-        isTorEnabled: boolean;
         isTestnet: boolean;
     };
     walletPassword: string;
@@ -1132,7 +1145,6 @@ async function restartLndForWalletCreation(
                 await startLnd({
                     args: '',
                     lndDir,
-                    isTorEnabled: false,
                     isTestnet
                 });
                 await waitForLndReady({

--- a/utils/TorUtils.ts
+++ b/utils/TorUtils.ts
@@ -153,4 +153,11 @@ const restartTor = async () => {
     await ensureTorStarted();
 };
 
-export { doTorRequest, restartTor, isOnionHttpsUrl, RequestMethod };
+export {
+    doTorRequest,
+    ensureTorStarted,
+    restartTor,
+    isOnionHttpsUrl,
+    RequestMethod,
+    SOCKS_PORT
+};

--- a/views/Settings/EmbeddedNode/Advanced.tsx
+++ b/views/Settings/EmbeddedNode/Advanced.tsx
@@ -185,6 +185,62 @@ export default class EmbeddedNodeAdvancedSettings extends React.Component<
                                 color={themeColor('secondaryText')}
                             />
                         </ListItem>
+                        <>
+                            <ListItem
+                                containerStyle={{
+                                    borderBottomWidth: 0,
+                                    backgroundColor: 'transparent'
+                                }}
+                            >
+                                <ListItem.Title
+                                    style={{
+                                        color: themeColor('text'),
+                                        fontFamily: 'PPNeueMontreal-Book'
+                                    }}
+                                >
+                                    {localeString('general.tor')}
+                                </ListItem.Title>
+                                <View
+                                    style={{
+                                        flex: 1,
+                                        flexDirection: 'row',
+                                        justifyContent: 'flex-end'
+                                    }}
+                                >
+                                    <Switch
+                                        value={embeddedTor}
+                                        onValueChange={async () => {
+                                            this.setState({
+                                                embeddedTor: !embeddedTor
+                                            });
+                                            await updateSettings({
+                                                embeddedTor: !embeddedTor
+                                            });
+                                            restartNeeded();
+                                        }}
+                                    />
+                                </View>
+                            </ListItem>
+                            <View
+                                style={{
+                                    margin: 10
+                                }}
+                            >
+                                <Text
+                                    style={{
+                                        color: themeColor('secondaryText')
+                                    }}
+                                >
+                                    {`${localeString(
+                                        'views.Settings.EmbeddedNode.embeddedTor.subtitle'
+                                    )} ${localeString(
+                                        'views.Settings.EmbeddedNode.embeddedTor.clearnetWarning'
+                                    )} ${localeString(
+                                        'views.Settings.EmbeddedNode.restart'
+                                    )}`}
+                                </Text>
+                            </View>
+                        </>
                         {Platform.OS === 'android' && (
                             <>
                                 <ListItem


### PR DESCRIPTION
## Description

Fixes #2373 (embedded node: Tor channels permanently offline).

### Root cause of #2373

The embedded node has no Tor integration, so users route it through Orbot's VPN mode. Orbot fakes DNS for .onion hosts (returning virtual 10.192.0.0/10 addresses, visible in the issue's logs) and accepts the TCP connect instantly, before any Tor circuit exists. That shifts the entire descriptor fetch + rendezvous into brontide's hard-coded 5-second ActTwo handshake deadline, which a cold onion rendezvous almost never meets, so every automatic reconnect dies with 'read tcp ... i/o timeout'. The manual Connect Peer workaround is the same code path; it only succeeds because the pile of failed automatic attempts has warmed Tor up by the time the user taps it.

### The fix

Zeus already ships a Tor daemon (react-native-nitro-tor, with a SOCKS5 listener we use for onion HTTP requests). This PR points the embedded node at it:

- Restores the embedded node Tor toggle (removed in 02e9b692f after the old TorService integration died) in Embedded node > Advanced, on both platforms, reusing the existing `embeddedTor` setting and locale strings.
- When enabled, `startLnd` bootstraps Tor first (hard-fail with the existing `error.torBootstrap` message rather than silently starting over clearnet) and launches LND with `--tor.active --tor.socks=127.0.0.1:<port>`.
- With a real SOCKS proxy, the SOCKS CONNECT does not return until the onion rendezvous is complete (under lnd's generous connectiontimeout), so the 5-second handshake window only covers one round trip on a live circuit. Onion peers reconnect automatically; no Orbot required.
- Tor args are now composed once on the JS side (where the SOCKS port is known); the dead `isTorEnabled` flag is removed from the native startLnd bridge on both platforms. Android also stops conditionally dropping `--nolisten`, a TorService-era leftover that made Tor-enabled nodes listen for inbound p2p connections.

### Behavior notes

- With `tor.active`, lnd routes all peer/neutrino dials and DNS lookups through the proxy (full-Tor for the node, matching the toggle's existing subtitle). Initial sync will be slower over Tor.
- lnd's `fee.url` estimator uses its own plain HTTP client upstream and stays clearnet, consistent with the toggle's existing clearnet warning for rates endpoints (as do app-level EGS/speedloader fetches).
- Android scheduled-sync worker starts (out of scope here) still run without Tor args; noted as a follow-up candidate.
- Wallet creation continues to run without Tor (existing behavior, `isTorEnabled: false`).

This pull request is categorized as a:

- [x] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A (changes to `utils/TorUtils.ts` and `utils/LndMobileUtils.ts` are native-bridge orchestration and export changes; no new unit-testable logic)

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND (device tests pending, see plan below)

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Device test plan (pending)

- [ ] Android device: enable toggle, restart, confirm lnd.log shows tor.active and onion channel peers come online without Orbot
- [ ] Android device: toggle off, restart, confirm clearnet behavior unchanged
- [ ] iOS device: same two passes
- [ ] Confirm Tor bootstrap failure (airplane mode) surfaces the torBootstrap error instead of starting clearnet
- [ ] Open a channel to a Tor-only peer with the toggle enabled, kill and relaunch the app, and verify the channel shows active within a minute or two without touching Connect Peer

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

No new locale strings: the toggle reuses `general.tor`, `views.Settings.EmbeddedNode.embeddedTor.subtitle`, `.clearnetWarning`, `.restart`, and `error.torBootstrap`, which all survived the old integration's removal.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
