### PR TITLE
fix(security): bind LNURL-auth callback host to signing domain

### DIFF
--- a/utils/LnurlPayUtils.test.ts
+++ b/utils/LnurlPayUtils.test.ts
@@ -4,7 +4,11 @@ import { sha256 } from '@noble/hashes/sha256';
 
 import Base64Utils from './Base64Utils';
 import Bolt11Utils from './Bolt11Utils';
-import { verifyLnurlPayInvoice, isLnurlCallbackAllowed } from './LnurlPayUtils';
+import {
+    verifyLnurlPayInvoice,
+    isLnurlCallbackAllowed,
+    verifyLnurlAuthCallback
+} from './LnurlPayUtils';
 
 const METADATA = '[["text/plain","Payment to Alice"]]';
 const MATCHING_HASH = Base64Utils.bytesToHex(
@@ -223,6 +227,90 @@ describe('LnurlPayUtils', () => {
         it('rejects an empty or missing callback', () => {
             expect(isLnurlCallbackAllowed('').ok).toBe(false);
             expect(isLnurlCallbackAllowed(undefined as any).ok).toBe(false);
+        });
+    });
+
+    describe('verifyLnurlAuthCallback', () => {
+        const K1 = 'a'.repeat(64);
+
+        it('accepts a callback whose host matches the signing domain', () => {
+            expect(
+                verifyLnurlAuthCallback(
+                    `https://service.example/auth?tag=login&k1=${K1}`,
+                    'service.example'
+                ).ok
+            ).toBe(true);
+        });
+
+        it('matches domains case-insensitively', () => {
+            expect(
+                verifyLnurlAuthCallback(
+                    `https://Service.Example/auth?tag=login&k1=${K1}`,
+                    'service.example'
+                ).ok
+            ).toBe(true);
+        });
+
+        it('allows http for onion services', () => {
+            expect(
+                verifyLnurlAuthCallback(
+                    `http://abcdef.onion/auth?tag=login&k1=${K1}`,
+                    'abcdef.onion'
+                ).ok
+            ).toBe(true);
+        });
+
+        it('rejects the backslash-userinfo parser-confusion PoC', () => {
+            // js-lnurl getDomain sees victim.example (signing/display);
+            // url.parse and native HTTP stacks contact attacker.example
+            const result = verifyLnurlAuthCallback(
+                `https://attacker.example\\@victim.example/?tag=login&k1=${K1}`,
+                'victim.example'
+            );
+            expect(result.ok).toBe(false);
+            expect(result.reason).toContain('backslash');
+        });
+
+        it('rejects a callback whose host differs from the signing domain', () => {
+            expect(
+                verifyLnurlAuthCallback(
+                    `https://attacker.example/auth?tag=login&k1=${K1}`,
+                    'victim.example'
+                ).ok
+            ).toBe(false);
+        });
+
+        it('rejects userinfo even when the host matches', () => {
+            const result = verifyLnurlAuthCallback(
+                `https://user@service.example/auth?tag=login&k1=${K1}`,
+                'service.example'
+            );
+            expect(result.ok).toBe(false);
+            expect(result.reason).toContain('userinfo');
+        });
+
+        it('rejects cleartext http to non-onion hosts', () => {
+            expect(
+                verifyLnurlAuthCallback(
+                    `http://service.example/auth?tag=login&k1=${K1}`,
+                    'service.example'
+                ).ok
+            ).toBe(false);
+        });
+
+        it('rejects an empty expected domain', () => {
+            expect(
+                verifyLnurlAuthCallback(
+                    `https://service.example/auth?tag=login&k1=${K1}`,
+                    ''
+                ).ok
+            ).toBe(false);
+        });
+
+        it('rejects missing callbacks', () => {
+            expect(
+                verifyLnurlAuthCallback(undefined as any, 'service.example').ok
+            ).toBe(false);
         });
     });
 });

--- a/utils/LnurlPayUtils.ts
+++ b/utils/LnurlPayUtils.ts
@@ -256,3 +256,47 @@ export const isLnurlCallbackAllowed = (callback: string): LnurlCheckResult => {
 
     return { ok: true };
 };
+
+/**
+ * Bind an LNURL-auth callback to the domain that is displayed to the user
+ * and used to derive the service-specific linking key. js-lnurl's getDomain
+ * and the url parser used for transmission disagree on URLs containing
+ * backslashes or userinfo: getDomain splits on the last '@' but not on '\',
+ * while url.parse (like WHATWG parsers and native HTTP stacks) treats '\'
+ * as a path delimiter. A crafted
+ * "https://attacker.example\@victim.example/?tag=login&k1=..." therefore
+ * displays and signs for victim.example while transmitting the signature to
+ * attacker.example, handing the attacker a valid login for the victim's
+ * account. Reject the ambiguous constructs outright and require the host
+ * that will actually be contacted to equal the displayed domain.
+ */
+export const verifyLnurlAuthCallback = (
+    callback: string,
+    expectedDomain: string
+): LnurlCheckResult => {
+    if (typeof callback === 'string' && callback.includes('\\')) {
+        return { ok: false, reason: 'callback URL contains a backslash' };
+    }
+
+    const allowed = isLnurlCallbackAllowed(callback);
+    if (!allowed.ok) return allowed;
+
+    const parsed = url.parse(callback);
+    if (parsed.auth) {
+        return { ok: false, reason: 'callback URL contains userinfo' };
+    }
+
+    const hostname = (parsed.hostname || '').toLowerCase();
+    if (
+        typeof expectedDomain !== 'string' ||
+        expectedDomain.length === 0 ||
+        hostname !== expectedDomain.toLowerCase()
+    ) {
+        return {
+            ok: false,
+            reason: `callback host "${hostname}" does not match signing domain "${expectedDomain}"`
+        };
+    }
+
+    return { ok: true };
+};

--- a/views/LnurlAuth.tsx
+++ b/views/LnurlAuth.tsx
@@ -21,6 +21,7 @@ import { themeColor } from '../utils/ThemeUtils';
 import { localeString } from '../utils/LocaleUtils';
 import BackendUtils from '../utils/BackendUtils';
 import Base64Utils from '../utils/Base64Utils';
+import { verifyLnurlAuthCallback } from '../utils/LnurlPayUtils';
 import {
     ecdsaSignDERHex,
     getCompressedPublicKeyHex
@@ -92,6 +93,17 @@ export default class LnurlAuth extends React.Component<
         const { route } = props;
         const lnurl = route.params?.lnurlParams;
 
+        // the callback host must match the domain that is displayed and
+        // used for linking-key derivation, or an ambiguous URL could send
+        // a valid signature for one service to another
+        const callbackCheck = verifyLnurlAuthCallback(
+            lnurl.callback,
+            lnurl.domain
+        );
+        if (!callbackCheck.ok) {
+            throw new Error(callbackCheck.reason);
+        }
+
         return {
             domain: lnurl.domain,
             action: lnurl.action,
@@ -152,6 +164,10 @@ export default class LnurlAuth extends React.Component<
     }
 
     componentDidMount() {
+        // domain is only empty when constructor validation failed;
+        // never derive or sign in that state
+        if (!this.state.domain) return;
+
         const { implementation } = this.props.SettingsStore;
         if (implementation === 'lndhub') {
             this.props.SettingsStore.updateSettings({
@@ -176,6 +192,22 @@ export default class LnurlAuth extends React.Component<
 
         const { route } = this.props;
         const lnurl = route.params?.lnurlParams;
+
+        // last gate before the signature leaves the device: the host the
+        // request goes to must still be the domain the key was derived for
+        const callbackCheck = verifyLnurlAuthCallback(
+            lnurl.callback,
+            this.state.domain
+        );
+        if (!callbackCheck.ok) {
+            this.setState({
+                authenticating: false,
+                signatureSuccess: false,
+                errorMsgAuth: callbackCheck.reason || ''
+            });
+            return;
+        }
+
         const u = url.parse(lnurl.callback);
         const qs = querystring.parse(u.query);
         qs.key = linkingKeyPub;


### PR DESCRIPTION
# Description

LnurlAuth displayed and derived its service-specific linking key from js-lnurl's `getDomain` while independently re-parsing the callback with `url.parse` for transmission. The two parsers disagree on URLs containing backslashes: `getDomain` splits on the last `@` but not on `\`, while `url.parse` (like WHATWG parsers and the native HTTP stacks that ultimately dial the socket) treats `\` as a path delimiter.

A crafted `https://attacker.example\@victim.example/?tag=login&k1=...` therefore showed **victim.example** to the user, derived victim.example's linking key, and sent the resulting signature to **attacker.example** — handing the attacker a valid login response for the victim's account on the target service. Reproduced offline against the installed parsers.

Changes:
- New `verifyLnurlAuthCallback` in `LnurlPayUtils`: rejects backslashes and userinfo outright, applies the same https-only / private-address callback policy LNURL-pay already enforces (`isLnurlCallbackAllowed`), and requires the parsed callback host to equal the displayed/derived domain (case-insensitive)
- Enforced at view construction (invalid-params alert) **and** again immediately before the signature leaves the device
- Key derivation is skipped entirely when constructor validation fails (previously `componentDidMount` would still sign)
- Regression tests including the parser-confusion PoC URL

`keyauth://` URLs are unaffected: `decodelnurl` rewrites them to `https://` (or `http://` for .onion) before they reach this view.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

`utils/LnurlPayUtils.test.ts` gains 9 cases for `verifyLnurlAuthCallback`: matching host, case-insensitivity, onion-over-http, the backslash PoC, host mismatch, userinfo, cleartext http, empty domain, missing callback.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Device tests pending (will update): normal LNURL-auth login against a real service on both platforms; crafted backslash URL rejected with invalid-params alert.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

The validation is backend-independent (it runs before `BackendUtils.lnurlAuth`); a login smoke test on one lnurlAuth-capable backend plus lndhub's auth-mode path should suffice.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding