### PR TITLE
utils: guard LNURL parsing against a decode-uri-component hang

### DIFF
--- a/components/LayerBalances/EcashSwipeableRow.tsx
+++ b/components/LayerBalances/EcashSwipeableRow.tsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import { Alert, View, I18nManager, TouchableOpacity } from 'react-native';
 import { SharedValue } from 'react-native-reanimated';
-import { getParams as getlnurlParams, LNURLWithdrawParams } from 'js-lnurl';
+import { LNURLWithdrawParams } from 'js-lnurl';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { inject, observer } from 'mobx-react';
 
 import BackendUtils from '../../utils/BackendUtils';
+import { getLnurlParams as getlnurlParams } from '../../utils/LnurlUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 

--- a/components/LayerBalances/LightningSwipeableRow.tsx
+++ b/components/LayerBalances/LightningSwipeableRow.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Alert, View, I18nManager, TouchableOpacity } from 'react-native';
 import { SharedValue } from 'react-native-reanimated';
-import { getParams as getlnurlParams, LNURLWithdrawParams } from 'js-lnurl';
+import { LNURLWithdrawParams } from 'js-lnurl';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { inject, observer } from 'mobx-react';
 
@@ -9,6 +9,7 @@ import ReactNativeBlobUtil from 'react-native-blob-util';
 
 import { doTorRequest, RequestMethod } from '../../utils/TorUtils';
 import BackendUtils from './../../utils/BackendUtils';
+import { getLnurlParams as getlnurlParams } from './../../utils/LnurlUtils';
 import { localeString } from './../../utils/LocaleUtils';
 import { themeColor } from './../../utils/ThemeUtils';
 

--- a/utils/LnurlUtils.test.ts
+++ b/utils/LnurlUtils.test.ts
@@ -1,0 +1,126 @@
+const mockGetParams = jest.fn();
+
+jest.mock('./LocaleUtils', () => ({ localeString: (k: string) => k }));
+
+// js-lnurl/lib/helpers is deliberately left unmocked, so the real bech32
+// decoder runs and the test exercises the payload an attacker actually
+// controls
+jest.mock('js-lnurl', () => ({
+    getParams: (...args: any[]) => mockGetParams(...args)
+}));
+
+import { bech32 } from 'bech32';
+
+import { getLnurlParams, hasUndecodableEscapes } from './LnurlUtils';
+
+// decodelnurl() accepts bech32 up to 20000 characters
+const encodeLnurl = (payload: string) =>
+    bech32.encode('lnurl', bech32.toWords(Buffer.from(payload)), 20000);
+
+describe('LnurlUtils', () => {
+    beforeEach(() => {
+        mockGetParams.mockReset();
+        mockGetParams.mockResolvedValue({ tag: 'payRequest' });
+    });
+
+    describe('hasUndecodableEscapes', () => {
+        it('accepts a plain URL', () => {
+            expect(
+                hasUndecodableEscapes('https://example.com/lnurlp/satoshi')
+            ).toBe(false);
+        });
+
+        it('accepts well-formed percent-encoding, however much of it', () => {
+            const url =
+                'https://example.com/?memo=' +
+                encodeURIComponent('é'.repeat(500));
+            expect(hasUndecodableEscapes(url)).toBe(false);
+        });
+
+        it('stays lenient about a stray escape or two', () => {
+            expect(
+                hasUndecodableEscapes('https://example.com/?memo=50%off')
+            ).toBe(false);
+            expect(
+                hasUndecodableEscapes('https://example.com/?a=%FF&b=%FE')
+            ).toBe(false);
+        });
+
+        it('rejects a URL packed with malformed escapes', () => {
+            expect(
+                hasUndecodableEscapes(
+                    'https://example.com/?a=' + '%FF'.repeat(600)
+                )
+            ).toBe(true);
+        });
+
+        it('rejects malformed escapes spread across many parameters', () => {
+            const query = Array.from(
+                { length: 100 },
+                (_, i) => `k${i}=%FF`
+            ).join('&');
+            expect(hasUndecodableEscapes(`https://example.com/?${query}`)).toBe(
+                true
+            );
+        });
+    });
+
+    describe('getLnurlParams', () => {
+        it('passes a legitimate LNURL through to js-lnurl', async () => {
+            const lnurl = encodeLnurl(
+                'https://example.com/lnurlp/satoshi?tag=payRequest'
+            );
+
+            await expect(getLnurlParams(lnurl)).resolves.toEqual({
+                tag: 'payRequest'
+            });
+            expect(mockGetParams).toHaveBeenCalledWith(lnurl);
+        });
+
+        it('passes a bare https LNURL through to js-lnurl', async () => {
+            const url = 'https://example.com/lnurlp/satoshi';
+
+            await expect(getLnurlParams(url)).resolves.toEqual({
+                tag: 'payRequest'
+            });
+            expect(mockGetParams).toHaveBeenCalledWith(url);
+        });
+
+        it('lets js-lnurl report input it cannot decode at all', async () => {
+            await expect(getLnurlParams('not-an-lnurl')).resolves.toEqual({
+                tag: 'payRequest'
+            });
+            expect(mockGetParams).toHaveBeenCalledWith('not-an-lnurl');
+        });
+
+        // Regression: js-lnurl runs query-string over the decoded payload
+        // before it makes any network request, and query-string@6 decodes
+        // through decode-uri-component@0.2.2, whose fallback decoder is
+        // superlinear in the number of malformed escapes (GHSA-vcc3-ghjq-m6fr).
+        // A scanned QR code or deep link carrying this payload used to wedge
+        // the JS thread for minutes.
+        it('rejects a decode-uri-component DoS payload before parsing it', async () => {
+            const lnurl = encodeLnurl(
+                'https://example.com/?a=' + '%FF'.repeat(2000)
+            );
+
+            await expect(getLnurlParams(lnurl)).rejects.toThrow();
+            expect(mockGetParams).not.toHaveBeenCalled();
+        });
+
+        // ~4000 escapes is the most that fits in the 20000 character bech32
+        // string decodelnurl() accepts, so this is the worst case an attacker
+        // can actually deliver through a QR code, deep link or share intent.
+        it('rejects the largest deliverable payload inside a frame budget', async () => {
+            const lnurl = encodeLnurl(
+                'https://example.com/?a=' + '%FF'.repeat(4000)
+            );
+            expect(lnurl.length).toBeLessThanOrEqual(20000);
+
+            const start = Date.now();
+            await expect(getLnurlParams(lnurl)).rejects.toThrow();
+            // unguarded, this payload runs for minutes
+            expect(Date.now() - start).toBeLessThan(1000);
+        });
+    });
+});

--- a/utils/LnurlUtils.ts
+++ b/utils/LnurlUtils.ts
@@ -1,0 +1,70 @@
+import { getParams } from 'js-lnurl';
+import { decodelnurl } from 'js-lnurl/lib/helpers';
+
+import { localeString } from './LocaleUtils';
+
+// js-lnurl parses the LNURL query string with query-string@6, which decodes
+// every key and value through decode-uri-component@0.2.2. When the native
+// decodeURIComponent throws, that package falls back to a split-and-retry
+// decoder whose cost grows superlinearly in the number of malformed escape
+// sequences (GHSA-vcc3-ghjq-m6fr). Measured end to end through getParams():
+// 200 escapes blocks the JS thread for 0.5s, 600 for 5.3s, and the ~6600 that
+// fit inside the 20000 character bech32 payload decodelnurl accepts run for
+// minutes. Hermes is slower still.
+//
+// getParams() runs that parse before it issues any network request, so a
+// scanned QR code, deep link, or share intent is on its own enough to wedge
+// the app. There is no clean dependency fix today: decode-uri-component 0.5.0
+// and the query-string 9 that depends on it are both ESM-only, and js-lnurl
+// 0.6.0 still pins query-string ^6.12.1.
+//
+// Genuine LNURLs are well-formed, so the slow decoder only ever runs on
+// malformed input. Sloppy-but-real URLs carry at most a stray escape or two,
+// so keep the lenient behaviour for a small budget and reject beyond it. The
+// cost is superlinear, so capping the total number of escapes in an
+// undecodable URL caps the total work at a few milliseconds.
+const MAX_ESCAPES_IN_MALFORMED_URL = 32;
+
+const ESCAPE_SEQUENCE = /%[0-9a-fA-F]{2}/g;
+
+/**
+ * True when `url` is not valid percent-encoding and carries more escape
+ * sequences than decode-uri-component can expand cheaply.
+ */
+export const hasUndecodableEscapes = (url: string): boolean => {
+    try {
+        decodeURIComponent(url);
+        return false;
+    } catch {
+        // A `%XX` run can never span a `&` or `=`, so if the whole URL fails
+        // to decode then at least one of the pieces query-string splits out
+        // fails too, and the fallback decoder will run on it.
+        return (
+            (url.match(ESCAPE_SEQUENCE) || []).length >
+            MAX_ESCAPES_IN_MALFORMED_URL
+        );
+    }
+};
+
+/**
+ * getParams() from js-lnurl, guarded against the decode-uri-component blowup
+ * described above. Rejects before any parsing or network request when the
+ * decoded LNURL cannot be decoded cheaply.
+ */
+export const getLnurlParams = async (lnurl: string) => {
+    let decoded;
+    try {
+        decoded = decodelnurl(lnurl);
+    } catch {
+        // Not decodable as an LNURL at all. Let js-lnurl report that itself so
+        // the error the caller sees does not change.
+    }
+
+    if (decoded && hasUndecodableEscapes(decoded)) {
+        throw new Error(
+            localeString('utils.handleAnything.invalidLnurlParams')
+        );
+    }
+
+    return getParams(lnurl);
+};

--- a/utils/handleAnything.ts
+++ b/utils/handleAnything.ts
@@ -1,5 +1,4 @@
 import { Alert, Platform } from 'react-native';
-import { getParams as getlnurlParams } from 'js-lnurl';
 import { findlnurl, decodelnurl } from 'js-lnurl/lib/helpers';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 
@@ -11,6 +10,7 @@ import Bolt11Utils from './Bolt11Utils';
 import CashuUtils from './CashuUtils';
 import ConnectionFormatUtils from './ConnectionFormatUtils';
 import ContactUtils from './ContactUtils';
+import { getLnurlParams as getlnurlParams } from './LnurlUtils';
 import { localeString } from './LocaleUtils';
 import NodeUriUtils from './NodeUriUtils';
 import NostrUtils from './NostrUtils';


### PR DESCRIPTION
# Description

Closes Dependabot alert #415 (`decode-uri-component` [GHSA-vcc3-ghjq-m6fr](https://github.com/advisories/GHSA-vcc3-ghjq-m6fr)) at the app boundary, because there is no clean dependency upgrade available.

## The bug

`js-lnurl` parses the LNURL query string with `query-string@6`, which decodes every key and value through `decode-uri-component@0.2.2`. When the native `decodeURIComponent` throws, that package falls back to a split-and-retry decoder whose cost grows superlinearly in the number of malformed escape sequences.

That parse happens inside `getParams()` **before js-lnurl issues any network request**, so a scanned QR code, deep link, or share intent is on its own enough to wedge the JS thread. The reachable paths:

- `utils/handleAnything.ts:283` and `:807`, fed by the QR scanner, NFC, share intent, deep links (`utils/LinkingUtils.ts:136`, `views/Wallet/Wallet.tsx:395`) and clipboard paste (`components/WalletHeader.tsx:205`)
- `components/LayerBalances/LightningSwipeableRow.tsx:136`
- `components/LayerBalances/EcashSwipeableRow.tsx:108`

Measured end to end through `getParams()` with a real bech32 LNURL, on desktop Node (Hermes is slower still):

| `%FF` escapes | bech32 length | JS thread blocked |
|---|---|---|
| 200 | 1009 | 508 ms |
| 400 | 1969 | 2216 ms |
| 600 | 2929 | 5276 ms |

Scaling is roughly O(n^2.2). `decodelnurl()` accepts bech32 up to 20000 characters, which fits about 4000 escapes, so the worst deliverable payload runs for minutes. Impact is denial of service only: no disclosure, no loss of funds, but the app hard-freezes until the OS kills it.

## Why not just bump the dependency

There is no CJS-compatible patched version:

- `decode-uri-component@0.5.0` (the first patched release) is ESM-only (`"type": "module"`), so a `resolutions` pin breaks `query-string@6`'s `require()` under Metro and Jest.
- Only `query-string@9.5.1` depends on `decode-uri-component ^0.5.0`, and it is ESM-only too.
- `js-lnurl@0.6.0`, now on `master` as of 403f1d5b5, still pins `query-string ^6.12.1`, so bumping js-lnurl did not close this either.

## The fix

New `utils/LnurlUtils.ts` wraps `getParams()`. It decodes the LNURL first, then rejects when the decoded URL both fails `decodeURIComponent` and carries more escape sequences than the fallback decoder can expand cheaply.

This targets the malicious shape rather than capping input length:

- Genuine LNURLs decode cleanly, so the slow decoder never runs on them at all, whatever their length. A length cap would have rejected legitimate long LNURLs while still admitting a short malicious one.
- Capping the *total* escape count rather than the longest run is what actually bounds the work. The cost is superlinear, so the worst case is every escape in a single run; many short runs are cheaper. A per-run cap would still have admitted roughly 800 runs of 16, about 1.4s.
- Sloppy-but-real URLs (a stray `%` in a memo, say) keep today's lenient behaviour up to a small budget.

All four `getParams` call sites now go through the wrapper.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

Full suite: 1551 passed, 1 failed. The one failure is `utils/PhotoUtils.test.ts` "groks out preset:// values", and it is an artifact of my running the suite from a git worktree: the test asserts a relative asset path, and the extra path depth makes it come back as `../../../.claude/worktrees/.../assets/images/lnd.jpg`. It passes in a normal checkout and in CI. Nothing to do with this change.

Rebased onto `master` at e438f9060. The only conflict was the `js-lnurl` import line in `utils/handleAnything.ts`, which 403f1d5b5 had split across the package root and `js-lnurl/lib/helpers`; `utils/LnurlUtils.ts` now takes `decodelnurl` from the same subpath, and `utils/LnurlUtils.test.ts` leaves that subpath unmocked so the real bech32 decoder still runs.

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

`utils/LnurlUtils.test.ts` adds 10 tests. It mocks only `getParams` and keeps the real `decodelnurl` via `jest.requireActual`, so the tests exercise genuine bech32 payloads rather than a stub. The headline case uses about 4000 escapes, the most that fits inside the 20000 character bech32 string `decodelnurl()` accepts, so it covers the true worst case an attacker can deliver.

I verified the regression tests are real: stubbing the guard out to `if (false)` turns both DoS tests red, and restoring it turns them green.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Device testing still owed. The change is pure TypeScript with no native surface, and the LNURL happy paths are covered by unit tests, but a real LNURL-pay and LNURL-withdraw scan on hardware is worth doing before this leaves draft.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

The guarded path is backend independent: it runs before any node interaction.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

Reuses the existing `utils.handleAnything.invalidLnurlParams` string, so no new locale text.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

