### PR TITLE
fix(cashu): hide custom amount field for zero-amount invoices

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2356,7 +2356,7 @@
     "stores.CashuStore.errorMintingToken": "Error minting token",
     "stores.CashuStore.insufficientBalance": "Insufficient balance",
     "stores.CashuStore.notEnoughFunds": "Not enough funds to cover payment",
-    "stores.CashuStore.noAmountInvoiceNotSupported": "This invoice has no amount. Cashu payments require a fixed amount invoice.",
+    "stores.CashuStore.noAmountInvoiceNotSupported": "This invoice has no amount, so it can't be paid with ecash. Pay it from a Lightning balance instead, or ask for an invoice with a fixed amount.",
     "stores.CashuStore.notEnoughFundsSelfSend": "Not enough funds to cover payment. {{mintName}} couldn't be used because it's this invoice's destination — pick a different mint to cover the gap.",
     "stores.CashuStore.meltFeeMismatch": "Multi-mint payment failed: {{mintName}} demanded a higher fee at melt time than it quoted ({{provided}} provided, {{needed}} needed). Top up {{mintName}}, pick a different mint, or lower the amount.",
     "stores.CashuStore.noMeltQuoteAvailable": "No melt quote available",

--- a/locales/en.json
+++ b/locales/en.json
@@ -2356,6 +2356,7 @@
     "stores.CashuStore.errorMintingToken": "Error minting token",
     "stores.CashuStore.insufficientBalance": "Insufficient balance",
     "stores.CashuStore.notEnoughFunds": "Not enough funds to cover payment",
+    "stores.CashuStore.noAmountInvoiceNotSupported": "This invoice has no amount. Cashu payments require a fixed amount invoice.",
     "stores.CashuStore.notEnoughFundsSelfSend": "Not enough funds to cover payment. {{mintName}} couldn't be used because it's this invoice's destination — pick a different mint to cover the gap.",
     "stores.CashuStore.meltFeeMismatch": "Multi-mint payment failed: {{mintName}} demanded a higher fee at melt time than it quoted ({{provided}} provided, {{needed}} needed). Top up {{mintName}}, pick a different mint, or lower the amount.",
     "stores.CashuStore.noMeltQuoteAvailable": "No melt quote available",

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -4205,7 +4205,17 @@ export default class CashuStore {
 
             let totalFeeEstimate = 0;
 
-            if (isMultiMint) {
+            if (rawPaymentAmt <= 0) {
+                // Cashu melts (paying a Lightning invoice with ecash) always
+                // require a fixed amount — the mint has no notion of an
+                // amount the payer chooses. Surface this up front instead of
+                // round-tripping to the mint for a melt quote request that
+                // would fail the same way.
+                computedPayReqError = localeString(
+                    'stores.CashuStore.noAmountInvoiceNotSupported'
+                );
+                this.meltQuotes = [];
+            } else if (isMultiMint) {
                 if (paymentAmt > 0) {
                     if (__DEV__) {
                         console.log(

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -4203,14 +4203,17 @@ export default class CashuStore {
             let singleMeltQuote: typeof this.meltQuote;
             let computedPayReqError: string | undefined;
 
-            let totalFeeEstimate = 0;
+            // Left undefined (rather than 0) in the no-amount branch below so
+            // the fee row doesn't render "0 sats" for an invoice that can't
+            // be paid; every branch here assigns it before use.
+            let totalFeeEstimate: number | undefined;
 
             if (rawPaymentAmt <= 0) {
-                // Cashu melts (paying a Lightning invoice with ecash) always
-                // require a fixed amount — the mint has no notion of an
-                // amount the payer chooses. Surface this up front instead of
-                // round-tripping to the mint for a melt quote request that
-                // would fail the same way.
+                // Zeus doesn't yet wire up CDK's amountless-melt option
+                // (MeltOptions.Amountless) from the JS side, so a no-amount
+                // invoice can't be melted here today. Surface that up front
+                // instead of round-tripping to the mint for a melt quote
+                // request that would fail the same way.
                 computedPayReqError = localeString(
                     'stores.CashuStore.noAmountInvoiceNotSupported'
                 );

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -6,6 +6,7 @@ import { nodeInfoStore, invoicesStore, settingsStore } from '../stores/Stores';
 
 import AddressUtils from './AddressUtils';
 import BackendUtils from './BackendUtils';
+import Bolt11Utils from './Bolt11Utils';
 import CashuUtils from './CashuUtils';
 import ConnectionFormatUtils from './ConnectionFormatUtils';
 import ContactUtils from './ContactUtils';
@@ -15,6 +16,7 @@ import NostrUtils from './NostrUtils';
 import { doTorRequest, RequestMethod } from './TorUtils';
 
 import CashuToken from '../models/CashuToken';
+import Invoice from '../models/Invoice';
 
 // Nostr
 import { DEFAULT_NOSTR_RELAYS } from '../stores/SettingsStore';
@@ -23,6 +25,17 @@ import wifUtils from './WIFUtils';
 
 const isClipboardValue = (data: string) =>
     handleAnything(data, undefined, true);
+
+// Cashu melts require a fixed-amount invoice, so a no-amount bolt11 can
+// never be paid via ecash. Used to skip offering that choice at all.
+const isAmountlessInvoice = (bolt11: string): boolean => {
+    try {
+        const invoice = new Invoice(Bolt11Utils.decode(bolt11));
+        return !invoice.getRequestAmount;
+    } catch {
+        return false;
+    }
+};
 
 const attemptNip05Lookup = async (data: string) => {
     try {
@@ -302,7 +315,7 @@ const handleAnything = async (
                     );
                 }
             } else {
-                if (ecash) {
+                if (ecash && !isAmountlessInvoice(lightning)) {
                     return [
                         'ChoosePaymentMethod',
                         {
@@ -357,7 +370,7 @@ const handleAnything = async (
         AddressUtils.isValidLightningPaymentRequest(value || lightning)
     ) {
         if (isClipboardValue) return true;
-        if (ecash) {
+        if (ecash && !isAmountlessInvoice(value || lightning)) {
             return [
                 'ChoosePaymentMethod',
                 {

--- a/views/Cashu/CashuPaymentRequest.tsx
+++ b/views/Cashu/CashuPaymentRequest.tsx
@@ -71,8 +71,6 @@ interface CashuPaymentRequestProps {
 }
 
 interface CashuPaymentRequestState {
-    customAmount: string;
-    satAmount: string | number;
     zaplockerToggle: boolean;
     slideToPayThreshold: number;
     donationsToggle: boolean;
@@ -104,8 +102,6 @@ export default class CashuPaymentRequest extends React.Component<
     swipeResetDisposer: any;
     donationLockRequest?: string;
     state = {
-        customAmount: '',
-        satAmount: '',
         zaplockerToggle: false,
         slideToPayThreshold: 10000,
         donationsToggle: false,
@@ -226,9 +222,7 @@ export default class CashuPaymentRequest extends React.Component<
         }
     }
 
-    sendPayment = ({
-        amount // used only for no-amount invoices
-    }: SendPaymentReq) => {
+    sendPayment = ({ amount }: SendPaymentReq) => {
         const { SettingsStore, navigation } = this.props;
         const { settings } = SettingsStore;
 
@@ -249,7 +243,7 @@ export default class CashuPaymentRequest extends React.Component<
     triggerPayment = () => {
         const { CashuStore, LnurlPayStore, SettingsStore, navigation } =
             this.props;
-        const { satAmount, multiMintEnabled, donationAmount } = this.state;
+        const { multiMintEnabled, donationAmount } = this.state;
 
         // Fail closed: if the invoice in the store no longer matches the one
         // the user reviewed, it was swapped out from under the review screen.
@@ -280,9 +274,7 @@ export default class CashuPaymentRequest extends React.Component<
         }
 
         const requestAmount = CashuStore.payReq?.getRequestAmount;
-        const paymentAmount = satAmount
-            ? satAmount.toString()
-            : requestAmount
+        const paymentAmount = requestAmount
             ? requestAmount.toString()
             : undefined;
 
@@ -431,7 +423,9 @@ export default class CashuPaymentRequest extends React.Component<
             paymentRequest !== this.state.reviewedPaymentRequest;
 
         const enableDonations =
-            Platform.OS !== 'ios' && settings?.payments?.enableDonations;
+            Platform.OS !== 'ios' &&
+            !isNoAmountInvoice &&
+            settings?.payments?.enableDonations;
 
         const showZaplockerWarning =
             isZaplocker ||

--- a/views/Cashu/CashuPaymentRequest.tsx
+++ b/views/Cashu/CashuPaymentRequest.tsx
@@ -14,7 +14,6 @@ import Slider from '@react-native-community/slider';
 import { ButtonGroup } from '@rneui/themed';
 
 import Amount from '../../components/Amount';
-import AmountInput from '../../components/AmountInput';
 import Button from '../../components/Button';
 import EcashMintPicker from '../../components/EcashMintPicker';
 import SwipeButton from '../../components/SwipeButton';
@@ -369,7 +368,6 @@ export default class CashuPaymentRequest extends React.Component<
         const { CashuStore, LnurlPayStore, SettingsStore, navigation } =
             this.props;
         const {
-            customAmount,
             zaplockerToggle,
             slideToPayThreshold,
             donationsToggle,
@@ -627,23 +625,7 @@ export default class CashuPaymentRequest extends React.Component<
                                             />
                                         </View>
                                     )}
-                                    {isNoAmountInvoice ? (
-                                        <AmountInput
-                                            amount={customAmount}
-                                            title={localeString(
-                                                'views.PaymentRequest.customAmt'
-                                            )}
-                                            onAmountChange={(
-                                                amount: string,
-                                                satAmount: string | number
-                                            ) => {
-                                                this.setState({
-                                                    customAmount: amount,
-                                                    satAmount
-                                                });
-                                            }}
-                                        />
-                                    ) : (
+                                    {!isNoAmountInvoice && (
                                         <View style={styles.center}>
                                             <Amount
                                                 sats={requestAmount}
@@ -1093,6 +1075,7 @@ export default class CashuPaymentRequest extends React.Component<
                     !loading &&
                     !loadingFeeEstimate &&
                     !payReqChanged &&
+                    !isNoAmountInvoice &&
                     BackendUtils.supportsLightningSends() && (
                         <View style={{ bottom: 10, top: 6 }}>
                             <View


### PR DESCRIPTION
# Description

Cashu melts require a fixed-amount Lightning invoice — the mint has no way to settle an amount-less one. Two problems followed from that:

1. The Cashu payment-request screen still showed a "Custom Amount" field and an active pay flow for these invoices, leading to a dead end (or a failed payment attempt).
2. Even after fixing that screen, users could still land on it: the payment-method picker offered "pay with ecash" for an amount-less invoice in the first place.

This PR fixes both, addressing the root cause instead of only patching the screen.

### Changes

**Routing (`utils/handleAnything.ts`)**
- Decode a plain bolt11 invoice up front and skip `ChoosePaymentMethod` entirely when it carries no amount — go straight to the normal Lightning `PaymentRequest` screen, exactly as when Cashu is disabled. Ecash is never offered as a choice for an invoice it can't pay.

**Store (`stores/CashuStore.ts`)**
- `getPayReq` still guards the remaining path (a BIP21 URI with multiple destinations, where the picker is shown for reasons unrelated to Cashu): it detects a zero/no-amount invoice early and sets one friendly error (`stores.CashuStore.noAmountInvoiceNotSupported`) instead of round-tripping to the mint for a melt quote that would fail the same way.
- The fee estimate is left `undefined` (not `0`) in that case, so the screen no longer shows a stale "0 sats" fee for an invoice that can't be paid.

**View (`views/Cashu/CashuPaymentRequest.tsx`)**
- Removed the "Custom Amount" input; the screen now shows a single warning (the store error above) instead of a duplicate message.
- Hides the "Sending from" mint picker and pay button when the invoice has no amount.
- Hides the donation section too (it previously rendered `0 + 0 = 0 sats` for an unpayable invoice).
- Removed now-dead `customAmount`/`satAmount` state left over from the removed input.

### Test plan

- [x] Scan/paste a **zero-amount** Lightning invoice with Cashu enabled → skips the picker, goes straight to the normal Lightning `PaymentRequest` screen
- [x] From a BIP21 URI with multiple destinations (address + zero-amount invoice) → picker still shows, but selecting ecash for that invoice surfaces one clear warning, no custom-amount field, no dead pay controls, no stale fee estimate
- [x] Scan a **normal (fixed-amount)** invoice → payment flow completely unaffected, including via the picker
- [x] `yarn verify` (typecheck / lint / prettier) passes

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
