### PR TITLE
Embedded LND: v0.21.3-beta-zeus

### DIFF
--- a/fetch-libraries-versions.json
+++ b/fetch-libraries-versions.json
@@ -1,8 +1,8 @@
 {
     "embedded-lnd": {
-        "version": "v0.21.2-beta-zeus",
-        "androidSha256": "7cb3253ea27ff43746fa4eb2d81e9a35014a822a37fdb1c3831b4e52bd6e269f",
-        "iosSha256": "58320b9a3b6de5a92b25405f02ec4bb8e279c657bbf70817a8439fa7e5560168"
+        "version": "v0.21.3-beta-zeus",
+        "androidSha256": "dd42bcad91e0d48afe61cada7735b3e70d6d5a1f53a9ac3f9099530a6e81bc36",
+        "iosSha256": "f57e485ccdc479437abb6ee1339e8815a1c457030029a82b15bb42b04db95b3a"
     },
     "ldk-node": {
         "version": "v0.7.0-zeus-rl-0.2.5",


### PR DESCRIPTION
# Description

Bumps embedded LND to `v0.21.3-beta-zeus`, rebasing the [ZeusLN/lnd](https://github.com/ZeusLN/lnd) fork's 18 Zeus commits onto upstream [`v0.21.3-beta`](https://github.com/lightningnetwork/lnd/releases/tag/v0.21.3-beta).

Fork branch: [`lnd-v0.21.3-beta-zeus`](https://github.com/ZeusLN/lnd/tree/lnd-v0.21.3-beta-zeus)
Release: [`v0.21.3-beta-zeus`](https://github.com/ZeusLN/lnd/releases/tag/v0.21.3-beta-zeus)

## Notable upstream fixes for embedded users

* [Native SQL invoice migration](https://github.com/lightningnetwork/lnd/pull/11106) now correctly associates legacy AMP invoice HTLCs with their AMP sub-invoices. Previously the HTLC rows were inserted without those associations, so verification failed and the migration transaction rolled back.
* [Lock order inversion](https://github.com/lightningnetwork/lnd/pull/11008) between `PsbtFundingVerify` and `handleFundingCancelRequest` could deadlock the wallet's `requestHandler` goroutine, permanently disabling all channel funding until restart.
* [Stuck incoming dust HTLC](https://github.com/lightningnetwork/lnd/pull/11140) after confirmation.
* [Incoming HTLC resolver](https://github.com/lightningnetwork/lnd/pull/10869) could treat a foreign commitment spend as its own success transaction and offer a phantom input to the sweeper.
* [Peer connections](https://github.com/lightningnetwork/lnd/pull/11131) now rate limit inbound ping replies and bound outgoing message queue growth, preventing peer-controlled resource exhaustion.
* Channel updates carrying inbound fees now sign the same bytes that are broadcast, preventing remote signature failures.
* [`GetTransactions` pagination](https://github.com/lightningnetwork/lnd/pull/11075) no longer panics on overflowing offset/limit combinations.
* REST WebSocket proxy [panic fix](https://github.com/lightningnetwork/lnd/pull/11122) and incoming message size bound.

## Rebase notes

All 18 Zeus commits replay cleanly. Conflicts were confined to `go.mod`/`go.sum` dependency churn plus one generated file:

* `go.mod`/`go.sum`: resolved by taking upstream's versions and keeping the fork's own requires, then `go mod tidy`, which re-raised the versions the fork's dependencies genuinely need (for example `macaroon-bakery` to v2.3.0 for chantools). `go mod tidy` at the tip is now a no-op.
* `lnrpc/walletrpc/walletkit.pb.go`: regenerated with `make rpc` rather than hand-merged. Upstream added the experimental `XCreateAccount` RPC to the same proto that carries our `rescan` + `birthday_height` additions to `ImportPublicKey`; the merged `.proto` retains both.
* `lnrpc/walletrpc/walletkit.pb.gw.go`: upstream's `XCreateAccount` gateway stub was checked in using the older grpc-gateway codegen style (`utilities.IOReaderFactory`). Regenerated with `make mobile-rpc` and amended into the existing "check in gateway stubs" commit so the file is internally consistent.

No btcwallet fork lockstep was needed: upstream stays on `btcwallet v0.16.19`, so the `ZeusLN/btcwallet v0.16.19-zeus` replace is unchanged.

**Graph DB caps unchanged.** `sqldb/migrations.go` `migrationConfig` is byte-identical between v0.21.2-beta and v0.21.3-beta (max `Version: 18`, `SchemaVersion: 15`), and `sqldb/sqlc/migrations/` is untouched, so `GRAPH_KNOWN_MAX_DB_VERSION = 18` / `GRAPH_KNOWN_SCHEMA_VERSION = 15` in `LndMobileTools.java`/`.swift` (#4528) remain correct and need no update.

## Verification performed

* `go build ./...` and the mobile-tag build (`go build -tags="mobile autopilotrpc chainrpc invoicesrpc neutrinorpc peersrpc signrpc wtclientrpc watchtowerrpc routerrpc walletrpc verrpc kvdb_sqlite" ./mobile/...`) both pass.
* Unit tests pass for the fork-touched packages: `lnrpc/invoicesrpc`, `lnrpc/walletrpc`, `lnwallet/btcwallet`.
* `git describe --tags --dirty` on the build tree reports exactly `v0.21.3-beta-zeus` (clean), so the artifacts embed the tagged commit.
* The two release assets were downloaded back from their `fetch-libraries.sh` URLs and verified against the hashes pinned here.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [x] Contributors will need to run `yarn` after this PR is merged in
    * `fetch-libraries.sh` runs on postinstall and re-downloads `Lndmobile.aar` / `Lndmobile.xcframework` at the new pinned hashes.
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

---

Draft pending on-device testing on Android and iOS with an embedded LND wallet (sync from scratch plus an existing wallet upgrading in place, to exercise the invoice migration path).
