### PR TITLE
fix(security): prevent iOS swipe-back from dismissing app lock

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -602,6 +602,10 @@ export default class App extends React.PureComponent {
                                                                 component={
                                                                     Lockscreen
                                                                 }
+                                                                options={{
+                                                                    gestureEnabled:
+                                                                        false // disables swipe back
+                                                                }}
                                                             />
                                                             <Stack.Screen
                                                                 name="Accounts" // @ts-ignore:next-line

--- a/views/Settings/Seed.tsx
+++ b/views/Settings/Seed.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import {
     Alert,
+    AppState,
     Modal,
+    NativeEventSubscription,
     ScrollView,
     StyleSheet,
     Text,
@@ -76,6 +78,7 @@ interface SeedState {
     isDeleteModalVisible: boolean;
     isChannelExporting: boolean;
     channelExportMessage: string;
+    revealResetKey: number;
 }
 
 const MnemonicWord = ({ index, word }: { index: any; word: any }) => {
@@ -134,13 +137,37 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
         showModal: false,
         isDeleteModalVisible: false,
         isChannelExporting: false,
-        channelExportMessage: ''
+        channelExportMessage: '',
+        revealResetKey: 0
     };
+
+    private appStateSubscription: NativeEventSubscription | undefined;
 
     componentDidMount() {
         // make sure we have latest settings and the seed phrase is accessible
         this.props.SettingsStore.getSettings();
+
+        // The background lock pushes Lockscreen over this view without
+        // unmounting it, so revealed words must not survive backgrounding
+        this.appStateSubscription = AppState.addEventListener(
+            'change',
+            this.handleAppStateChange
+        );
     }
+
+    componentWillUnmount() {
+        this.appStateSubscription?.remove();
+    }
+
+    handleAppStateChange = (nextAppState: string) => {
+        if (nextAppState === 'background') {
+            this.setState((prevState) => ({
+                understood: this.props.route.params?.skipWarning ?? false,
+                showModal: false,
+                revealResetKey: prevState.revealResetKey + 1
+            }));
+        }
+    };
 
     renderDeleteModal = () => {
         const { navigation } = this.props;
@@ -244,7 +271,8 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
             understood,
             showModal,
             isChannelExporting,
-            channelExportMessage
+            channelExportMessage,
+            revealResetKey
         } = this.state;
         // Prefer an explicit seed for the wallet being viewed. SettingsStore
         // only mirrors the active node, so inactive wallets must pass
@@ -589,7 +617,7 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                                             <MnemonicWord
                                                 index={index}
                                                 word={word}
-                                                key={`mnemonic-${index}`}
+                                                key={`mnemonic-${revealResetKey}-${index}`}
                                             />
                                         ))}
                             </View>
@@ -606,7 +634,7 @@ export default class Seed extends React.PureComponent<SeedProps, SeedState> {
                                                     )
                                                 }
                                                 word={word}
-                                                key={`mnemonic-${
+                                                key={`mnemonic-${revealResetKey}-${
                                                     index +
                                                     Math.ceil(
                                                         seedPhrase.length / 2


### PR DESCRIPTION
# Description

The Lockscreen was registered as an ordinary native-stack screen with the default iOS interactive pop gesture enabled. When the background lock engages, `Wallet.handleAppStateChange` pushes Lockscreen **over** the existing route stack, so a single edge swipe on an OS-unlocked phone dismissed the lock and revealed whatever screen was underneath while `loggedIn` remained false. Android hardware back was already blocked in `App.tsx`, but `BackHandler` is a no-op on iOS. The codebase already disables this gesture selectively (PaymentRequest, VerifyOnChain, CashuPaymentRequest) — Lockscreen was not on the list.

Worst case: the Seed view kept per-word reveal state and the "I understand" acknowledgement across backgrounding, so a swipe could land directly on previously revealed seed words.

Changes:
- Register Lockscreen with `gestureEnabled: false`, matching the existing PaymentRequest pattern
- Defense in depth: the Seed view now subscribes to AppState and, on backgrounding, re-masks all mnemonic words (via a remount key on the per-word reveal state), closes the dangerous-copy modal, and drops back behind the warning acknowledgement

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Device tests pending (will update):
- iOS: enable background lock, open Seed, reveal words, background, foreground, attempt edge swipe on Lockscreen (should not dismiss); verify words re-masked and warning screen shown after unlock
- iOS: cold-start lock swipe attempt
- Android: regression check that hardware back on Lockscreen still exits the app

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Backend-independent: navigation options and view-local state only.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding