### PR TITLE
feat(nwc): allow viewing connection secret after creation

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2046,6 +2046,8 @@
     "views.Settings.NostrWalletConnect.publicKey": "Public Key",
     "views.Settings.NostrWalletConnect.connectionSecret": "Connection Secret",
     "views.Settings.NostrWalletConnect.connectionSecretDescription": "Scan this QR code or copy the connection secret in your Nostr app to link this connection.",
+    "views.Settings.NostrWalletConnect.viewConnectionSecret": "View Connection Secret",
+    "views.Settings.NostrWalletConnect.connectionSecretUnavailable": "The connection secret for this connection could not be rebuilt. Regenerate the connection to get a new pairing code.",
     "views.Settings.NostrWalletConnect.waitingForAppToConnect": "Waiting for app to connect...",
     "views.Settings.NostrWalletConnect.waitingToFinishPendingRequest": "Waiting to finish a pending request...",
     "views.Settings.NostrWalletConnect.noEventReceivedTimeoutDescription": "We didn't receive any event from your Nostr client, but you can still close this screen and use your connection. The connection will work once your Nostr client sends a request.",

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1066,11 +1066,15 @@ export default class NostrWalletConnectStore {
     /**
      * Rebuilds a connection's pairing URL from persisted state (the stored
      * client private key, the wallet service pubkey, and the connection's
-     * relay/lud16) so it can be viewed again after the QR screen shown at
+     * relay) so it can be viewed again after the QR screen shown at
      * create/regenerate time has been dismissed. Nothing about the URL is
-     * ephemeral except the route param that originally carried it.
-     * Returns null if the connection or its client key can no longer be
-     * found (e.g. it was created before client keys were persisted).
+     * ephemeral except the route param that originally carried it. The
+     * lud16 param reflects the current lud16Enabled setting and lightning
+     * address, not whatever was in effect when the connection was created.
+     * Returns null if the connection, its client key, or the wallet
+     * service keys can no longer be found (e.g. it was created before
+     * client keys were persisted) rather than regenerating anything, since
+     * this is a read-only path.
      */
     public getConnectionUrl = async (
         connectionId: string
@@ -1078,9 +1082,6 @@ export default class NostrWalletConnectStore {
         const { connection } = this.getConnection({ connectionId });
         if (!connection) return null;
 
-        if (!this.walletServiceKeys?.publicKey) {
-            await this.loadWalletServiceKeys();
-        }
         if (!this.walletServiceKeys?.publicKey) return null;
 
         const clientPrivateKey = await this.getClientPrivateKey(

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -1063,6 +1063,41 @@ export default class NostrWalletConnectStore {
         return { connection, index };
     };
 
+    /**
+     * Rebuilds a connection's pairing URL from persisted state (the stored
+     * client private key, the wallet service pubkey, and the connection's
+     * relay/lud16) so it can be viewed again after the QR screen shown at
+     * create/regenerate time has been dismissed. Nothing about the URL is
+     * ephemeral except the route param that originally carried it.
+     * Returns null if the connection or its client key can no longer be
+     * found (e.g. it was created before client keys were persisted).
+     */
+    public getConnectionUrl = async (
+        connectionId: string
+    ): Promise<string | null> => {
+        const { connection } = this.getConnection({ connectionId });
+        if (!connection) return null;
+
+        if (!this.walletServiceKeys?.publicKey) {
+            await this.loadWalletServiceKeys();
+        }
+        if (!this.walletServiceKeys?.publicKey) return null;
+
+        const clientPrivateKey = await this.getClientPrivateKey(
+            connection.pubkey
+        );
+        if (!clientPrivateKey) return null;
+
+        const lud16 = this.lud16Enabled ? this.getLightningAddress() : null;
+
+        return NostrConnectUtils.buildWalletConnectConnectionUrl(
+            this.walletServiceKeys.publicKey,
+            connection.relayUrl,
+            clientPrivateKey,
+            lud16
+        );
+    };
+
     public getActivities = async (
         connectionId: string
     ): Promise<{ name: string; activity: ConnectionActivity[] }> => {
@@ -3539,6 +3574,17 @@ export default class NostrWalletConnectStore {
                     'stores.NostrWalletConnectStore.error.failedToStorePrivateKey'
                 )
             );
+        }
+    }
+    private async getClientPrivateKey(pubkey: string): Promise<string | null> {
+        try {
+            const storedKeys = await Storage.getItem(NWC_CLIENT_KEYS);
+            if (!storedKeys) return null;
+            const keys: ClientKeys = JSON.parse(storedKeys);
+            return keys[pubkey] || null;
+        } catch (error) {
+            console.error('Failed to read client keys:', error);
+            return null;
         }
     }
     private async deleteClientKeys(pubkey: string): Promise<void> {

--- a/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionDetails.tsx
@@ -24,6 +24,7 @@ import ModalStore from '../../../stores/ModalStore';
 import { confirmAction } from '../../../utils/ActionUtils';
 import DateTimeUtils from '../../../utils/DateTimeUtils';
 import NostrConnectUtils from '../../../utils/NostrConnectUtils';
+import { reAuthNavigation } from '../../../utils/NavigationUtils';
 import { themeColor } from '../../../utils/ThemeUtils';
 import { localeString } from '../../../utils/LocaleUtils';
 
@@ -183,6 +184,15 @@ export default class NWCConnectionDetails extends React.Component<
         });
     };
 
+    viewConnectionSecret = (connectionId: string) => {
+        // The pairing URL is a bearer credential for this connection's
+        // permissions, so re-displaying it on demand is gated behind the
+        // same re-auth prompt used for other secret reveals (e.g. the seed).
+        reAuthNavigation(this.props.navigation, 'NWCConnectionQR', {
+            connectionId
+        });
+    };
+
     buildConnectionParams = (connection: NWCConnection): any => {
         const params: any = {
             id: connection.id,
@@ -262,7 +272,7 @@ export default class NWCConnectionDetails extends React.Component<
             const nostrUrl = await NostrWalletConnectStore.createConnection(
                 params
             );
-            if (nostrUrl) {
+            if (nostrUrl && !this.isUnmounted) {
                 const createdConnection =
                     NostrWalletConnectStore.connections[0];
                 navigation.navigate('NWCConnectionQR', {
@@ -719,6 +729,17 @@ export default class NWCConnectionDetails extends React.Component<
                                     </Text>
                                 </View>
                             )}
+                            <Button
+                                title={localeString(
+                                    'views.Settings.NostrWalletConnect.viewConnectionSecret'
+                                )}
+                                onPress={() =>
+                                    this.viewConnectionSecret(connection.id)
+                                }
+                                disabled={regenerating || deleting}
+                                secondary
+                                noUppercase
+                            />
                             <Button
                                 title={localeString(
                                     'views.Settings.NostrWalletConnect.regenerateConnection'

--- a/views/Settings/NostrWalletConnect/NWCConnectionQR.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionQR.tsx
@@ -56,9 +56,16 @@ export default class NWCConnectionQR extends React.Component<
     connectionTimeout: ReturnType<typeof setTimeout> | null = null;
     navigateBackTimeout: ReturnType<typeof setTimeout> | null = null;
     isUnmounted = false;
+    // True when this screen was opened to re-display an existing
+    // connection's secret (no nostrUrl route param) rather than right
+    // after creating/regenerating one. In this mode the connection is
+    // already paired, so the waiting-for-first-connection flow (spinner,
+    // timeout modal, success redirect) does not apply.
+    isViewOnly: boolean;
 
     constructor(props: NWCConnectionQRProps) {
         super(props);
+        this.isViewOnly = !props.route.params.nostrUrl;
         this.state = {
             isConnected: false,
             appState: AppState.currentState,
@@ -72,37 +79,52 @@ export default class NWCConnectionQR extends React.Component<
     componentDidMount() {
         const { NostrWalletConnectStore, route } = this.props;
         const { connectionId } = route.params;
-        NostrWalletConnectStore.startWaitingForConnection(connectionId);
         this.appStateSubscription = AppState.addEventListener(
             'change',
             this.handleAppStateChange
         );
-        this.connectionTimeout = setTimeout(() => {
-            if (
-                NostrWalletConnectStore.waitingForConnection &&
-                !NostrWalletConnectStore.connectionJustSucceeded
-            ) {
-                this.setState({ showTimeoutMessage: true });
-            }
-        }, CONNECTION_TIMEOUT_MS);
+
+        if (!this.isViewOnly) {
+            NostrWalletConnectStore.startWaitingForConnection(connectionId);
+            this.connectionTimeout = setTimeout(() => {
+                if (
+                    NostrWalletConnectStore.waitingForConnection &&
+                    !NostrWalletConnectStore.connectionJustSucceeded
+                ) {
+                    this.setState({ showTimeoutMessage: true });
+                }
+            }, CONNECTION_TIMEOUT_MS);
+        }
 
         if (!this.state.nostrUrl) {
-            NostrWalletConnectStore.getConnectionUrl(connectionId).then(
-                (nostrUrl) => {
+            NostrWalletConnectStore.getConnectionUrl(connectionId)
+                .then((nostrUrl) => {
                     if (this.isUnmounted) return;
                     this.setState({
                         nostrUrl,
                         loadingUrl: false,
                         urlUnavailable: !nostrUrl
                     });
-                }
-            );
+                })
+                .catch((error) => {
+                    console.error(
+                        'Failed to load NWC connection secret:',
+                        error
+                    );
+                    if (this.isUnmounted) return;
+                    this.setState({
+                        nostrUrl: null,
+                        loadingUrl: false,
+                        urlUnavailable: true
+                    });
+                });
         }
     }
 
     componentDidUpdate() {
         const { NostrWalletConnectStore, navigation } = this.props;
         if (
+            !this.isViewOnly &&
             NostrWalletConnectStore.connectionJustSucceeded &&
             !this.state.isConnected
         ) {
@@ -159,7 +181,11 @@ export default class NWCConnectionQR extends React.Component<
     handleGoBack = () => {
         const { navigation } = this.props;
         this.setState({ showTimeoutMessage: false });
-        navigation.popTo('NostrWalletConnect');
+        if (this.isViewOnly) {
+            navigation.goBack();
+        } else {
+            navigation.popTo('NostrWalletConnect');
+        }
     };
 
     renderConnectedSuccess = () => (
@@ -249,7 +275,7 @@ export default class NWCConnectionQR extends React.Component<
     );
 
     render() {
-        const { navigation, NostrWalletConnectStore } = this.props;
+        const { NostrWalletConnectStore } = this.props;
         const { isConnected, nostrUrl, loadingUrl, urlUnavailable } =
             this.state;
 
@@ -297,9 +323,7 @@ export default class NWCConnectionQR extends React.Component<
                         >
                             <Button
                                 title={localeString('general.close')}
-                                onPress={() => {
-                                    navigation.popTo('NostrWalletConnect');
-                                }}
+                                onPress={this.handleGoBack}
                                 secondary
                                 noUppercase
                             />

--- a/views/Settings/NostrWalletConnect/NWCConnectionQR.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionQR.tsx
@@ -276,13 +276,28 @@ export default class NWCConnectionQR extends React.Component<
     );
 
     renderUrlUnavailable = () => (
-        <Text
-            style={[styles.description, { color: themeColor('secondaryText') }]}
-        >
-            {localeString(
-                'views.Settings.NostrWalletConnect.connectionSecretUnavailable'
+        <>
+            <Text
+                style={[
+                    styles.description,
+                    { color: themeColor('secondaryText') }
+                ]}
+            >
+                {localeString(
+                    'views.Settings.NostrWalletConnect.connectionSecretUnavailable'
+                )}
+            </Text>
+            {this.isViewOnly && (
+                <View style={styles.goBackButton}>
+                    <Button
+                        title={localeString('general.goBack')}
+                        onPress={this.handleGoBack}
+                        secondary
+                        noUppercase
+                    />
+                </View>
             )}
-        </Text>
+        </>
     );
 
     render() {

--- a/views/Settings/NostrWalletConnect/NWCConnectionQR.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionQR.tsx
@@ -254,7 +254,18 @@ export default class NWCConnectionQR extends React.Component<
                 <CollapsedQR value={nostrUrl} hideText={true} expanded />
             </View>
 
-            {this.renderWaitingStatus()}
+            {this.isViewOnly ? (
+                <View style={styles.goBackButton}>
+                    <Button
+                        title={localeString('general.goBack')}
+                        onPress={this.handleGoBack}
+                        secondary
+                        noUppercase
+                    />
+                </View>
+            ) : (
+                this.renderWaitingStatus()
+            )}
         </>
     );
 
@@ -314,7 +325,7 @@ export default class NWCConnectionQR extends React.Component<
                             : this.renderConnectionContent(nostrUrl)}
                     </ScrollView>
 
-                    {!isConnected && (
+                    {!isConnected && !this.isViewOnly && (
                         <View
                             style={[
                                 styles.footer,
@@ -436,6 +447,11 @@ const styles = StyleSheet.create({
         paddingVertical: 20,
         paddingHorizontal: 12,
         alignItems: 'center'
+    },
+    goBackButton: {
+        width: '100%',
+        maxWidth: 340,
+        marginTop: 20
     },
     statusContainer: {
         marginTop: 28,

--- a/views/Settings/NostrWalletConnect/NWCConnectionQR.tsx
+++ b/views/Settings/NostrWalletConnect/NWCConnectionQR.tsx
@@ -28,7 +28,10 @@ import SuccessAnimation from '../../../components/SuccessAnimation';
 
 interface NWCConnectionQRProps {
     navigation: NativeStackNavigationProp<any, any>;
-    route: Route<'NWCConnectionQR', { connectionId: string; nostrUrl: string }>;
+    route: Route<
+        'NWCConnectionQR',
+        { connectionId: string; nostrUrl?: string }
+    >;
     NostrWalletConnectStore: NostrWalletConnectStore;
 }
 
@@ -36,6 +39,9 @@ interface NWCConnectionQRState {
     isConnected: boolean;
     appState: AppStateStatus;
     showTimeoutMessage: boolean;
+    nostrUrl: string | null;
+    loadingUrl: boolean;
+    urlUnavailable: boolean;
 }
 const CONNECTION_TIMEOUT_MS = 20000;
 const CONNECTED_REDIRECT_MS = 2000;
@@ -49,13 +55,17 @@ export default class NWCConnectionQR extends React.Component<
     appStateSubscription: NativeEventSubscription | null = null;
     connectionTimeout: ReturnType<typeof setTimeout> | null = null;
     navigateBackTimeout: ReturnType<typeof setTimeout> | null = null;
+    isUnmounted = false;
 
     constructor(props: NWCConnectionQRProps) {
         super(props);
         this.state = {
             isConnected: false,
             appState: AppState.currentState,
-            showTimeoutMessage: false
+            showTimeoutMessage: false,
+            nostrUrl: props.route.params.nostrUrl ?? null,
+            loadingUrl: !props.route.params.nostrUrl,
+            urlUnavailable: false
         };
     }
 
@@ -75,6 +85,19 @@ export default class NWCConnectionQR extends React.Component<
                 this.setState({ showTimeoutMessage: true });
             }
         }, CONNECTION_TIMEOUT_MS);
+
+        if (!this.state.nostrUrl) {
+            NostrWalletConnectStore.getConnectionUrl(connectionId).then(
+                (nostrUrl) => {
+                    if (this.isUnmounted) return;
+                    this.setState({
+                        nostrUrl,
+                        loadingUrl: false,
+                        urlUnavailable: !nostrUrl
+                    });
+                }
+            );
+        }
     }
 
     componentDidUpdate() {
@@ -96,6 +119,7 @@ export default class NWCConnectionQR extends React.Component<
 
     componentWillUnmount() {
         const { NostrWalletConnectStore } = this.props;
+        this.isUnmounted = true;
         NostrWalletConnectStore.cancelWaitingForConnection();
         if (this.appStateSubscription) {
             this.appStateSubscription.remove();
@@ -208,10 +232,26 @@ export default class NWCConnectionQR extends React.Component<
         </>
     );
 
+    renderLoadingUrl = () => (
+        <View style={styles.statusContainer}>
+            <LoadingIndicator size={36} />
+        </View>
+    );
+
+    renderUrlUnavailable = () => (
+        <Text
+            style={[styles.description, { color: themeColor('secondaryText') }]}
+        >
+            {localeString(
+                'views.Settings.NostrWalletConnect.connectionSecretUnavailable'
+            )}
+        </Text>
+    );
+
     render() {
-        const { navigation, NostrWalletConnectStore, route } = this.props;
-        const { nostrUrl } = route.params;
-        const { isConnected } = this.state;
+        const { navigation, NostrWalletConnectStore } = this.props;
+        const { isConnected, nostrUrl, loadingUrl, urlUnavailable } =
+            this.state;
 
         return (
             <Screen>
@@ -241,6 +281,10 @@ export default class NWCConnectionQR extends React.Component<
                     >
                         {isConnected
                             ? this.renderConnectedSuccess()
+                            : loadingUrl
+                            ? this.renderLoadingUrl()
+                            : urlUnavailable || !nostrUrl
+                            ? this.renderUrlUnavailable()
                             : this.renderConnectionContent(nostrUrl)}
                     </ScrollView>
 


### PR DESCRIPTION
# Description

Relates to issue: [**ZEUS-4525**](https://github.com/ZeusLN/zeus/issues/4525)

## Summary

- Previously, the NWC pairing URL (connection secret) was only ever shown once, at connection creation/regeneration time, via a route param passed into `NWCConnectionQR`. Once that screen was dismissed there was no way to see it again.
- Adds a "View Connection Secret" button on `NWCConnectionDetails` that navigates to `NWCConnectionQR` with just a `connectionId` (no `nostrUrl`), gated behind the app's existing re-auth prompt (same pattern used for other secret reveals like the seed).

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-04 at 16 02 49" src="https://github.com/user-attachments/assets/6dc45d34-f028-44aa-a2c7-5282a836ac73" />


- Adds `NostrWalletConnectStore.getConnectionUrl(connectionId)`, which rebuilds the pairing URL from persisted state — the stored client private key, the wallet service pubkey, and the connection's relay/lud16 — since nothing about the URL is actually ephemeral except the route param that used to carry it.
- `NWCConnectionQR` now supports loading the URL asynchronously when it's not passed via route params: shows a loading indicator while fetching, and a fallback message if the URL can't be rebuilt (e.g. connections created before client keys were persisted).
- Minor: guard `createConnection`'s post-navigation state update with `!this.isUnmounted` to avoid a set-state-after-unmount warning.

## Test plan
- [x] Create a new NWC connection, confirm the QR/secret still displays immediately as before.
- [x] From the connection details screen, tap "View Connection Secret", complete re-auth, and confirm the same pairing URL/QR is shown.
- [x] Verify the fallback "connection secret unavailable" message appears for a connection whose client key can't be found.
- [x] Regenerate a connection and confirm the regenerate flow is unaffected.


This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
