### PR TITLE
fix(patches): re-anchor reanimated SET fixes for 4.7 and fail loudly on a miss

### DIFF
--- a/patches/index.mjs
+++ b/patches/index.mjs
@@ -11,12 +11,17 @@ import { patchReanimatedSetFixes } from './patch-reanimated-set-fixes.mjs';
 console.log('Running postinstall patches...\n');
 
 (async () => {
-    patchJcenter();
-    patchNativeEventEmitter();
-    patchReactNativeNotifications();
-    patchNobleHashes();
-    patchReanimatedBoundaryAndroid();
-    patchReanimatedSetFixes();
+    try {
+        patchJcenter();
+        patchNativeEventEmitter();
+        patchReactNativeNotifications();
+        patchNobleHashes();
+        patchReanimatedBoundaryAndroid();
+        patchReanimatedSetFixes();
+    } catch (error) {
+        console.error(`\nPostinstall patch failed:\n\n${error.message}\n`);
+        process.exit(1);
+    }
 
     console.log('\nAll patches applied successfully.');
 })();

--- a/patches/patch-reanimated-set-fixes.mjs
+++ b/patches/patch-reanimated-set-fixes.mjs
@@ -1,7 +1,7 @@
 // Two behavioral fixes to react-native-reanimated's experimental shared
 // element transition proxy (LayoutAnimationsProxy_Experimental.cpp), applied
 // as source patches. Both were root-caused on-device in ZEUS; neither is
-// fixed upstream as of 4.5.1 (checked 2026-07-13).
+// fixed upstream as of 4.7.0-nightly-20260901 (re-checked 2026-09-02).
 //
 // Tracking: https://github.com/ZeusLN/zeus/issues/4222
 // Remove each edit once the corresponding upstream fix ships in a release.
@@ -27,45 +27,38 @@
 // shared element transitions die app-wide until restart. Only keep waiting
 // while the closing screen is actually mid-removal (tracked but detached
 // from its parent).
+//
+// Each fix carries one anchor per upstream source layout, because reanimated
+// 4.7.0 refactored the proxy to one instance per surface:
+//   4.6.x and earlier: `topScreen[surfaceId]`, `surfaceId` parameter,
+//                      `filteredMutations` passed to updateLightTree()
+//   4.7.x and later:   `topScreen_`, `surfaceId_` member, `TransactionMeta`
+// The member names the edits rely on (lightNodes_, closingScreenTag_,
+// findActiveBoundary, findBoundaryGuess, LightNode::parent/children) are
+// unchanged across both layouts. If no anchor matches, this patch fails the
+// install rather than warning: an unapplied edit reintroduces two silent
+// SET failures that no test or log would surface.
 
 import fs from 'fs';
 
 const PROXY_CPP_PATH =
     './node_modules/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy_Experimental.cpp';
 
-const POP_FALLBACK_ANCHOR = `    auto afterTopScreen = findActiveBoundary(root);
-    topScreen[surfaceId] = afterTopScreen;`;
-
-const POP_FALLBACK_REPLACEMENT = `    auto afterTopScreen = findActiveBoundary(root);
-    // ZEUS PATCH (see patches/patch-reanimated-set-fixes.mjs):
+const POP_FALLBACK_COMMENT = `    // ZEUS PATCH (see patches/patch-reanimated-set-fixes.mjs):
     // When the screen holding the previous top boundary is removed (pop),
     // the revealed screen's boundary may not have received \`isActive=true\`
     // yet — react-navigation's focus update can land a commit after the one
     // containing the removal, so return transitions would silently race.
-    // In that case fall back to the topmost mounted boundary.
-    if (!afterTopScreen && beforeTopScreen && !lightNodes_.contains(beforeTopScreen->current.tag)) {
-      afterTopScreen = findBoundaryGuess(root);
-    }
-    topScreen[surfaceId] = afterTopScreen;`;
+    // In that case fall back to the topmost mounted boundary.`;
 
-const RESYNC_ANCHOR = `  } else if (!synchronized_) {
-    updateLightTree(propsParserContext, mutations, filteredMutations);
-    if (!lightNodes_.contains(closingScreenTag_)) {
-      topScreen[surfaceId] = findActiveBoundary(lightNodes_[surfaceId]);
-      synchronized_ = true;
-      closingScreenTag_ = -1;
-    }
-  } else if (!mutations.empty()) {`;
-
-const RESYNC_REPLACEMENT = `  } else if (!synchronized_) {
-    updateLightTree(propsParserContext, mutations, filteredMutations);
-    // ZEUS PATCH (see patches/patch-reanimated-set-fixes.mjs):
+const RESYNC_COMMENT = `    // ZEUS PATCH (see patches/patch-reanimated-set-fixes.mjs):
     // Only keep waiting while the closing screen is actually mid-removal
     // (tracked but detached from its parent). A cancelled interactive pop
     // emits a closing event for a screen that never unmounts; waiting for
     // it would block resynchronization forever and permanently disable
-    // shared element transitions.
-    bool waitingForRemoval = false;
+    // shared element transitions.`;
+
+const RESYNC_GUARD = `    bool waitingForRemoval = false;
     const auto closingIt = lightNodes_.find(closingScreenTag_);
     if (closingIt != lightNodes_.end()) {
       const auto &closingNode = closingIt->second;
@@ -74,27 +67,95 @@ const RESYNC_REPLACEMENT = `  } else if (!synchronized_) {
           std::find(closingParent->children.begin(), closingParent->children.end(), closingNode) !=
               closingParent->children.end();
       waitingForRemoval = !attached;
+    }`;
+
+const POP_FALLBACK_EDITS = [
+    {
+        layout: '4.6.x',
+        anchor: `    auto afterTopScreen = findActiveBoundary(root);
+    topScreen[surfaceId] = afterTopScreen;`,
+        replacement: `    auto afterTopScreen = findActiveBoundary(root);
+${POP_FALLBACK_COMMENT}
+    if (!afterTopScreen && beforeTopScreen && !lightNodes_.contains(beforeTopScreen->current.tag)) {
+      afterTopScreen = findBoundaryGuess(root);
     }
+    topScreen[surfaceId] = afterTopScreen;`
+    },
+    {
+        layout: '4.7.x',
+        anchor: `    auto afterTopScreen = findActiveBoundary(root);
+    topScreen_ = afterTopScreen;`,
+        replacement: `    auto afterTopScreen = findActiveBoundary(root);
+${POP_FALLBACK_COMMENT}
+    if (!afterTopScreen && beforeTopScreen && !lightNodes_.contains(beforeTopScreen->current.tag)) {
+      afterTopScreen = findBoundaryGuess(root);
+    }
+    topScreen_ = afterTopScreen;`
+    }
+];
+
+const RESYNC_EDITS = [
+    {
+        layout: '4.6.x',
+        anchor: `  } else if (!synchronized_) {
+    updateLightTree(propsParserContext, mutations, filteredMutations);
+    if (!lightNodes_.contains(closingScreenTag_)) {
+      topScreen[surfaceId] = findActiveBoundary(lightNodes_[surfaceId]);
+      synchronized_ = true;
+      closingScreenTag_ = -1;
+    }
+  } else if (!mutations.empty()) {`,
+        replacement: `  } else if (!synchronized_) {
+    updateLightTree(propsParserContext, mutations, filteredMutations);
+${RESYNC_COMMENT}
+${RESYNC_GUARD}
     if (!waitingForRemoval) {
       topScreen[surfaceId] = findActiveBoundary(lightNodes_[surfaceId]);
       synchronized_ = true;
       closingScreenTag_ = -1;
     }
-  } else if (!mutations.empty()) {`;
-
-function applyEdit(content, anchor, replacement, label) {
-    if (content.includes(replacement)) {
-        console.log(`  - ${label}: already applied, skipping`);
-        return content;
+  } else if (!mutations.empty()) {`
+    },
+    {
+        layout: '4.7.x',
+        anchor: `  } else if (!synchronized_) {
+    updateLightTree(propsParserContext, mutations, transaction);
+    if (!lightNodes_.contains(closingScreenTag_)) {
+      topScreen_ = findActiveBoundary(lightNodes_[surfaceId_]);
+      synchronized_ = true;
+      closingScreenTag_ = -1;
     }
-    if (!content.includes(anchor)) {
-        console.warn(
-            `  - ${label}: anchor not found (reanimated version changed?) — NOT applied`
+  } else if (!mutations.empty()) {`,
+        replacement: `  } else if (!synchronized_) {
+    updateLightTree(propsParserContext, mutations, transaction);
+${RESYNC_COMMENT}
+${RESYNC_GUARD}
+    if (!waitingForRemoval) {
+      topScreen_ = findActiveBoundary(lightNodes_[surfaceId_]);
+      synchronized_ = true;
+      closingScreenTag_ = -1;
+    }
+  } else if (!mutations.empty()) {`
+    }
+];
+
+function applyEdit(content, edits, label) {
+    const applied = edits.find((edit) => content.includes(edit.replacement));
+    if (applied) {
+        console.log(
+            `  - ${label}: already applied (${applied.layout}), skipping`
         );
         return content;
     }
-    console.log(`  - ${label}: applied`);
-    return content.replace(anchor, replacement);
+
+    const match = edits.find((edit) => content.includes(edit.anchor));
+    if (!match) {
+        console.warn(`  - ${label}: no anchor matched`);
+        return null;
+    }
+
+    console.log(`  - ${label}: applied (${match.layout})`);
+    return content.replace(match.anchor, match.replacement);
 }
 
 export function patchReanimatedSetFixes() {
@@ -110,17 +171,42 @@ export function patchReanimatedSetFixes() {
     }
 
     let content = fs.readFileSync(PROXY_CPP_PATH, 'utf8');
-    content = applyEdit(
-        content,
-        RESYNC_ANCHOR,
-        RESYNC_REPLACEMENT,
-        'resync fix (cancelled close wedge)'
-    );
-    content = applyEdit(
-        content,
-        POP_FALLBACK_ANCHOR,
-        POP_FALLBACK_REPLACEMENT,
-        'pop fallback (return transition race)'
-    );
+    const failed = [];
+
+    for (const [edits, label] of [
+        [RESYNC_EDITS, 'resync fix (cancelled close wedge)'],
+        [POP_FALLBACK_EDITS, 'pop fallback (return transition race)']
+    ]) {
+        const next = applyEdit(content, edits, label);
+        if (next === null) {
+            failed.push(label);
+            continue;
+        }
+        content = next;
+    }
+
+    if (failed.length && process.env.ZEUS_ALLOW_UNPATCHED_REANIMATED === '1') {
+        console.warn(
+            `  - WARNING: ${failed.join(
+                ', '
+            )} NOT applied (ZEUS_ALLOW_UNPATCHED_REANIMATED=1). ` +
+                'Shared element transitions will be broken; see ZeusLN/zeus#4222.'
+        );
+    } else if (failed.length) {
+        throw new Error(
+            `react-native-reanimated shared element transition fixes could not be applied: ${failed.join(
+                ', '
+            )}.\n` +
+                'The proxy source changed shape, so the anchors in ' +
+                'patches/patch-reanimated-set-fixes.mjs need to be updated for this ' +
+                'reanimated version. Leaving them unapplied silently breaks shared ' +
+                'element transitions (ZeusLN/zeus#4222); check whether ' +
+                'software-mansion/react-native-reanimated#9944 and #9945 shipped first, ' +
+                'and drop the corresponding edit if so.\n' +
+                'To install anyway (transitions will be broken), set ' +
+                'ZEUS_ALLOW_UNPATCHED_REANIMATED=1.'
+        );
+    }
+
     fs.writeFileSync(PROXY_CPP_PATH, content);
 }


### PR DESCRIPTION
# Description

Relates to issue: **[#4222](https://github.com/ZeusLN/zeus/issues/4222)** (also relevant to [#4221](https://github.com/ZeusLN/zeus/issues/4221))

reanimated 4.7.0 refactors `LayoutAnimationsProxy_Experimental` to one proxy instance per surface, which breaks both anchors in `patches/patch-reanimated-set-fixes.mjs`:

| 4.6.x and earlier | 4.7.x |
| --- | --- |
| `topScreen[surfaceId]` | `topScreen_` |
| `surfaceId` parameter | `surfaceId_` member |
| `filteredMutations` arg to `updateLightTree()` | `TransactionMeta transaction` |

Today a missed anchor only warns, and `patches/index.mjs` then prints "All patches applied successfully" anyway. So a bump to 4.7.0 would produce a build with neither SET fix applied, silently reintroducing the two bugs tracked in #4222: return transitions racing the boundary's `isActive` update on pop (Android), and a cancelled screen close permanently wedging resynchronization (iOS). Both failure modes are invisible, with no error, no log, and nothing a test would catch.

This is not hypothetical timing. 4.7.0 is also the release that finally ships `react-native.config.js` (upstream [#10375](https://github.com/software-mansion/react-native-reanimated/pull/10375), merged 2026-08-25, still unreleased), so the bump that lets us delete the packaging patch from #4221 is the same bump that would disable this one.

Changes:

- each fix carries an anchor per source layout (`4.6.x` and `4.7.x`), selected automatically
- the patch throws when no anchor matches, so the install fails loudly instead of producing a quietly broken build. `ZEUS_ALLOW_UNPATCHED_REANIMATED=1` overrides for anyone who needs to install anyway
- `patches/index.mjs` catches patch failures, prints the message, and exits non-zero instead of reporting success

The member names the edits depend on (`lightNodes_`, `closingScreenTag_`, `findActiveBoundary`, `findBoundaryGuess`, `LightNode::parent`/`children`) are unchanged in 4.7, so the two edits port over as-is. Upstream [#9944](https://github.com/software-mansion/react-native-reanimated/issues/9944) and [#9945](https://github.com/software-mansion/react-native-reanimated/issues/9945) are both still open and still unfixed in 4.7.0 nightlies (verified in the nightly source, not just by issue state), so both edits remain necessary.

No behavior change on the currently pinned 4.6.0: the same two edits are applied by the same anchors as before.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

All four pass: `tsc` clean, `eslint` clean, `prettier --check "**/*.ts*"` clean, jest 68 suites and 1498 tests passing, plus `check-styles.test.ts` passing. Note that `prettier` and `tsc` only match `**/*.ts*`, so neither actually covers these two `.mjs` files; `eslint` does cover them.

I had to exclude `.claude/**` locally to run `lint` and `test` at all, since this checkout has git worktrees nested under `.claude/worktrees/` and neither `eslint.config.js` nor the jest `testPathIgnorePatterns` excludes them. `eslint .` then lints roughly thirty full copies of the repo (over 25 minutes at 100% CPU before I killed it, versus 17 seconds when excluded), and jest picks up the stale test copies (56 spurious suite failures). This is a local-only artifact, CI checkouts have no such directory, and it is unrelated to this PR.

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

Verified by running the patch against pristine upstream tarball sources rather than by inspection:

| source | result |
| --- | --- |
| 4.6.0 pristine (currently pinned) | both edits apply via the `4.6.x` anchors |
| 4.7.0-nightly-20260901 pristine | both edits apply via the `4.7.x` anchors |
| already-patched file (current `node_modules`) | detected, skipped, no double apply |
| re-run over any of the above | no-op |
| unrecognized layout | throws, install fails |
| unrecognized layout with `ZEUS_ALLOW_UNPATCHED_REANIMATED=1` | warns, install proceeds |

The resulting 4.7 diff was reviewed for correctness against the refactored source, and `<algorithm>` is already included there for the `std::find` call.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

This is a build-time patch script change with no app code in it, and the 4.7.x path cannot be exercised on device until we actually bump reanimated. Device re-testing of the transitions themselves (Contacts to ContactDetails, push and pop, plus a cancelled back swipe, on both platforms) is owed as part of that bump, which is why this is a draft.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

N/A, no node interaction.

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

No dependency change. Existing checkouts do not need to re-run `yarn`, since the pinned 4.6.0 result is byte-identical to what is already patched in `node_modules`.

### Other:

Neither #4221 nor #4222 can be closed by this PR. Both stay open until a reanimated release actually ships the fixes.

