### PR TITLE
fix(security): require confirmation before LNURL-channel peer connect

### DIFF
--- a/views/LnurlChannel.tsx
+++ b/views/LnurlChannel.tsx
@@ -93,11 +93,11 @@ export default class LnurlChannel extends React.Component<
             connectingToPeer: false,
             peerSuccess: false,
             lnurlChannelSuccess: false,
-            errorMsgPeer: 'Error'
+            errorMsgPeer: ''
         };
     }
 
-    triggerConnect() {
+    triggerConnect(onSuccess?: () => void) {
         const { node_pubkey_string, host } = this.state;
         this.setState({ connectingToPeer: true });
 
@@ -105,11 +105,14 @@ export default class LnurlChannel extends React.Component<
             addr: {
                 pubkey: node_pubkey_string,
                 host
-            }
+            },
+            // don't persist a peer the user hasn't opened a channel with
+            perm: false
         })
             .then(() => {
                 this.setState({ connectingToPeer: false });
                 this.setState({ peerSuccess: true });
+                if (onSuccess) onSuccess();
             })
             .catch((error: any) => {
                 // handle error
@@ -121,11 +124,9 @@ export default class LnurlChannel extends React.Component<
                     this.state.errorMsgPeer.includes('already')
                 ) {
                     this.setState({ peerSuccess: true });
+                    if (onSuccess) onSuccess();
                 }
             });
-    }
-    componentDidMount() {
-        this.triggerConnect();
     }
 
     sendValues() {
@@ -276,9 +277,17 @@ export default class LnurlChannel extends React.Component<
                                 color: themeColor('background')
                             }}
                             onPress={() => {
-                                this.sendValues();
+                                // only contact the service-supplied peer
+                                // after explicit user confirmation
+                                if (this.state.peerSuccess) {
+                                    this.sendValues();
+                                } else {
+                                    this.triggerConnect(() =>
+                                        this.sendValues()
+                                    );
+                                }
                             }}
-                            disabled={!peerSuccess}
+                            disabled={this.state.connectingToPeer}
                         />
                     </View>
 


### PR DESCRIPTION
# Description

`LnurlChannel` called `connectPeer` in `componentDidMount`, so scanning an attacker-controlled channel-request QR immediately opened an outbound Lightning transport connection to a service-chosen host — disclosing the node's identity pubkey and network address (IP, unless the node is Tor-configured) before any visible confirmation. On ldk-node the peer was additionally persisted (`persist` defaults on when `perm` is omitted) and reconnected across restarts.

Changes:
- The peer connection now happens when the user presses the Connect button; on success the channel request proceeds in the same press (already-connected peers short-circuit as before via the "already connected" error path)
- `perm: false` is passed so the peer is not persisted before a channel actually exists (LDK Node maps `perm` to `persist`; Embedded LND forwards it; remote LND already defaults to non-persistent; CLNRest ignores it)
- The peer error message initializes empty instead of a stale hardcoded 'Error' string that previously flashed before the mount-time connect resolved

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Device tests pending (will update): scan an lnurl-channel QR and verify no peer connection occurs until Connect is pressed (node peer list / service logs); full happy-path channel open via an LSP offering lnurl-channel; ldk-node restart to confirm the peer is not persisted after backing out.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Reaches `connectPeer` on peer-capable backends: LDK Node (persist behavior), Embedded LND, LND REST, LNC, CLNRest. NWC/LndHub don't support lnurl-channel.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding