### PR TITLE
locales: fix contradictory incorrect-payment-details error copy

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1821,7 +1821,7 @@
     "error.failureReasonTimeout": "There are more routes to try, but the payment timeout was exceeded.",
     "error.failureReasonNoRoute": "No route found",
     "error.failureReasonError": "A non-recoverable error has occured",
-    "error.failureReasonIncorrectPaymentDetails": "Payment failed because the invoice was rejected, canceled, or is no longer valid. For a canceled hold invoice, the held payment is released and your funds are not sent. Check Activity for the final payment state.",
+    "error.failureReasonIncorrectPaymentDetails": "Payment failed: the recipient rejected it, or the invoice was canceled or is no longer valid. Any held funds have been returned to your balance.",
     "error.failureReasonIncorrectPaymentDetailsKeysend": "The receiving node might not accept keysend payments.",
     "error.failureReasonInsufficientBalance": "Insufficient local balance",
     "error.ldk.recipientRejected": "Payment rejected by recipient",

--- a/utils/ErrorUtils.test.ts
+++ b/utils/ErrorUtils.test.ts
@@ -129,7 +129,7 @@ describe('ErrorUtils', () => {
                     ['UnhandledContext']
                 )
             ).toEqual(
-                'Payment failed because the invoice was rejected, canceled, or is no longer valid. For a canceled hold invoice, the held payment is released and your funds are not sent. Check Activity for the final payment state.'
+                'Payment failed: the recipient rejected it, or the invoice was canceled or is no longer valid. Any held funds have been returned to your balance.'
             );
         });
 
@@ -141,7 +141,7 @@ describe('ErrorUtils', () => {
                     )
                 )
             ).toEqual(
-                'Payment failed because the invoice was rejected, canceled, or is no longer valid. For a canceled hold invoice, the held payment is released and your funds are not sent. Check Activity for the final payment state.'
+                'Payment failed: the recipient rejected it, or the invoice was canceled or is no longer valid. Any held funds have been returned to your balance.'
             );
         });
 
@@ -155,7 +155,7 @@ describe('ErrorUtils', () => {
                     ['Keysend']
                 )
             ).toEqual(
-                'Payment failed because the invoice was rejected, canceled, or is no longer valid. For a canceled hold invoice, the held payment is released and your funds are not sent. Check Activity for the final payment state. The receiving node might not accept keysend payments.'
+                'Payment failed: the recipient rejected it, or the invoice was canceled or is no longer valid. Any held funds have been returned to your balance. The receiving node might not accept keysend payments.'
             );
         });
 
@@ -168,7 +168,7 @@ describe('ErrorUtils', () => {
                     ['Keysend']
                 )
             ).toEqual(
-                'Payment failed because the invoice was rejected, canceled, or is no longer valid. For a canceled hold invoice, the held payment is released and your funds are not sent. Check Activity for the final payment state. The receiving node might not accept keysend payments.'
+                'Payment failed: the recipient rejected it, or the invoice was canceled or is no longer valid. Any held funds have been returned to your balance. The receiving node might not accept keysend payments.'
             );
         });
 


### PR DESCRIPTION
# Description

Relates to issue: **#2001** (follow-up to #4085)

Fixes the self-contradictory copy in `error.failureReasonIncorrectPaymentDetails`.

`FAILURE_REASON_INCORRECT_PAYMENT_DETAILS` is only ever surfaced on payments in the terminal `FAILED` state: LND sets `failure_reason` only once every HTLC attempt has been resolved, and `handlePayment` in `TransactionsStore` excludes `IN_FLIGHT` from the error path. By the time the user sees this message the payment is definitively failed and any held HTLC has been failed back. Telling users to "Check Activity for the final payment state" reintroduced exactly the uncertainty the first sentence resolved; that phrasing belongs to the genuinely non-terminal messages (`inTransit`, `paymentTimedOut`) it was copied from.

Also drops "your funds are not sent", which is implied by "Payment failed". The released-funds reassurance is kept (reworded) for hold invoice payers who watched their spendable balance drop while the HTLC was held, which was the original complaint in #2001. The message stays generic because the wire error is the same `incorrect_or_unknown_payment_details` code for canceled hold invoices, unknown hashes, and already-settled or expired invoices, so Zeus cannot distinguish those causes at this layer.

Before:

> Payment failed because the invoice was rejected, canceled, or is no longer valid. For a canceled hold invoice, the held payment is released and your funds are not sent. Check Activity for the final payment state.

After:

> Payment failed: the recipient rejected it, or the invoice was canceled or is no longer valid. Any held funds have been returned to your balance.

The keysend-specific suffix ("The receiving node might not accept keysend payments.") is unchanged and still appended through the locale-key path.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

Existing `utils/ErrorUtils.test.ts` expectations updated to the new copy (locale-key path, raw LND REST error path, and both keysend variants).

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Copy-only change; the error surface is exercised by the updated unit tests.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
