### PR TITLE
chore: replace deprecated InteractionManager with requestIdleCallback

### DIFF
--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -1,5 +1,5 @@
 import { action, observable, runInAction } from 'mobx';
-import { Alert, InteractionManager } from 'react-native';
+import { Alert } from 'react-native';
 import Bolt11Utils from '../utils/Bolt11Utils';
 import url from 'url';
 import querystring from 'querystring-es3';
@@ -63,6 +63,7 @@ import { localeString } from '../utils/LocaleUtils';
 import MigrationsUtils from '../utils/MigrationUtils';
 import { themeColor, getUpgradeBackgroundColor } from '../utils/ThemeUtils';
 import { RATING_MODAL_TRIGGER_DELAY } from '../utils/RatingUtils';
+import { runWhenIdle } from '../utils/SchedulingUtils';
 
 import NavigationService from '../NavigationService';
 
@@ -3084,9 +3085,14 @@ export default class CashuStore {
         });
     };
 
+    /**
+     * Fire-and-forget sweep of pending invoices and unspent sent tokens.
+     * Deferred to idle time so the mint round trips do not compete with
+     * startup work. Use checkSentTokensSpentStatus when you need to await.
+     */
     @action
     public checkPendingItems = async () => {
-        InteractionManager.runAfterInteractions(async () => {
+        runWhenIdle(async () => {
             // Skip items for mints that are no longer configured: polling
             // them goes through ensureMintAdded, which would re-add a
             // removed mint on the next boot

--- a/typings/idle-callback.d.ts
+++ b/typings/idle-callback.d.ts
@@ -1,0 +1,26 @@
+// React Native installs `requestIdleCallback`/`cancelIdleCallback` as globals
+// (Libraries/Core/setUpTimers.js) but ships no TypeScript declarations for
+// them, and Zeus does not pull in the DOM lib. These mirror the Flow types in
+// react-native/src/private/webapis/idlecallbacks/specs/NativeIdleCallbacks.js.
+//
+// The handle is opaque on purpose: the bridgeless implementation returns a
+// jsi::Object, the legacy JSTimers implementation returns a number. Only ever
+// hand it back to cancelIdleCallback.
+
+declare interface IdleDeadline {
+    didTimeout: boolean;
+    timeRemaining: () => number;
+}
+
+declare interface IdleRequestOptions {
+    timeout?: number;
+}
+
+declare type IdleCallbackHandle = unknown;
+
+declare function requestIdleCallback(
+    callback: (deadline: IdleDeadline) => void,
+    options?: IdleRequestOptions
+): IdleCallbackHandle;
+
+declare function cancelIdleCallback(handle: IdleCallbackHandle): void;

--- a/utils/SchedulingUtils.test.ts
+++ b/utils/SchedulingUtils.test.ts
@@ -1,0 +1,174 @@
+import { runWhenIdle } from './SchedulingUtils';
+
+const globalScope = global as any;
+
+const flushMicrotasks = () =>
+    new Promise<void>((resolve) => setImmediate(resolve));
+
+describe('SchedulingUtils', () => {
+    const originalRequestIdleCallback = globalScope.requestIdleCallback;
+    const originalCancelIdleCallback = globalScope.cancelIdleCallback;
+
+    afterEach(() => {
+        globalScope.requestIdleCallback = originalRequestIdleCallback;
+        globalScope.cancelIdleCallback = originalCancelIdleCallback;
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+    });
+
+    describe('runWhenIdle with an idle scheduler', () => {
+        it('defers the task to the idle queue', () => {
+            const requestIdle = jest.fn();
+            globalScope.requestIdleCallback = requestIdle;
+            const task = jest.fn();
+
+            runWhenIdle(task, 500);
+
+            expect(task).not.toHaveBeenCalled();
+            expect(requestIdle).toHaveBeenCalledTimes(1);
+
+            requestIdle.mock.calls[0][0]();
+
+            expect(task).toHaveBeenCalledTimes(1);
+        });
+
+        it('passes the caller timeout as a backstop', () => {
+            const requestIdle = jest.fn();
+            globalScope.requestIdleCallback = requestIdle;
+
+            runWhenIdle(jest.fn(), 500);
+
+            expect(requestIdle.mock.calls[0][1]).toEqual({ timeout: 500 });
+        });
+
+        it('applies a default timeout when none is given', () => {
+            const requestIdle = jest.fn();
+            globalScope.requestIdleCallback = requestIdle;
+
+            runWhenIdle(jest.fn());
+
+            expect(requestIdle.mock.calls[0][1]).toEqual({ timeout: 2000 });
+        });
+
+        it('cancels a pending task and hands the handle back', () => {
+            const handle = { nativeHandle: true };
+            const requestIdle = jest.fn().mockReturnValue(handle);
+            const cancelIdle = jest.fn();
+            globalScope.requestIdleCallback = requestIdle;
+            globalScope.cancelIdleCallback = cancelIdle;
+            const task = jest.fn();
+
+            const cancel = runWhenIdle(task);
+            cancel();
+
+            expect(cancelIdle).toHaveBeenCalledWith(handle);
+
+            // Belt and braces: a callback that fires anyway must not run the
+            // task, since cancellation is not guaranteed to be synchronous.
+            requestIdle.mock.calls[0][0]();
+
+            expect(task).not.toHaveBeenCalled();
+        });
+
+        it('is a no-op when cancelled after the task has run', () => {
+            const requestIdle = jest.fn().mockReturnValue({});
+            const cancelIdle = jest.fn();
+            globalScope.requestIdleCallback = requestIdle;
+            globalScope.cancelIdleCallback = cancelIdle;
+            const task = jest.fn();
+
+            const cancel = runWhenIdle(task);
+            requestIdle.mock.calls[0][0]();
+            cancel();
+
+            expect(task).toHaveBeenCalledTimes(1);
+            expect(cancelIdle).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('runWhenIdle without an idle scheduler', () => {
+        it('falls back to a timer when requestIdleCallback is missing', () => {
+            jest.useFakeTimers();
+            delete globalScope.requestIdleCallback;
+            const task = jest.fn();
+
+            runWhenIdle(task);
+
+            expect(task).not.toHaveBeenCalled();
+
+            jest.runAllTimers();
+
+            expect(task).toHaveBeenCalledTimes(1);
+        });
+
+        it('falls back to a timer when requestIdleCallback throws', () => {
+            jest.useFakeTimers();
+            globalScope.requestIdleCallback = jest.fn(() => {
+                throw new Error(
+                    'requestIdleCallback is not supported in legacy runtime scheduler'
+                );
+            });
+            const task = jest.fn();
+
+            runWhenIdle(task);
+            jest.runAllTimers();
+
+            expect(task).toHaveBeenCalledTimes(1);
+        });
+
+        it('cancels a pending timer', () => {
+            jest.useFakeTimers();
+            delete globalScope.requestIdleCallback;
+            const task = jest.fn();
+
+            runWhenIdle(task)();
+            jest.runAllTimers();
+
+            expect(task).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('runWhenIdle error handling', () => {
+        it('logs a rejected task instead of leaving it unhandled', async () => {
+            const consoleError = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+            const requestIdle = jest.fn();
+            globalScope.requestIdleCallback = requestIdle;
+            const error = new Error('sweep failed');
+
+            runWhenIdle(async () => {
+                throw error;
+            });
+            requestIdle.mock.calls[0][0]();
+            await flushMicrotasks();
+
+            expect(consoleError).toHaveBeenCalledWith(
+                'runWhenIdle: deferred task failed:',
+                error
+            );
+        });
+
+        it('logs a task that throws synchronously', async () => {
+            const consoleError = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+            const requestIdle = jest.fn();
+            globalScope.requestIdleCallback = requestIdle;
+            const error = new Error('boom');
+
+            runWhenIdle(() => {
+                throw error;
+            });
+
+            expect(() => requestIdle.mock.calls[0][0]()).not.toThrow();
+
+            await flushMicrotasks();
+
+            expect(consoleError).toHaveBeenCalledWith(
+                'runWhenIdle: deferred task failed:',
+                error
+            );
+        });
+    });
+});

--- a/utils/SchedulingUtils.test.ts
+++ b/utils/SchedulingUtils.test.ts
@@ -163,6 +163,27 @@ describe('SchedulingUtils', () => {
             );
         });
 
+        it('awaits a promise returned by a non-async task', async () => {
+            // Call sites hand back the promise of a store call rather than
+            // dropping it, so the rejection is logged here instead of
+            // surfacing as an unhandled rejection.
+            const consoleError = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => {});
+            const requestIdle = jest.fn();
+            globalScope.requestIdleCallback = requestIdle;
+            const error = new Error('melt failed');
+
+            runWhenIdle(() => Promise.reject(error));
+            requestIdle.mock.calls[0][0]();
+            await flushMicrotasks();
+
+            expect(consoleError).toHaveBeenCalledWith(
+                'runWhenIdle: deferred task failed:',
+                error
+            );
+        });
+
         it('logs a task that throws synchronously', async () => {
             const consoleError = jest
                 .spyOn(console, 'error')

--- a/utils/SchedulingUtils.test.ts
+++ b/utils/SchedulingUtils.test.ts
@@ -116,6 +116,20 @@ describe('SchedulingUtils', () => {
             expect(task).toHaveBeenCalledTimes(1);
         });
 
+        it('does not hold the task back for the caller timeout', () => {
+            // The timeout is a deadline for the idle scheduler, not a delay.
+            // With no scheduler to wait on, the fallback runs on the next
+            // macrotask rather than at the deadline.
+            jest.useFakeTimers();
+            delete globalScope.requestIdleCallback;
+            const task = jest.fn();
+
+            runWhenIdle(task, 5000);
+            jest.advanceTimersByTime(0);
+
+            expect(task).toHaveBeenCalledTimes(1);
+        });
+
         it('cancels a pending timer', () => {
             jest.useFakeTimers();
             delete globalScope.requestIdleCallback;

--- a/utils/SchedulingUtils.test.ts
+++ b/utils/SchedulingUtils.test.ts
@@ -32,7 +32,8 @@ describe('SchedulingUtils', () => {
             expect(task).toHaveBeenCalledTimes(1);
         });
 
-        it('passes the caller timeout as a backstop', () => {
+        it('passes the caller timeout on to the idle scheduler', () => {
+            jest.useFakeTimers();
             const requestIdle = jest.fn();
             globalScope.requestIdleCallback = requestIdle;
 
@@ -42,12 +43,64 @@ describe('SchedulingUtils', () => {
         });
 
         it('applies a default timeout when none is given', () => {
+            jest.useFakeTimers();
             const requestIdle = jest.fn();
             globalScope.requestIdleCallback = requestIdle;
 
             runWhenIdle(jest.fn());
 
-            expect(requestIdle.mock.calls[0][1]).toEqual({ timeout: 2000 });
+            expect(requestIdle.mock.calls[0][1]).toEqual({ timeout: 10000 });
+        });
+
+        it('runs the task at the deadline when idle time never comes', () => {
+            // React Native drops the `timeout` option, so the deadline has to
+            // be held by a timer of ours. Without it a busy queue can hold an
+            // idle task back well past the caller's deadline.
+            jest.useFakeTimers();
+            globalScope.requestIdleCallback = jest.fn();
+            const task = jest.fn();
+
+            runWhenIdle(task, 500);
+
+            jest.advanceTimersByTime(499);
+            expect(task).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(1);
+            expect(task).toHaveBeenCalledTimes(1);
+        });
+
+        it('runs the task once when the deadline passes after idle time', () => {
+            jest.useFakeTimers();
+            const requestIdle = jest.fn().mockReturnValue({});
+            const cancelIdle = jest.fn();
+            globalScope.requestIdleCallback = requestIdle;
+            globalScope.cancelIdleCallback = cancelIdle;
+            const task = jest.fn();
+
+            runWhenIdle(task, 500);
+            requestIdle.mock.calls[0][0]();
+            jest.runAllTimers();
+
+            expect(task).toHaveBeenCalledTimes(1);
+        });
+
+        it('drops the idle callback once the deadline has fired', () => {
+            const handle = { nativeHandle: true };
+            jest.useFakeTimers();
+            const requestIdle = jest.fn().mockReturnValue(handle);
+            const cancelIdle = jest.fn();
+            globalScope.requestIdleCallback = requestIdle;
+            globalScope.cancelIdleCallback = cancelIdle;
+            const task = jest.fn();
+
+            runWhenIdle(task, 500);
+            jest.advanceTimersByTime(500);
+
+            expect(cancelIdle).toHaveBeenCalledWith(handle);
+
+            requestIdle.mock.calls[0][0]();
+
+            expect(task).toHaveBeenCalledTimes(1);
         });
 
         it('cancels a pending task and hands the handle back', () => {
@@ -128,6 +181,29 @@ describe('SchedulingUtils', () => {
             jest.advanceTimersByTime(0);
 
             expect(task).toHaveBeenCalledTimes(1);
+        });
+
+        it('falls back to a timer when reading the global throws', () => {
+            // React Native installs the global as a lazy getter over
+            // TurboModuleRegistry.getEnforcing, so a missing native module
+            // throws on the property read rather than on the call.
+            jest.useFakeTimers();
+            Object.defineProperty(globalScope, 'requestIdleCallback', {
+                configurable: true,
+                get() {
+                    throw new Error(
+                        "TurboModuleRegistry.getEnforcing(...): 'NativeIdleCallbacksCxx' could not be found"
+                    );
+                }
+            });
+            const task = jest.fn();
+
+            expect(() => runWhenIdle(task)).not.toThrow();
+            jest.runAllTimers();
+
+            expect(task).toHaveBeenCalledTimes(1);
+
+            delete globalScope.requestIdleCallback;
         });
 
         it('cancels a pending timer', () => {

--- a/utils/SchedulingUtils.ts
+++ b/utils/SchedulingUtils.ts
@@ -26,6 +26,12 @@ const runTask = async (task: () => void | Promise<void>) => {
 /**
  * Run `task` once the JS thread goes idle, or after `timeoutMs` at the latest.
  *
+ * `timeoutMs` is a deadline, not a delay. It is handed to
+ * `requestIdleCallback` as its `timeout` option, so it only bounds how long
+ * the idle scheduler may hold the task back. It has no effect on the fallback
+ * path, where there is no idle scheduler to wait on and the task runs on the
+ * next macrotask, well inside the deadline.
+ *
  * Returns a cancel function. Call it (from `componentWillUnmount`, say) to
  * drop a task that has not run yet; calling it afterwards is a no-op.
  */
@@ -61,7 +67,9 @@ export const runWhenIdle = (
 
     // No idle scheduler (Jest, legacy runtime). A macrotask at least gets the
     // work off the current call stack, which is all the deprecated
-    // `runAfterInteractions` stub did anyway.
+    // `runAfterInteractions` stub did anyway. Not `timeoutMs`: that is the
+    // latest the task may run, and with nothing to wait for there is no
+    // reason to hold it back.
     const timeoutId = setTimeout(run, 0);
     return () => {
         if (settled) return;

--- a/utils/SchedulingUtils.ts
+++ b/utils/SchedulingUtils.ts
@@ -13,9 +13,15 @@
 // first, short enough that a deferred sweep is not put off indefinitely.
 const DEFAULT_IDLE_TIMEOUT_MS = 2000;
 
+// A task may resolve to anything: the value is ignored, but the promise is
+// awaited so a rejection lands in the catch below. Typing this as
+// `Promise<void>` would reject the common `() => store.doSomething()` shape
+// and push callers into dropping the promise instead.
+type IdleTask = () => void | PromiseLike<unknown>;
+
 // Never rejects: nothing observes the result of an idle callback, so a
 // rejected task would otherwise surface as an unhandled rejection.
-const runTask = async (task: () => void | Promise<void>) => {
+const runTask = async (task: IdleTask) => {
     try {
         await task();
     } catch (error) {
@@ -34,9 +40,12 @@ const runTask = async (task: () => void | Promise<void>) => {
  *
  * Returns a cancel function. Call it (from `componentWillUnmount`, say) to
  * drop a task that has not run yet; calling it afterwards is a no-op.
+ *
+ * Return the promise from an async `task` rather than dropping it, so a
+ * rejection is logged here instead of surfacing as an unhandled rejection.
  */
 export const runWhenIdle = (
-    task: () => void | Promise<void>,
+    task: IdleTask,
     timeoutMs: number = DEFAULT_IDLE_TIMEOUT_MS
 ): (() => void) => {
     // Guards both directions: a cancel after the task ran, and a callback

--- a/utils/SchedulingUtils.ts
+++ b/utils/SchedulingUtils.ts
@@ -5,13 +5,23 @@
  * is now a stub that resolves on the next `setImmediate` tick, so it no longer
  * waits for animations or gestures to settle. `requestIdleCallback` is the
  * supported replacement: it runs the task when the JS runtime has spare time
- * in a frame, and it takes a timeout so the task still runs on a thread that
- * never goes idle.
+ * in a frame.
+ *
+ * Its `timeout` option is not a working backstop, so we keep our own timer
+ * alongside it. In `NativeIdleCallbacks::requestIdleCallback` the local
+ * `timeout` is declared and never assigned: `options.timeout` only feeds
+ * `expirationTime`, which sets the `didTimeout` flag we ignore. Every idle
+ * task is therefore scheduled with the default idle expiration of 5 minutes.
+ * Nothing fires a task when its expiration passes either: expiration is only
+ * the task queue's sort key, so a busy queue can hold an idle task back for
+ * as long as higher priority work keeps sorting ahead of it. Verified in
+ * 0.86.0, still present in 0.87.1.
  */
 
-// Backstop for background work. Long enough to let a busy startup finish
-// first, short enough that a deferred sweep is not put off indefinitely.
-const DEFAULT_IDLE_TIMEOUT_MS = 2000;
+// Backstop for background work. Long enough that a busy startup gets to
+// finish first rather than having a sweep dropped on top of it, short enough
+// that the work is not put off indefinitely.
+const DEFAULT_IDLE_TIMEOUT_MS = 10000;
 
 // A task may resolve to anything: the value is ignored, but the promise is
 // awaited so a rejection lands in the catch below. Typing this as
@@ -32,11 +42,12 @@ const runTask = async (task: IdleTask) => {
 /**
  * Run `task` once the JS thread goes idle, or after `timeoutMs` at the latest.
  *
- * `timeoutMs` is a deadline, not a delay. It is handed to
- * `requestIdleCallback` as its `timeout` option, so it only bounds how long
- * the idle scheduler may hold the task back. It has no effect on the fallback
- * path, where there is no idle scheduler to wait on and the task runs on the
- * next macrotask, well inside the deadline.
+ * `timeoutMs` is a deadline, not a delay: a thread with spare time runs the
+ * task well before it. The deadline is held by a timer of ours, not by
+ * `requestIdleCallback`, whose `timeout` option React Native drops (see the
+ * note at the top of this file). It has no effect on the fallback path, where
+ * there is no idle scheduler to wait on and the task runs on the next
+ * macrotask, well inside the deadline.
  *
  * Returns a cancel function. Call it (from `componentWillUnmount`, say) to
  * drop a task that has not run yet; calling it afterwards is a no-op.
@@ -51,27 +62,66 @@ export const runWhenIdle = (
     // Guards both directions: a cancel after the task ran, and a callback
     // that fires anyway after a cancel.
     let settled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    // Opaque `IdleCallbackHandle` (see typings/idle-callback.d.ts), so its
+    // presence is tracked separately rather than by testing it for undefined.
+    let idleHandle: unknown;
+    let hasIdleHandle = false;
+
+    // Whichever of the two fires first drops the other.
+    const clearPending = () => {
+        if (timeoutId !== undefined) {
+            clearTimeout(timeoutId);
+            timeoutId = undefined;
+        }
+        if (hasIdleHandle) {
+            hasIdleHandle = false;
+            if (typeof cancelIdleCallback === 'function') {
+                cancelIdleCallback(idleHandle);
+            }
+        }
+    };
+
     const run = () => {
         if (settled) return;
         settled = true;
+        clearPending();
         runTask(task);
     };
 
-    if (typeof requestIdleCallback === 'function') {
-        try {
-            const handle = requestIdleCallback(run, { timeout: timeoutMs });
-            return () => {
-                if (settled) return;
-                settled = true;
-                if (typeof cancelIdleCallback === 'function') {
-                    cancelIdleCallback(handle);
-                }
-            };
-        } catch {
-            // The legacy runtime scheduler throws 'requestIdleCallback is not
-            // supported in legacy runtime scheduler'. Fall through to the
-            // timer below rather than dropping the task on the floor.
+    const runFromIdle = () => {
+        // The scheduler is already running this callback, so the handle is
+        // spent and there is nothing left to cancel.
+        hasIdleHandle = false;
+        run();
+    };
+
+    const cancel = () => {
+        if (settled) return;
+        settled = true;
+        clearPending();
+    };
+
+    try {
+        // The feature detect is inside the try on purpose. React Native
+        // installs these globals as lazy getters over
+        // `TurboModuleRegistry.getEnforcing`, so a missing native module
+        // throws on the property read itself, not on the call.
+        if (typeof requestIdleCallback === 'function') {
+            // Still passed for correctness, and so this becomes a priority
+            // hint if React Native ever wires the option up. The timer below
+            // is what actually bounds the wait.
+            idleHandle = requestIdleCallback(runFromIdle, {
+                timeout: timeoutMs
+            });
+            hasIdleHandle = true;
+            timeoutId = setTimeout(run, timeoutMs);
+            return cancel;
         }
+    } catch {
+        // The legacy runtime scheduler throws 'requestIdleCallback is not
+        // supported in legacy runtime scheduler'. Fall through to the
+        // timer below rather than dropping the task on the floor.
     }
 
     // No idle scheduler (Jest, legacy runtime). A macrotask at least gets the
@@ -79,10 +129,6 @@ export const runWhenIdle = (
     // `runAfterInteractions` stub did anyway. Not `timeoutMs`: that is the
     // latest the task may run, and with nothing to wait for there is no
     // reason to hold it back.
-    const timeoutId = setTimeout(run, 0);
-    return () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timeoutId);
-    };
+    timeoutId = setTimeout(run, 0);
+    return cancel;
 };

--- a/utils/SchedulingUtils.ts
+++ b/utils/SchedulingUtils.ts
@@ -1,0 +1,71 @@
+/**
+ * Helpers for deferring work that should not compete with rendering.
+ *
+ * React Native 0.86 deprecated `InteractionManager`. Its `runAfterInteractions`
+ * is now a stub that resolves on the next `setImmediate` tick, so it no longer
+ * waits for animations or gestures to settle. `requestIdleCallback` is the
+ * supported replacement: it runs the task when the JS runtime has spare time
+ * in a frame, and it takes a timeout so the task still runs on a thread that
+ * never goes idle.
+ */
+
+// Backstop for background work. Long enough to let a busy startup finish
+// first, short enough that a deferred sweep is not put off indefinitely.
+const DEFAULT_IDLE_TIMEOUT_MS = 2000;
+
+// Never rejects: nothing observes the result of an idle callback, so a
+// rejected task would otherwise surface as an unhandled rejection.
+const runTask = async (task: () => void | Promise<void>) => {
+    try {
+        await task();
+    } catch (error) {
+        console.error('runWhenIdle: deferred task failed:', error);
+    }
+};
+
+/**
+ * Run `task` once the JS thread goes idle, or after `timeoutMs` at the latest.
+ *
+ * Returns a cancel function. Call it (from `componentWillUnmount`, say) to
+ * drop a task that has not run yet; calling it afterwards is a no-op.
+ */
+export const runWhenIdle = (
+    task: () => void | Promise<void>,
+    timeoutMs: number = DEFAULT_IDLE_TIMEOUT_MS
+): (() => void) => {
+    // Guards both directions: a cancel after the task ran, and a callback
+    // that fires anyway after a cancel.
+    let settled = false;
+    const run = () => {
+        if (settled) return;
+        settled = true;
+        runTask(task);
+    };
+
+    if (typeof requestIdleCallback === 'function') {
+        try {
+            const handle = requestIdleCallback(run, { timeout: timeoutMs });
+            return () => {
+                if (settled) return;
+                settled = true;
+                if (typeof cancelIdleCallback === 'function') {
+                    cancelIdleCallback(handle);
+                }
+            };
+        } catch {
+            // The legacy runtime scheduler throws 'requestIdleCallback is not
+            // supported in legacy runtime scheduler'. Fall through to the
+            // timer below rather than dropping the task on the floor.
+        }
+    }
+
+    // No idle scheduler (Jest, legacy runtime). A macrotask at least gets the
+    // work off the current call stack, which is all the deprecated
+    // `runAfterInteractions` stub did anyway.
+    const timeoutId = setTimeout(run, 0);
+    return () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+    };
+};

--- a/views/Cashu/CashuSendingLightning.tsx
+++ b/views/Cashu/CashuSendingLightning.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
     BackHandler,
     Dimensions,
-    InteractionManager,
     NativeEventSubscription,
     Text,
     TouchableOpacity,
@@ -33,6 +32,7 @@ import NodeInfoStore from '../../stores/NodeInfoStore';
 
 import ContactUtils from '../../utils/ContactUtils';
 import { localeString } from '../../utils/LocaleUtils';
+import { runWhenIdle } from '../../utils/SchedulingUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import UrlUtils from '../../utils/UrlUtils';
 
@@ -85,6 +85,8 @@ export default class CashuSendingLightning extends React.Component<
 
     private focusListener: (() => void) | undefined;
 
+    private cancelPaymentKickoff: (() => void) | undefined;
+
     constructor(props: CashuSendingLightningProps) {
         super(props);
         this.state = {
@@ -106,13 +108,17 @@ export default class CashuSendingLightning extends React.Component<
         const { CashuStore, navigation, route } = this.props;
         const { paymentAmount } = route.params || {};
 
-        // Reset payment state and start payment after navigation completes
+        // Reset payment state and start the payment once the JS thread is
+        // free, so the melt does not jank the navigation transition. The
+        // short timeout keeps the wait bounded on a busy thread; the kickoff
+        // is cancelled on unmount so a screen the user has already left never
+        // starts a payment.
         CashuStore.resetPaymentState();
-        InteractionManager.runAfterInteractions(() => {
+        this.cancelPaymentKickoff = runWhenIdle(() => {
             CashuStore.payLnInvoiceFromEcash({
                 amount: paymentAmount
             });
-        });
+        }, 500);
 
         this.focusListener = navigation.addListener('focus', () => {
             const noteKey = CashuStore.noteKey;
@@ -291,6 +297,7 @@ export default class CashuSendingLightning extends React.Component<
     }
 
     componentWillUnmount(): void {
+        this.cancelPaymentKickoff?.();
         if (this.focusListener) {
             this.focusListener();
         }

--- a/views/Cashu/CashuSendingLightning.tsx
+++ b/views/Cashu/CashuSendingLightning.tsx
@@ -114,11 +114,13 @@ export default class CashuSendingLightning extends React.Component<
         // is cancelled on unmount so a screen the user has already left never
         // starts a payment.
         CashuStore.resetPaymentState();
-        this.cancelPaymentKickoff = runWhenIdle(() => {
-            CashuStore.payLnInvoiceFromEcash({
-                amount: paymentAmount
-            });
-        }, 500);
+        this.cancelPaymentKickoff = runWhenIdle(
+            () =>
+                CashuStore.payLnInvoiceFromEcash({
+                    amount: paymentAmount
+                }),
+            500
+        );
 
         this.focusListener = navigation.addListener('focus', () => {
             const noteKey = CashuStore.noteKey;

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -14,8 +14,7 @@ import {
     TouchableOpacity,
     View,
     Alert,
-    AlertButton,
-    InteractionManager
+    AlertButton
 } from 'react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import {
@@ -988,11 +987,15 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
                     const batterySaverEnabled = await isBatterySaverEnabled();
                     if (batterySaverEnabled) {
                         if (Platform.OS === 'ios') {
-                            InteractionManager.runAfterInteractions(() => {
-                                setTimeout(() => {
-                                    this.showBatterySaverModal();
-                                }, 500);
-                            });
+                            // The delay is what actually lets the navigation
+                            // transition settle before the modal appears. The
+                            // InteractionManager wrapper this replaces added
+                            // nothing beyond a microtask in RN 0.86, where
+                            // runAfterInteractions no longer waits for
+                            // interactions at all.
+                            setTimeout(() => {
+                                this.showBatterySaverModal();
+                            }, 500);
                         } else {
                             this.showBatterySaverModal();
                         }


### PR DESCRIPTION
# Description

Relates to issue: **#4196**

`InteractionManager` is deprecated in React Native 0.86 and logs a warning the moment it is imported. Worth knowing before reading the diff: in 0.86 `InteractionManager` is no longer an implementation at all, it is a stub whose `runAfterInteractions` just calls `setImmediate` (`Libraries/Interaction/InteractionManager.js`), which under bridgeless is `queueMicrotask`. So all three call sites had already silently lost the wait-for-animations behaviour they were written for when the RN bump landed. This restores real deferral where it was wanted and removes the wrapper where it was not.

### New: `utils/SchedulingUtils.runWhenIdle`

A thin wrapper over the global `requestIdleCallback` that:

- holds its own timer alongside the idle callback, so the task still runs on a thread that never goes idle. React Native declares the `timeout` option on `requestIdleCallback` but never forwards it to the scheduler, so the option on its own is not a backstop: see [this thread](https://github.com/ZeusLN/zeus/pull/4533#discussion_r3916159460)
- returns a cancel function, safe to call after the task has run
- logs task failures rather than leaving an unhandled rejection behind (nothing observes the return value of an idle callback)
- falls back to a `setTimeout` macrotask where no idle scheduler exists: Jest, and the legacy runtime scheduler, where `requestIdleCallback` throws `requestIdleCallback is not supported in legacy runtime scheduler`

React Native ships no TypeScript declarations for `requestIdleCallback` and Zeus does not pull in the DOM lib, so `typings/idle-callback.d.ts` mirrors the Flow types from `NativeIdleCallbacks`. The handle is typed opaque on purpose: bridgeless returns a `jsi::Object`, legacy JSTimers returns a number.

### Call sites

**`stores/CashuStore.ts` `checkPendingItems()`** migrated. The pending invoice and unspent token sweep now waits for real idle time instead of a microtask, so its mint round trips no longer compete with startup. Still fire and forget, which the added doc comment now says out loud, pointing at `checkSentTokensSpentStatus` for the awaitable variant.

**`views/Cashu/CashuSendingLightning.tsx`** migrated with a 500 ms backstop. Two things worth reviewing:

- the kickoff is cancelled in `componentWillUnmount`, so a screen the user has already backed out of cannot start a payment. Previously the payment fired in a microtask so there was no window; with idle deferral there is one.
- no blank frame results from the delay: `render()` gates the sending animation on `!paymentSuccess && !paymentError`, not on `loading`, so `SendingLoadingView` is up from first paint either way.

**`views/Wallet/Wallet.tsx`** wrapper dropped, `setTimeout(..., 500)` kept. The timer is what actually lets the navigation transition settle before the iOS battery saver modal appears; the `InteractionManager` wrapper around it contributed nothing beyond a microtask. Behaviour is unchanged here by design, per the "keep a short timeout and note the rationale" option in the issue.

No source file imports `InteractionManager` any more, and no dependency imports React Native's `InteractionManager` on native (`react-native-gesture-handler` has a class by the same name, but it is its own web only implementation), so the deprecation warning should be gone.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

`utils/SchedulingUtils.test.ts`, 10 cases: idle scheduling, timeout backstop and default, cancellation in both directions, both fallback paths, and error handling for sync throws and rejected promises.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

Both platforms are green across the full [test plan](https://github.com/ZeusLN/zeus/pull/4533#issuecomment-5481825789): deprecation warning gone on a full bundle reload and confirmed still present on `master` as a baseline, repeated ecash Lightning payments all kicking off with no blank frame, failure path and fast back-out both clean, Cashu pending invoice and spent token sweeps still settling, and the embedded LND battery saver modal appearing unchanged under battery saver / Low Power Mode.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [x] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

Settled in review: the `timeout` option is dropped by React Native, so as originally written neither number affected scheduling at all. `runWhenIdle` now keeps its own timer as the deadline. The payment kickoff stays at 500 ms; the background sweep default moved from 2000 ms to 10 s, since a timer that really does fire would otherwise drop the mint round trips onto a startup that is still busy, which is what deferring them was for. Both are still judgement calls rather than measurements, happy to tune either.


