### PR TITLE
lndmobile: make EGS graph reset non-destructive, repair bricked graph DBs

### DIFF
--- a/android/app/src/main/java/com/zeus/LndMobileTools.java
+++ b/android/app/src/main/java/com/zeus/LndMobileTools.java
@@ -441,8 +441,163 @@ class LndMobileTools extends ReactContextBaseJavaModule {
     return fileOrDirectory.delete() && success;
   }
 
+  // Graph SQL database maintenance.
+  //
+  // The embedded LND fork stores the gossip graph in native-SQL tables inside
+  // lnd.sqlite. LND decides which migrations to run from the single highest
+  // version in migration_tracker, so deleting individual tracker rows never
+  // makes it re-run a migration. The pre-v13.2.1 reset dropped the graph
+  // tables and deleted tracker rows 9/10 while rows 11-18 remained, leaving
+  // databases LND could never open again (issue #4524). The reset now only
+  // DELETEs rows inside one transaction and treats migration_tracker and
+  // schema_migrations as LND-owned. Repair rebuilds the schema for wallets
+  // the old reset already damaged.
+  //
+  // The DDL below mirrors the lnd fork's migrations 000008_graph and
+  // 000009_graph_v2 and must stay in sync with the fork pinned in
+  // fetch-libraries-versions.json. If the fork's highest migration version
+  // moves past GRAPH_KNOWN_MAX_DB_VERSION, repair fails closed until these
+  // definitions are reviewed against the new migrations.
+  private static final int GRAPH_V2_MIGRATION_VERSION = 11;   // 000009_graph_v2
+  private static final int GRAPH_KNOWN_MAX_DB_VERSION = 18;   // 000015_chain_params
+  private static final int GRAPH_KNOWN_SCHEMA_VERSION = 15;   // golang-migrate version at db version 18
+
+  private static final String[] GRAPH_TABLES_CHILD_FIRST = {
+    "graph_channel_policy_extra_types",
+    "graph_channel_policies",
+    "graph_channel_features",
+    "graph_channel_extra_types",
+    "graph_source_nodes",
+    "graph_channels",
+    "graph_node_addresses",
+    "graph_node_features",
+    "graph_node_extra_types",
+    "graph_nodes",
+    "graph_zombie_channels",
+    "graph_prune_log",
+    "graph_closed_scids"
+  };
+
+  // Tables as created by 000008_graph, followed by the 000009_graph_v2
+  // column additions.
+  private static final String[] GRAPH_TABLE_DDL = {
+    "CREATE TABLE IF NOT EXISTS graph_nodes (" +
+      "id INTEGER PRIMARY KEY, " +
+      "version SMALLINT NOT NULL, " +
+      "pub_key BLOB NOT NULL, " +
+      "alias TEXT, " +
+      "last_update BIGINT, " +
+      "color VARCHAR, " +
+      "signature BLOB)",
+    "CREATE TABLE IF NOT EXISTS graph_node_extra_types (" +
+      "node_id BIGINT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE, " +
+      "type BIGINT NOT NULL, " +
+      "value BLOB)",
+    "CREATE TABLE IF NOT EXISTS graph_node_features (" +
+      "node_id BIGINT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE, " +
+      "feature_bit INTEGER NOT NULL)",
+    "CREATE TABLE IF NOT EXISTS graph_node_addresses (" +
+      "node_id BIGINT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE, " +
+      "type SMALLINT NOT NULL, " +
+      "position INTEGER NOT NULL, " +
+      "address TEXT NOT NULL)",
+    "CREATE TABLE IF NOT EXISTS graph_source_nodes (" +
+      "node_id BIGINT NOT NULL REFERENCES graph_nodes (id) ON DELETE CASCADE)",
+    "CREATE TABLE IF NOT EXISTS graph_channels (" +
+      "id INTEGER PRIMARY KEY, " +
+      "version SMALLINT NOT NULL, " +
+      "scid BLOB NOT NULL, " +
+      "node_id_1 BIGINT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE, " +
+      "node_id_2 BIGINT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE, " +
+      "outpoint TEXT NOT NULL, " +
+      "capacity BIGINT, " +
+      "bitcoin_key_1 BLOB, " +
+      "bitcoin_key_2 BLOB, " +
+      "node_1_signature BLOB, " +
+      "node_2_signature BLOB, " +
+      "bitcoin_1_signature BLOB, " +
+      "bitcoin_2_signature BLOB)",
+    "CREATE TABLE IF NOT EXISTS graph_channel_features (" +
+      "channel_id BIGINT NOT NULL REFERENCES graph_channels(id) ON DELETE CASCADE, " +
+      "feature_bit INTEGER NOT NULL)",
+    "CREATE TABLE IF NOT EXISTS graph_channel_extra_types (" +
+      "channel_id BIGINT NOT NULL REFERENCES graph_channels(id) ON DELETE CASCADE, " +
+      "type BIGINT NOT NULL, " +
+      "value BLOB)",
+    "CREATE TABLE IF NOT EXISTS graph_channel_policies (" +
+      "id INTEGER PRIMARY KEY, " +
+      "version SMALLINT NOT NULL, " +
+      "channel_id BIGINT NOT NULL REFERENCES graph_channels(id) ON DELETE CASCADE, " +
+      "node_id BIGINT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE, " +
+      "timelock INTEGER NOT NULL, " +
+      "fee_ppm BIGINT NOT NULL, " +
+      "base_fee_msat BIGINT NOT NULL, " +
+      "min_htlc_msat BIGINT NOT NULL, " +
+      "max_htlc_msat BIGINT, " +
+      "last_update BIGINT, " +
+      "disabled bool, " +
+      "inbound_base_fee_msat BIGINT, " +
+      "inbound_fee_rate_milli_msat BIGINT, " +
+      "message_flags SMALLINT CHECK (message_flags >= 0 AND message_flags <= 255), " +
+      "channel_flags SMALLINT CHECK (channel_flags >= 0 AND channel_flags <= 255), " +
+      "signature BLOB)",
+    "CREATE TABLE IF NOT EXISTS graph_channel_policy_extra_types (" +
+      "channel_policy_id BIGINT NOT NULL REFERENCES graph_channel_policies(id) ON DELETE CASCADE, " +
+      "type BIGINT NOT NULL, " +
+      "value BLOB)",
+    "CREATE TABLE IF NOT EXISTS graph_zombie_channels (" +
+      "scid BLOB NOT NULL, " +
+      "version SMALLINT NOT NULL, " +
+      "node_key_1 BLOB, " +
+      "node_key_2 BLOB)",
+    "CREATE TABLE IF NOT EXISTS graph_prune_log (" +
+      "block_height BIGINT PRIMARY KEY, " +
+      "block_hash BLOB NOT NULL)",
+    "CREATE TABLE IF NOT EXISTS graph_closed_scids (" +
+      "scid BLOB PRIMARY KEY)",
+    "ALTER TABLE graph_nodes ADD COLUMN block_height BIGINT",
+    "ALTER TABLE graph_channels ADD COLUMN signature BLOB",
+    "ALTER TABLE graph_channels ADD COLUMN funding_pk_script BLOB",
+    "ALTER TABLE graph_channels ADD COLUMN merkle_root_hash BLOB",
+    "ALTER TABLE graph_channel_policies ADD COLUMN block_height BIGINT",
+    "ALTER TABLE graph_channel_policies ADD COLUMN disable_flags SMALLINT " +
+      "CHECK (disable_flags >= 0 AND disable_flags <= 255)"
+  };
+
+  // The index set after 000009_graph_v2 has been applied.
+  private static final String[] GRAPH_INDEX_DDL = {
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_nodes_unique ON graph_nodes (pub_key, version)",
+    "CREATE INDEX IF NOT EXISTS graph_node_last_update_idx ON graph_nodes(version, last_update, pub_key)",
+    "CREATE INDEX IF NOT EXISTS graph_node_block_height_idx ON graph_nodes (version, block_height, pub_key)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_node_extra_types_unique ON graph_node_extra_types (type, node_id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_node_features_unique ON graph_node_features (node_id, feature_bit)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_node_addresses_unique ON graph_node_addresses (node_id, type, position)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_source_nodes_unique ON graph_source_nodes (node_id)",
+    "CREATE INDEX IF NOT EXISTS graph_channels_node_id_1_idx ON graph_channels(node_id_1, version)",
+    "CREATE INDEX IF NOT EXISTS graph_channels_node_id_2_idx ON graph_channels(node_id_2, version)",
+    "CREATE INDEX IF NOT EXISTS graph_channels_version_id_idx ON graph_channels(version, id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_channels_unique ON graph_channels(version, scid DESC)",
+    "CREATE INDEX IF NOT EXISTS graph_channels_version_outpoint_idx ON graph_channels(version, outpoint)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_channel_features_unique ON graph_channel_features (channel_id, feature_bit)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_channel_extra_types_unique ON graph_channel_extra_types (type, channel_id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_channel_policies_unique ON graph_channel_policies (channel_id, node_id, version)",
+    "CREATE INDEX IF NOT EXISTS graph_channel_policy_last_update_idx ON graph_channel_policies(last_update)",
+    "CREATE INDEX IF NOT EXISTS graph_channel_policy_block_height_idx ON graph_channel_policies (version, block_height)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_channel_policy_extra_types_unique ON graph_channel_policy_extra_types (type, channel_policy_id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_zombie_channels_channel_id_version_idx ON graph_zombie_channels(scid, version)"
+  };
+
   @ReactMethod
-  public void DEBUG_resetGraphDb(String lndDir, String network, Promise promise) {
+  public void repairGraphDb(String lndDir, String network, Promise promise) {
+    graphDbMaintenance(lndDir, network, false, promise);
+  }
+
+  @ReactMethod
+  public void resetGraphDb(String lndDir, String network, Promise promise) {
+    graphDbMaintenance(lndDir, network, true, promise);
+  }
+
+  private void graphDbMaintenance(String lndDir, String network, boolean resetData, Promise promise) {
     String basePath;
     if (lndDir == null || lndDir.isEmpty() || lndDir.equals("lnd")) {
       basePath = getReactApplicationContext().getFilesDir().toString();
@@ -453,57 +608,115 @@ class LndMobileTools extends ReactContextBaseJavaModule {
 
     File dbFile = new File(dbPath);
     if (!dbFile.exists()) {
-      promise.resolve(true);
+      promise.resolve("noop");
       return;
     }
 
-    android.database.sqlite.SQLiteDatabase db = null;
+    SQLiteDatabase db = null;
     try {
-      db = android.database.sqlite.SQLiteDatabase.openDatabase(
-        dbPath, null, android.database.sqlite.SQLiteDatabase.OPEN_READWRITE
-      );
+      db = SQLiteDatabase.openDatabase(dbPath, null, SQLiteDatabase.OPEN_READWRITE);
 
-      String[] statements = {
-        "DROP INDEX IF EXISTS graph_nodes_unique",
-        "DROP INDEX IF EXISTS graph_node_extra_types_unique",
-        "DROP INDEX IF EXISTS graph_node_features_unique",
-        "DROP INDEX IF EXISTS graph_node_addresses_unique",
-        "DROP INDEX IF EXISTS graph_node_last_update_idx",
-        "DROP INDEX IF EXISTS graph_source_nodes_unique",
-        "DROP INDEX IF EXISTS graph_channels_node_id_1_idx",
-        "DROP INDEX IF EXISTS graph_channels_node_id_2_idx",
-        "DROP INDEX IF EXISTS graph_channels_unique",
-        "DROP INDEX IF EXISTS graph_channels_version_outpoint_idx",
-        "DROP INDEX IF EXISTS graph_channels_version_id_idx",
-        "DROP INDEX IF EXISTS graph_channel_features_unique",
-        "DROP INDEX IF EXISTS graph_channel_extra_types_unique",
-        "DROP INDEX IF EXISTS graph_channel_policies_unique",
-        "DROP INDEX IF EXISTS graph_channel_policy_extra_types_unique",
-        "DROP INDEX IF EXISTS graph_channel_policy_last_update_idx",
-        "DROP INDEX IF EXISTS graph_zombie_channels_channel_id_version_idx",
-        "DROP TABLE IF EXISTS graph_channel_policy_extra_types",
-        "DROP TABLE IF EXISTS graph_channel_policies",
-        "DROP TABLE IF EXISTS graph_channel_features",
-        "DROP TABLE IF EXISTS graph_channel_extra_types",
-        "DROP TABLE IF EXISTS graph_channels",
-        "DROP TABLE IF EXISTS graph_source_nodes",
-        "DROP TABLE IF EXISTS graph_node_addresses",
-        "DROP TABLE IF EXISTS graph_node_features",
-        "DROP TABLE IF EXISTS graph_node_extra_types",
-        "DROP TABLE IF EXISTS graph_nodes",
-        "DROP TABLE IF EXISTS graph_zombie_channels",
-        "DROP TABLE IF EXISTS graph_prune_log",
-        "DROP TABLE IF EXISTS graph_closed_scids",
-        "DELETE FROM migration_tracker WHERE version IN (9, 10)",
-        "DELETE FROM schema_migrations",
-        "INSERT INTO schema_migrations (version, dirty) VALUES (7, 0)"
-      };
-
-      for (String sql : statements) {
-        db.execSQL(sql);
+      long trackerExists = android.database.DatabaseUtils.longForQuery(db,
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='migration_tracker'", null);
+      if (trackerExists == 0) {
+        // Pre-native-SQL database; the graph does not live here.
+        promise.resolve("noop");
+        return;
       }
 
-      promise.resolve(true);
+      long dbVersion = android.database.DatabaseUtils.longForQuery(db,
+        "SELECT COALESCE(MAX(version), 0) FROM migration_tracker", null);
+
+      java.util.Set<String> presentTables = new java.util.HashSet<>();
+      android.database.Cursor cursor = db.rawQuery(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'graph!_%' ESCAPE '!'", null);
+      try {
+        while (cursor.moveToNext()) {
+          presentTables.add(cursor.getString(0));
+        }
+      } finally {
+        cursor.close();
+      }
+
+      java.util.List<String> missingTables = new ArrayList<>();
+      for (String table : GRAPH_TABLES_CHILD_FIRST) {
+        if (!presentTables.contains(table)) {
+          missingTables.add(table);
+        }
+      }
+      java.util.Set<String> unknownTables = new java.util.HashSet<>(presentTables);
+      unknownTables.removeAll(Arrays.asList(GRAPH_TABLES_CHILD_FIRST));
+
+      if (missingTables.isEmpty()) {
+        boolean knownSchema = dbVersion <= GRAPH_KNOWN_MAX_DB_VERSION && unknownTables.isEmpty();
+        if (!resetData && !knownSchema) {
+          promise.resolve("ok");
+          return;
+        }
+        if (resetData && !unknownTables.isEmpty()) {
+          promise.reject("error", "Refusing to reset graph db: unrecognized graph tables " +
+            unknownTables + ". Update the graph schema definitions to match the lnd fork.");
+          return;
+        }
+        db.beginTransaction();
+        try {
+          if (resetData) {
+            for (String table : GRAPH_TABLES_CHILD_FIRST) {
+              db.execSQL("DELETE FROM " + table);
+            }
+          }
+          if (knownSchema) {
+            // Restore any indexes a partially-run legacy reset dropped;
+            // no-ops on healthy databases.
+            for (String sql : GRAPH_INDEX_DDL) {
+              db.execSQL(sql);
+            }
+          }
+          db.setTransactionSuccessful();
+        } finally {
+          db.endTransaction();
+        }
+        promise.resolve(resetData ? "reset" : "ok");
+        return;
+      }
+
+      // Some graph tables are missing.
+      if (dbVersion < GRAPH_V2_MIGRATION_VERSION) {
+        // The graph migrations have not run yet; LND will create the
+        // schema itself on next start.
+        promise.resolve("noop");
+        return;
+      }
+      if (dbVersion > GRAPH_KNOWN_MAX_DB_VERSION || !unknownTables.isEmpty()) {
+        promise.reject("error", "Graph db is missing tables " + missingTables +
+          " but its schema (version " + dbVersion + ") is not recognized by this build; refusing to repair.");
+        return;
+      }
+
+      // migration_tracker says the graph schema exists but the tables are
+      // gone: this wallet was damaged by the pre-v13.2.1 reset. Rebuild the
+      // schema exactly as migrations 000008_graph + 000009_graph_v2 define
+      // it and restore the bookkeeping the legacy reset removed.
+      db.beginTransaction();
+      try {
+        for (String table : GRAPH_TABLES_CHILD_FIRST) {
+          db.execSQL("DROP TABLE IF EXISTS " + table);
+        }
+        for (String sql : GRAPH_TABLE_DDL) {
+          db.execSQL(sql);
+        }
+        for (String sql : GRAPH_INDEX_DDL) {
+          db.execSQL(sql);
+        }
+        db.execSQL("INSERT OR IGNORE INTO migration_tracker (version, migration_time) VALUES (9, CURRENT_TIMESTAMP)");
+        db.execSQL("INSERT OR IGNORE INTO migration_tracker (version, migration_time) VALUES (10, CURRENT_TIMESTAMP)");
+        db.execSQL("DELETE FROM schema_migrations");
+        db.execSQL("INSERT INTO schema_migrations (version, dirty) VALUES (" + GRAPH_KNOWN_SCHEMA_VERSION + ", 0)");
+        db.setTransactionSuccessful();
+      } finally {
+        db.endTransaction();
+      }
+      promise.resolve("repaired");
     } catch (Exception e) {
       promise.reject("error", e.getMessage());
     } finally {

--- a/ios/LndMobile/LndMobileTools.m
+++ b/ios/LndMobile/LndMobileTools.m
@@ -74,7 +74,14 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-  DEBUG_resetGraphDb: (NSString)lndDir
+  repairGraphDb: (NSString)lndDir
+  network: (NSString)network
+  resolver: (RCTPromiseResolveBlock)resolve
+  rejecter: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
+  resetGraphDb: (NSString)lndDir
   network: (NSString)network
   resolver: (RCTPromiseResolveBlock)resolve
   rejecter: (RCTPromiseRejectBlock)reject

--- a/ios/LndMobile/LndMobileTools.swift
+++ b/ios/LndMobile/LndMobileTools.swift
@@ -284,8 +284,232 @@ class LndMobileTools: RCTEventEmitter {
     resolve(true)
   }
 
-  @objc(DEBUG_resetGraphDb:network:resolver:rejecter:)
-  func DEBUG_resetGraphDb(lndDir: String, network: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+  // Graph SQL database maintenance.
+  //
+  // The embedded LND fork stores the gossip graph in native-SQL tables inside
+  // lnd.sqlite. LND decides which migrations to run from the single highest
+  // version in migration_tracker, so deleting individual tracker rows never
+  // makes it re-run a migration. The pre-v13.2.1 reset dropped the graph
+  // tables and deleted tracker rows 9/10 while rows 11-18 remained, leaving
+  // databases LND could never open again (issue #4524). The reset now only
+  // DELETEs rows inside one transaction and treats migration_tracker and
+  // schema_migrations as LND-owned. Repair rebuilds the schema for wallets
+  // the old reset already damaged.
+  //
+  // The DDL below mirrors the lnd fork's migrations 000008_graph and
+  // 000009_graph_v2 and must stay in sync with the fork pinned in
+  // fetch-libraries-versions.json. If the fork's highest migration version
+  // moves past graphKnownMaxDbVersion, repair fails closed until these
+  // definitions are reviewed against the new migrations.
+  static let graphV2MigrationVersion: Int64 = 11  // 000009_graph_v2
+  static let graphKnownMaxDbVersion: Int64 = 18   // 000015_chain_params
+  static let graphKnownSchemaVersion = 15         // golang-migrate version at db version 18
+
+  static let graphTablesChildFirst = [
+    "graph_channel_policy_extra_types",
+    "graph_channel_policies",
+    "graph_channel_features",
+    "graph_channel_extra_types",
+    "graph_source_nodes",
+    "graph_channels",
+    "graph_node_addresses",
+    "graph_node_features",
+    "graph_node_extra_types",
+    "graph_nodes",
+    "graph_zombie_channels",
+    "graph_prune_log",
+    "graph_closed_scids"
+  ]
+
+  // Tables as created by 000008_graph, followed by the 000009_graph_v2
+  // column additions.
+  static let graphTableDdl = [
+    """
+    CREATE TABLE IF NOT EXISTS graph_nodes (
+      id INTEGER PRIMARY KEY,
+      version SMALLINT NOT NULL,
+      pub_key BLOB NOT NULL,
+      alias TEXT,
+      last_update BIGINT,
+      color VARCHAR,
+      signature BLOB
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS graph_node_extra_types (
+      node_id BIGINT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+      type BIGINT NOT NULL,
+      value BLOB
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS graph_node_features (
+      node_id BIGINT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+      feature_bit INTEGER NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS graph_node_addresses (
+      node_id BIGINT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+      type SMALLINT NOT NULL,
+      position INTEGER NOT NULL,
+      address TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS graph_source_nodes (
+      node_id BIGINT NOT NULL REFERENCES graph_nodes (id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS graph_channels (
+      id INTEGER PRIMARY KEY,
+      version SMALLINT NOT NULL,
+      scid BLOB NOT NULL,
+      node_id_1 BIGINT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+      node_id_2 BIGINT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+      outpoint TEXT NOT NULL,
+      capacity BIGINT,
+      bitcoin_key_1 BLOB,
+      bitcoin_key_2 BLOB,
+      node_1_signature BLOB,
+      node_2_signature BLOB,
+      bitcoin_1_signature BLOB,
+      bitcoin_2_signature BLOB
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS graph_channel_features (
+      channel_id BIGINT NOT NULL REFERENCES graph_channels(id) ON DELETE CASCADE,
+      feature_bit INTEGER NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS graph_channel_extra_types (
+      channel_id BIGINT NOT NULL REFERENCES graph_channels(id) ON DELETE CASCADE,
+      type BIGINT NOT NULL,
+      value BLOB
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS graph_channel_policies (
+      id INTEGER PRIMARY KEY,
+      version SMALLINT NOT NULL,
+      channel_id BIGINT NOT NULL REFERENCES graph_channels(id) ON DELETE CASCADE,
+      node_id BIGINT NOT NULL REFERENCES graph_nodes(id) ON DELETE CASCADE,
+      timelock INTEGER NOT NULL,
+      fee_ppm BIGINT NOT NULL,
+      base_fee_msat BIGINT NOT NULL,
+      min_htlc_msat BIGINT NOT NULL,
+      max_htlc_msat BIGINT,
+      last_update BIGINT,
+      disabled bool,
+      inbound_base_fee_msat BIGINT,
+      inbound_fee_rate_milli_msat BIGINT,
+      message_flags SMALLINT CHECK (message_flags >= 0 AND message_flags <= 255),
+      channel_flags SMALLINT CHECK (channel_flags >= 0 AND channel_flags <= 255),
+      signature BLOB
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS graph_channel_policy_extra_types (
+      channel_policy_id BIGINT NOT NULL REFERENCES graph_channel_policies(id) ON DELETE CASCADE,
+      type BIGINT NOT NULL,
+      value BLOB
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS graph_zombie_channels (
+      scid BLOB NOT NULL,
+      version SMALLINT NOT NULL,
+      node_key_1 BLOB,
+      node_key_2 BLOB
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS graph_prune_log (
+      block_height BIGINT PRIMARY KEY,
+      block_hash BLOB NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS graph_closed_scids (
+      scid BLOB PRIMARY KEY
+    )
+    """,
+    "ALTER TABLE graph_nodes ADD COLUMN block_height BIGINT",
+    "ALTER TABLE graph_channels ADD COLUMN signature BLOB",
+    "ALTER TABLE graph_channels ADD COLUMN funding_pk_script BLOB",
+    "ALTER TABLE graph_channels ADD COLUMN merkle_root_hash BLOB",
+    "ALTER TABLE graph_channel_policies ADD COLUMN block_height BIGINT",
+    "ALTER TABLE graph_channel_policies ADD COLUMN disable_flags SMALLINT CHECK (disable_flags >= 0 AND disable_flags <= 255)"
+  ]
+
+  // The index set after 000009_graph_v2 has been applied.
+  static let graphIndexDdl = [
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_nodes_unique ON graph_nodes (pub_key, version)",
+    "CREATE INDEX IF NOT EXISTS graph_node_last_update_idx ON graph_nodes(version, last_update, pub_key)",
+    "CREATE INDEX IF NOT EXISTS graph_node_block_height_idx ON graph_nodes (version, block_height, pub_key)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_node_extra_types_unique ON graph_node_extra_types (type, node_id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_node_features_unique ON graph_node_features (node_id, feature_bit)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_node_addresses_unique ON graph_node_addresses (node_id, type, position)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_source_nodes_unique ON graph_source_nodes (node_id)",
+    "CREATE INDEX IF NOT EXISTS graph_channels_node_id_1_idx ON graph_channels(node_id_1, version)",
+    "CREATE INDEX IF NOT EXISTS graph_channels_node_id_2_idx ON graph_channels(node_id_2, version)",
+    "CREATE INDEX IF NOT EXISTS graph_channels_version_id_idx ON graph_channels(version, id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_channels_unique ON graph_channels(version, scid DESC)",
+    "CREATE INDEX IF NOT EXISTS graph_channels_version_outpoint_idx ON graph_channels(version, outpoint)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_channel_features_unique ON graph_channel_features (channel_id, feature_bit)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_channel_extra_types_unique ON graph_channel_extra_types (type, channel_id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_channel_policies_unique ON graph_channel_policies (channel_id, node_id, version)",
+    "CREATE INDEX IF NOT EXISTS graph_channel_policy_last_update_idx ON graph_channel_policies(last_update)",
+    "CREATE INDEX IF NOT EXISTS graph_channel_policy_block_height_idx ON graph_channel_policies (version, block_height)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_channel_policy_extra_types_unique ON graph_channel_policy_extra_types (type, channel_policy_id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS graph_zombie_channels_channel_id_version_idx ON graph_zombie_channels(scid, version)"
+  ]
+
+  private func graphDbScalar(_ db: OpaquePointer?, _ sql: String) -> Int64? {
+    var stmt: OpaquePointer?
+    guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
+    defer { sqlite3_finalize(stmt) }
+    guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
+    return sqlite3_column_int64(stmt, 0)
+  }
+
+  private func graphDbExec(_ db: OpaquePointer?, _ sql: String) -> String? {
+    var errMsg: UnsafeMutablePointer<CChar>?
+    if sqlite3_exec(db, sql, nil, nil, &errMsg) != SQLITE_OK {
+      let error = errMsg != nil ? String(cString: errMsg!) : "Unknown SQLite error"
+      sqlite3_free(errMsg)
+      return error
+    }
+    return nil
+  }
+
+  private func graphDbExecTransaction(_ db: OpaquePointer?, _ statements: [String]) -> String? {
+    if let error = graphDbExec(db, "BEGIN IMMEDIATE") {
+      return error
+    }
+    for sql in statements {
+      if let error = graphDbExec(db, sql) {
+        _ = graphDbExec(db, "ROLLBACK")
+        return error
+      }
+    }
+    return graphDbExec(db, "COMMIT")
+  }
+
+  @objc(repairGraphDb:network:resolver:rejecter:)
+  func repairGraphDb(lndDir: String, network: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+    graphDbMaintenance(lndDir: lndDir, network: network, resetData: false, resolver: resolve, rejecter: reject)
+  }
+
+  @objc(resetGraphDb:network:resolver:rejecter:)
+  func resetGraphDb(lndDir: String, network: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+    graphDbMaintenance(lndDir: lndDir, network: network, resetData: true, resolver: resolve, rejecter: reject)
+  }
+
+  private func graphDbMaintenance(lndDir: String, network: String, resetData: Bool, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
     let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
     let folderName = lndDir.isEmpty ? "lnd" : lndDir
     let networkName = network.isEmpty ? "mainnet" : network
@@ -296,7 +520,7 @@ class LndMobileTools: RCTEventEmitter {
     let dbPath = graphPath.appendingPathComponent("lnd.sqlite").path
 
     guard FileManager.default.fileExists(atPath: dbPath) else {
-      resolve(true)
+      resolve("noop")
       return
     }
 
@@ -307,51 +531,101 @@ class LndMobileTools: RCTEventEmitter {
     }
     defer { sqlite3_close(db) }
 
-    let sql = """
-      DROP INDEX IF EXISTS graph_nodes_unique;
-      DROP INDEX IF EXISTS graph_node_extra_types_unique;
-      DROP INDEX IF EXISTS graph_node_features_unique;
-      DROP INDEX IF EXISTS graph_node_addresses_unique;
-      DROP INDEX IF EXISTS graph_node_last_update_idx;
-      DROP INDEX IF EXISTS graph_source_nodes_unique;
-      DROP INDEX IF EXISTS graph_channels_node_id_1_idx;
-      DROP INDEX IF EXISTS graph_channels_node_id_2_idx;
-      DROP INDEX IF EXISTS graph_channels_unique;
-      DROP INDEX IF EXISTS graph_channels_version_outpoint_idx;
-      DROP INDEX IF EXISTS graph_channels_version_id_idx;
-      DROP INDEX IF EXISTS graph_channel_features_unique;
-      DROP INDEX IF EXISTS graph_channel_extra_types_unique;
-      DROP INDEX IF EXISTS graph_channel_policies_unique;
-      DROP INDEX IF EXISTS graph_channel_policy_extra_types_unique;
-      DROP INDEX IF EXISTS graph_channel_policy_last_update_idx;
-      DROP INDEX IF EXISTS graph_zombie_channels_channel_id_version_idx;
-      DROP TABLE IF EXISTS graph_channel_policy_extra_types;
-      DROP TABLE IF EXISTS graph_channel_policies;
-      DROP TABLE IF EXISTS graph_channel_features;
-      DROP TABLE IF EXISTS graph_channel_extra_types;
-      DROP TABLE IF EXISTS graph_channels;
-      DROP TABLE IF EXISTS graph_source_nodes;
-      DROP TABLE IF EXISTS graph_node_addresses;
-      DROP TABLE IF EXISTS graph_node_features;
-      DROP TABLE IF EXISTS graph_node_extra_types;
-      DROP TABLE IF EXISTS graph_nodes;
-      DROP TABLE IF EXISTS graph_zombie_channels;
-      DROP TABLE IF EXISTS graph_prune_log;
-      DROP TABLE IF EXISTS graph_closed_scids;
-      DELETE FROM migration_tracker WHERE version IN (9, 10);
-      DELETE FROM schema_migrations;
-      INSERT INTO schema_migrations (version, dirty) VALUES (7, 0);
-    """
-
-    var errMsg: UnsafeMutablePointer<CChar>?
-    if sqlite3_exec(db, sql, nil, nil, &errMsg) != SQLITE_OK {
-      let error = errMsg != nil ? String(cString: errMsg!) : "Unknown SQLite error"
-      sqlite3_free(errMsg)
-      reject("error", error, nil)
+    guard let trackerExists = graphDbScalar(db,
+      "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='migration_tracker'") else {
+      reject("error", "Failed to inspect lnd.sqlite", nil)
+      return
+    }
+    if trackerExists == 0 {
+      // Pre-native-SQL database; the graph does not live here.
+      resolve("noop")
       return
     }
 
-    resolve(true)
+    guard let dbVersion = graphDbScalar(db,
+      "SELECT COALESCE(MAX(version), 0) FROM migration_tracker") else {
+      reject("error", "Failed to read migration_tracker", nil)
+      return
+    }
+
+    var presentTables = Set<String>()
+    var stmt: OpaquePointer?
+    guard sqlite3_prepare_v2(db,
+      "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'graph!_%' ESCAPE '!'",
+      -1, &stmt, nil) == SQLITE_OK else {
+      reject("error", "Failed to inspect lnd.sqlite", nil)
+      return
+    }
+    while sqlite3_step(stmt) == SQLITE_ROW {
+      if let name = sqlite3_column_text(stmt, 0) {
+        presentTables.insert(String(cString: name))
+      }
+    }
+    sqlite3_finalize(stmt)
+
+    let missingTables = LndMobileTools.graphTablesChildFirst.filter { !presentTables.contains($0) }
+    let unknownTables = presentTables.subtracting(LndMobileTools.graphTablesChildFirst)
+
+    if missingTables.isEmpty {
+      let knownSchema = dbVersion <= LndMobileTools.graphKnownMaxDbVersion && unknownTables.isEmpty
+      if !resetData && !knownSchema {
+        resolve("ok")
+        return
+      }
+      if resetData && !unknownTables.isEmpty {
+        reject("error", "Refusing to reset graph db: unrecognized graph tables " +
+          unknownTables.sorted().joined(separator: ", ") +
+          ". Update the graph schema definitions to match the lnd fork.", nil)
+        return
+      }
+      var statements: [String] = []
+      if resetData {
+        statements += LndMobileTools.graphTablesChildFirst.map { "DELETE FROM \($0)" }
+      }
+      if knownSchema {
+        // Restore any indexes a partially-run legacy reset dropped;
+        // no-ops on healthy databases.
+        statements += LndMobileTools.graphIndexDdl
+      }
+      if let error = graphDbExecTransaction(db, statements) {
+        reject("error", error, nil)
+        return
+      }
+      resolve(resetData ? "reset" : "ok")
+      return
+    }
+
+    // Some graph tables are missing.
+    if dbVersion < LndMobileTools.graphV2MigrationVersion {
+      // The graph migrations have not run yet; LND will create the schema
+      // itself on next start.
+      resolve("noop")
+      return
+    }
+    if dbVersion > LndMobileTools.graphKnownMaxDbVersion || !unknownTables.isEmpty {
+      reject("error", "Graph db is missing tables " + missingTables.joined(separator: ", ") +
+        " but its schema (version \(dbVersion)) is not recognized by this build; refusing to repair.", nil)
+      return
+    }
+
+    // migration_tracker says the graph schema exists but the tables are
+    // gone: this wallet was damaged by the pre-v13.2.1 reset. Rebuild the
+    // schema exactly as migrations 000008_graph + 000009_graph_v2 define
+    // it and restore the bookkeeping the legacy reset removed.
+    var statements = LndMobileTools.graphTablesChildFirst.map { "DROP TABLE IF EXISTS \($0)" }
+    statements += LndMobileTools.graphTableDdl
+    statements += LndMobileTools.graphIndexDdl
+    statements += [
+      "INSERT OR IGNORE INTO migration_tracker (version, migration_time) VALUES (9, CURRENT_TIMESTAMP)",
+      "INSERT OR IGNORE INTO migration_tracker (version, migration_time) VALUES (10, CURRENT_TIMESTAMP)",
+      "DELETE FROM schema_migrations",
+      "INSERT INTO schema_migrations (version, dirty) VALUES (\(LndMobileTools.graphKnownSchemaVersion), 0)"
+    ]
+    if let error = graphDbExecTransaction(db, statements) {
+      reject("error", error, nil)
+      return
+    }
+    resolve("repaired")
   }
 
   @objc(checkApplicationSupportExists:rejecter:)

--- a/lndmobile/LndMobile.d.ts
+++ b/lndmobile/LndMobile.d.ts
@@ -114,7 +114,8 @@ export interface ILndMobileTools {
     saveChannelsBackup(base64Backups: string): Promise<string>;
     saveChannelBackupFile(network: string): Promise<boolean>;
     DEBUG_getWalletPasswordFromKeychain(): Promise<string>;
-    DEBUG_resetGraphDb(lndDir: string, network: string): Promise<boolean>;
+    repairGraphDb(lndDir: string, network: string): Promise<string>;
+    resetGraphDb(lndDir: string, network: string): Promise<string>;
     DEBUG_deleteSpeedloaderLastrunFile(): Promise<boolean>;
     DEBUG_deleteSpeedloaderDgraphDirectory(): Promise<null>;
     deleteLndDirectory(lndDir: string): Promise<null>;

--- a/utils/LndMobileUtils.ts
+++ b/utils/LndMobileUtils.ts
@@ -340,8 +340,9 @@ export async function deleteLndWallet(lndDir: string): Promise<boolean> {
     }
 }
 
-export async function expressGraphSync() {
+export async function expressGraphSync(): Promise<{ resetFailed: boolean }> {
     return await new Promise(async (resolve) => {
+        let resetFailed = false;
         syncStore.setExpressGraphSyncStatus(true);
         const start = new Date();
 
@@ -350,7 +351,7 @@ export async function expressGraphSync() {
             console.log('Express graph sync cancelling...');
             cancelGossipSync();
             console.log('Express graph sync cancelled...');
-            resolve(true);
+            resolve({ resetFailed });
         });
 
         if (settingsStore?.settings?.resetExpressGraphSyncOnStartup) {
@@ -370,11 +371,17 @@ export async function expressGraphSync() {
                         settingsStore?.embeddedLndNetwork === 'Mainnet'
                             ? 'mainnet'
                             : 'testnet';
-                    await NativeModules.LndMobileTools.DEBUG_resetGraphDb(
-                        lndDir,
-                        network
-                    );
+                    const status =
+                        await NativeModules.LndMobileTools.resetGraphDb(
+                            lndDir,
+                            network
+                        );
+                    log.d(`Graph database reset: ${status}`);
                 } catch (error) {
+                    // The reset runs in a single transaction, so a failure
+                    // leaves the database untouched. Report it so the reset
+                    // flag is kept and retried on the next startup.
+                    resetFailed = true;
                     log.e('Graph database reset failed', [error]);
                 }
             }
@@ -394,11 +401,11 @@ export async function expressGraphSync() {
                 (new Date().getTime() - start.getTime()) / 1000 + 's';
             console.log('gossipStatus', `${gossipStatus} - ${completionTime}`);
             syncStore.setExpressGraphSyncStatus(false);
-            resolve(true);
+            resolve({ resetFailed });
         } catch (e) {
             log.e('GossipSync exception!', [e]);
             syncStore.setExpressGraphSyncStatus(false);
-            resolve(true);
+            resolve({ resetFailed });
         }
     });
 }
@@ -418,6 +425,23 @@ export async function initializeLnd({
 }) {
     const { initialize } = lndMobile.index;
     await writeLndConfig({ lndDir, isTestnet, rescan, compactDb, isSqlite });
+
+    if (isSqlite) {
+        // Repair graph databases damaged by the pre-v13.2.1 EGS reset
+        // (issue #4524) before anything opens lnd.sqlite.
+        try {
+            const status = await NativeModules.LndMobileTools.repairGraphDb(
+                lndDir,
+                isTestnet ? 'testnet' : 'mainnet'
+            );
+            if (status === 'repaired') {
+                log.i('Repaired damaged graph database');
+            }
+        } catch (error) {
+            log.e('Graph database repair failed', [error]);
+        }
+    }
+
     await initialize();
 }
 

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -876,7 +876,7 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                                 '[Performance] Express Graph Sync starting...'
                             );
 
-                            await expressGraphSync();
+                            const { resetFailed } = await expressGraphSync();
 
                             const expressGraphSyncDuration =
                                 new Date().getTime() - expressGraphSyncStart;
@@ -884,7 +884,12 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                                 `[Performance] Express Graph Sync completed in ${expressGraphSyncDuration}ms`
                             );
 
-                            if (settings.resetExpressGraphSyncOnStartup) {
+                            // Keep the reset flag if the graph reset failed
+                            // so it is retried on the next startup
+                            if (
+                                settings.resetExpressGraphSyncOnStartup &&
+                                !resetFailed
+                            ) {
                                 await updateSettings({
                                     resetExpressGraphSyncOnStartup: false
                                 });


### PR DESCRIPTION
# Description

Relates to issue: **#4524**

Implements the ZEUS-side fixes from @ziggie1984's root-cause analysis in #4524. The Express Graph Sync reset for native-SQL wallets dropped LND's graph tables, deleted `migration_tracker` rows 9/10, and rewound `schema_migrations` to 7. LND derives its database version from the single highest `migration_tracker` row, so with rows 11-18 still present the graph migrations were skipped forever and every subsequent start failed with `no such table: graph_source_nodes`. Restarting could never recover.

## What changed

**Reset is now non-destructive and atomic.** `DEBUG_resetGraphDb` is replaced by `resetGraphDb`, which empties the 13 graph tables with `DELETE`s (children first) inside a single transaction. `migration_tracker` and `schema_migrations` are treated as LND-owned internals and are never touched. Since a fully-migrated empty graph schema is exactly the state of a fresh wallet, LND re-creates its source node on start and EGS repopulates the graph.

**Bricked wallets are repaired automatically.** A new `repairGraphDb` runs on every embedded-LND sqlite startup, before EGS or `startLnd` open `lnd.sqlite`. If `migration_tracker` says the graph schema should exist (version >= 11) but the tables are missing, it transactionally rebuilds the schema exactly as the fork's `000008_graph` + `000009_graph_v2` migrations define it, restores tracker rows 9/10, and sets `schema_migrations` to the true schema version (15). Affected wallets, including the reporter's, recover on first launch of the patched build without a seed restore.

**Fail closed on unknown schemas.** Both operations refuse to act if `migration_tracker` reports a version above 18 or if unrecognized `graph_*` tables exist, so a future fork bump can never be silently corrupted; the embedded DDL must be re-reviewed against the fork's migrations when the pin moves (noted in code comments).

**Reset flag semantics.** The reset flag is now only cleared after a successful reset, so failures are retried on the next startup instead of being silently dropped. The pre-existing interrupted-reset hazard (index drops without table drops) is also healed: the reset path re-creates any missing indexes via `CREATE INDEX IF NOT EXISTS`.

## Verification

Simulation against the real fork migrations (sqlite fixture built by executing `000001`-`000015` from `v0.21.2-beta-zeus`, tracker rows 1-18, then applying the exact v13.2.0 reset statements to reproduce the bricked state):

- repair rebuilds a schema **identical** to the real-migration schema: columns, foreign keys, index definitions, normalized SQL text, tracker rows, and `schema_migrations` all match
- reset empties all graph tables and leaves schema + trackers byte-identical
- reset heals an interrupted legacy reset (indexes dropped, tables intact) back to the exact index set
- the Java and Swift SQL statement lists are verified equal

Tested on iOS and Android devices.

Not covered here (follow-ups from ziggie's writeup): moving reset/repair into lndmobile behind an LND-fork API, the speedloader's `ApplyAllMigrations`/`MigrateGraphToSQL` split, and upstream migration-tracker continuity validation.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A (native SQL paths; schema equivalence verified by simulation against the fork's real migration files, script in PR discussion)

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

