### PR TITLE
feat(swaps): add Coinos and SATS Routing providers, retire Eldamar Swaps

### DIFF
--- a/.claude/skills/zeus-config-and-flags/SKILL.md
+++ b/.claude/skills/zeus-config-and-flags/SKILL.md
@@ -216,8 +216,8 @@ Per-network TRIPLETS (mainnet/testnet/mutinynet). The canonical resolver is `get
 
 | Axis | Options | Default |
 |---|---|---|
-| `hostMainnet` | `SWAP_HOST_KEYS_MAINNET`: ZEUS (`https://swaps.zeuslsp.com/api/v2`), Boltz, SwapMarket, Eldamar Swaps, Custom | ZEUS host (`DEFAULT_SWAP_HOST_MAINNET`) |
-| `hostTestnet` | `SWAP_HOST_KEYS_TESTNET`: ZEUS, Boltz, Custom | `https://testnet-swaps.zeuslsp.com/api/v2` |
+| `hostMainnet` | `SWAP_HOST_KEYS_MAINNET`: Boltz, SwapMarket, Coinos, SATS Routing, Custom | `https://api.boltz.exchange/v2` (`DEFAULT_SWAP_HOST_MAINNET`) |
+| `hostTestnet` | `SWAP_HOST_KEYS_TESTNET`: Boltz, Custom | `https://api.testnet.boltz.exchange/v2` |
 | `customHost` | string | `''` |
 | `proEnabled` | bool — unlocks `pro: true` hosts (Boltz mainnet, Custom) | `false` |
 

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -347,8 +347,14 @@ export const SWAP_HOST_KEYS_MAINNET = [
         supportsRescue: true
     },
     {
-        key: 'Eldamar Swaps',
-        value: 'https://boltz-api.eldamar.icu/v2',
+        key: 'Coinos',
+        value: 'https://swap.coinos.io/v2',
+        pro: false,
+        supportsRescue: true
+    },
+    {
+        key: 'SATS Routing',
+        value: 'https://satsrouting.exchange/v2',
         pro: false,
         supportsRescue: true
     },
@@ -1383,6 +1389,9 @@ export const DEFAULT_SWAP_HOST_TESTNET =
 export const LEGACY_ZEUS_SWAP_HOST_MAINNET = 'https://swaps.zeuslsp.com/api/v2';
 export const LEGACY_ZEUS_SWAP_HOST_TESTNET =
     'https://testnet-swaps.zeuslsp.com/api/v2';
+// Swap providers that have shut down; users pinned to one are moved
+// back to the default host by MigrationUtils.migrateRetiredSwapHosts
+export const RETIRED_SWAP_HOSTS_MAINNET = ['https://boltz-api.eldamar.icu/v2'];
 
 export const DEFAULT_NOSTR_RELAYS_2023 = [
     'wss://nostr.mutinywallet.com',
@@ -1941,6 +1950,7 @@ export default class SettingsStore {
                 this.settings = parsedSettings;
                 await MigrationsUtils.migrateRgsDefaultsToV2(parsedSettings);
                 await MigrationsUtils.migrateSwapHostsToBoltz(parsedSettings);
+                await MigrationsUtils.migrateRetiredSwapHosts(parsedSettings);
                 await MigrationsUtils.migrateInvoiceExpiryDisplay(
                     parsedSettings
                 );

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -68,6 +68,7 @@ jest.mock('../stores/SettingsStore', () => ({
     DEFAULT_SWAP_HOST_TESTNET: 'https://api.testnet.boltz.exchange/v2',
     LEGACY_ZEUS_SWAP_HOST_MAINNET: 'https://swaps.zeuslsp.com/api/v2',
     LEGACY_ZEUS_SWAP_HOST_TESTNET: 'https://testnet-swaps.zeuslsp.com/api/v2',
+    RETIRED_SWAP_HOSTS_MAINNET: ['https://boltz-api.eldamar.icu/v2'],
     DEFAULT_NOSTR_RELAYS_2023: [
         'wss://nostr.mutinywallet.com',
         'wss://relay.damus.io',
@@ -442,6 +443,119 @@ describe('MigrationUtils', () => {
 
             expect(settings.swaps.hostMainnet).toBe(
                 'https://swaps.zeuslsp.com/api/v2'
+            );
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('migrateRetiredSwapHosts', () => {
+        const EncryptedStorage = require('react-native-encrypted-storage');
+        const { settingsStore } = require('../stores/Stores');
+
+        beforeEach(() => {
+            EncryptedStorage.getItem.mockReset();
+            EncryptedStorage.setItem.mockReset();
+            settingsStore.setSettings.mockReset();
+        });
+
+        it('moves a shut-down provider back to the default mainnet host', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                swaps: {
+                    hostMainnet: 'https://boltz-api.eldamar.icu/v2',
+                    hostTestnet: 'https://api.testnet.boltz.exchange/v2',
+                    customHost: '',
+                    proEnabled: false
+                }
+            };
+
+            await MigrationUtils.migrateRetiredSwapHosts(settings);
+
+            expect(settings.swaps.hostMainnet).toBe(
+                'https://api.boltz.exchange/v2'
+            );
+            expect(settings.swaps.hostTestnet).toBe(
+                'https://api.testnet.boltz.exchange/v2'
+            );
+            expect(settingsStore.setSettings).toHaveBeenCalledTimes(1);
+            expect(settingsStore.setSettings.mock.calls[0][0]).toBe(settings);
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'swap-hosts-retired-eldamar',
+                'true'
+            );
+        });
+
+        it('leaves a custom host pointed at a retired provider alone', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                swaps: {
+                    hostMainnet: 'Custom',
+                    customHost: 'https://boltz-api.eldamar.icu/v2',
+                    proEnabled: false
+                }
+            };
+
+            await MigrationUtils.migrateRetiredSwapHosts(settings);
+
+            expect(settings.swaps.hostMainnet).toBe('Custom');
+            expect(settings.swaps.customHost).toBe(
+                'https://boltz-api.eldamar.icu/v2'
+            );
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'swap-hosts-retired-eldamar',
+                'true'
+            );
+        });
+
+        it('leaves still-operating providers untouched', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {
+                swaps: {
+                    hostMainnet: 'https://swap.coinos.io/v2',
+                    proEnabled: false
+                }
+            };
+
+            await MigrationUtils.migrateRetiredSwapHosts(settings);
+
+            expect(settings.swaps.hostMainnet).toBe(
+                'https://swap.coinos.io/v2'
+            );
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'swap-hosts-retired-eldamar',
+                'true'
+            );
+        });
+
+        it('only sets the flag when settings have no swaps block', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            const settings: any = {};
+
+            await MigrationUtils.migrateRetiredSwapHosts(settings);
+
+            expect(settings).toEqual({});
+            expect(settingsStore.setSettings).not.toHaveBeenCalled();
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'swap-hosts-retired-eldamar',
+                'true'
+            );
+        });
+
+        it('is a no-op when the migration flag is already set', async () => {
+            EncryptedStorage.getItem.mockResolvedValue('true');
+            const settings: any = {
+                swaps: {
+                    hostMainnet: 'https://boltz-api.eldamar.icu/v2'
+                }
+            };
+
+            await MigrationUtils.migrateRetiredSwapHosts(settings);
+
+            expect(settings.swaps.hostMainnet).toBe(
+                'https://boltz-api.eldamar.icu/v2'
             );
             expect(settingsStore.setSettings).not.toHaveBeenCalled();
             expect(EncryptedStorage.setItem).not.toHaveBeenCalled();

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -26,6 +26,7 @@ import {
     DEFAULT_SWAP_HOST_TESTNET,
     LEGACY_ZEUS_SWAP_HOST_MAINNET,
     LEGACY_ZEUS_SWAP_HOST_TESTNET,
+    RETIRED_SWAP_HOSTS_MAINNET,
     DEFAULT_NOSTR_RELAYS_2023,
     PosEnabled,
     DEFAULT_SLIDE_TO_PAY_THRESHOLD,
@@ -471,6 +472,9 @@ class MigrationsUtils {
         // migrate retired ZEUS swap server hosts to Boltz
         await this.migrateSwapHostsToBoltz(newSettings);
 
+        // move users off swap providers that have shut down
+        await this.migrateRetiredSwapHosts(newSettings);
+
         return newSettings;
     }
 
@@ -612,6 +616,32 @@ class MigrationsUtils {
 
         if (changed) await settingsStore.setSettings(settings);
         await EncryptedStorage.setItem(MOD_KEY_SWAP_HOSTS, 'true');
+        return settings;
+    }
+
+    // Move users pinned to a swap provider that has shut down back to the
+    // default host. Without this their persisted host no longer matches any
+    // entry in SWAP_HOST_KEYS_MAINNET, so the provider dropdown renders no
+    // selection while every swap request goes to a dead endpoint. Custom
+    // hosts are left alone: a retired host is only rewritten when it was
+    // picked from the dropdown, not typed in as a custom host. Must run on
+    // both the legacy and modern (zeus-settings-v2) paths.
+    public async migrateRetiredSwapHosts(settings: any) {
+        const MOD_KEY_RETIRED_SWAP_HOSTS = 'swap-hosts-retired-eldamar';
+        const mod = await EncryptedStorage.getItem(MOD_KEY_RETIRED_SWAP_HOSTS);
+        if (mod) return settings;
+
+        let changed = false;
+        if (
+            settings?.swaps?.hostMainnet &&
+            RETIRED_SWAP_HOSTS_MAINNET.includes(settings.swaps.hostMainnet)
+        ) {
+            settings.swaps.hostMainnet = DEFAULT_SWAP_HOST_MAINNET;
+            changed = true;
+        }
+
+        if (changed) await settingsStore.setSettings(settings);
+        await EncryptedStorage.setItem(MOD_KEY_RETIRED_SWAP_HOSTS, 'true');
         return settings;
     }
 


### PR DESCRIPTION
# Description

Adds [Coinos](https://swap.coinos.io/swap) and [SATS Routing](https://satsrouting.exchange/) to the mainnet swap provider list, and removes Eldamar Swaps, which has shut down.

### Endpoints

The URLs above are the web frontends. Both deployments serve the Boltz v2 API from the same origin under `/v2`, so the hosts are `https://swap.coinos.io/v2` and `https://satsrouting.exchange/v2`. Neither has an `api.` subdomain (those fail to resolve), and Coinos' frontend bundle confirms it: `apiUrl: {normal: 'https://swap.coinos.io', tor: 'https://swap.coinos.io'}`. SATS Routing's is empty, i.e. same origin.

| | API base | Backend | Node | Limits |
|---|---|---|---|---|
| Coinos | `https://swap.coinos.io/v2` | Boltz 3.13.0 | CLN `030dfc53...` | 25k - 600k sats |
| SATS Routing | `https://satsrouting.exchange/v2` | Boltz 3.13.0 | LND `02b06bf3...` | 50k - 5M sats |

Verified live on both hosts, covering every route ZEUS calls:

- `GET /v2/swap/submarine` and `GET /v2/swap/reverse` return a `BTC.BTC` pair, which is what `SwapStore.getSwapFees` reads
- `POST /v2/swap/submarine` and `POST /v2/swap/reverse`
- `GET /v2/swap/{id}`, `GET /v2/swap/submarine/{id}/transaction`, `POST /v2/swap/submarine/{id}/claim`
- `POST /v2/swap/restore` answers with `[]` for an unknown xpub, so both are flagged `supportsRescue: true` and appear in the rescue-key restore picker in Seed Recovery
- `wss://<host>/v2/ws` returns `101 Switching Protocols`, the socket `SwapDetails` opens to track swap status
- `GET /v2/chain/BTC/height` matches mainnet, and both frontend bundles are configured `network: 'mainnet'`. Neither offers testnet, so `SWAP_HOST_KEYS_TESTNET` is unchanged.

Sending `Referral: pro` returns byte-identical pair hashes on both, so neither is marked `pro` and the Pro switch stays hidden for them, same as SwapMarket.

### Eldamar removal

`boltz-api.eldamar.icu` returns 404 on every path including `/v2/version`, and `eldamar.icu` itself returns 502.

Dropping the entry alone would strand anyone currently pinned to it: their persisted `swaps.hostMainnet` would match no entry in `SWAP_HOST_KEYS_MAINNET`, so the provider dropdown would render no selection while every swap request kept going to a dead endpoint. `MigrationUtils.migrateRetiredSwapHosts` moves those users back to `DEFAULT_SWAP_HOST_MAINNET`. It is guarded by MOD_KEY `swap-hosts-retired-eldamar`, runs on both the legacy and modern (`zeus-settings-v2`) settings paths, and leaves custom hosts alone, so an Eldamar URL typed in by hand is preserved rather than silently rewritten.

Swaps already created against Eldamar are unaffected by the roster change: `SwapStore` polls `swap.endpoint || getHost`, so they keep their original host and simply fail to refresh, as they would today.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass


## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

Five new cases for `migrateRetiredSwapHosts`: rewrites a pinned retired host, leaves a hand-typed custom host alone, leaves still-operating providers alone, only sets the flag when there is no `swaps` block, and is a no-op once the MOD_KEY is set.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Opening as a draft: the endpoint probes prove the routes exist and answer, not that a swap settles end to end. Needs a real submarine and reverse swap against each new provider on device before this ships.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

Provider names render from the `key` field verbatim, so no locale strings are added.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

