### PR TITLE
LSPS7: surface extendable-channels fetch errors, show maxed-out leases

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -624,6 +624,7 @@
     "views.Channel.lease.lspDiscretion.explainer2": "If you would like to ensure your channel remains open, consider purchasing a channel lease.",
     "views.Channel.lease.purchaseLease": "Purchase channel lease",
     "views.Channel.lease.extendLease": "Extend channel lease",
+    "views.Channel.lease.fetchError": "Unable to fetch channel lease info from your LSP",
     "views.Channel.closureReason.unknown": "Channel closed: unknown reason",
     "views.Channel.closureReason.counterpartyForceClosed": "Channel rejected by counterparty: {{peerMessage}}",
     "views.Channel.closureReason.counterpartyForceClosedDefault": "Channel rejected: counterparty force closed",

--- a/stores/LSPStore.ts
+++ b/stores/LSPStore.ts
@@ -57,6 +57,7 @@ export default class LSPStore {
     // LSPS7
     @observable public getExtendableChannelsId: string;
     @observable public getExtendableChannelsData: any = [];
+    @observable public getExtendableChannelsError: boolean = false;
     @observable public createExtensionOrderId: string;
     @observable public createExtensionOrderResponse: any = {};
     @observable public getExtensionOrderId: string;
@@ -633,11 +634,17 @@ export default class LSPStore {
             return true;
         } else if (data.id === this.getExtendableChannelsId) {
             if (data.error) {
+                console.error(
+                    'Error fetching LSPS7 extendable channels:',
+                    data.error
+                );
+                this.getExtendableChannelsError = true;
                 this.error = true;
                 this.error_msg = data?.error?.message
                     ? errorToUserFriendly(data?.error?.message)
                     : '';
             } else {
+                this.getExtendableChannelsError = false;
                 this.getExtendableChannelsData =
                     data?.result?.extendable_channels;
             }
@@ -1148,6 +1155,7 @@ export default class LSPStore {
                 // Normalize camelCase keys from native module to snake_case
                 // to match the JSON-RPC custom message format
                 runInAction(() => {
+                    this.getExtendableChannelsError = false;
                     this.getExtendableChannelsData = channels.map(
                         (ch: any) => ({
                             short_channel_id: ch.shortChannelId,
@@ -1162,7 +1170,12 @@ export default class LSPStore {
                 });
                 return;
             } catch (error: any) {
+                console.error(
+                    'Error fetching LSPS7 extendable channels:',
+                    error
+                );
                 runInAction(() => {
+                    this.getExtendableChannelsError = true;
                     this.error = true;
                     this.error_msg =
                         error?.message ||

--- a/views/Channels/Channel.tsx
+++ b/views/Channels/Channel.tsx
@@ -30,7 +30,10 @@ import LoadingIndicator from '../../components/LoadingIndicator';
 import OnchainFeeInput from '../../components/OnchainFeeInput';
 import { Row } from '../../components/layout/Row';
 import Screen from '../../components/Screen';
-import { ErrorMessage } from '../../components/SuccessErrorMessage';
+import {
+    ErrorMessage,
+    WarningMessage
+} from '../../components/SuccessErrorMessage';
 import Switch from '../../components/Switch';
 import Text from '../../components/Text';
 import TextInput from '../../components/TextInput';
@@ -308,6 +311,7 @@ export default class ChannelView extends React.Component<
         const {
             navigation,
             SettingsStore,
+            LSPStore,
             ModalStore,
             NodeInfoStore,
             ChannelsStore
@@ -534,7 +538,18 @@ export default class ChannelView extends React.Component<
                                 )}: ${confs.current} / ${confs.total}`}
                             </Text>
                         )}
-                        {!!renewalInfo.maxExtensionInBlocks && (
+                        {LSPStore.getExtendableChannelsError &&
+                            remotePubkey === LSPStore.getLSPSPubkey() &&
+                            !renewalInfo.maxExtensionInBlocks &&
+                            !renewalInfo.expirationBlock && (
+                                <WarningMessage
+                                    message={localeString(
+                                        'views.Channel.lease.fetchError'
+                                    )}
+                                />
+                            )}
+                        {(!!renewalInfo.maxExtensionInBlocks ||
+                            !!renewalInfo.expirationBlock) && (
                             <>
                                 <Row
                                     justify="space-between"
@@ -642,42 +657,46 @@ export default class ChannelView extends React.Component<
                                             </Text>
                                         </TouchableOpacity>
                                     )}
-                                    <ElementButton
-                                        title={
-                                            renewalInfo.expiresInBlocks
-                                                ? localeString(
-                                                      'views.Channel.lease.extendLease'
-                                                  )
-                                                : localeString(
-                                                      'views.Channel.lease.purchaseLease'
-                                                  )
-                                        }
-                                        onPress={() => {
-                                            navigation.navigate('LSPS7', {
-                                                chanId: renewalInfo.scid,
-                                                maxExtensionInBlocks:
-                                                    renewalInfo.maxExtensionInBlocks,
-                                                expirationBlock:
-                                                    renewalInfo.expirationBlock
-                                            });
-                                        }}
-                                        ViewComponent={LinearGradient as any}
-                                        linearGradientProps={{
-                                            colors: [
-                                                'rgb(180, 26, 20)',
-                                                'rgb(255, 169, 0)'
-                                            ],
-                                            start: { x: 0, y: 0.5 },
-                                            end: { x: 1, y: 0.5 }
-                                        }}
-                                        buttonStyle={{
-                                            borderRadius: 5
-                                        }}
-                                        titleStyle={{
-                                            ...styles.text,
-                                            fontSize: 15
-                                        }}
-                                    />
+                                    {!!renewalInfo.maxExtensionInBlocks && (
+                                        <ElementButton
+                                            title={
+                                                renewalInfo.expiresInBlocks
+                                                    ? localeString(
+                                                          'views.Channel.lease.extendLease'
+                                                      )
+                                                    : localeString(
+                                                          'views.Channel.lease.purchaseLease'
+                                                      )
+                                            }
+                                            onPress={() => {
+                                                navigation.navigate('LSPS7', {
+                                                    chanId: renewalInfo.scid,
+                                                    maxExtensionInBlocks:
+                                                        renewalInfo.maxExtensionInBlocks,
+                                                    expirationBlock:
+                                                        renewalInfo.expirationBlock
+                                                });
+                                            }}
+                                            ViewComponent={
+                                                LinearGradient as any
+                                            }
+                                            linearGradientProps={{
+                                                colors: [
+                                                    'rgb(180, 26, 20)',
+                                                    'rgb(255, 169, 0)'
+                                                ],
+                                                start: { x: 0, y: 0.5 },
+                                                end: { x: 1, y: 0.5 }
+                                            }}
+                                            buttonStyle={{
+                                                borderRadius: 5
+                                            }}
+                                            titleStyle={{
+                                                ...styles.text,
+                                                fontSize: 15
+                                            }}
+                                        />
+                                    )}
                                 </Row>
 
                                 <Divider


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

Fixes the LDK Node report of channel details missing the lease time, together with server-side ZeusLN/olympus-lsps#128.

**Background:** Olympus can emit a negative `max_channel_extension_expiry_blocks` in `lsps7.get_extendable_channels` when an admin-granted extension pushed a lease expiry past `height + maxLifetimeBlocks`. The LDK Node backend parses that response natively with strict serde (`u32`), so one bad entry fails the entire response: the message is dropped, the native call times out after 5s, and ZEUS silently showed no lease info for any channel. The embedded LND custom-message path tolerates the same JSON, which is why only LDK Node was affected. Verified with a parse probe against the rust-lightning fork's actual LSPS7 types.

This PR addresses the two client-side gaps that made the failure invisible and that keep affecting maxed-out leases even after the server clamp:

1. `LSPStore` now tracks LSPS7 extendable-channels fetch failures in a dedicated `getExtendableChannelsError` observable (cleared on success) and logs the underlying error. Previously the error was stashed in `error_msg` with no consumer.
2. The Channel view shows a warning on channels with the LSP when the fetch failed and no lease data is available, instead of rendering nothing.
3. The lease block was gated on `max_channel_extension_expiry_blocks` being non-zero, so a lease already at the LSP's max lifetime (0 remaining extension, e.g. after an admin grant plus the server clamp in ZeusLN/olympus-lsps#128) hid its expiry entirely. The lease expiry now renders whenever an expiration block is known; only the extend/purchase button is hidden when no extension is available.

Known follow-up (out of scope here): `renewalInfo` is computed once in the Channel view constructor, so LSPS7 data arriving after the view opens still is not reflected until re-entry; the channels list recomputes per render and does not have this issue.

Screenshots pending device testing.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass (two pre-existing failures in `utils/LnurlHelpers.test.ts` and `utils/PhotoUtils.test.ts` reproduce on pristine master in the same environment and are unrelated to this diff)

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
