### PR TITLE
fix(nwc): return RATE_LIMITED instead of UNAUTHORIZED during connection updates

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1776,7 +1776,7 @@
     "stores.NostrWalletConnectStore.error.failedToStartService": "Failed to start service",
     "stores.NostrWalletConnectStore.error.connectionNameExists": "Connection name already exists",
     "stores.NostrWalletConnectStore.error.connectionNotFound": "Connection not found",
-    "stores.NostrWalletConnectStore.error.connectionUpdating": "Connection is being updated, please try again",
+    "stores.NostrWalletConnectStore.error.connectionUpdating": "Connection is being updated. Please try again.",
     "stores.NostrWalletConnectStore.error.paymentQueueWaitExceeded": "Another payment was in progress and this request waited too long; it was not executed. Please try again.",
     "stores.NostrWalletConnectStore.error.makeInvoiceRateLimited": "Too many invoice requests from this connection. Please wait before trying again.",
     "stores.NostrWalletConnectStore.error.failedToConnectRelay": "Failed to Connect {{relayUrl}}",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1776,6 +1776,7 @@
     "stores.NostrWalletConnectStore.error.failedToStartService": "Failed to start service",
     "stores.NostrWalletConnectStore.error.connectionNameExists": "Connection name already exists",
     "stores.NostrWalletConnectStore.error.connectionNotFound": "Connection not found",
+    "stores.NostrWalletConnectStore.error.connectionUpdating": "Connection is being updated, please try again",
     "stores.NostrWalletConnectStore.error.paymentQueueWaitExceeded": "Another payment was in progress and this request waited too long; it was not executed. Please try again.",
     "stores.NostrWalletConnectStore.error.makeInvoiceRateLimited": "Too many invoice requests from this connection. Please wait before trying again.",
     "stores.NostrWalletConnectStore.error.failedToConnectRelay": "Failed to Connect {{relayUrl}}",

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1306,7 +1306,10 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
                 error: undefined
             })
         );
-        expect(lateResponse.error?.code).toBe('UNAUTHORIZED');
+        expect(lateResponse.error).toEqual({
+            code: 'INTERNAL_ERROR',
+            message: 'stores.NostrWalletConnectStore.error.connectionUpdating'
+        });
 
         releaseHandler({ result: { ok: true } });
         await handlerDone;
@@ -1314,6 +1317,35 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
 
         expect(updated).toBe(true);
         expect(connection.maxAmountSats).toBe(0);
+    });
+
+    it('returns an internal error when an update starts while marking a connection used', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+        const handler = jest.fn();
+
+        jest.spyOn(store as any, 'markConnectionUsed').mockImplementation(
+            async () => {
+                (store as any).pendingConnectionMutations.set(
+                    connection.id,
+                    'update'
+                );
+                return true;
+            }
+        );
+
+        const response = await (store as any).withGlobalHandler(
+            connection.id,
+            handler
+        );
+
+        expect(response.error).toEqual({
+            code: 'INTERNAL_ERROR',
+            message: 'stores.NostrWalletConnectStore.error.connectionUpdating'
+        });
+        expect(handler).not.toHaveBeenCalled();
     });
 
     it('defers relay release when updateConnection awaited in-flight handlers', async () => {

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -278,6 +278,54 @@ describe('NostrWalletConnectStore relay rotation', () => {
         ).toBe('delete');
     });
 
+    it('does not downgrade a pre-existing delete marker when an update starts', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store);
+        (store as any).pendingConnectionMutations.set(connection.id, 'delete');
+
+        let markerDuringUpdate: string | undefined;
+        jest.spyOn(store as any, 'subscribeToConnection').mockImplementation(
+            async () => {
+                markerDuringUpdate = (
+                    store as any
+                ).pendingConnectionMutations.get(connection.id);
+            }
+        );
+
+        await store.updateConnection(connection.id, {
+            name: 'Renamed App'
+        });
+
+        expect(markerDuringUpdate).toBe('delete');
+        expect(
+            (store as any).pendingConnectionMutations.get(connection.id)
+        ).toBe('delete');
+    });
+
+    it('does not downgrade a pre-existing rotate marker when a second update starts', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store);
+        (store as any).pendingConnectionMutations.set(connection.id, 'rotate');
+
+        let markerDuringUpdate: string | undefined;
+        jest.spyOn(store as any, 'subscribeToConnection').mockImplementation(
+            async () => {
+                markerDuringUpdate = (
+                    store as any
+                ).pendingConnectionMutations.get(connection.id);
+            }
+        );
+
+        await store.updateConnection(connection.id, {
+            name: 'Renamed App'
+        });
+
+        expect(markerDuringUpdate).toBe('rotate');
+        expect(
+            (store as any).pendingConnectionMutations.get(connection.id)
+        ).toBe('rotate');
+    });
+
     it('leaves relayUrl unchanged when storing the new key fails so retry can rotate', async () => {
         const store = buildStore();
         const connection = seedConnection(store);
@@ -1235,6 +1283,30 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
         expect(deleted).toBe(true);
         expect(store.connections).toHaveLength(0);
         expect(store.waitingForInFlightHandlers).toBe(false);
+    });
+
+    it('does not clear a marker installed by a concurrent update when delete finishes', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+
+        jest.spyOn(store as any, 'deleteClientKeys').mockImplementation(
+            async () => {
+                // Simulate an update overwriting the marker after this
+                // delete already committed to removing the connection.
+                (store as any).pendingConnectionMutations.set(
+                    connection.id,
+                    'update'
+                );
+            }
+        );
+
+        await store.deleteConnection(connection.id);
+
+        expect(
+            (store as any).pendingConnectionMutations.get(connection.id)
+        ).toBe('update');
     });
 
     it('defers relay release when delete awaited in-flight handlers', async () => {

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -231,6 +231,53 @@ describe('NostrWalletConnectStore relay rotation', () => {
         expect((store as any).publishedRelays.has(OLD_RELAY)).toBe(false);
     });
 
+    it('marks a relay-changing update as rotate, not update, while in flight', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store);
+        let markerDuringMutation: string | undefined;
+        jest.spyOn(store as any, 'subscribeToConnection').mockImplementation(
+            async () => {
+                markerDuringMutation = (
+                    store as any
+                ).pendingConnectionMutations.get(connection.id);
+            }
+        );
+
+        const result = await store.updateConnection(connection.id, {
+            relayUrl: NEW_RELAY
+        });
+
+        expect(result.success).toBe(true);
+        expect(markerDuringMutation).toBe('rotate');
+        expect(
+            (store as any).pendingConnectionMutations.has(connection.id)
+        ).toBe(false);
+    });
+
+    it('does not clear a concurrent delete marker when an update finishes', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store);
+
+        jest.spyOn(store as any, 'subscribeToConnection').mockImplementation(
+            async () => {
+                // Simulate a delete winning the race while this update is
+                // still in its critical section.
+                (store as any).pendingConnectionMutations.set(
+                    connection.id,
+                    'delete'
+                );
+            }
+        );
+
+        await store.updateConnection(connection.id, {
+            name: 'Renamed App'
+        });
+
+        expect(
+            (store as any).pendingConnectionMutations.get(connection.id)
+        ).toBe('delete');
+    });
+
     it('leaves relayUrl unchanged when storing the new key fails so retry can rotate', async () => {
         const store = buildStore();
         const connection = seedConnection(store);
@@ -1307,7 +1354,7 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
             })
         );
         expect(lateResponse.error).toEqual({
-            code: 'INTERNAL_ERROR',
+            code: 'RATE_LIMITED',
             message: 'stores.NostrWalletConnectStore.error.connectionUpdating'
         });
 
@@ -1319,7 +1366,7 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
         expect(connection.maxAmountSats).toBe(0);
     });
 
-    it('returns an internal error when an update starts while marking a connection used', async () => {
+    it('returns a rate-limit error when an update starts while marking a connection used', async () => {
         const store = buildStore();
         const connection = seedConnection(store, {
             expiresAt: new Date(Date.now() + 60_000)
@@ -1342,8 +1389,66 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
         );
 
         expect(response.error).toEqual({
-            code: 'INTERNAL_ERROR',
+            code: 'RATE_LIMITED',
             message: 'stores.NostrWalletConnectStore.error.connectionUpdating'
+        });
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('returns UNAUTHORIZED when a delete starts while marking a connection used', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+        const handler = jest.fn();
+
+        jest.spyOn(store as any, 'markConnectionUsed').mockImplementation(
+            async () => {
+                (store as any).pendingConnectionMutations.set(
+                    connection.id,
+                    'delete'
+                );
+                return true;
+            }
+        );
+
+        const response = await (store as any).withGlobalHandler(
+            connection.id,
+            handler
+        );
+
+        expect(response.error).toEqual({
+            code: 'UNAUTHORIZED',
+            message: 'stores.NostrWalletConnectStore.error.connectionNotFound'
+        });
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('returns UNAUTHORIZED when a relay rotation starts while marking a connection used', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+        const handler = jest.fn();
+
+        jest.spyOn(store as any, 'markConnectionUsed').mockImplementation(
+            async () => {
+                (store as any).pendingConnectionMutations.set(
+                    connection.id,
+                    'rotate'
+                );
+                return true;
+            }
+        );
+
+        const response = await (store as any).withGlobalHandler(
+            connection.id,
+            handler
+        );
+
+        expect(response.error).toEqual({
+            code: 'UNAUTHORIZED',
+            message: 'stores.NostrWalletConnectStore.error.connectionNotFound'
         });
         expect(handler).not.toHaveBeenCalled();
     });

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -110,6 +110,8 @@ export const DEFAULT_NOSTR_RELAYS = [
 
 type AppStateSubscription = ReturnType<typeof AppState.addEventListener>;
 
+type PendingConnectionMutation = 'delete' | 'update' | 'rotate';
+
 interface ClientKeys {
     [pubkey: string]: string;
 }
@@ -187,7 +189,10 @@ export default class NostrWalletConnectStore {
         number
     >();
     private makeInvoiceTimestampsByConnection = new Map<string, number[]>();
-    private pendingConnectionMutations = new Map<string, 'delete' | 'update'>();
+    private pendingConnectionMutations = new Map<
+        string,
+        PendingConnectionMutation
+    >();
     private inFlightHandlersByConnection = new Map<
         string,
         Set<Promise<unknown>>
@@ -701,7 +706,16 @@ export default class NostrWalletConnectStore {
                 }
                 await this.saveConnections();
             } finally {
-                this.pendingConnectionMutations.delete(connectionId);
+                // Only clear our own marker: an update/rotate that started
+                // while this delete was in flight leaves 'delete' in place
+                // (see updateConnection) and must not have it cleared out
+                // from under it by whichever finally runs second.
+                if (
+                    this.pendingConnectionMutations.get(connectionId) ===
+                    'delete'
+                ) {
+                    this.pendingConnectionMutations.delete(connectionId);
+                }
             }
         } catch (error: any) {
             runInAction(() => {
@@ -781,7 +795,24 @@ export default class NostrWalletConnectStore {
                   }
                 | undefined;
 
-            this.pendingConnectionMutations.set(connectionId, 'update');
+            // A relay change rotates the client pubkey (see below) and
+            // permanently invalidates the old pairing once it commits, so it
+            // is marked 'rotate' and treated like a delete by withGlobalHandler
+            // rather than the retryable 'update' signal.
+            const ownMutationKind: PendingConnectionMutation = relayUrlChanged
+                ? 'rotate'
+                : 'update';
+            // Never downgrade a concurrent delete: if this connection is
+            // already being deleted, leave that marker in place so requests
+            // keep seeing the (correct) revocation signal.
+            if (
+                this.pendingConnectionMutations.get(connectionId) !== 'delete'
+            ) {
+                this.pendingConnectionMutations.set(
+                    connectionId,
+                    ownMutationKind
+                );
+            }
             try {
                 const hadActiveSubscription =
                     this.activeSubscriptions.has(connectionId);
@@ -897,7 +928,15 @@ export default class NostrWalletConnectStore {
                 await this.subscribeToConnection(connection);
                 return { success: true };
             } finally {
-                this.pendingConnectionMutations.delete(connectionId);
+                // Only clear our own marker: if a concurrent delete
+                // superseded it (see above), leave that marker for
+                // deleteConnection's own finally to clear.
+                if (
+                    this.pendingConnectionMutations.get(connectionId) ===
+                    ownMutationKind
+                ) {
+                    this.pendingConnectionMutations.delete(connectionId);
+                }
             }
         } catch (error: any) {
             console.error('Failed to update NWC connection:', error);
@@ -1723,6 +1762,26 @@ export default class NostrWalletConnectStore {
         ) as T;
     }
 
+    // 'delete' and 'rotate' are true revocations (the pairing is ending, or
+    // has just been rebound to a new pubkey) so they get UNAUTHORIZED.
+    // 'update' is a short, retryable critical section so it gets RATE_LIMITED
+    // rather than a signal some clients read as permanent revocation.
+    private mutationRejection<T>(connectionId: string): T | undefined {
+        const mutation = this.pendingConnectionMutations.get(connectionId);
+        if (mutation === 'delete' || mutation === 'rotate') {
+            return this.unauthorizedConnectionResponse<T>();
+        }
+        if (mutation === 'update') {
+            return NostrConnectUtils.createNip47Error(
+                localeString(
+                    'stores.NostrWalletConnectStore.error.connectionUpdating'
+                ),
+                Nip47ErrorCode.RATE_LIMITED
+            ) as T;
+        }
+        return undefined;
+    }
+
     /**
      * Runs every subscribed NWC request through one gate: reject (and drop
      * the subscription) when the connection is missing or has expired.
@@ -1752,17 +1811,9 @@ export default class NostrWalletConnectStore {
                 this.unsubscribeFromConnection(connectionId);
                 return this.unauthorizedConnectionResponse<T>();
             }
-            const mutation = this.pendingConnectionMutations.get(connectionId);
-            if (mutation === 'delete') {
-                return this.unauthorizedConnectionResponse<T>();
-            }
-            if (mutation === 'update') {
-                return NostrConnectUtils.createNip47Error(
-                    localeString(
-                        'stores.NostrWalletConnectStore.error.connectionUpdating'
-                    ),
-                    Nip47ErrorCode.INTERNAL_ERROR
-                ) as T;
+            const mutationRejection = this.mutationRejection<T>(connectionId);
+            if (mutationRejection !== undefined) {
+                return mutationRejection;
             }
             if (connection.isExpired) {
                 this.unsubscribeFromConnection(connectionId);
@@ -1777,18 +1828,10 @@ export default class NostrWalletConnectStore {
             if (!marked) {
                 return this.unauthorizedConnectionResponse<T>();
             }
-            const mutationAfterMark =
-                this.pendingConnectionMutations.get(connectionId);
-            if (mutationAfterMark === 'delete') {
-                return this.unauthorizedConnectionResponse<T>();
-            }
-            if (mutationAfterMark === 'update') {
-                return NostrConnectUtils.createNip47Error(
-                    localeString(
-                        'stores.NostrWalletConnectStore.error.connectionUpdating'
-                    ),
-                    Nip47ErrorCode.INTERNAL_ERROR
-                ) as T;
+            const mutationRejectionAfterMark =
+                this.mutationRejection<T>(connectionId);
+            if (mutationRejectionAfterMark !== undefined) {
+                return mutationRejectionAfterMark;
             }
             return await handler();
         } finally {

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -802,11 +802,15 @@ export default class NostrWalletConnectStore {
             const ownMutationKind: PendingConnectionMutation = relayUrlChanged
                 ? 'rotate'
                 : 'update';
-            // Never downgrade a concurrent delete: if this connection is
-            // already being deleted, leave that marker in place so requests
-            // keep seeing the (correct) revocation signal.
+            // Never downgrade a concurrent delete or rotate: if this
+            // connection already has one of those revocation markers set,
+            // leave it in place so requests keep seeing the (correct)
+            // revocation signal instead of being demoted to retryable.
+            const existingMutation =
+                this.pendingConnectionMutations.get(connectionId);
             if (
-                this.pendingConnectionMutations.get(connectionId) !== 'delete'
+                existingMutation !== 'delete' &&
+                existingMutation !== 'rotate'
             ) {
                 this.pendingConnectionMutations.set(
                     connectionId,

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -187,7 +187,7 @@ export default class NostrWalletConnectStore {
         number
     >();
     private makeInvoiceTimestampsByConnection = new Map<string, number[]>();
-    private pendingConnectionMutationIds = new Set<string>();
+    private pendingConnectionMutations = new Map<string, 'delete' | 'update'>();
     private inFlightHandlersByConnection = new Map<
         string,
         Set<Promise<unknown>>
@@ -655,7 +655,7 @@ export default class NostrWalletConnectStore {
                     )
                 );
             }
-            this.pendingConnectionMutationIds.add(connectionId);
+            this.pendingConnectionMutations.set(connectionId, 'delete');
             try {
                 const relayUrl = connection.relayUrl;
                 const hadActiveSubscription =
@@ -701,7 +701,7 @@ export default class NostrWalletConnectStore {
                 }
                 await this.saveConnections();
             } finally {
-                this.pendingConnectionMutationIds.delete(connectionId);
+                this.pendingConnectionMutations.delete(connectionId);
             }
         } catch (error: any) {
             runInAction(() => {
@@ -781,7 +781,7 @@ export default class NostrWalletConnectStore {
                   }
                 | undefined;
 
-            this.pendingConnectionMutationIds.add(connectionId);
+            this.pendingConnectionMutations.set(connectionId, 'update');
             try {
                 const hadActiveSubscription =
                     this.activeSubscriptions.has(connectionId);
@@ -897,7 +897,7 @@ export default class NostrWalletConnectStore {
                 await this.subscribeToConnection(connection);
                 return { success: true };
             } finally {
-                this.pendingConnectionMutationIds.delete(connectionId);
+                this.pendingConnectionMutations.delete(connectionId);
             }
         } catch (error: any) {
             console.error('Failed to update NWC connection:', error);
@@ -1752,8 +1752,17 @@ export default class NostrWalletConnectStore {
                 this.unsubscribeFromConnection(connectionId);
                 return this.unauthorizedConnectionResponse<T>();
             }
-            if (this.pendingConnectionMutationIds.has(connectionId)) {
+            const mutation = this.pendingConnectionMutations.get(connectionId);
+            if (mutation === 'delete') {
                 return this.unauthorizedConnectionResponse<T>();
+            }
+            if (mutation === 'update') {
+                return NostrConnectUtils.createNip47Error(
+                    localeString(
+                        'stores.NostrWalletConnectStore.error.connectionUpdating'
+                    ),
+                    Nip47ErrorCode.INTERNAL_ERROR
+                ) as T;
             }
             if (connection.isExpired) {
                 this.unsubscribeFromConnection(connectionId);
@@ -1765,11 +1774,21 @@ export default class NostrWalletConnectStore {
                 ) as T;
             }
             const marked = await this.markConnectionUsed(connectionId);
-            if (
-                !marked ||
-                this.pendingConnectionMutationIds.has(connectionId)
-            ) {
+            if (!marked) {
                 return this.unauthorizedConnectionResponse<T>();
+            }
+            const mutationAfterMark =
+                this.pendingConnectionMutations.get(connectionId);
+            if (mutationAfterMark === 'delete') {
+                return this.unauthorizedConnectionResponse<T>();
+            }
+            if (mutationAfterMark === 'update') {
+                return NostrConnectUtils.createNip47Error(
+                    localeString(
+                        'stores.NostrWalletConnectStore.error.connectionUpdating'
+                    ),
+                    Nip47ErrorCode.INTERNAL_ERROR
+                ) as T;
             }
             return await handler();
         } finally {


### PR DESCRIPTION
# Description

Fixes #4503

### Problem
`withGlobalHandler` rejected every NWC request while a connection was in `pendingConnectionMutationIds` with `UNAUTHORIZED` + "connection not found".

- For **delete** this is correct (the pairing is ending).
- For **update** (budget, permissions, name, expiry) it is only a short critical section. Many NWC clients treat `UNAUTHORIZED` as permanent revocation and drop the connection.

### Changes
- Track mutation kind (`'delete' | 'update' | 'rotate'`) instead of a plain set
- Keep returning `UNAUTHORIZED` for in-progress **deletes** and **relay rotations** (true revocation)
- Return `RATE_LIMITED` with a clear temporary message for in-progress **updates** (clients treat this as retryable, not as pairing revocation)
- Never downgrade a concurrent delete marker to `update`
- Only clear a mutation’s own marker in its `finally` block (prevents one mutation from unguarding another)
- Apply the same distinction both before and after `markConnectionUsed`
- Extract shared rejection logic into `mutationRejection()`

The race guard introduced in #4500 is preserved; only the error signal for the update window changes.

### Notes
- Relay change rotates the client pubkey and permanently invalidates the old pairing, so it is intentionally treated like a delete (`UNAUTHORIZED`).
- `RATE_LIMITED` matches existing precedent in this store (`paymentQueueWaitExceeded`, `makeInvoiceRateLimited`) and carries explicit retry semantics.

---

### Test plan

- [x] Start an NWC connection, then edit budget/permissions while a client is actively requesting (`get_info` / `get_balance` / `pay_invoice`)
- [x] Confirm the client receives `RATE_LIMITED` (not `UNAUTHORIZED`) and does **not** drop the pairing
- [x] Delete a connection while a request is in flight → still receives `UNAUTHORIZED`
- [x] Change relay / regenerate → still receives `UNAUTHORIZED` for the old pairing
- [x] Concurrent delete + update does not downgrade the delete marker
- [x] `yarn verify` (tsc / eslint / prettier) passes
- [x] Store unit tests pass

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
