### PR TITLE
chore(deps): bump js-lnurl to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "hash.js": "1.1.7",
     "humanize-duration": "3.34.0",
     "identicon.js": "2.3.3",
-    "js-lnurl": "0.5.1",
+    "js-lnurl": "0.6.0",
     "js-sha256": "0.12.0",
     "lodash": "4.18.1",
     "long": "5.3.2",

--- a/utils/LnurlHelpers.test.ts
+++ b/utils/LnurlHelpers.test.ts
@@ -1,0 +1,106 @@
+import { getParams } from 'js-lnurl';
+import {
+    decipherAES,
+    decodelnurl,
+    findlnurl,
+    getDomain
+} from 'js-lnurl/lib/helpers';
+
+// js-lnurl 0.6.0 stopped re-exporting the helpers from the package root, so
+// `import { findlnurl } from 'js-lnurl'` resolves fine but hands back
+// undefined at runtime. handleAnything and LnurlPay/Success both depend on
+// these helpers, so pin the import surface we actually rely on.
+describe('js-lnurl import surface', () => {
+    it('exposes getParams from the package root', () => {
+        expect(typeof getParams).toBe('function');
+    });
+
+    it('exposes the helpers from js-lnurl/lib/helpers', () => {
+        expect(typeof findlnurl).toBe('function');
+        expect(typeof decodelnurl).toBe('function');
+        expect(typeof decipherAES).toBe('function');
+        expect(typeof getDomain).toBe('function');
+    });
+
+    it('does not expose the helpers from the package root', () => {
+        // guards against a future version silently re-adding them, which would
+        // make the subpath imports above look optional again
+        const root = require('js-lnurl');
+        expect(root.findlnurl).toBeUndefined();
+        expect(root.decodelnurl).toBeUndefined();
+        expect(root.decipherAES).toBeUndefined();
+    });
+});
+
+describe('js-lnurl helpers', () => {
+    // LUD-01 test vector
+    const BECH32_LNURL =
+        'LNURL1DP68GURN8GHJ7UM9WFMXJCM99E3K7MF0V9CXJ0M385EKVCENXC6R2C35XVUKXEFCV5MKVV34X5EKZD3EV56NYD3HXQURZEPEXEJXXEPNXSCRVWFNV9NXZCN9XQ6XYEFHVGCXXCMYXYMNSERXFQ5FNS';
+    const DECODED_URL =
+        'https://service.com/api?q=3fc3645b439ce8e7f2553a69e5267081d96dcd340693afabe04be7b0ccd178df';
+
+    describe('decodelnurl', () => {
+        it('decodes a bech32 lnurl', () => {
+            expect(decodelnurl(BECH32_LNURL)).toBe(DECODED_URL);
+        });
+
+        it('upgrades lnurlp:// to https://', () => {
+            expect(decodelnurl('lnurlp://service.com/api?q=1')).toBe(
+                'https://service.com/api?q=1'
+            );
+        });
+
+        it('keeps .onion hosts on http://', () => {
+            expect(decodelnurl('lnurlw://abcdef.onion/api')).toBe(
+                'http://abcdef.onion/api'
+            );
+        });
+
+        it('throws on input that is not an lnurl', () => {
+            expect(() => decodelnurl('not an lnurl')).toThrow();
+        });
+    });
+
+    describe('findlnurl', () => {
+        it('pulls a lowercased lnurl out of surrounding text', () => {
+            expect(findlnurl(`pay me here: ${BECH32_LNURL} thanks`)).toBe(
+                BECH32_LNURL.toLowerCase()
+            );
+        });
+
+        it('returns null when there is no lnurl', () => {
+            expect(findlnurl('bitcoin:bc1qexample')).toBeNull();
+        });
+    });
+
+    describe('getDomain', () => {
+        it('strips scheme, port, path and query', () => {
+            expect(getDomain('https://service.com:8080/api?q=1')).toBe(
+                'service.com'
+            );
+        });
+    });
+
+    describe('decipherAES', () => {
+        // AES-256-CBC, key = preimage bytes, generated with node crypto
+        const preimage =
+            '3fc3645b439ce8e7f2553a69e5267081d96dcd340693afabe04be7b0ccd178df';
+
+        it('decrypts an aes successAction with the payment preimage', () => {
+            const plaintext = decipherAES(
+                {
+                    tag: 'aes',
+                    iv: 'AAECAwQFBgcICQoLDA0ODw==',
+                    ciphertext:
+                        'JTJgrpQpKVbTh2x7Jy059dX4t3+QS50Fcl9q1QDHD6VXFX6VLPD8G/A1sZDzy36F'
+                } as any,
+                preimage
+            );
+            expect(plaintext).toBe('here is your voucher code: ZEUS-1234');
+        });
+
+        it('returns an empty string for non-aes successActions', () => {
+            expect(decipherAES({ tag: 'message' } as any, preimage)).toBe('');
+        });
+    });
+});

--- a/utils/handleAnything.test.ts
+++ b/utils/handleAnything.test.ts
@@ -106,7 +106,9 @@ jest.mock('react-native-fs', () => ({}));
 const mockGetLnurlParamsFn = jest.fn();
 const mockFindLnurl = jest.fn();
 jest.mock('js-lnurl', () => ({
-    getParams: (...args: any[]) => mockGetLnurlParamsFn(...args),
+    getParams: (...args: any[]) => mockGetLnurlParamsFn(...args)
+}));
+jest.mock('js-lnurl/lib/helpers', () => ({
     findlnurl: (...args: any[]) => mockFindLnurl(...args),
     decodelnurl: () => null
 }));

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -1,5 +1,6 @@
 import { Alert } from 'react-native';
-import { getParams as getlnurlParams, findlnurl, decodelnurl } from 'js-lnurl';
+import { getParams as getlnurlParams } from 'js-lnurl';
+import { findlnurl, decodelnurl } from 'js-lnurl/lib/helpers';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 
 import { nodeInfoStore, invoicesStore, settingsStore } from '../stores/Stores';

--- a/views/LnurlPay/Success.tsx
+++ b/views/LnurlPay/Success.tsx
@@ -9,7 +9,8 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
-import { LNURLPaySuccessAction, decipherAES } from 'js-lnurl';
+import { LNURLPaySuccessAction } from 'js-lnurl';
+import { decipherAES } from 'js-lnurl/lib/helpers';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2795,11 +2795,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
 
-"@types/node@^17.0.0":
-  version "17.0.45"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
-  integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
-
 "@types/object-hash@1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-1.3.4.tgz#079ba142be65833293673254831b5e3e847fe58b"
@@ -6757,14 +6752,13 @@ joi@^17.2.1:
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
-js-lnurl@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/js-lnurl/-/js-lnurl-0.5.1.tgz#d755a2fbefa5dfd2764d65addee64253c60c6108"
-  integrity sha512-nNGiRInXfjw9EnzF/nfzqMCOeT2fqgyzB3iXuPSxktPa3UGV3HRHuhTSUid+G/GwblZj1o9y27gi6sdZTNO+7Q==
+js-lnurl@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/js-lnurl/-/js-lnurl-0.6.0.tgz#eabaabbe4feb4799a647da9601449e49679d4bd0"
+  integrity sha512-U4hnInqlHVM9DyYMnOLk0IqlD293A7GVen8JBNWbXrq7C1IigQpTfoal+Fgz/eTZOsYtIEFEOyW9mKgFD/Oc0w==
   dependencies:
     "@types/aes-js" "^3.1.1"
     "@types/base64-js" "^1.2.5"
-    "@types/node" "^17.0.0"
     aes-js "^3.1.2"
     base64-js "^1.3.1"
     bech32 "^1.1.4"


### PR DESCRIPTION
# Description

Bumps `js-lnurl` from 0.5.1 to 0.6.0, the latest published version. This was the one dependency held back from #4534 because it cannot be bumped without a code change.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## What 0.6.0 changes

0.6.0 is a pure repackaging. A tarball diff against 0.5.1 shows `getParams`, all four helper implementations and `lib/types.d.ts` are byte-identical. The real changes are:

- `helpers.ts` was split into `src/helpers/{decipherAES,decodelnurl,findlnurl,getDomain}.ts`, and `export * from './helpers'` was dropped from `lib/index.js` / `lib/index.d.ts`. The package root now exports **only** `getParams` and the types.
- `randomHex` was deleted (ZEUS never used it).
- The `@types/node ^17` dependency was dropped.
- `sideEffects: false` was added.

## Why it needs a code change

The removed re-export is a silent failure, not a build error. `import { findlnurl } from 'js-lnurl'` still *resolves* after the bump, the binding just comes back `undefined` at runtime:

```
> require('js-lnurl')
{ getParams: [Function] }
> require('js-lnurl').findlnurl
undefined
```

That would have disabled LNURL detection in `utils/handleAnything.ts` (`findlnurl`, `decodelnurl`) and AES successAction decryption in `views/LnurlPay/Success.tsx` (`decipherAES`) with no compile-time signal.

Both now import from `js-lnurl/lib/helpers`, the path the 0.6.0 README documents. The other nine files that import `js-lnurl` only pull types (`LNURLWithdrawParams`, `LNURLPaySuccessAction`), which are unchanged, so they are untouched.

## Verification

- `utils/handleAnything.test.ts` mocked `js-lnurl` wholesale, so it would have passed green even with the broken root imports. Split into a `js-lnurl` mock for `getParams` plus a `js-lnurl/lib/helpers` mock for the helpers.
- Added `utils/LnurlHelpers.test.ts` (12 tests, real module, no mock): asserts the root does *not* export the helpers, that the subpath does, and exercises `decodelnurl` with the LUD-01 vector and `decipherAES` with an AES-256-CBC vector. A future repackaging now fails the suite instead of quietly disabling LNURL.
- `tsc` and Jest do not prove Metro resolves a directory-index subpath, so I built a real Android bundle (`npx react-native bundle --platform android --dev true --entry-file index.js`, exit 0) and confirmed all four `js-lnurl/lib/helpers/*.js` modules plus `index.js` are present in the output.
- The lockfile diff is only the `js-lnurl` entry plus removal of the now-orphaned `@types/node@^17.0.0`. Hoisted `node_modules/@types/node` stays at 22.14.1, unchanged from master, so there is no global type surface drift.
- `js-lnurl` is pure JS with no pod, so `ios/Podfile.lock` is untouched.

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

Full `yarn verify`: 68 suites, 1473 tests passing.

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

**Draft until device tests are done.** The four paths that changed and need exercising on hardware:

1. LNURL-pay, including a payment whose `successAction` is `aes` (that is the `decipherAES` path)
2. LNURL-withdraw
3. An `lnurl1...` bech32 string pasted from the clipboard (the `findlnurl` path in `handleAnything`)
4. An lnurl scanned as a QR code

LNURL handling is backend-agnostic here, so one Android and one iOS pass against a single node should cover it.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [x] Contributors will need to run `yarn` after this PR is merged in
- [x] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms
