### PR TITLE
fix(security): dispose CDK handles before full-wipe database sweep

### DIFF
--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -485,10 +485,10 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     repo = newRepo
                     walletUnit = currencyUnit
                     // Publish the path only now that these are the handles
-                    // actually open: clearCDKDatabaseForNode keys its
-                    // dispose-before-unlink decision off getDatabasePath(),
-                    // so a path published before construction succeeded would
-                    // point the guard at a database the module never opened
+                    // actually open: closeWalletDatabase keys its
+                    // dispose-before-unlink decision off this path, so one
+                    // published before construction succeeded would point
+                    // the guard at a database the module never opened
                     currentDbPath = dbPath
                     isInitialized = true
                     previous
@@ -1899,8 +1899,14 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
      */
     @ReactMethod
     fun deleteWalletDatabase(promise: Promise) {
-        val path = currentDbPath
-        disposeHandles()
+        // Read the path in the same critical section that takes the handles:
+        // read outside it, a concurrent initializeWallet could swap wallets
+        // in between, disposing one wallet's handles and unlinking another's
+        // files
+        val (path, taken) = synchronized(handleLock) {
+            Pair(currentDbPath, takeHandlesLocked())
+        }
+        destroyHandles(taken)
         if (path == null) {
             promise.resolve(false)
             return
@@ -1912,6 +1918,36 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                 Log.w(TAG, "deleteWalletDatabase: failed to delete $p", e)
             }
         }
+        promise.resolve(true)
+    }
+
+    /**
+     * Disposes the open CDK handles if, and only if, the database currently
+     * open is [dbFileName], compared by basename because the JS side cannot
+     * reconstruct the absolute path this module resolves. The compare and the
+     * handle swap happen under one handleLock acquisition, so a wallet switch
+     * cannot land between the check and the teardown - the check-then-act gap
+     * a JS-side getDatabasePath() + deleteWalletDatabase() pair has, where a
+     * switch in the gap retargets the dispose (and its unlink) at the newly
+     * opened wallet's database. Unlinks nothing: the caller owns file
+     * deletion. Resolves true if the handles were disposed, false when no
+     * database or a different wallet's is open.
+     */
+    @ReactMethod
+    fun closeWalletDatabase(dbFileName: String, promise: Promise) {
+        val taken = synchronized(handleLock) {
+            val open = currentDbPath
+            if (open != null && File(open).name == dbFileName) {
+                takeHandlesLocked()
+            } else {
+                null
+            }
+        }
+        if (taken == null) {
+            promise.resolve(false)
+            return
+        }
+        destroyHandles(taken)
         promise.resolve(true)
     }
 

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -254,7 +254,25 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
             currentRepo.createWallet(url, walletUnit, null)
             currentRepo.getWallet(url, walletUnit)
         }
-        wallets[normalized] = wallet
+        // Insert under handleLock with a staleness check: this is the one
+        // map write that can land after a teardown drained the map (the repo
+        // was read before the create above, outside the lock), and an
+        // unconditional insert would park an undestroyed Wallet - holding
+        // its own reference to the closed database - in the map until the
+        // next initializeWallet drains it, briefly reopening the
+        // reachability window the wipe paths exist to close
+        val inserted = synchronized(handleLock) {
+            if (repo === currentRepo) {
+                wallets[normalized] = wallet
+                true
+            } else {
+                false
+            }
+        }
+        if (!inserted) {
+            destroyHandles(listOf(wallet))
+            throw FfiException.Internal("Wallet not initialized")
+        }
         return wallet
     }
 

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -40,11 +40,101 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
     private var isInitialized = false
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
+    // Guards the swap of the handle set above. destroy() is idempotent, so
+    // this only has to keep two teardowns from taking the same handles, and
+    // a teardown from racing an initialization
+    private val handleLock = Any()
+
     companion object {
         private const val TAG = "CashuDevKitModule"
     }
 
     override fun getName(): String = "CashuDevKitModule"
+
+    // ========================================================================
+    // Handle Lifecycle
+    // ========================================================================
+
+    /**
+     * Removes every CDK handle from the module's state and returns them for
+     * destruction. Call under handleLock.
+     *
+     * Order matters: the per-mint Wallet handles and any outstanding
+     * PreparedSend hold their own references to the repository and database,
+     * so the SQLite connection is not released until those are destroyed
+     * first.
+     */
+    private fun takeHandlesLocked(): List<Disposable> {
+        val taken = mutableListOf<Disposable>()
+        taken.addAll(preparedSends.values)
+        preparedSends.clear()
+        taken.addAll(wallets.values)
+        wallets.clear()
+        repo?.let { taken.add(it) }
+        repo = null
+        db?.let { taken.add(it) }
+        db = null
+        isInitialized = false
+        currentDbPath = null
+        return taken
+    }
+
+    private fun destroyHandles(handles: List<Disposable>) {
+        for (handle in handles) {
+            try {
+                handle.destroy()
+            } catch (e: Exception) {
+                // Best effort: one handle failing to release must not strand
+                // the others, and destroy() is a no-op if it already ran
+                Log.w(
+                    TAG,
+                    "destroyHandles: failed to destroy ${handle.javaClass.simpleName}",
+                    e
+                )
+            }
+        }
+    }
+
+    /**
+     * Runs [block] on a transient CDK handle and destroys the handle after,
+     * success or not.
+     *
+     * Same reasoning as disposeHandles: a prepared melt or send holds its own
+     * reference to the wallet's database, so one left for the Cleaner keeps
+     * the SQLite connection alive past a teardown that destroyed everything
+     * the module tracks. Inline so suspending calls inside the block stay
+     * legal.
+     */
+    private inline fun <T : Disposable, R> T.useHandle(block: (T) -> R): R {
+        try {
+            return block(this)
+        } finally {
+            destroyHandles(listOf(this))
+        }
+    }
+
+    /**
+     * Destroys every live CDK handle and resets the module to uninitialized.
+     *
+     * The uniffi bindings are Disposable: dropping the Kotlin reference alone
+     * leaves the Rust object - and the SQLite connection it owns - alive
+     * until the Cleaner next runs after a GC. An unlinked database file
+     * therefore keeps its blocks allocated for an unbounded time, which is
+     * the reachability the wipe paths exist to close. iOS has no equivalent
+     * gap: ARC frees the handle as soon as the last reference goes.
+     *
+     * In-flight work is aborted rather than left to finish. uniffi keeps an
+     * already-started call alive (the Rust side holds its own reference), but
+     * the next call on a destroyed handle throws IllegalStateException, which
+     * the per-method catch turns into a promise rejection. That is the
+     * intended outcome: every caller here has either torn the wallet down or
+     * switched to a different one, and the methods below re-read repo/db
+     * between steps, so letting a half-finished flow continue would mean
+     * operating on a mix of the outgoing and incoming wallet's state.
+     */
+    private fun disposeHandles() {
+        destroyHandles(synchronized(handleLock) { takeHandlesLocked() })
+    }
 
     // ========================================================================
     // Helper Methods
@@ -168,6 +258,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         return wallet
     }
 
+    @Volatile
     private var currentDbPath: String? = null
 
     private fun getDatabasePath(mnemonic: String): String {
@@ -370,7 +461,6 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         scope.launch {
             try {
                 val dbPath = getDatabasePath(mnemonic)
-                currentDbPath = dbPath
                 val database = WalletSqliteDatabase(dbPath)
 
                 val currencyUnit = parseCurrencyUnit(unit)
@@ -383,11 +473,27 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     store = WalletStore.Custom(database)
                 )
 
-                db = database
-                repo = newRepo
-                walletUnit = currencyUnit
-                wallets.clear()
-                isInitialized = true
+                // Swap atomically and destroy what we replaced. Switching
+                // wallets does not restart the app, so without this the
+                // outgoing wallet's SQLite connection stays open for the rest
+                // of the session and its database file survives deletion as
+                // unreclaimed blocks. Building the new handles first keeps a
+                // construction failure from tearing down a working wallet.
+                val outgoing = synchronized(handleLock) {
+                    val previous = takeHandlesLocked()
+                    db = database
+                    repo = newRepo
+                    walletUnit = currencyUnit
+                    // Publish the path only now that these are the handles
+                    // actually open: clearCDKDatabaseForNode keys its
+                    // dispose-before-unlink decision off getDatabasePath(),
+                    // so a path published before construction succeeded would
+                    // point the guard at a database the module never opened
+                    currentDbPath = dbPath
+                    isInitialized = true
+                    previous
+                }
+                destroyHandles(outgoing)
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(null)
@@ -1044,8 +1150,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         scope.launch {
             try {
                 val wallet = getWallet(mintUrl)
-                val prepared = wallet.prepareMelt(quoteId)
-                val melted = prepared.confirm()
+                val melted = wallet.prepareMelt(quoteId).useHandle { it.confirm() }
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(encodeMelted(melted).toString())
@@ -1109,8 +1214,8 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                 }
 
                 // Step 3: Two-phase melt with the selected proofs
-                val prepared = wallet.prepareMeltProofs(quote.id, mintProofs)
-                val melted = prepared.confirm()
+                val melted = wallet.prepareMeltProofs(quote.id, mintProofs)
+                    .useHandle { it.confirm() }
 
                 withContext(Dispatchers.Main) {
                     promise.resolve(encodeMelted(melted).toString())
@@ -1241,8 +1346,13 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     promise.reject("CONFIRM_SEND_ERROR", e.message, e)
                 }
             } finally {
-                // Always clean up prepared send, whether success or failure
-                preparedSends.remove(preparedSendId)
+                // Always clean up prepared send, whether success or failure.
+                // Destroy it rather than only dropping the reference: the
+                // handle holds the wallet's database open until the Cleaner
+                // runs (see disposeHandles)
+                preparedSends.remove(preparedSendId)?.let {
+                    destroyHandles(listOf(it))
+                }
             }
         }
     }
@@ -1273,8 +1383,13 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     promise.reject("CANCEL_SEND_ERROR", e.message, e)
                 }
             } finally {
-                // Always clean up prepared send, whether success or failure
-                preparedSends.remove(preparedSendId)
+                // Always clean up prepared send, whether success or failure.
+                // Destroy it rather than only dropping the reference: the
+                // handle holds the wallet's database open until the Cleaner
+                // runs (see disposeHandles)
+                preparedSends.remove(preparedSendId)?.let {
+                    destroyHandles(listOf(it))
+                }
             }
         }
     }
@@ -1776,19 +1891,16 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
     /**
      * Closes the repository/database handles and deletes the proof db (and its
      * WAL/SHM sidecars) from disk. Used by "Delete Cashu data" so plaintext
-     * bearer proofs do not survive the user's deletion. Nulling the repository
-     * and db references (and dropping the per-mint wallet handles) releases the
-     * underlying SQLite connection before the files are unlinked. Resolves
-     * false if no database was opened this session.
+     * bearer proofs do not survive the user's deletion. disposeHandles()
+     * destroys the uniffi handles rather than only dropping the references, so
+     * the SQLite connection is closed before the files are unlinked: unlinking
+     * under a live connection succeeds but leaves the blocks allocated to it.
+     * Resolves false if no database was opened this session.
      */
     @ReactMethod
     fun deleteWalletDatabase(promise: Promise) {
         val path = currentDbPath
-        repo = null
-        db = null
-        wallets.clear()
-        preparedSends.clear()
-        isInitialized = false
+        disposeHandles()
         if (path == null) {
             promise.resolve(false)
             return
@@ -1800,7 +1912,6 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                 Log.w(TAG, "deleteWalletDatabase: failed to delete $p", e)
             }
         }
-        currentDbPath = null
         promise.resolve(true)
     }
 
@@ -1810,10 +1921,9 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
     override fun onCatalystInstanceDestroy() {
         scope.cancel()
-        repo = null
-        db = null
-        wallets.clear()
-        preparedSends.clear()
-        isInitialized = false
+        // Destroy, not just dereference: a bridge teardown that is not a
+        // process restart (an iOS-style JS reload, a dev reload) would
+        // otherwise leave the previous instance's connection open
+        disposeHandles()
     }
 }

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -260,20 +260,27 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         // unconditional insert would park an undestroyed Wallet - holding
         // its own reference to the closed database - in the map until the
         // next initializeWallet drains it, briefly reopening the
-        // reachability window the wipe paths exist to close
-        val inserted = synchronized(handleLock) {
+        // reachability window the wipe paths exist to close. The insert is
+        // also first-wins: two callers racing the first access to the same
+        // mint both reach here with a fresh handle, and an overwrite would
+        // orphan the earlier one to the Cleaner the same way
+        val winner = synchronized(handleLock) {
             if (repo === currentRepo) {
-                wallets[normalized] = wallet
-                true
+                wallets[normalized] ?: wallet.also {
+                    wallets[normalized] = wallet
+                }
             } else {
-                false
+                null
             }
         }
-        if (!inserted) {
+        if (winner == null) {
             destroyHandles(listOf(wallet))
             throw FfiException.Internal("Wallet not initialized")
         }
-        return wallet
+        if (winner !== wallet) {
+            destroyHandles(listOf(wallet))
+        }
+        return winner
     }
 
     @Volatile

--- a/cashu-cdk/CashuDevKit.ts
+++ b/cashu-cdk/CashuDevKit.ts
@@ -850,6 +850,26 @@ class CashuDevKit {
             throw mapCDKError(error);
         }
     }
+
+    /**
+     * Close the wallet/database handles if, and only if, the database the
+     * native module currently has open is `dbFileName`. The basename compare
+     * and the handle teardown are atomic under the native module's lock, so a
+     * concurrent wallet switch cannot land between the check and the
+     * disposal. Never deletes files: the caller owns the unlink. Resolves
+     * whether the handles were disposed.
+     */
+    async closeWalletDatabase(dbFileName: string): Promise<boolean> {
+        try {
+            const disposed = await CashuDevKitModule.closeWalletDatabase(
+                dbFileName
+            );
+            if (disposed) this.initialized = false;
+            return disposed;
+        } catch (error) {
+            throw mapCDKError(error);
+        }
+    }
 }
 
 // Export singleton instance

--- a/cashu-cdk/types.ts
+++ b/cashu-cdk/types.ts
@@ -336,4 +336,8 @@ export interface CashuDevKitNativeModule {
     // Closes the wallet/db handles and deletes the proof db (+ WAL/SHM).
     // Resolves false if no database was opened this session.
     deleteWalletDatabase(): Promise<boolean>;
+    // Disposes the handles iff the open db's basename is dbFileName, with
+    // the check and the teardown atomic under the native module's lock.
+    // Never unlinks files. Resolves whether it disposed.
+    closeWalletDatabase(dbFileName: string): Promise<boolean>;
 }

--- a/ios/CashuDevKit/CashuDevKitModule.m
+++ b/ios/CashuDevKit/CashuDevKitModule.m
@@ -18,6 +18,11 @@ RCT_EXTERN_METHOD(getDatabasePath:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(deleteWalletDatabase:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+// Atomic check-and-dispose of the handles for one wallet's db (no unlink)
+RCT_EXTERN_METHOD(closeWalletDatabase:(NSString *)dbFileName
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 // Wallet Management
 RCT_EXTERN_METHOD(initializeWallet:(NSString *)mnemonic
                   unit:(NSString *)unit

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -454,7 +454,6 @@ class CashuDevKitModule: RCTEventEmitter {
         Task {
             do {
                 let dbPath = getDatabasePath(for: mnemonic)
-                self.currentDbPath = dbPath
                 let sqliteDb = try WalletSqliteDatabase(filePath: dbPath)
 
                 let currencyUnit = parseCurrencyUnit(unit)
@@ -467,11 +466,24 @@ class CashuDevKitModule: RCTEventEmitter {
                     store: .custom(db: sqliteDb)
                 )
 
+                // ARC releases the outgoing wallet's handles as soon as these
+                // assignments drop the last reference, so the previous
+                // SQLite connection closes here (the Kotlin module has to
+                // destroy() its uniffi handles by hand - see disposeHandles).
+                // preparedSends is cleared for the same reason: a send
+                // prepared against the previous wallet must not outlive it.
                 walletQueue.sync {
                     self.db = sqliteDb
                     self.repo = newRepo
                     self.walletUnit = currencyUnit
                     self.wallets.removeAll()
+                    self.preparedSends.removeAll()
+                    // Publish the path only now that these are the handles
+                    // actually open: clearCDKDatabaseForNode keys its
+                    // dispose-before-unlink decision off getDatabasePath(),
+                    // so a path published before construction succeeded would
+                    // point the guard at a database never opened here
+                    self.currentDbPath = dbPath
                     self.isInitialized = true
                 }
 

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -180,7 +180,20 @@ class CashuDevKitModule: RCTEventEmitter {
             try await repo.createWallet(mintUrl: url, unit: unit, targetProofCount: nil)
             wallet = try await repo.getWallet(mintUrl: url, unit: unit)
         }
-        walletQueue.sync { wallets[normalized] = wallet }
+        // Insert under the queue with a staleness check: this is the one map
+        // write that can land after a teardown drained the map (the repo was
+        // read before the create above, outside the queue), and an
+        // unconditional insert would park an orphaned Wallet - keeping the
+        // closed database alive via its own reference - in the map until the
+        // next initializeWallet drains it
+        let inserted = walletQueue.sync { () -> Bool in
+            guard self.repo === repo else { return false }
+            wallets[normalized] = wallet
+            return true
+        }
+        guard inserted else {
+            throw FfiError.Internal(errorMessage: "Wallet not initialized")
+        }
         return wallet
     }
 

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -479,10 +479,10 @@ class CashuDevKitModule: RCTEventEmitter {
                     self.wallets.removeAll()
                     self.preparedSends.removeAll()
                     // Publish the path only now that these are the handles
-                    // actually open: clearCDKDatabaseForNode keys its
-                    // dispose-before-unlink decision off getDatabasePath(),
-                    // so a path published before construction succeeded would
-                    // point the guard at a database never opened here
+                    // actually open: closeWalletDatabase keys its
+                    // dispose-before-unlink decision off this path, so one
+                    // published before construction succeeded would point
+                    // the guard at a database never opened here
                     self.currentDbPath = dbPath
                     self.isInitialized = true
                 }
@@ -1660,13 +1660,19 @@ class CashuDevKitModule: RCTEventEmitter {
     @objc(deleteWalletDatabase:rejecter:)
     func deleteWalletDatabase(_ resolve: @escaping RCTPromiseResolveBlock,
                               reject: @escaping RCTPromiseRejectBlock) {
-        let path = self.currentDbPath
-        walletQueue.sync {
+        // Read the path in the same queue block that drops the handles:
+        // read outside it, a concurrent initializeWallet could swap wallets
+        // in between, disposing one wallet's handles and unlinking another's
+        // files
+        let path: String? = walletQueue.sync {
+            let open = self.currentDbPath
             self.repo = nil
             self.db = nil
             self.wallets.removeAll()
             self.preparedSends.removeAll()
             self.isInitialized = false
+            self.currentDbPath = nil
+            return open
         }
         guard let dbPath = path else {
             resolve(false)
@@ -1682,8 +1688,38 @@ class CashuDevKitModule: RCTEventEmitter {
                 }
             }
         }
-        self.currentDbPath = nil
         resolve(true)
+    }
+
+    /// Disposes the open CDK handles if, and only if, the database currently
+    /// open is `dbFileName`, compared by basename because the JS side cannot
+    /// reconstruct the absolute path this module resolves. The compare and
+    /// the teardown happen inside one walletQueue block, so a wallet switch
+    /// cannot land between the check and the act - the check-then-act gap a
+    /// JS-side getDatabasePath() + deleteWalletDatabase() pair has, where a
+    /// switch in the gap retargets the dispose (and its unlink) at the newly
+    /// opened wallet's database. Unlinks nothing: the caller owns file
+    /// deletion. ARC closes the SQLite connection as the last references
+    /// drop. Resolves true if the handles were disposed, false when no
+    /// database or a different wallet's is open.
+    @objc(closeWalletDatabase:resolver:rejecter:)
+    func closeWalletDatabase(_ dbFileName: String,
+                             resolve: @escaping RCTPromiseResolveBlock,
+                             reject: @escaping RCTPromiseRejectBlock) {
+        let disposed: Bool = walletQueue.sync {
+            guard let open = self.currentDbPath,
+                  (open as NSString).lastPathComponent == dbFileName else {
+                return false
+            }
+            self.repo = nil
+            self.db = nil
+            self.wallets.removeAll()
+            self.preparedSends.removeAll()
+            self.isInitialized = false
+            self.currentDbPath = nil
+            return true
+        }
+        resolve(disposed)
     }
 
     // MARK: - Cleanup

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -185,16 +185,21 @@ class CashuDevKitModule: RCTEventEmitter {
         // read before the create above, outside the queue), and an
         // unconditional insert would park an orphaned Wallet - keeping the
         // closed database alive via its own reference - in the map until the
-        // next initializeWallet drains it
-        let inserted = walletQueue.sync { () -> Bool in
-            guard self.repo === repo else { return false }
+        // next initializeWallet drains it. The insert is also first-wins:
+        // two callers racing the first access to the same mint both reach
+        // here with a fresh handle, and an overwrite would drop the earlier
+        // one out of teardown's reach (the loser here is simply released by
+        // ARC)
+        let winner = walletQueue.sync { () -> Wallet? in
+            guard self.repo === repo else { return nil }
+            if let existing = wallets[normalized] { return existing }
             wallets[normalized] = wallet
-            return true
+            return wallet
         }
-        guard inserted else {
+        guard let winner = winner else {
             throw FfiError.Internal(errorMessage: "Wallet not initialized")
         }
-        return wallet
+        return winner
     }
 
     private var currentDbPath: String?

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -1175,6 +1175,52 @@ describe('CDK database deletion', () => {
                 );
                 expect(bridge).toContain('closeWalletDatabase:');
             });
+
+            // getWallet's lazy insert is the one wallet-map write outside
+            // the locked teardown/init paths: created from a repo read taken
+            // before the lock, it can land after a teardown drained the map
+            // and park an undestroyed handle that keeps the unlinked
+            // database open until the next init. Assert the insert sits
+            // behind a same-repo check inside the lock/queue.
+            it('guards the lazy wallet-map insert in the Android module', () => {
+                const source = fs.readFileSync(
+                    path.join(
+                        __dirname,
+                        '../android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt'
+                    ),
+                    'utf8'
+                );
+                const body = source.slice(
+                    source.indexOf('suspend fun getWallet')
+                );
+                expect(
+                    body.indexOf('synchronized(handleLock)')
+                ).toBeGreaterThan(-1);
+                expect(body.indexOf('repo === currentRepo')).toBeGreaterThan(
+                    -1
+                );
+                expect(body.indexOf('synchronized(handleLock)')).toBeLessThan(
+                    body.indexOf('wallets[normalized] = wallet')
+                );
+                expect(body.indexOf('repo === currentRepo')).toBeLessThan(
+                    body.indexOf('wallets[normalized] = wallet')
+                );
+            });
+
+            it('guards the lazy wallet-map insert in the iOS module', () => {
+                const source = fs.readFileSync(
+                    path.join(
+                        __dirname,
+                        '../ios/CashuDevKit/CashuDevKitModule.swift'
+                    ),
+                    'utf8'
+                );
+                const body = source.slice(source.indexOf('func getWallet'));
+                expect(body.indexOf('self.repo === repo')).toBeGreaterThan(-1);
+                expect(body.indexOf('self.repo === repo')).toBeLessThan(
+                    body.indexOf('wallets[normalized] = wallet')
+                );
+            });
         });
     });
 });

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -40,7 +40,8 @@ jest.mock('../cashu-cdk', () => ({
     default: {
         isAvailable: jest.fn().mockReturnValue(true),
         getDatabasePath: jest.fn().mockResolvedValue(''),
-        deleteWalletDatabase: jest.fn().mockResolvedValue(true)
+        deleteWalletDatabase: jest.fn().mockResolvedValue(true),
+        closeWalletDatabase: jest.fn().mockResolvedValue(true)
     }
 }));
 
@@ -825,14 +826,15 @@ describe('CDK database deletion', () => {
     const unlinkedPaths = () => mockedUnlink.mock.calls.map((call) => call[0]);
 
     const mockedIsAvailable = CashuDevKit.isAvailable as jest.Mock;
-    const mockedGetDatabasePath = CashuDevKit.getDatabasePath as jest.Mock;
     const mockedDeleteWalletDatabase =
         CashuDevKit.deleteWalletDatabase as jest.Mock;
+    const mockedCloseWalletDatabase =
+        CashuDevKit.closeWalletDatabase as jest.Mock;
 
     // Dispose must precede every unlink: a POSIX unlink under a live handle
     // succeeds while leaving the proofs readable through that connection.
-    const disposedBeforeFirstUnlink = () =>
-        mockedDeleteWalletDatabase.mock.invocationCallOrder[0] <
+    const disposedBeforeFirstUnlink = (disposeMock: jest.Mock) =>
+        disposeMock.mock.invocationCallOrder[0] <
         mockedUnlink.mock.invocationCallOrder[0];
 
     beforeEach(() => {
@@ -842,8 +844,8 @@ describe('CDK database deletion', () => {
         mockedExists.mockResolvedValue(false);
         mockedUnlink.mockResolvedValue(undefined);
         mockedIsAvailable.mockReturnValue(true);
-        mockedGetDatabasePath.mockResolvedValue('');
         mockedDeleteWalletDatabase.mockResolvedValue(true);
+        mockedCloseWalletDatabase.mockResolvedValue(true);
     });
 
     describe('clearCDKDatabase (full-wipe sweep)', () => {
@@ -884,7 +886,9 @@ describe('CDK database deletion', () => {
             await clearCDKDatabase();
 
             expect(mockedDeleteWalletDatabase).toHaveBeenCalled();
-            expect(disposedBeforeFirstUnlink()).toBe(true);
+            expect(disposedBeforeFirstUnlink(mockedDeleteWalletDatabase)).toBe(
+                true
+            );
         });
 
         // The prefix sweep is strictly broader than the native delete (it
@@ -1036,20 +1040,23 @@ describe('CDK database deletion', () => {
             });
 
             expect(mockedUnlink).not.toHaveBeenCalled();
-            expect(mockedGetDatabasePath).not.toHaveBeenCalled();
+            expect(mockedCloseWalletDatabase).not.toHaveBeenCalled();
         });
 
         // This runs for the ACTIVE wallet too: deleteNodeConfig stops
-        // LND/LDK first, neither of which closes the CDK connection.
+        // LND/LDK first, neither of which closes the CDK connection. The
+        // "is this the open database" check lives in closeWalletDatabase on
+        // the native side, atomic with the teardown under the module's lock:
+        // a JS-side getDatabasePath() check would leave a window where a
+        // wallet switch retargets the dispose at the newly opened wallet's
+        // database. What this suite can prove is the call shape - the
+        // basename argument, the ordering against the unlinks, and the
+        // failure paths; the atomicity itself is native.
         describe('native handle disposal', () => {
             const seedWords = ['abandon', 'ability', 'able', 'about'];
             const seedDbFile = `cashu_wallet_${walletDbHash(
                 seedWords.join(' ')
             )}.db`;
-            // Native reports the resolved absolute path (Android filesDir),
-            // which never string-matches the `${DocumentDir}/../files` form
-            // built on the JS side - hence the basename comparison.
-            const nativeDir = '/data/user/0/app.zeusln.zeus/files';
 
             const deleteThisWallet = () =>
                 clearCDKDatabaseForNode({
@@ -1066,49 +1073,36 @@ describe('CDK database deletion', () => {
                 mockedExists.mockResolvedValue(true);
             });
 
-            it('disposes before unlinking when CDK has this wallet open', async () => {
-                mockedGetDatabasePath.mockResolvedValue(
-                    `${nativeDir}/${seedDbFile}`
-                );
-
+            // Basename, not a path: native tracks the resolved absolute
+            // filesDir while JS builds `${DocumentDir}/../files`, so any
+            // path form would never match on the native side.
+            it('disposes via the atomic check-and-close, basename only, before unlinking', async () => {
                 await deleteThisWallet();
 
-                expect(mockedDeleteWalletDatabase).toHaveBeenCalled();
-                expect(disposedBeforeFirstUnlink()).toBe(true);
+                expect(mockedCloseWalletDatabase).toHaveBeenCalledWith(
+                    seedDbFile
+                );
+                expect(
+                    disposedBeforeFirstUnlink(mockedCloseWalletDatabase)
+                ).toBe(true);
+                // The blunt instrument stays reserved for the full wipe: it
+                // unlinks whatever db is open, so calling it here while a
+                // different wallet is warm would destroy that wallet's proofs
+                expect(mockedDeleteWalletDatabase).not.toHaveBeenCalled();
             });
 
-            // Data-loss regression: deleteWalletDatabase() takes no argument
-            // and unlinks whatever db the native module currently has open
-            // (currentDbPath). Calling it while another wallet is warm would
-            // destroy THAT wallet's proofs. Nothing is open on this file, so
-            // the plain unlink below is already safe.
-            it('never disposes when a different wallet is the open one', async () => {
-                mockedGetDatabasePath.mockResolvedValue(
-                    `${nativeDir}/cashu_wallet_ffffffffffffffff.db`
-                );
+            it('still unlinks when nothing was disposed (different or no wallet open)', async () => {
+                mockedCloseWalletDatabase.mockResolvedValue(false);
 
                 await deleteThisWallet();
 
-                expect(mockedDeleteWalletDatabase).not.toHaveBeenCalled();
                 expect(
                     unlinkedPaths().some((p) => p.endsWith(seedDbFile))
                 ).toBe(true);
             });
 
-            it('skips the dispose when no database was opened this session', async () => {
-                mockedGetDatabasePath.mockResolvedValue('');
-
-                await deleteThisWallet();
-
-                expect(mockedDeleteWalletDatabase).not.toHaveBeenCalled();
-                expect(mockedUnlink).toHaveBeenCalled();
-            });
-
             it('still unlinks when the dispose call throws', async () => {
-                mockedGetDatabasePath.mockResolvedValue(
-                    `${nativeDir}/${seedDbFile}`
-                );
-                mockedDeleteWalletDatabase.mockRejectedValue(
+                mockedCloseWalletDatabase.mockRejectedValue(
                     new Error('NO_WALLET')
                 );
 
@@ -1124,11 +1118,62 @@ describe('CDK database deletion', () => {
 
                 await deleteThisWallet();
 
-                expect(mockedGetDatabasePath).not.toHaveBeenCalled();
-                expect(mockedDeleteWalletDatabase).not.toHaveBeenCalled();
+                expect(mockedCloseWalletDatabase).not.toHaveBeenCalled();
                 expect(
                     unlinkedPaths().some((p) => p.endsWith(seedDbFile))
                 ).toBe(true);
+            });
+
+            // Lockstep guards in the style of the filename-hashing scans
+            // above: the wrapper calls closeWalletDatabase, so its absence
+            // from either native module (or the ObjC bridge) would fail only
+            // on-device. Assert the atomicity carrier too - the compare must
+            // sit inside the same synchronized/queue block as the teardown.
+            it('is implemented atomically in the Android module', () => {
+                const source = fs.readFileSync(
+                    path.join(
+                        __dirname,
+                        '../android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt'
+                    ),
+                    'utf8'
+                );
+                expect(source).toContain('fun closeWalletDatabase');
+                const body = source.slice(
+                    source.indexOf('fun closeWalletDatabase')
+                );
+                expect(
+                    body.indexOf('synchronized(handleLock)')
+                ).toBeGreaterThan(-1);
+                expect(body.indexOf('synchronized(handleLock)')).toBeLessThan(
+                    body.indexOf('takeHandlesLocked()')
+                );
+            });
+
+            it('is implemented atomically in the iOS module and bridged', () => {
+                const source = fs.readFileSync(
+                    path.join(
+                        __dirname,
+                        '../ios/CashuDevKit/CashuDevKitModule.swift'
+                    ),
+                    'utf8'
+                );
+                expect(source).toContain('func closeWalletDatabase');
+                const body = source.slice(
+                    source.indexOf('func closeWalletDatabase')
+                );
+                expect(body.indexOf('walletQueue.sync')).toBeGreaterThan(-1);
+                expect(body.indexOf('walletQueue.sync')).toBeLessThan(
+                    body.indexOf('lastPathComponent')
+                );
+
+                const bridge = fs.readFileSync(
+                    path.join(
+                        __dirname,
+                        '../ios/CashuDevKit/CashuDevKitModule.m'
+                    ),
+                    'utf8'
+                );
+                expect(bridge).toContain('closeWalletDatabase:');
             });
         });
     });

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -1181,7 +1181,10 @@ describe('CDK database deletion', () => {
             // before the lock, it can land after a teardown drained the map
             // and park an undestroyed handle that keeps the unlinked
             // database open until the next init. Assert the insert sits
-            // behind a same-repo check inside the lock/queue.
+            // behind a same-repo check inside the lock/queue, and that it is
+            // first-wins: two callers racing the first access to the same
+            // mint must not overwrite (and thereby orphan) the earlier
+            // handle.
             it('guards the lazy wallet-map insert in the Android module', () => {
                 const source = fs.readFileSync(
                     path.join(
@@ -1205,6 +1208,13 @@ describe('CDK database deletion', () => {
                 expect(body.indexOf('repo === currentRepo')).toBeLessThan(
                     body.indexOf('wallets[normalized] = wallet')
                 );
+                const recheck = body.indexOf('wallets[normalized] ?:');
+                expect(recheck).toBeGreaterThan(
+                    body.indexOf('synchronized(handleLock)')
+                );
+                expect(recheck).toBeLessThan(
+                    body.indexOf('wallets[normalized] = wallet')
+                );
             });
 
             it('guards the lazy wallet-map insert in the iOS module', () => {
@@ -1218,6 +1228,15 @@ describe('CDK database deletion', () => {
                 const body = source.slice(source.indexOf('func getWallet'));
                 expect(body.indexOf('self.repo === repo')).toBeGreaterThan(-1);
                 expect(body.indexOf('self.repo === repo')).toBeLessThan(
+                    body.indexOf('wallets[normalized] = wallet')
+                );
+                const recheck = body.indexOf(
+                    'if let existing = wallets[normalized]'
+                );
+                expect(recheck).toBeGreaterThan(
+                    body.indexOf('self.repo === repo')
+                );
+                expect(recheck).toBeLessThan(
                     body.indexOf('wallets[normalized] = wallet')
                 );
             });

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -31,6 +31,19 @@ jest.mock('../storage', () => ({
     blockWrites: jest.fn()
 }));
 
+// Native CDK bridge. Both wipe paths must drop the SQLite handles before
+// unlinking, so isAvailable() defaults to true here: with the real (absent)
+// native module it returns false and the dispose branches would never run in
+// this suite.
+jest.mock('../cashu-cdk', () => ({
+    __esModule: true,
+    default: {
+        isAvailable: jest.fn().mockReturnValue(true),
+        getDatabasePath: jest.fn().mockResolvedValue(''),
+        deleteWalletDatabase: jest.fn().mockResolvedValue(true)
+    }
+}));
+
 // The functions under regression - assert clearAllData delegates to them.
 jest.mock('./LndMobileUtils', () => ({
     deleteLndWallet: jest.fn().mockResolvedValue(true)
@@ -143,6 +156,7 @@ import ReactNativeBlobUtil from 'react-native-blob-util';
 import fs from 'fs';
 import path from 'path';
 
+import CashuDevKit from '../cashu-cdk';
 import Storage from '../storage';
 import { deriveEmbeddedNodeId } from './AezeedUtils';
 import {
@@ -810,12 +824,26 @@ describe('CDK database deletion', () => {
     const mockedUnlink = ReactNativeBlobUtil.fs.unlink as jest.Mock;
     const unlinkedPaths = () => mockedUnlink.mock.calls.map((call) => call[0]);
 
+    const mockedIsAvailable = CashuDevKit.isAvailable as jest.Mock;
+    const mockedGetDatabasePath = CashuDevKit.getDatabasePath as jest.Mock;
+    const mockedDeleteWalletDatabase =
+        CashuDevKit.deleteWalletDatabase as jest.Mock;
+
+    // Dispose must precede every unlink: a POSIX unlink under a live handle
+    // succeeds while leaving the proofs readable through that connection.
+    const disposedBeforeFirstUnlink = () =>
+        mockedDeleteWalletDatabase.mock.invocationCallOrder[0] <
+        mockedUnlink.mock.invocationCallOrder[0];
+
     beforeEach(() => {
         jest.clearAllMocks();
         mockedStorageGetItem.mockResolvedValue(null);
         mockedLs.mockResolvedValue([]);
         mockedExists.mockResolvedValue(false);
         mockedUnlink.mockResolvedValue(undefined);
+        mockedIsAvailable.mockReturnValue(true);
+        mockedGetDatabasePath.mockResolvedValue('');
+        mockedDeleteWalletDatabase.mockResolvedValue(true);
     });
 
     describe('clearCDKDatabase (full-wipe sweep)', () => {
@@ -848,6 +876,42 @@ describe('CDK database deletion', () => {
             await clearCDKDatabase();
 
             expect(mockedUnlink).toHaveBeenCalledTimes(2);
+        });
+
+        it('drops the live CDK handles before unlinking anything', async () => {
+            mockedLs.mockResolvedValue(['cashu_wallet_a.db']);
+
+            await clearCDKDatabase();
+
+            expect(mockedDeleteWalletDatabase).toHaveBeenCalled();
+            expect(disposedBeforeFirstUnlink()).toBe(true);
+        });
+
+        // The prefix sweep is strictly broader than the native delete (it
+        // catches every wallet's hashed db, not just the tracked one), so a
+        // dispose failure must never abort it.
+        it('still sweeps when disposing the handles throws', async () => {
+            mockedDeleteWalletDatabase.mockRejectedValue(
+                new Error('NO_WALLET')
+            );
+            mockedLs.mockResolvedValue([
+                'cashu_wallet_a.db',
+                'cashu_wallet_b.db'
+            ]);
+
+            await clearCDKDatabase();
+
+            expect(mockedUnlink).toHaveBeenCalledTimes(2);
+        });
+
+        it('sweeps without disposing when the native module is absent', async () => {
+            mockedIsAvailable.mockReturnValue(false);
+            mockedLs.mockResolvedValue(['cashu_wallet_a.db']);
+
+            await clearCDKDatabase();
+
+            expect(mockedDeleteWalletDatabase).not.toHaveBeenCalled();
+            expect(mockedUnlink).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -972,6 +1036,100 @@ describe('CDK database deletion', () => {
             });
 
             expect(mockedUnlink).not.toHaveBeenCalled();
+            expect(mockedGetDatabasePath).not.toHaveBeenCalled();
+        });
+
+        // This runs for the ACTIVE wallet too: deleteNodeConfig stops
+        // LND/LDK first, neither of which closes the CDK connection.
+        describe('native handle disposal', () => {
+            const seedWords = ['abandon', 'ability', 'able', 'about'];
+            const seedDbFile = `cashu_wallet_${walletDbHash(
+                seedWords.join(' ')
+            )}.db`;
+            // Native reports the resolved absolute path (Android filesDir),
+            // which never string-matches the `${DocumentDir}/../files` form
+            // built on the JS side - hence the basename comparison.
+            const nativeDir = '/data/user/0/app.zeusln.zeus/files';
+
+            const deleteThisWallet = () =>
+                clearCDKDatabaseForNode({
+                    implementation: 'embedded-lnd',
+                    lndDir: 'lnd-abc'
+                });
+
+            beforeEach(() => {
+                mockedStorageGetItem.mockImplementation((key: string) =>
+                    key === 'lnd-abc-cashu-seed-phrase'
+                        ? Promise.resolve(JSON.stringify(seedWords))
+                        : Promise.resolve(null)
+                );
+                mockedExists.mockResolvedValue(true);
+            });
+
+            it('disposes before unlinking when CDK has this wallet open', async () => {
+                mockedGetDatabasePath.mockResolvedValue(
+                    `${nativeDir}/${seedDbFile}`
+                );
+
+                await deleteThisWallet();
+
+                expect(mockedDeleteWalletDatabase).toHaveBeenCalled();
+                expect(disposedBeforeFirstUnlink()).toBe(true);
+            });
+
+            // Data-loss regression: deleteWalletDatabase() takes no argument
+            // and unlinks whatever db the native module currently has open
+            // (currentDbPath). Calling it while another wallet is warm would
+            // destroy THAT wallet's proofs. Nothing is open on this file, so
+            // the plain unlink below is already safe.
+            it('never disposes when a different wallet is the open one', async () => {
+                mockedGetDatabasePath.mockResolvedValue(
+                    `${nativeDir}/cashu_wallet_ffffffffffffffff.db`
+                );
+
+                await deleteThisWallet();
+
+                expect(mockedDeleteWalletDatabase).not.toHaveBeenCalled();
+                expect(
+                    unlinkedPaths().some((p) => p.endsWith(seedDbFile))
+                ).toBe(true);
+            });
+
+            it('skips the dispose when no database was opened this session', async () => {
+                mockedGetDatabasePath.mockResolvedValue('');
+
+                await deleteThisWallet();
+
+                expect(mockedDeleteWalletDatabase).not.toHaveBeenCalled();
+                expect(mockedUnlink).toHaveBeenCalled();
+            });
+
+            it('still unlinks when the dispose call throws', async () => {
+                mockedGetDatabasePath.mockResolvedValue(
+                    `${nativeDir}/${seedDbFile}`
+                );
+                mockedDeleteWalletDatabase.mockRejectedValue(
+                    new Error('NO_WALLET')
+                );
+
+                await deleteThisWallet();
+
+                expect(
+                    unlinkedPaths().some((p) => p.endsWith(seedDbFile))
+                ).toBe(true);
+            });
+
+            it('unlinks without disposing when the native module is absent', async () => {
+                mockedIsAvailable.mockReturnValue(false);
+
+                await deleteThisWallet();
+
+                expect(mockedGetDatabasePath).not.toHaveBeenCalled();
+                expect(mockedDeleteWalletDatabase).not.toHaveBeenCalled();
+                expect(
+                    unlinkedPaths().some((p) => p.endsWith(seedDbFile))
+                ).toBe(true);
+            });
         });
     });
 });

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -383,26 +383,25 @@ export async function clearCDKDatabaseForNode(node: any): Promise<void> {
         // leaves the proofs readable through that connection for the rest of
         // the session.
         //
-        // Guarded by a path match because deleteWalletDatabase() takes no
-        // argument: it drops the handles and unlinks whatever single database
-        // the native module currently has open (currentDbPath in
-        // CashuDevKitModule.kt/.swift). Calling it while a DIFFERENT wallet is
-        // warm would delete that wallet's proof database instead - deleting
-        // wallet B would destroy wallet A's ecash. Matching on basename, not
-        // the full path: dbDir here is `${DocumentDir}/../files` on Android
-        // while native reports the resolved absolute filesDir, so the strings
-        // never compare equal. CDK holds one database open at a time and
-        // destroys the outgoing wallet's handles when a new one is
-        // initialized (initializeWallet in CashuDevKitModule.kt/.swift), so a
-        // non-match proves no connection is open on this file and the plain
-        // unlink below is already safe - including after a wallet switch,
-        // where the wallet being deleted is no longer the tracked one.
+        // closeWalletDatabase(dbFile) disposes the handles only if the
+        // database the native module currently has open IS this one, with
+        // the check and the teardown atomic under the native module's lock
+        // (CashuDevKitModule.kt/.swift). An unconditional dispose here would
+        // be a data-loss bug: deleteWalletDatabase() takes no argument and
+        // unlinks whatever database is open, so deleting wallet B while A is
+        // warm would destroy A's ecash. A JS-side getDatabasePath() check
+        // has the same flaw one window narrower: a wallet switch landing
+        // between the check and the dispose retargets the teardown at the
+        // newly opened wallet's database. The native compare is on basename
+        // because dbDir here is `${DocumentDir}/../files` on Android while
+        // native tracks the resolved absolute filesDir, so full paths never
+        // string-match. CDK holds one database open at a time and destroys
+        // the outgoing wallet's handles on switch (initializeWallet), so a
+        // non-match resolves false without touching anything: no connection
+        // is open on this file and the plain unlink below is already safe.
         try {
             if (CashuDevKit.isAvailable()) {
-                const openPath = await CashuDevKit.getDatabasePath();
-                if (openPath && openPath.split('/').pop() === dbFile) {
-                    await CashuDevKit.deleteWalletDatabase();
-                }
+                await CashuDevKit.closeWalletDatabase(dbFile);
             }
         } catch (e) {
             console.warn(

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -391,9 +391,12 @@ export async function clearCDKDatabaseForNode(node: any): Promise<void> {
         // wallet B would destroy wallet A's ecash. Matching on basename, not
         // the full path: dbDir here is `${DocumentDir}/../files` on Android
         // while native reports the resolved absolute filesDir, so the strings
-        // never compare equal. CDK holds one database open at a time, so a
-        // non-match proves nothing is open on this file and the plain unlink
-        // below is already safe.
+        // never compare equal. CDK holds one database open at a time and
+        // destroys the outgoing wallet's handles when a new one is
+        // initialized (initializeWallet in CashuDevKitModule.kt/.swift), so a
+        // non-match proves no connection is open on this file and the plain
+        // unlink below is already safe - including after a wallet switch,
+        // where the wallet being deleted is no longer the tracked one.
         try {
             if (CashuDevKit.isAvailable()) {
                 const openPath = await CashuDevKit.getDatabasePath();

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -337,6 +337,9 @@ export async function clearCDKDatabase(): Promise<void> {
  * rules match clearNodeKeychainData: only embedded-lnd and ldk-node have an
  * unambiguous namespace; remote nodes share the 'lnd' default, so deleting
  * "their" database could destroy another wallet's proofs.
+ *
+ * Disposes the native CDK handles first, but only when the open database is
+ * this wallet's - see the path-match guard below.
  */
 export async function clearCDKDatabaseForNode(node: any): Promise<void> {
     if (!node) return;
@@ -371,8 +374,42 @@ export async function clearCDKDatabaseForNode(node: any): Promise<void> {
             .digest('hex')
             .slice(0, 16);
         const dbDir = cdkDatabaseDir();
+        const dbFile = `cashu_wallet_${hash}.db`;
+
+        // Close the live CDK handle before unlinking, same reason as
+        // clearCDKDatabase: this runs for the ACTIVE wallet too
+        // (WalletConfiguration.deleteNodeConfig stops LND/LDK first, neither
+        // of which touches CDK), and a POSIX unlink under an open handle
+        // leaves the proofs readable through that connection for the rest of
+        // the session.
+        //
+        // Guarded by a path match because deleteWalletDatabase() takes no
+        // argument: it drops the handles and unlinks whatever single database
+        // the native module currently has open (currentDbPath in
+        // CashuDevKitModule.kt/.swift). Calling it while a DIFFERENT wallet is
+        // warm would delete that wallet's proof database instead - deleting
+        // wallet B would destroy wallet A's ecash. Matching on basename, not
+        // the full path: dbDir here is `${DocumentDir}/../files` on Android
+        // while native reports the resolved absolute filesDir, so the strings
+        // never compare equal. CDK holds one database open at a time, so a
+        // non-match proves nothing is open on this file and the plain unlink
+        // below is already safe.
+        try {
+            if (CashuDevKit.isAvailable()) {
+                const openPath = await CashuDevKit.getDatabasePath();
+                if (openPath && openPath.split('/').pop() === dbFile) {
+                    await CashuDevKit.deleteWalletDatabase();
+                }
+            }
+        } catch (e) {
+            console.warn(
+                '[ClearData] Error disposing CDK database handles for node:',
+                e
+            );
+        }
+
         for (const suffix of ['', '-wal', '-shm']) {
-            const path = `${dbDir}/cashu_wallet_${hash}.db${suffix}`;
+            const path = `${dbDir}/${dbFile}${suffix}`;
             try {
                 if (await ReactNativeBlobUtil.fs.exists(path)) {
                     await ReactNativeBlobUtil.fs.unlink(path);

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -3,6 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import EncryptedStorage from 'react-native-encrypted-storage';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 import { BackHandler, Platform } from 'react-native';
+import CashuDevKit from '../cashu-cdk';
 import Storage from '../storage';
 
 import {
@@ -287,6 +288,21 @@ function cdkDatabaseDir(): string {
  * this destroys every wallet's ecash state.
  */
 export async function clearCDKDatabase(): Promise<void> {
+    // Close any live CDK handles (and delete the currently tracked db)
+    // before sweeping by filename, mirroring deleteCashuData's
+    // dispose-then-unlink order: unlinking under an open handle succeeds on
+    // POSIX but leaves the proof data reachable through the still-open
+    // connection until restart. Best effort: the sweep below is strictly
+    // broader (it catches every wallet's hashed db, not just the tracked
+    // one) and must run regardless.
+    try {
+        if (CashuDevKit.isAvailable()) {
+            await CashuDevKit.deleteWalletDatabase();
+        }
+    } catch (e) {
+        console.warn('[ClearData] Error disposing CDK database handles:', e);
+    }
+
     try {
         const dbDir = cdkDatabaseDir();
         const entries: string[] = await ReactNativeBlobUtil.fs.ls(dbDir);


### PR DESCRIPTION
# Description

`clearCDKDatabase` (used by `clearAllData`, including the duress-PIN and failed-authentication wipes) unlinked Cashu database files without first closing native CDK handles. POSIX unlink succeeds under an open handle, but the proof data stays reachable through the still-open connection until the app restarts, and the tracked db path could re-materialize files in a warm session.

This applies the same dispose-then-unlink ordering `deleteCashuData` already uses (#4376): `CashuDevKit.deleteWalletDatabase()` is called best-effort (guarded by `isAvailable()`) before the filename sweep. The prefix sweep remains the primary mechanism since it covers every wallet's hashed database plus WAL/SHM sidecars, not just the currently tracked one. Errors remain swallowed by design on the duress path (surfacing them would disclose the duress mechanism).

Round 3, per @shubhamkmr04's review: the dispose was not actually closing anything on Android. The uniffi bindings are `Disposable`, and `CashuDevKitModule.kt` only nulled the Kotlin references, so the Rust object and the SQLite connection it owns survived until the Cleaner next ran after a GC. That was bounded on the full-wipe path (every `clearAllData()` caller restarts in a `finally`, and Android's `restartApp()` is a ProcessPhoenix rebirth that closes every fd) but unbounded on the single-wallet path, where switching wallets leaves the outgoing wallet's connection open with no restart to close it. The handles are now destroyed, dependents first (prepared sends and per-mint wallets before the repository and database), a prepared melt or a confirmed/cancelled send is destroyed at the end of its operation for the same reason, and `currentDbPath` is published only once the handles it describes are the ones actually open, so the guard above cannot point at a database the module never opened. iOS was already correct under ARC and picks up the `currentDbPath` ordering plus a `preparedSends` clear on re-init.

Round 4, per @ajaysehwal's review: the JS-side guard in `clearCDKDatabaseForNode` was itself a check-then-act race across two bridge calls, so the basename compare and the handle teardown moved into a single native critical section, `closeWalletDatabase(dbFileName)` (`synchronized(handleLock)` on Android, `walletQueue.sync` on iOS). It unlinks nothing; file deletion stays with the JS caller.

Behavior note: because a wipe or wallet switch now destroys handles immediately instead of leaving them to the GC Cleaner, an in-flight Cashu operation that loses the race fails with a promise rejection instead of continuing against stale state. The vendored uniffi bindings make this safe (every call runs on a cloned Arc and the Rust free is deferred until the last in-flight call completes), so it is an error-surface change only, and deliberate: an operation surviving a wallet switch would otherwise mix two wallets' state.

Follow-up to #4328 / #4376; closes the last lifecycle gap noted in the internal assessment for the full-wipe path.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Device tests pending (will update): initialize a Cashu wallet, run Clear All Data with the wallet warm, verify `cashu_wallet*` files (including `-wal`/`-shm`) are gone from the app container and no Cashu state resurfaces after restart; duress-PIN wipe smoke test; and for the native handle change, switch from wallet A to wallet B without restarting, delete A, and confirm no process still holds A's database open (`ls -l /proc/<pid>/fd` on Android) plus a send/melt on B afterwards to check the disposal did not take the live wallet's handles with it.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Backend-independent: affects the wipe path for Cashu native state only.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

