### PR TITLE
cashu: count the donation in the funds check

### DIFF
--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -1845,6 +1845,8 @@ export default class CashuStore {
         this.paymentPreimage = undefined;
         this.getPayReqError = undefined;
         this.feeEstimate = undefined;
+        this.payReqMintBalance = 0;
+        this.payReqAmount = 0;
         this.meltQuotes = [];
         this.meltQuote = undefined;
         this.noteKey = undefined;
@@ -4132,6 +4134,8 @@ export default class CashuStore {
         this.paymentRequest = bolt11Invoice;
         this.feeEstimate = undefined;
         this.getPayReqError = undefined;
+        this.payReqMintBalance = 0;
+        this.payReqAmount = 0;
 
         try {
             if (__DEV__) {

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -223,6 +223,13 @@ export default class CashuStore {
     @observable public paymentError?: boolean;
     @observable public paymentErrorMsg?: string;
     @observable public feeEstimate?: number;
+    // Inputs of the single-mint sufficiency check run by getPayReq(), exposed
+    // so the payment view can extend it with the donation that is sent from
+    // the same mint right after the invoice is paid. Both stay 0 when that
+    // check did not run: multi-mint plans its own coverage in
+    // MultimintPayment, which refuses to start when the mints fall short.
+    @observable public payReqMintBalance: number = 0;
+    @observable public payReqAmount: number = 0;
     @observable public meltQuotes: {
         mintUrl: string;
         meltQuote: CDKMeltQuote;
@@ -4213,6 +4220,8 @@ export default class CashuStore {
             // the fee row doesn't render "0 sats" for an invoice that can't
             // be paid; every branch here assigns it before use.
             let totalFeeEstimate: number | undefined;
+            let mintBalanceChecked = 0;
+            let amountChecked = 0;
 
             if (rawPaymentAmt <= 0) {
                 // Zeus doesn't yet wire up CDK's amountless-melt option
@@ -4300,6 +4309,8 @@ export default class CashuStore {
                         : undefined;
 
                 totalFeeEstimate = Number(singleMeltQuote.fee_reserve) || 0;
+                mintBalanceChecked = mintBalance;
+                amountChecked = Number(singleMeltQuote.amount) || 0;
                 this.meltQuotes = [];
             }
 
@@ -4312,6 +4323,8 @@ export default class CashuStore {
                 this.meltQuote = singleMeltQuote;
                 this.feeEstimate = totalFeeEstimate;
                 this.getPayReqError = computedPayReqError;
+                this.payReqMintBalance = mintBalanceChecked;
+                this.payReqAmount = amountChecked;
             });
             if (__DEV__) {
                 console.log('getPayReq: Success, setting loading = false');

--- a/utils/DonationUtils.test.ts
+++ b/utils/DonationUtils.test.ts
@@ -6,6 +6,7 @@ jest.mock('react-native-blob-util', () => ({
 import ReactNativeBlobUtil from 'react-native-blob-util';
 import {
     calculateDonationAmount,
+    calculateTotalWithDonation,
     findDonationPercentageIndex,
     loadDonationLnurl
 } from './DonationUtils';
@@ -30,6 +31,39 @@ describe('DonationUtils', () => {
         it('should default to zero on falsy requestAmount', () => {
             expect(calculateDonationAmount(0, 10)).toBe(0);
             expect(calculateDonationAmount(undefined as any, 10)).toBe(0);
+        });
+    });
+
+    describe('calculateTotalWithDonation', () => {
+        it('should add the donation on top of the amount and the fee', () => {
+            expect(calculateTotalWithDonation(1000, 5, 100)).toBe(1105);
+        });
+
+        it('should equal amount plus fee when there is no donation', () => {
+            expect(calculateTotalWithDonation(1000, 5, 0)).toBe(1005);
+            expect(calculateTotalWithDonation(1000, 5)).toBe(1005);
+        });
+
+        it('should handle string inputs', () => {
+            expect(calculateTotalWithDonation('1000', '5', '100')).toBe(1105);
+        });
+
+        it('should default missing values to zero', () => {
+            expect(calculateTotalWithDonation(1000)).toBe(1000);
+            expect(
+                calculateTotalWithDonation(
+                    1000,
+                    undefined as any,
+                    undefined as any
+                )
+            ).toBe(1000);
+            expect(calculateTotalWithDonation(0, 0, 0)).toBe(0);
+        });
+
+        it('should stay exact on amounts that lose precision as floats', () => {
+            // 0.1 + 0.2 !== 0.3 in floating point; sats are integers, but the
+            // helper takes the same string inputs the views pass around
+            expect(calculateTotalWithDonation('0.1', '0.2', '0')).toBe(0.3);
         });
     });
 

--- a/utils/DonationUtils.test.ts
+++ b/utils/DonationUtils.test.ts
@@ -8,6 +8,7 @@ import {
     calculateDonationAmount,
     calculateTotalWithDonation,
     findDonationPercentageIndex,
+    getDonationToSend,
     loadDonationLnurl
 } from './DonationUtils';
 
@@ -31,6 +32,30 @@ describe('DonationUtils', () => {
         it('should default to zero on falsy requestAmount', () => {
             expect(calculateDonationAmount(0, 10)).toBe(0);
             expect(calculateDonationAmount(undefined as any, 10)).toBe(0);
+        });
+    });
+
+    describe('getDonationToSend', () => {
+        it('should return the donation when it will be sent', () => {
+            expect(getDonationToSend(true, true, 100)).toBe(100);
+            expect(getDonationToSend(true, true, '100')).toBe(100);
+        });
+
+        it('should return zero off mainnet', () => {
+            expect(getDonationToSend(false, true, 100)).toBe(0);
+            expect(getDonationToSend(undefined, true, 100)).toBe(0);
+        });
+
+        it('should return zero when donations are disabled', () => {
+            expect(getDonationToSend(true, false, 100)).toBe(0);
+            expect(getDonationToSend(true, undefined, 100)).toBe(0);
+        });
+
+        it('should return zero for a missing or unusable amount', () => {
+            expect(getDonationToSend(true, true, undefined)).toBe(0);
+            expect(getDonationToSend(true, true, 0)).toBe(0);
+            expect(getDonationToSend(true, true, '')).toBe(0);
+            expect(getDonationToSend(true, true, 'abc')).toBe(0);
         });
     });
 

--- a/utils/DonationUtils.ts
+++ b/utils/DonationUtils.ts
@@ -24,6 +24,27 @@ export const calculateDonationAmount = (
 };
 
 /**
+ * Calculates the balance needed to pay an invoice and then send the donation
+ * that follows it. The donation is a separate payment drawn from the same
+ * balance once the invoice is paid, so a balance that only covers the invoice
+ * and its fee reserve leaves the donation unpayable.
+ * @param paymentAmount - Invoice amount, can be a number or string
+ * @param feeReserve - Fee reserve quoted for the invoice
+ * @param donationAmount - Donation sent after the payment, 0 when disabled
+ * @returns The total amount that has to be available
+ */
+export const calculateTotalWithDonation = (
+    paymentAmount: number | string,
+    feeReserve: number | string = 0,
+    donationAmount: number | string = 0
+): number => {
+    return new BigNumber(paymentAmount || 0)
+        .plus(feeReserve || 0)
+        .plus(donationAmount || 0)
+        .toNumber();
+};
+
+/**
  * Finds the index of a matching percentage in predefined percentage options.
  * @param value - The donation percentage value to find
  * @param options - The list of available percentage options

--- a/utils/DonationUtils.ts
+++ b/utils/DonationUtils.ts
@@ -24,6 +24,25 @@ export const calculateDonationAmount = (
 };
 
 /**
+ * Resolves the donation that will actually leave the wallet after a payment.
+ * The sending views only send one on mainnet, with donations enabled and a
+ * non-zero amount, so every other combination costs the balance nothing and
+ * must not be counted against it.
+ * @param isMainNet - Whether the node is on mainnet
+ * @param donationsEnabled - Whether donations are enabled for this payment
+ * @param donationAmount - The donation the user picked, if any
+ * @returns The donation that will be sent, or 0
+ */
+export const getDonationToSend = (
+    isMainNet: boolean | undefined,
+    donationsEnabled: boolean | undefined,
+    donationAmount: number | string | undefined
+): number => {
+    if (!isMainNet || !donationsEnabled) return 0;
+    return Number(donationAmount) || 0;
+};
+
+/**
  * Calculates the balance needed to pay an invoice and then send the donation
  * that follows it. The donation is a separate payment drawn from the same
  * balance once the invoice is paid, so a balance that only covers the invoice

--- a/views/Cashu/CashuPaymentRequest.tsx
+++ b/views/Cashu/CashuPaymentRequest.tsx
@@ -46,7 +46,8 @@ import { numberWithCommas } from '../../utils/UnitsUtils';
 import {
     calculateDonationAmount,
     calculateTotalWithDonation,
-    findDonationPercentageIndex
+    findDonationPercentageIndex,
+    getDonationToSend
 } from '../../utils/DonationUtils';
 
 import { Row } from '../../components/layout/Row';
@@ -441,10 +442,11 @@ export default class CashuPaymentRequest extends React.Component<
         // after this one, so the balance has to cover both. Only count it
         // under the conditions CashuSendingLightning checks before it sends
         // the donation; anything else means nothing extra leaves the wallet.
-        const donationToCover =
-            NodeInfoStore?.nodeInfo?.isMainNet && enableDonations
-                ? Number(donationAmount) || 0
-                : 0;
+        const donationToCover = getDonationToSend(
+            NodeInfoStore?.nodeInfo?.isMainNet,
+            enableDonations,
+            donationAmount
+        );
         // payReqMintBalance is 0 when the single-mint check did not run, and
         // getPayReqError already covers the invoice falling short on its own.
         const donationLeavesTooLittle =

--- a/views/Cashu/CashuPaymentRequest.tsx
+++ b/views/Cashu/CashuPaymentRequest.tsx
@@ -36,6 +36,7 @@ import TransactionsStore, {
 import UnitsStore from '../../stores/UnitsStore';
 import LnurlPayStore from '../../stores/LnurlPayStore';
 import SettingsStore from '../../stores/SettingsStore';
+import NodeInfoStore from '../../stores/NodeInfoStore';
 
 import { localeString } from '../../utils/LocaleUtils';
 import BackendUtils from '../../utils/BackendUtils';
@@ -44,6 +45,7 @@ import { themeColor } from '../../utils/ThemeUtils';
 import { numberWithCommas } from '../../utils/UnitsUtils';
 import {
     calculateDonationAmount,
+    calculateTotalWithDonation,
     findDonationPercentageIndex
 } from '../../utils/DonationUtils';
 
@@ -68,6 +70,7 @@ interface CashuPaymentRequestProps {
     UnitsStore: UnitsStore;
     LnurlPayStore: LnurlPayStore;
     SettingsStore: SettingsStore;
+    NodeInfoStore: NodeInfoStore;
 }
 
 interface CashuPaymentRequestState {
@@ -88,7 +91,8 @@ interface CashuPaymentRequestState {
     'TransactionsStore',
     'UnitsStore',
     'LnurlPayStore',
-    'SettingsStore'
+    'SettingsStore',
+    'NodeInfoStore'
 )
 @observer
 export default class CashuPaymentRequest extends React.Component<
@@ -357,8 +361,13 @@ export default class CashuPaymentRequest extends React.Component<
     };
 
     render() {
-        const { CashuStore, LnurlPayStore, SettingsStore, navigation } =
-            this.props;
+        const {
+            CashuStore,
+            LnurlPayStore,
+            SettingsStore,
+            NodeInfoStore,
+            navigation
+        } = this.props;
         const {
             zaplockerToggle,
             slideToPayThreshold,
@@ -375,7 +384,9 @@ export default class CashuPaymentRequest extends React.Component<
             loadingFeeEstimate,
             feeEstimate,
             clearPayReq,
-            totalBalanceSats
+            totalBalanceSats,
+            payReqMintBalance,
+            payReqAmount
         } = CashuStore;
 
         // Zaplocker
@@ -409,7 +420,6 @@ export default class CashuPaymentRequest extends React.Component<
         const showMultiMintToggle = !!settings?.ecash?.enableMultiMint;
 
         const noBalance = totalBalanceSats === 0;
-        const hasPayReqError = !!getPayReqError;
 
         // The screen renders whatever invoice is in the shared CashuStore, so
         // when the store no longer matches the pinned invoice the user has a
@@ -426,6 +436,33 @@ export default class CashuPaymentRequest extends React.Component<
             Platform.OS !== 'ios' &&
             !isNoAmountInvoice &&
             settings?.payments?.enableDonations;
+
+        // The donation is a second payment drawn from the same mint right
+        // after this one, so the balance has to cover both. Only count it
+        // under the conditions CashuSendingLightning checks before it sends
+        // the donation; anything else means nothing extra leaves the wallet.
+        const donationToCover =
+            NodeInfoStore?.nodeInfo?.isMainNet && enableDonations
+                ? Number(donationAmount) || 0
+                : 0;
+        // payReqMintBalance is 0 when the single-mint check did not run, and
+        // getPayReqError already covers the invoice falling short on its own.
+        const donationLeavesTooLittle =
+            !getPayReqError &&
+            donationToCover > 0 &&
+            payReqMintBalance > 0 &&
+            payReqMintBalance <
+                calculateTotalWithDonation(
+                    payReqAmount,
+                    feeEstimate || 0,
+                    donationToCover
+                );
+        const payReqWarning = getPayReqError
+            ? getPayReqError
+            : donationLeavesTooLittle
+            ? localeString('stores.CashuStore.notEnoughFunds')
+            : undefined;
+        const hasPayReqError = !!payReqWarning;
 
         const showZaplockerWarning =
             isZaplocker ||
@@ -607,7 +644,7 @@ export default class CashuPaymentRequest extends React.Component<
                                                 />
                                             </View>
                                         )}
-                                    {!!getPayReqError && (
+                                    {!!payReqWarning && (
                                         <View
                                             style={{
                                                 paddingTop: 10,
@@ -615,7 +652,7 @@ export default class CashuPaymentRequest extends React.Component<
                                             }}
                                         >
                                             <WarningMessage
-                                                message={getPayReqError}
+                                                message={payReqWarning}
                                             />
                                         </View>
                                     )}

--- a/views/Cashu/CashuPaymentRequest.tsx
+++ b/views/Cashu/CashuPaymentRequest.tsx
@@ -227,28 +227,42 @@ export default class CashuPaymentRequest extends React.Component<
         }
     }
 
-    sendPayment = ({ amount }: SendPaymentReq) => {
-        const { SettingsStore, navigation } = this.props;
-        const { settings } = SettingsStore;
-
-        const enableDonations =
-            Platform.OS !== 'ios' && settings?.payments?.enableDonations;
+    // The donation that will actually be sent with this payment. Resolved in
+    // one place so the coverage check below and the amount handed to the
+    // sending views cannot disagree: those views take this as decided rather
+    // than re-reading the store, which is what stops a donation the check
+    // never counted from going out once nodeInfo arrives mid-payment.
+    resolveDonationToSend = () => {
+        const { CashuStore, SettingsStore, NodeInfoStore } = this.props;
         const { donationAmount } = this.state;
 
+        const donationsAllowed =
+            Platform.OS !== 'ios' &&
+            !!CashuStore.payReq?.getRequestAmount &&
+            SettingsStore.settings?.payments?.enableDonations;
+
+        return getDonationToSend(
+            NodeInfoStore?.nodeInfo?.isMainNet,
+            donationsAllowed,
+            donationAmount
+        );
+    };
+
+    sendPayment = ({ amount }: SendPaymentReq) => {
+        const { navigation } = this.props;
+        const donationToSend = this.resolveDonationToSend();
+
         navigation.navigate('CashuSendingLightning', {
-            enableDonations,
-            ...(enableDonations &&
-                donationAmount > 0 && {
-                    donationAmount: donationAmount.toString()
-                }),
+            ...(donationToSend > 0 && {
+                donationAmount: donationToSend.toString()
+            }),
             paymentAmount: amount ? amount : undefined
         });
     };
 
     triggerPayment = () => {
-        const { CashuStore, LnurlPayStore, SettingsStore, navigation } =
-            this.props;
-        const { multiMintEnabled, donationAmount } = this.state;
+        const { CashuStore, LnurlPayStore, navigation } = this.props;
+        const { multiMintEnabled } = this.state;
 
         // Fail closed: if the invoice in the store no longer matches the one
         // the user reviewed, it was swapped out from under the review screen.
@@ -283,23 +297,18 @@ export default class CashuPaymentRequest extends React.Component<
             ? requestAmount.toString()
             : undefined;
 
-        const enableDonations =
-            Platform.OS !== 'ios' &&
-            SettingsStore.settings?.payments?.enableDonations;
-
         const isMultiMint =
             multiMintEnabled &&
             Array.isArray(CashuStore?.multiMintSelectedUrls) &&
             CashuStore!.multiMintSelectedUrls.length > 1;
 
         if (isMultiMint) {
+            const donationToSend = this.resolveDonationToSend();
             navigation.navigate('MultimintPayment', {
                 paymentAmount,
-                enableDonations,
-                ...(enableDonations &&
-                    donationAmount > 0 && {
-                        donationAmount: donationAmount.toString()
-                    })
+                ...(donationToSend > 0 && {
+                    donationAmount: donationToSend.toString()
+                })
             });
             return;
         }
@@ -362,13 +371,8 @@ export default class CashuPaymentRequest extends React.Component<
     };
 
     render() {
-        const {
-            CashuStore,
-            LnurlPayStore,
-            SettingsStore,
-            NodeInfoStore,
-            navigation
-        } = this.props;
+        const { CashuStore, LnurlPayStore, SettingsStore, navigation } =
+            this.props;
         const {
             zaplockerToggle,
             slideToPayThreshold,
@@ -439,14 +443,10 @@ export default class CashuPaymentRequest extends React.Component<
             settings?.payments?.enableDonations;
 
         // The donation is a second payment drawn from the same mint right
-        // after this one, so the balance has to cover both. Only count it
-        // under the conditions CashuSendingLightning checks before it sends
-        // the donation; anything else means nothing extra leaves the wallet.
-        const donationToCover = getDonationToSend(
-            NodeInfoStore?.nodeInfo?.isMainNet,
-            enableDonations,
-            donationAmount
-        );
+        // after this one, so the balance has to cover both. This is the same
+        // value the sending views are handed, so what is checked here and
+        // what is sent are the same number.
+        const donationToCover = this.resolveDonationToSend();
         // payReqMintBalance is 0 when the single-mint check did not run, and
         // getPayReqError already covers the invoice falling short on its own.
         const donationLeavesTooLittle =

--- a/views/Cashu/CashuSendingLightning.tsx
+++ b/views/Cashu/CashuSendingLightning.tsx
@@ -28,7 +28,6 @@ import { sendingStyles } from '../../components/sendingStyles';
 import CashuStore from '../../stores/CashuStore';
 import ContactStore from '../../stores/ContactStore';
 import LnurlPayStore from '../../stores/LnurlPayStore';
-import NodeInfoStore from '../../stores/NodeInfoStore';
 
 import ContactUtils from '../../utils/ContactUtils';
 import { localeString } from '../../utils/LocaleUtils';
@@ -50,12 +49,10 @@ interface CashuSendingLightningProps {
     CashuStore: CashuStore;
     ContactStore: ContactStore;
     LnurlPayStore: LnurlPayStore;
-    NodeInfoStore: NodeInfoStore;
     route: Route<
         'CashuSendingLightning',
         {
             donationAmount?: string;
-            enableDonations: boolean;
             paymentAmount?: string;
         }
     >;
@@ -75,7 +72,7 @@ interface CashuSendingLightningState {
     showPaymentDetails: boolean;
 }
 
-@inject('CashuStore', 'ContactStore', 'LnurlPayStore', 'NodeInfoStore')
+@inject('CashuStore', 'ContactStore', 'LnurlPayStore')
 @observer
 export default class CashuSendingLightning extends React.Component<
     CashuSendingLightningProps,
@@ -144,9 +141,9 @@ export default class CashuSendingLightning extends React.Component<
     }
 
     componentDidUpdate() {
-        const { CashuStore, NodeInfoStore, route } = this.props;
+        const { CashuStore, route } = this.props;
         const { donationIsPaid } = this.state;
-        const { donationAmount, enableDonations } = route.params;
+        const { donationAmount } = route.params;
 
         const wasSuccessful = this.successfullySent(CashuStore);
 
@@ -156,11 +153,12 @@ export default class CashuSendingLightning extends React.Component<
             this.setState({ wasSuccessful: false });
         }
 
+        // donationAmount is only set when CashuPaymentRequest resolved a
+        // donation to send, against the same balance check it showed the
+        // user. Deciding again here could send one that was never counted.
         if (
-            NodeInfoStore!.nodeInfo.isMainNet &&
             wasSuccessful &&
             !this.state.wasSuccessful &&
-            enableDonations &&
             donationAmount &&
             !donationIsPaid
         ) {

--- a/views/Cashu/MultimintPayment.tsx
+++ b/views/Cashu/MultimintPayment.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../utils/CashuUtils';
 import {
     calculateTotalWithDonation,
+    getDonationToSend,
     loadDonationLnurl
 } from '../../utils/DonationUtils';
 import { localeString } from '../../utils/LocaleUtils';
@@ -111,19 +112,15 @@ export default class MultimintPayment extends React.Component<
             Number(route.params?.paymentAmount || 0);
         const feeEstimate = Number(CashuStore?.feeEstimate) || 0;
         // The donation is drawn from the same mints right after the invoice is
-        // paid, so it has to be covered before the payment starts. Mirrors the
-        // conditions componentDidMount checks before it sends the donation:
-        // anything else means no donation leaves the wallet.
-        const donationAmount =
-            NodeInfoStore?.nodeInfo?.isMainNet &&
-            route.params?.enableDonations &&
-            route.params?.donationAmount
-                ? Number(route.params.donationAmount) || 0
-                : 0;
+        // paid, so it has to be covered before the payment starts.
         const totalNeeded = calculateTotalWithDonation(
             requestAmount,
             feeEstimate,
-            donationAmount
+            getDonationToSend(
+                NodeInfoStore?.nodeInfo?.isMainNet,
+                route.params?.enableDonations,
+                route.params?.donationAmount
+            )
         );
 
         const hasNoMintsSelected = effectiveMints.length === 0;
@@ -193,6 +190,34 @@ export default class MultimintPayment extends React.Component<
         });
 
         if (this.state.step !== MultinutPaymentStep.FAILED) {
+            // nodeInfo starts out empty and is filled in once the node
+            // responds, so the constructor may have run before isMainNet was
+            // known and left the donation out of the coverage check. Redo it
+            // here, where the donation is read anyway, so a payment never
+            // starts against a balance that cannot also cover the donation.
+            const { NodeInfoStore, route } = this.props;
+            const totalNeeded = calculateTotalWithDonation(
+                this.paymentAmountSat,
+                Number(CashuStore?.feeEstimate) || 0,
+                getDonationToSend(
+                    NodeInfoStore?.nodeInfo?.isMainNet,
+                    route.params?.enableDonations,
+                    route.params?.donationAmount
+                )
+            );
+            const { totalSelectedBalance } = this.state;
+
+            if (
+                totalSelectedBalance > 0 &&
+                totalNeeded > totalSelectedBalance
+            ) {
+                this.setState({
+                    step: MultinutPaymentStep.FAILED,
+                    error: localeString('stores.CashuStore.notEnoughFunds')
+                });
+                return;
+            }
+
             this.executePayment();
         }
     }

--- a/views/Cashu/MultimintPayment.tsx
+++ b/views/Cashu/MultimintPayment.tsx
@@ -24,7 +24,6 @@ import Screen from '../../components/Screen';
 import { sendingStyles } from '../../components/sendingStyles';
 
 import CashuStore from '../../stores/CashuStore';
-import NodeInfoStore from '../../stores/NodeInfoStore';
 
 import {
     MintPaymentStatus,
@@ -33,7 +32,6 @@ import {
 } from '../../utils/CashuUtils';
 import {
     calculateTotalWithDonation,
-    getDonationToSend,
     loadDonationLnurl
 } from '../../utils/DonationUtils';
 import { localeString } from '../../utils/LocaleUtils';
@@ -51,11 +49,9 @@ interface MultimintPaymentProps {
         {
             paymentAmount?: string;
             donationAmount?: string;
-            enableDonations?: boolean;
         }
     >;
     CashuStore?: CashuStore;
-    NodeInfoStore?: NodeInfoStore;
 }
 
 interface MultimintPaymentState {
@@ -75,7 +71,7 @@ interface MultimintPaymentState {
     amountDonated: number | null;
 }
 
-@inject('CashuStore', 'NodeInfoStore')
+@inject('CashuStore')
 @observer
 export default class MultimintPayment extends React.Component<
     MultimintPaymentProps,
@@ -83,12 +79,13 @@ export default class MultimintPayment extends React.Component<
 > {
     private focusListener: (() => void) | undefined;
     private paymentAmountSat: number = 0;
+    private donationToSend: number = 0;
     private paymentHash?: string;
 
     constructor(props: MultimintPaymentProps) {
         super(props);
 
-        const { CashuStore, NodeInfoStore, route } = props;
+        const { CashuStore, route } = props;
         const selectedMintUrls = CashuStore?.multiMintSelectedUrls || [];
         const selectedMintSet = new Set(selectedMintUrls);
         const availableMints = CashuStore?.getMultimintInfo() || [];
@@ -111,16 +108,15 @@ export default class MultimintPayment extends React.Component<
             CashuStore?.payReq?.getRequestAmount ||
             Number(route.params?.paymentAmount || 0);
         const feeEstimate = Number(CashuStore?.feeEstimate) || 0;
-        // The donation is drawn from the same mints right after the invoice is
-        // paid, so it has to be covered before the payment starts.
+        // The donation is drawn from the same mints right after the invoice
+        // is paid, so it has to be covered before the payment starts. It is
+        // resolved once here and executePayment sends that same number, so
+        // the coverage check and the send cannot disagree.
+        this.donationToSend = Number(route.params?.donationAmount) || 0;
         const totalNeeded = calculateTotalWithDonation(
             requestAmount,
             feeEstimate,
-            getDonationToSend(
-                NodeInfoStore?.nodeInfo?.isMainNet,
-                route.params?.enableDonations,
-                route.params?.donationAmount
-            )
+            this.donationToSend
         );
 
         const hasNoMintsSelected = effectiveMints.length === 0;
@@ -190,34 +186,6 @@ export default class MultimintPayment extends React.Component<
         });
 
         if (this.state.step !== MultinutPaymentStep.FAILED) {
-            // nodeInfo starts out empty and is filled in once the node
-            // responds, so the constructor may have run before isMainNet was
-            // known and left the donation out of the coverage check. Redo it
-            // here, where the donation is read anyway, so a payment never
-            // starts against a balance that cannot also cover the donation.
-            const { NodeInfoStore, route } = this.props;
-            const totalNeeded = calculateTotalWithDonation(
-                this.paymentAmountSat,
-                Number(CashuStore?.feeEstimate) || 0,
-                getDonationToSend(
-                    NodeInfoStore?.nodeInfo?.isMainNet,
-                    route.params?.enableDonations,
-                    route.params?.donationAmount
-                )
-            );
-            const { totalSelectedBalance } = this.state;
-
-            if (
-                totalSelectedBalance > 0 &&
-                totalNeeded > totalSelectedBalance
-            ) {
-                this.setState({
-                    step: MultinutPaymentStep.FAILED,
-                    error: localeString('stores.CashuStore.notEnoughFunds')
-                });
-                return;
-            }
-
             this.executePayment();
         }
     }
@@ -253,7 +221,7 @@ export default class MultimintPayment extends React.Component<
     };
 
     executePayment = async () => {
-        const { CashuStore, NodeInfoStore, route } = this.props;
+        const { CashuStore, route } = this.props;
 
         try {
             this.setState((prev) => ({
@@ -296,13 +264,12 @@ export default class MultimintPayment extends React.Component<
             this.paymentHash =
                 CashuStore?.payReq?.payment_hash || this.paymentHash;
 
-            const { donationAmount, enableDonations } = route.params || {};
-            if (
-                NodeInfoStore?.nodeInfo?.isMainNet &&
-                enableDonations &&
-                donationAmount
-            ) {
-                void this.handleDonationPayment(donationAmount);
+            // Send exactly what the coverage check in the constructor
+            // counted, rather than deciding again here: re-reading the
+            // store could send a donation the balance was never checked
+            // against.
+            if (this.donationToSend > 0) {
+                void this.handleDonationPayment(this.donationToSend.toString());
             }
         } catch (error: any) {
             this.setState({

--- a/views/Cashu/MultimintPayment.tsx
+++ b/views/Cashu/MultimintPayment.tsx
@@ -31,7 +31,10 @@ import {
     MintProgressInfo,
     MultinutPaymentStep
 } from '../../utils/CashuUtils';
-import { loadDonationLnurl } from '../../utils/DonationUtils';
+import {
+    calculateTotalWithDonation,
+    loadDonationLnurl
+} from '../../utils/DonationUtils';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
 import UrlUtils from '../../utils/UrlUtils';
@@ -84,7 +87,7 @@ export default class MultimintPayment extends React.Component<
     constructor(props: MultimintPaymentProps) {
         super(props);
 
-        const { CashuStore, route } = props;
+        const { CashuStore, NodeInfoStore, route } = props;
         const selectedMintUrls = CashuStore?.multiMintSelectedUrls || [];
         const selectedMintSet = new Set(selectedMintUrls);
         const availableMints = CashuStore?.getMultimintInfo() || [];
@@ -107,7 +110,21 @@ export default class MultimintPayment extends React.Component<
             CashuStore?.payReq?.getRequestAmount ||
             Number(route.params?.paymentAmount || 0);
         const feeEstimate = Number(CashuStore?.feeEstimate) || 0;
-        const totalNeeded = requestAmount + feeEstimate;
+        // The donation is drawn from the same mints right after the invoice is
+        // paid, so it has to be covered before the payment starts. Mirrors the
+        // conditions componentDidMount checks before it sends the donation:
+        // anything else means no donation leaves the wallet.
+        const donationAmount =
+            NodeInfoStore?.nodeInfo?.isMainNet &&
+            route.params?.enableDonations &&
+            route.params?.donationAmount
+                ? Number(route.params.donationAmount) || 0
+                : 0;
+        const totalNeeded = calculateTotalWithDonation(
+            requestAmount,
+            feeEstimate,
+            donationAmount
+        );
 
         const hasNoMintsSelected = effectiveMints.length === 0;
         const hasInsufficientBalance =


### PR DESCRIPTION
# Description

Relates to issue: #4138

The donation is a second payment, drawn from the same balance right after the invoice is paid, but the funds check only covered the invoice and its fee reserve. A balance that cleared that check could still be too small for the donation, so the payment went out and the donation failed afterwards.

That failure is invisible. Every insufficient-funds branch that would report it is guarded by `if (!isDonationPayment)`, so when the donation is the payment that falls short, nothing is set and nothing is shown. The warning before paying is the only place a user can learn about it, which is what this PR fixes.

Both paths that send a donation now count it:

- Single mint. `CashuStore.getPayReq()` compared the mint balance against the melt quote amount plus its fee reserve. It now also exposes the two numbers it compared, and `CashuPaymentRequest` extends the check with the donation. The store's own verdict is untouched, so nothing that reads `getPayReqError` today behaves differently.
- Multi mint. `MultimintPayment` computes its own coverage check in the constructor and sets `step: FAILED` when the selected mints fall short, which is what stops `componentDidMount()` from starting the payment. That check now includes the donation.

A donation is only counted under the conditions the sending views apply before they send one: mainnet, donations enabled, and a non-zero amount. Those conditions used to be spelled out in each view; they are now resolved in one place by `getDonationToSend`. On testnet, on iOS, or with donations off, the check is unchanged.

One timing detail worth calling out. `NodeInfoStore.nodeInfo` starts as an empty object and is replaced once the node responds, so `isMainNet` can still be undefined while the `MultimintPayment` constructor runs, and the donation would be left out of a check made seconds before the donation is actually sent. `componentDidMount()` therefore redoes the check with the values available at that point and refuses to start the payment when the mints cannot cover both. `CashuPaymentRequest` does not need this: its check runs in `render()` and the component observes `nodeInfo`, so it re-renders once the value arrives.

The warning reuses `stores.CashuStore.notEnoughFunds`, so there is no new locale text. It also gates the pay button, and since the donation slider is on the same screen, lowering the donation clears it.

### What this does not cover

- The donation's own fee reserve. The full requirement is invoice + fee reserve + donation + the donation's fee reserve. The last one needs a separate melt quote, which needs an LNURL round trip before the user has paid anything, so this PR counts the donation only and can still be one fee reserve short.
- iOS. Only Android was tested; the donation paths are gated to non-iOS anyway, but the code was not exercised there.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

`getDonationToSend` and `calculateTotalWithDonation` are covered in `utils/DonationUtils.test.ts`. The two call sites are view code and there are no component tests in the repo, so they are not covered by tests.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

Pixel 9 Pro emulator, x86_64, Android 16. Both flows verified: the single-mint warning appearing with a donation and clearing from the slider, and the multimint refuse-to-start. Details and screenshots in a comment below.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

None of these: the flow this PR touches is Cashu ecash. The wallet was an LDK Node mainnet wallet, used only so `isMainNet` is genuine; no LDK payment was made.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding


