### PR TITLE
chore(deps): bump flagged pins in the vendored lnc-rn yarn.lock

### DIFF
--- a/zeus_modules/@lightninglabs/lnc-rn/package.json
+++ b/zeus_modules/@lightninglabs/lnc-rn/package.json
@@ -89,9 +89,10 @@
   "resolutions": {
     "protobufjs": "7.5.8",
     "fast-xml-parser": "5.7.0",
-    "mocha/js-yaml": "4.3.1",
+    "mocha/js-yaml": "4.3.2",
     "serialize-javascript": "7.0.5",
-    "minimatch": "9.0.7"
+    "minimatch": "9.0.7",
+    "mocha/nanoid": "3.3.18"
   },
   "license": "MIT"
 }

--- a/zeus_modules/@lightninglabs/lnc-rn/yarn.lock
+++ b/zeus_modules/@lightninglabs/lnc-rn/yarn.lock
@@ -3750,17 +3750,17 @@ joi@^17.2.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0, js-yaml@4.3.1, js-yaml@^4.3.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
-  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
+js-yaml@4.1.0, js-yaml@4.3.2, js-yaml@^4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.2.tgz#8e44fb14a2643c59726bb15787b5f1512cb3d3fb"
+  integrity sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==
   dependencies:
     argparse "^2.0.1"
 
 js-yaml@^3.13.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
-  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
+  version "3.15.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.2.tgz#3f83823ac6be17f570f23b2ecdef3777ff5ea364"
+  integrity sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -4438,10 +4438,10 @@ ms@2.1.3, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
-  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
+nanoid@3.3.1, nanoid@3.3.18:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
# Description

Clears Dependabot alerts #422, #434, and #435, all filed against the vendored `zeus_modules/@lightninglabs/lnc-rn/yarn.lock`, by bumping the flagged pins in place.

| Advisory | Package | Before | After | Alerts |
|---|---|---|---|---|
| CVE-2026-84375 / GHSA-2883-xcg3-v3hh (CPU exhaustion on empty merge sources) | js-yaml 4.x | 4.3.1 | 4.3.2 | #434 |
| CVE-2026-84375 | js-yaml 3.x | 3.15.1 | 3.15.2 | #435 |
| CVE-2026-73086 / GHSA-xwg4-73v4-xw9w (integer overflow) | nanoid | 3.3.1 | 3.3.18 | #422 |

js-yaml 4.x and nanoid are exact pins requested by mocha, so the module's `resolutions` block changes too: `mocha/js-yaml` moves from 4.3.1 to 4.3.2 and `mocha/nanoid: 3.3.18` is added (same pattern as the existing `mocha/js-yaml` pin from the last round of bumps). js-yaml 3.x was an in-range refresh.

The lockfile was regenerated by yarn itself (`yarn install --ignore-scripts` inside the vendored directory, nested `node_modules` removed afterward since a leftover nested tree breaks Metro resolution), so the entry shapes are canonical, and the diff is exactly the three entries plus the resolutions.

Context: these alerts are phantoms. lnc-rn is not a dependency in the root `package.json`; unlike lnc-core, it is imported by relative path (`backends/LightningNodeConnect.ts`), so the root install never consumes this lockfile and its deps resolve from the root tree (where nanoid is already 3.3.18 and js-yaml is patched by #4641). Dependabot scans the file anyway, so this is alert hygiene; the shipped bundle is byte-for-byte unaffected. The related lnc-core lockfile is already clean (js-yaml 3.15.2 via #4614, no nanoid entry).

The `nanoid@3.3.1, nanoid@3.3.18` entry key is how yarn v1 records a resolutions override alongside the original exact request; it is expected output, not a hand-edit artifact.

Validation: lockfile is self-consistent by construction (yarn generated it); root `yarn install --frozen-lockfile` behavior is unaffected since the root lockfile is untouched. No runtime device testing applies.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [x] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
