### PR TITLE
views/Send: tie send max toggle to the UTXO selection

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -926,6 +926,7 @@
     "views.Send.zaplockerWarning": "This is a Zaplocker invoices that will hold payment up to 24 hours. Open ZEUS regularly after payment to help mitigate the risk of a force closed channel. Proceed at your own risk.",
     "views.Send.addOutput": "Add output",
     "views.Send.removeOutput": "Remove output",
+    "views.Send.fundMaxUtxos": "Use all selected UTXOs",
     "views.Send.payBolt12.offerFetchFailure": "Couldn't fetch offer",
     "views.Send.payBolt12.invoiceFetchFailure": "Couldn't fetch invoice",
     "views.Send.payBolt12.specifyAmount": "Amount must be specified",

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -298,12 +298,29 @@ export default class Send extends React.Component<SendProps, SendState> {
         utxoBalance: number,
         account: string
     ) => {
-        this.setState((prevState) => ({
-            utxos,
-            utxoBalance,
-            account,
-            fundMax: account === 'default' ? prevState.fundMax : false
-        }));
+        const { confirmedBlockchainBalance } = this.props.BalanceStore;
+
+        this.setState((prevState) => {
+            // send max is only offered on the default account
+            const fundMax = account === 'default' ? prevState.fundMax : false;
+
+            let amount = prevState.amount;
+            let satAmount = prevState.satAmount;
+
+            if (fundMax) {
+                // send max is bound to the selection, so the amount it will
+                // send has to follow the selection as it changes
+                satAmount =
+                    utxoBalance > 0 ? utxoBalance : confirmedBlockchainBalance;
+            } else if (prevState.fundMax) {
+                // send max was just turned off, so put back the amount that
+                // was entered before it was enabled
+                amount = this.previousAmount || '';
+                satAmount = this.previousSatAmount || '0';
+            }
+
+            return { utxos, utxoBalance, account, fundMax, amount, satAmount };
+        });
     };
 
     validateAdditionalOutputFields = (
@@ -946,21 +963,39 @@ export default class Send extends React.Component<SendProps, SendState> {
                                     forceUnit={fundMax ? 'sats' : undefined}
                                 />
 
+                                {BackendUtils.supportsCoinControl() && (
+                                    <View style={{ marginBottom: 20 }}>
+                                        <UTXOPicker
+                                            onValueChange={this.selectUTXOs}
+                                            UTXOsStore={UTXOsStore}
+                                        />
+                                    </View>
+                                )}
+
                                 {BackendUtils.supportsOnchainSendMax() &&
                                     additionalOutputs.length === 0 &&
                                     account === 'default' && (
-                                        <View style={{ marginBottom: 18 }}>
+                                        <View
+                                            style={{
+                                                flexDirection: 'row',
+                                                alignItems: 'center',
+                                                justifyContent: 'space-between',
+                                                marginBottom: 18
+                                            }}
+                                        >
                                             <Text
                                                 style={{
-                                                    marginTop: -20,
-                                                    top: 20,
+                                                    flex: 1,
+                                                    marginRight: 12,
                                                     color: themeColor(
                                                         'secondaryText'
                                                     )
                                                 }}
                                             >
                                                 {localeString(
-                                                    'views.OpenChannel.fundMax'
+                                                    utxos.length > 0
+                                                        ? 'views.Send.fundMaxUtxos'
+                                                        : 'views.OpenChannel.fundMax'
                                                 )}
                                             </Text>
                                             <Switch
@@ -1151,15 +1186,6 @@ export default class Send extends React.Component<SendProps, SendState> {
                                             />
                                         </View>
                                     )}
-
-                                {BackendUtils.supportsCoinControl() && (
-                                    <View style={{ marginBottom: 20 }}>
-                                        <UTXOPicker
-                                            onValueChange={this.selectUTXOs}
-                                            UTXOsStore={UTXOsStore}
-                                        />
-                                    </View>
-                                )}
 
                                 <Text
                                     style={{


### PR DESCRIPTION
# Description

Follow-up to a user report: when sending a single UTXO in full, the send fails because the fee has nowhere to come from, and there is no obvious way to have it subtracted.

The capability already exists. The **Use all possible funds** toggle on the on-chain Send screen is selection-aware: with UTXOs picked in coin control, it maxes out the *selection* rather than the whole balance, producing a single-output sweep with the fee subtracted and no change. On LND-family backends that goes out as `SendCoins` with `outpoints` + `send_all` (needs lnd v0.18.3+, gated by `supportsOnchainSendMax`); CLN uses `withdraw satoshi=all utxos=[...]`, LDK Node uses `sendAllToOnchainAddressWithUtxos`.

Nothing on screen communicated that. The toggle sat directly under the amount field while the UTXO picker sat well below it, past the multi-output section, and the label never changed when a selection was active. So the feature reads as absent.

This PR:

1. **Fixes a stale amount.** `selectUTXOs` updated `utxos`/`utxoBalance` but not `satAmount`. Enabling the toggle *before* picking UTXOs therefore left `satAmount` at the full confirmed balance. The amount field itself looked right because it derives from `utxoBalance`, but the stale value was forwarded to `VerifyOnChain`, whose total comes from `satAmount`, so the confirmation screen showed the whole wallet balance instead of the selection. The broadcast was never wrong, since `send_all` drops the amount, but the number shown before signing was. Selecting a non-default account (which force-disables send max) now also restores the previously entered amount instead of leaving `amount` empty with a non-zero `satAmount`.

2. **Improves toggle placement.** The UTXO picker and the toggle now sit together immediately under the amount field, so the switch is adjacent both to the amount it locks and the selection it applies to. `Add output` moved below the toggle, so enabling send max no longer makes a control disappear from above the switch and shift it under the user's finger.

3. **Changes the label when UTXOs are selected.** With a selection active the toggle reads **Use all selected UTXOs**; with no selection it keeps the existing string. `views.OpenChannel.fundMax` is shared with the channel-open screen, so it is left untouched and one new key is added rather than changing an existing translated string.

Also replaces the `marginTop: -20 / top: 20` hack that faked the label and switch onto one row with a flex row, per #2794. That hack also collided with the switch on longer translations; the label now wraps cleanly.

Not addressed here: nothing in the flow yet states that the fee is deducted, and #4508's fee estimate deliberately skips coin control and send max. Worth a follow-up.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

One new key: `views.Send.fundMaxUtxos` = "Use all selected UTXOs". No existing string was modified.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

Device tests pending. Suggested passes:

* Select one UTXO, enable the toggle, confirm the label reads "Use all selected UTXOs" and that `VerifyOnChain` shows the selection total rather than the wallet balance.
* Enable the toggle *first*, then select a UTXO. This is the ordering that was broken.
* Change the selection while the toggle is on, and clear the selection while it is on. The amount should track each time.
* Switch to a non-default account with the toggle on. It should turn off and restore the amount previously entered.
* Broadcast a single-UTXO send to confirm one output, no change, fee deducted.
