### PR TITLE
fix(security): route LND WebSocket streams through Tor SOCKS proxy

### DIFF
--- a/android/app/src/main/java/app/zeusln/zeus/TorWebSocketModule.kt
+++ b/android/app/src/main/java/app/zeusln/zeus/TorWebSocketModule.kt
@@ -1,0 +1,138 @@
+package app.zeusln.zeus
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+
+/**
+ * WebSocket transport routed through the local Tor SOCKS proxy started by
+ * react-native-nitro-tor. React Native's own WebSocket module builds its
+ * OkHttp client without a proxy, so it cannot honor the app's Tor setting.
+ *
+ * OkHttp hands SOCKS proxies an unresolved hostname (RouteSelector creates
+ * InetSocketAddress.createUnresolved for Proxy.Type.SOCKS), so DNS
+ * resolution happens inside Tor and .onion hosts work. TLS for wss URLs is
+ * negotiated end-to-end through the tunnel with standard certificate
+ * validation, matching the direct WebSocket path's behavior.
+ */
+class TorWebSocketModule(private val reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+    private val sockets = ConcurrentHashMap<String, WebSocket>()
+    private var client: OkHttpClient? = null
+    private var clientSocksPort: Int = -1
+
+    override fun getName(): String = "TorWebSocketModule"
+
+    @Synchronized
+    private fun getClient(socksPort: Int): OkHttpClient {
+        val existing = client
+        if (existing != null && clientSocksPort == socksPort) return existing
+        val created = OkHttpClient.Builder()
+            .proxy(
+                Proxy(
+                    Proxy.Type.SOCKS,
+                    InetSocketAddress.createUnresolved("127.0.0.1", socksPort)
+                )
+            )
+            .connectTimeout(60, TimeUnit.SECONDS)
+            // streams stay open indefinitely
+            .readTimeout(0, TimeUnit.MILLISECONDS)
+            .pingInterval(30, TimeUnit.SECONDS)
+            .build()
+        client = created
+        clientSocksPort = socksPort
+        return created
+    }
+
+    private fun emit(event: String, id: String, fill: (WritableMap) -> Unit = {}) {
+        val map = Arguments.createMap()
+        map.putString("id", id)
+        fill(map)
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit(event, map)
+    }
+
+    @ReactMethod
+    fun connect(id: String, url: String, headers: ReadableMap, socksPort: Int) {
+        val builder = Request.Builder().url(url)
+        val iterator = headers.keySetIterator()
+        while (iterator.hasNextKey()) {
+            val key = iterator.nextKey()
+            headers.getString(key)?.let { builder.addHeader(key, it) }
+        }
+
+        val socket = getClient(socksPort).newWebSocket(
+            builder.build(),
+            object : WebSocketListener() {
+                override fun onOpen(webSocket: WebSocket, response: Response) {
+                    emit("TorWebSocketOpen", id)
+                }
+
+                override fun onMessage(webSocket: WebSocket, text: String) {
+                    emit("TorWebSocketMessage", id) { it.putString("data", text) }
+                }
+
+                override fun onFailure(
+                    webSocket: WebSocket,
+                    t: Throwable,
+                    response: Response?
+                ) {
+                    if (sockets.remove(id) != null) {
+                        emit("TorWebSocketError", id) {
+                            it.putString("message", t.message ?: t.toString())
+                        }
+                        // mirror React Native's WebSocket, which emits
+                        // close after error
+                        emit("TorWebSocketClose", id)
+                    }
+                }
+
+                override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                    webSocket.close(code, reason)
+                }
+
+                override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                    if (sockets.remove(id) != null) {
+                        emit("TorWebSocketClose", id) {
+                            it.putInt("code", code)
+                            it.putString("reason", reason)
+                        }
+                    }
+                }
+            }
+        )
+        sockets[id] = socket
+    }
+
+    @ReactMethod
+    fun send(id: String, message: String) {
+        sockets[id]?.send(message)
+    }
+
+    @ReactMethod
+    fun close(id: String) {
+        sockets.remove(id)?.close(1000, null)
+    }
+
+    // Required stubs for NativeEventEmitter on the new architecture interop
+    @ReactMethod
+    fun addListener(eventName: String) {}
+
+    @ReactMethod
+    fun removeListeners(count: Int) {}
+}

--- a/android/app/src/main/java/app/zeusln/zeus/TorWebSocketPackage.kt
+++ b/android/app/src/main/java/app/zeusln/zeus/TorWebSocketPackage.kt
@@ -1,0 +1,19 @@
+package app.zeusln.zeus
+
+import java.util.Arrays
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class TorWebSocketPackage : ReactPackage {
+
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return Arrays.asList<NativeModule>(TorWebSocketModule(reactContext))
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return emptyList<ViewManager<*, *>>()
+    }
+}

--- a/android/app/src/main/java/com/zeus/MainApplication.kt
+++ b/android/app/src/main/java/com/zeus/MainApplication.kt
@@ -33,6 +33,7 @@ class MainApplication : Application(), ReactApplication {
                     add(CashuDevKitPackage())
                     add(LdkNodePackage())
                     add(ZipUtilsPackage())
+                    add(TorWebSocketPackage())
                 },
         )
     }

--- a/backends/LND.ts
+++ b/backends/LND.ts
@@ -5,6 +5,7 @@ import {
     isOnionHttpsUrl,
     RequestMethod
 } from '../utils/TorUtils';
+import TorWebSocket from '../utils/TorWebSocket';
 import Invoice from './../models/Invoice';
 import OpenChannelRequest from './../models/OpenChannelRequest';
 import Base64Utils from './../utils/Base64Utils';
@@ -150,51 +151,15 @@ export default class LND {
         return isSupportedVersion(version, minVersion, eosVersion);
     };
 
-    wsReq = (route: string, method: string, data?: any) => {
-        const { host, lndhubUrl, port, macaroonHex, accessToken } =
-            settingsStore;
-
-        const auth = macaroonHex || accessToken;
-        const headers: any = this.getHeaders(auth, true);
-        const methodRoute = `${route}?method=${method}`;
-        const url = this.getURL(host || lndhubUrl, port, methodRoute, true);
-
-        return new Promise(function (resolve, reject) {
-            const ws: any = new WebSocket(url, null, {
-                headers
-            });
-
-            // keep pulling in responses until the socket closes
-            let resp: any;
-
-            ws.addEventListener('open', () => {
-                // connection opened
-                ws.send(JSON.stringify(data)); // send a message
-            });
-
-            ws.addEventListener('message', (e: any) => {
-                // a message was received
-                const data = JSON.parse(e.data);
-                if (data.error) {
-                    reject(data.error);
-                } else {
-                    resp = e.data;
-                }
-            });
-
-            ws.addEventListener('error', (e: any) => {
-                const certWarning = localeString('backends.LND.wsReq.warning');
-                // an error occurred
-                reject(
-                    e.message ? `${certWarning} (${e.message})` : certWarning
-                );
-            });
-
-            ws.addEventListener('close', () => {
-                // connection closed
-                resolve(JSON.parse(resp));
-            });
-        });
+    // React Native's global WebSocket has no proxy support, so when Tor
+    // is enabled the streaming endpoints must use the SOCKS-proxied
+    // native transport or they would silently leak the node host and the
+    // user's IP with a direct clearnet connection.
+    createWebSocket = (url: string, headers: any): any => {
+        if (settingsStore.enableTor) {
+            return new TorWebSocket(url, headers);
+        }
+        return new WebSocket(url, null, { headers });
     };
 
     getHeaders = (macaroonHex: string, ws?: boolean): any => {
@@ -318,9 +283,7 @@ export default class LND {
         const methodRoute = `${route}?method=${method}`;
         const url = this.getURL(host || lndhubUrl, port, methodRoute, true);
 
-        const ws: any = new WebSocket(url, null, {
-            headers
-        });
+        const ws: any = this.createWebSocket(url, headers);
 
         ws.addEventListener('open', () => {
             // connection opened
@@ -483,10 +446,9 @@ export default class LND {
         const methodRoute = '/v1/channels/stream?method=POST';
         const url = this.getURL(host || lndhubUrl, port, methodRoute, true);
 
+        const createWebSocket = this.createWebSocket;
         return new Promise(function (resolve, reject) {
-            const ws: any = new WebSocket(url, null, {
-                headers
-            });
+            const ws: any = createWebSocket(url, headers);
 
             // keep pulling in responses until the socket closes
             let resp: any;
@@ -858,9 +820,7 @@ export default class LND {
             true
         );
 
-        const ws: any = new WebSocket(url, null, {
-            headers
-        });
+        const ws: any = this.createWebSocket(url, headers);
 
         // keep pulling in responses until the socket closes
         let resp: any;

--- a/ios/TorWebSocket/TorWebSocketModule.m
+++ b/ios/TorWebSocket/TorWebSocketModule.m
@@ -1,0 +1,10 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface RCT_EXTERN_MODULE(TorWebSocketModule, RCTEventEmitter)
+
+RCT_EXTERN_METHOD(connect:(NSString *)id url:(NSString *)url headers:(NSDictionary *)headers socksPort:(nonnull NSNumber *)socksPort)
+RCT_EXTERN_METHOD(send:(NSString *)id message:(NSString *)message)
+RCT_EXTERN_METHOD(close:(NSString *)id)
+
+@end

--- a/ios/TorWebSocket/TorWebSocketModule.swift
+++ b/ios/TorWebSocket/TorWebSocketModule.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+/**
+ * WebSocket transport routed through the local Tor SOCKS proxy started by
+ * react-native-nitro-tor. React Native's WebSocket implementation has no
+ * proxy support, so it cannot honor the app's Tor setting.
+ *
+ * Uses NSURLSessionWebSocketTask with a SOCKS connectionProxyDictionary.
+ * The dictionary uses the literal "SOCKSEnable"/"SOCKSProxy"/"SOCKSPort"
+ * keys: the kCFNetworkProxiesSOCKS* symbols are macOS-only in the SDK
+ * headers, but the CFNetwork proxy layer honors them on iOS (this is the
+ * standard Tor integration approach). Hostnames are resolved by the proxy,
+ * so .onion hosts work. TLS for wss URLs is negotiated end-to-end through
+ * the tunnel with standard certificate validation, matching the direct
+ * WebSocket path's behavior.
+ */
+@objc(TorWebSocketModule)
+class TorWebSocketModule: RCTEventEmitter, URLSessionWebSocketDelegate {
+
+    private var tasks = [String: URLSessionWebSocketTask]()
+    private var idsByTask = [Int: String]()
+    private var session: URLSession?
+    private var sessionSocksPort: Int = -1
+    private let lock = NSLock()
+
+    @objc
+    override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
+    override func supportedEvents() -> [String]! {
+        return [
+            "TorWebSocketOpen",
+            "TorWebSocketMessage",
+            "TorWebSocketError",
+            "TorWebSocketClose"
+        ]
+    }
+
+    private func getSession(socksPort: Int) -> URLSession {
+        if let existing = session, sessionSocksPort == socksPort {
+            return existing
+        }
+        let config = URLSessionConfiguration.ephemeral
+        config.connectionProxyDictionary = [
+            "SOCKSEnable": 1,
+            "SOCKSProxy": "127.0.0.1",
+            "SOCKSPort": socksPort
+        ]
+        config.timeoutIntervalForRequest = 60
+        let created = URLSession(
+            configuration: config,
+            delegate: self,
+            delegateQueue: nil
+        )
+        session = created
+        sessionSocksPort = socksPort
+        return created
+    }
+
+    @objc(connect:url:headers:socksPort:)
+    func connect(
+        _ id: String,
+        url: String,
+        headers: NSDictionary,
+        socksPort: NSNumber
+    ) {
+        guard let parsedUrl = URL(string: url) else {
+            sendEvent(
+                withName: "TorWebSocketError",
+                body: ["id": id, "message": "invalid URL"]
+            )
+            sendEvent(withName: "TorWebSocketClose", body: ["id": id])
+            return
+        }
+
+        var request = URLRequest(url: parsedUrl)
+        for (key, value) in headers {
+            if let headerName = key as? String,
+                let headerValue = value as? String {
+                request.setValue(headerValue, forHTTPHeaderField: headerName)
+            }
+        }
+
+        let task = getSession(socksPort: socksPort.intValue)
+            .webSocketTask(with: request)
+
+        lock.lock()
+        tasks[id] = task
+        idsByTask[task.taskIdentifier] = id
+        lock.unlock()
+
+        receiveLoop(id: id, task: task)
+        task.resume()
+    }
+
+    private func receiveLoop(id: String, task: URLSessionWebSocketTask) {
+        task.receive { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let message):
+                var text: String?
+                switch message {
+                case .string(let value):
+                    text = value
+                case .data(let value):
+                    text = String(data: value, encoding: .utf8)
+                @unknown default:
+                    break
+                }
+                if let text = text {
+                    self.sendEvent(
+                        withName: "TorWebSocketMessage",
+                        body: ["id": id, "data": text]
+                    )
+                }
+                self.receiveLoop(id: id, task: task)
+            case .failure(let error):
+                if self.removeTask(id: id) != nil {
+                    self.sendEvent(
+                        withName: "TorWebSocketError",
+                        body: ["id": id, "message": error.localizedDescription]
+                    )
+                    // mirror React Native's WebSocket, which emits close
+                    // after error
+                    self.sendEvent(
+                        withName: "TorWebSocketClose",
+                        body: ["id": id]
+                    )
+                }
+            }
+        }
+    }
+
+    private func removeTask(id: String) -> URLSessionWebSocketTask? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let task = tasks.removeValue(forKey: id) else { return nil }
+        idsByTask.removeValue(forKey: task.taskIdentifier)
+        return task
+    }
+
+    private func idFor(task: URLSessionWebSocketTask) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return idsByTask[task.taskIdentifier]
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didOpenWithProtocol protocolName: String?
+    ) {
+        if let id = idFor(task: webSocketTask) {
+            sendEvent(withName: "TorWebSocketOpen", body: ["id": id])
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+        reason: Data?
+    ) {
+        if let id = idFor(task: webSocketTask),
+            removeTask(id: id) != nil {
+            sendEvent(
+                withName: "TorWebSocketClose",
+                body: ["id": id, "code": closeCode.rawValue]
+            )
+        }
+    }
+
+    @objc(send:message:)
+    func send(_ id: String, message: String) {
+        lock.lock()
+        let task = tasks[id]
+        lock.unlock()
+        task?.send(.string(message)) { [weak self] error in
+            if let error = error, let self = self {
+                self.sendEvent(
+                    withName: "TorWebSocketError",
+                    body: ["id": id, "message": error.localizedDescription]
+                )
+            }
+        }
+    }
+
+    @objc(close:)
+    func close(_ id: String) {
+        removeTask(id: id)?.cancel(with: .normalClosure, reason: nil)
+    }
+}

--- a/ios/zeus.xcodeproj/project.pbxproj
+++ b/ios/zeus.xcodeproj/project.pbxproj
@@ -159,6 +159,8 @@
 		B1C2D3E62D36C99900000003 /* LDKNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E52D36C99900000002 /* LDKNode.swift */; };
 		B1C2D3E92D36C99900000006 /* LdkNodeModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E72D36C99900000004 /* LdkNodeModule.swift */; };
 		B1C2D3EA2D36C99900000007 /* LdkNodeModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E82D36C99900000005 /* LdkNodeModule.m */; };
+		7B7054A32E6B000000000004 /* TorWebSocketModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7054A12E6B000000000002 /* TorWebSocketModule.swift */; };
+		7B7054A42E6B000000000005 /* TorWebSocketModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7054A22E6B000000000003 /* TorWebSocketModule.m */; };
 		B1C2D3EC2D36C99900000009 /* LogFileObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3EB2D36C99900000008 /* LogFileObserver.swift */; };
 		B1DB19555C1C4546922217C2 /* eye_closed.svg in Resources */ = {isa = PBXBuildFile; fileRef = 744BE042F00E4B16BDC79870 /* eye_closed.svg */; };
 		B20A92EA4E82493CB6D1A2F0 /* NFC.svg in Resources */ = {isa = PBXBuildFile; fileRef = 3C37D42473A54AD981B549B4 /* NFC.svg */; };
@@ -665,6 +667,8 @@
 		B1C2D3E52D36C99900000002 /* LDKNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LDKNode.swift; sourceTree = "<group>"; };
 		B1C2D3E72D36C99900000004 /* LdkNodeModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LdkNodeModule.swift; sourceTree = "<group>"; };
 		B1C2D3E82D36C99900000005 /* LdkNodeModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LdkNodeModule.m; sourceTree = "<group>"; };
+		7B7054A12E6B000000000002 /* TorWebSocketModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TorWebSocketModule.swift; sourceTree = "<group>"; };
+		7B7054A22E6B000000000003 /* TorWebSocketModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TorWebSocketModule.m; sourceTree = "<group>"; };
 		B1C2D3EB2D36C99900000008 /* LogFileObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogFileObserver.swift; sourceTree = "<group>"; };
 		B362E70907794D2F924BCB42 /* temple.jpeg */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = temple.jpeg; path = ../assets/images/onboarding/temple.jpeg; sourceTree = "<group>"; };
 		B36D434AE9B14EE7AD5E6BCE /* Routing.svg */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Routing.svg; path = ../assets/images/SVG/Routing.svg; sourceTree = "<group>"; };
@@ -905,6 +909,7 @@
 				51BF29FB2ED5FB940044B4FB /* ShareBridge.h */,
 				51BF29FC2ED5FB940044B4FB /* ShareBridge.m */,
 				B1C2D3E42D36C99900000001 /* LdkNodeMobile */,
+				7B7054A02E6B000000000001 /* TorWebSocket */,
 				74B637782A5A350A00750202 /* LncMobile */,
 				745388372A54C2B6000927CE /* LndMobile */,
 				CDC0DEEE2A54C2B6000927CE /* CashuDevKit */,
@@ -1133,6 +1138,15 @@
 				B1C2D3E82D36C99900000005 /* LdkNodeModule.m */,
 			);
 			path = LdkNodeMobile;
+			sourceTree = "<group>";
+		};
+		7B7054A02E6B000000000001 /* TorWebSocket */ = {
+			isa = PBXGroup;
+			children = (
+				7B7054A12E6B000000000002 /* TorWebSocketModule.swift */,
+				7B7054A22E6B000000000003 /* TorWebSocketModule.m */,
+			);
+			path = TorWebSocket;
 			sourceTree = "<group>";
 		};
 		C313040DFF224D8A9EC46990 /* Resources */ = {
@@ -2070,6 +2084,8 @@
 				B1C2D3E62D36C99900000003 /* LDKNode.swift in Sources */,
 				B1C2D3E92D36C99900000006 /* LdkNodeModule.swift in Sources */,
 				B1C2D3EA2D36C99900000007 /* LdkNodeModule.m in Sources */,
+				7B7054A32E6B000000000004 /* TorWebSocketModule.swift in Sources */,
+				7B7054A42E6B000000000005 /* TorWebSocketModule.m in Sources */,
 				B1C2D3EC2D36C99900000009 /* LogFileObserver.swift in Sources */,
 				745388452A54C2B6000927CE /* LndMobileScheduledSync.swift in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,

--- a/utils/TorUtils.ts
+++ b/utils/TorUtils.ts
@@ -153,4 +153,11 @@ const restartTor = async () => {
     await ensureTorStarted();
 };
 
-export { doTorRequest, restartTor, isOnionHttpsUrl, RequestMethod };
+export {
+    doTorRequest,
+    restartTor,
+    ensureTorStarted,
+    isOnionHttpsUrl,
+    RequestMethod,
+    SOCKS_PORT
+};

--- a/utils/TorWebSocket.test.ts
+++ b/utils/TorWebSocket.test.ts
@@ -1,0 +1,159 @@
+const mockConnect = jest.fn();
+const mockSend = jest.fn();
+const mockClose = jest.fn();
+
+type Handler = (event: any) => void;
+const nativeListeners: { [event: string]: Handler[] } = {};
+
+const emitNative = (event: string, payload: any) => {
+    (nativeListeners[event] || []).forEach((handler) => handler(payload));
+};
+
+jest.mock('react-native', () => ({
+    NativeModules: {
+        TorWebSocketModule: {
+            connect: (...args: any[]) => mockConnect(...args),
+            send: (...args: any[]) => mockSend(...args),
+            close: (...args: any[]) => mockClose(...args)
+        }
+    },
+    NativeEventEmitter: class {
+        addListener(event: string, handler: Handler) {
+            (nativeListeners[event] = nativeListeners[event] || []).push(
+                handler
+            );
+            return {
+                remove: () => {
+                    const idx = nativeListeners[event].indexOf(handler);
+                    if (idx !== -1) nativeListeners[event].splice(idx, 1);
+                }
+            };
+        }
+    }
+}));
+
+const mockEnsureTorStarted = jest.fn();
+jest.mock('./TorUtils', () => ({
+    ensureTorStarted: () => mockEnsureTorStarted(),
+    SOCKS_PORT: 9056
+}));
+
+import TorWebSocket from './TorWebSocket';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('TorWebSocket', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        Object.keys(nativeListeners).forEach(
+            (key) => delete nativeListeners[key]
+        );
+        mockEnsureTorStarted.mockResolvedValue(undefined);
+    });
+
+    it('connects through the SOCKS port after Tor is started', async () => {
+        const ws = new TorWebSocket('wss://node.example:8080/v1/x', {
+            'Grpc-Metadata-Macaroon': 'beef'
+        });
+        expect(ws).toBeTruthy();
+        expect(mockConnect).not.toHaveBeenCalled();
+
+        await flush();
+
+        expect(mockEnsureTorStarted).toHaveBeenCalled();
+        expect(mockConnect).toHaveBeenCalledWith(
+            expect.any(String),
+            'wss://node.example:8080/v1/x',
+            { 'Grpc-Metadata-Macaroon': 'beef' },
+            9056
+        );
+    });
+
+    it('routes native events only to the owning socket', async () => {
+        const first = new TorWebSocket('wss://a.example/x');
+        const second = new TorWebSocket('wss://b.example/x');
+        await flush();
+
+        const firstId = mockConnect.mock.calls[0][0];
+        const secondId = mockConnect.mock.calls[1][0];
+        expect(firstId).not.toEqual(secondId);
+
+        const firstMessages: any[] = [];
+        const secondMessages: any[] = [];
+        first.addEventListener('message', (e) => firstMessages.push(e.data));
+        second.addEventListener('message', (e) => secondMessages.push(e.data));
+
+        emitNative('TorWebSocketMessage', { id: firstId, data: 'one' });
+        emitNative('TorWebSocketMessage', { id: secondId, data: 'two' });
+
+        expect(firstMessages).toEqual(['one']);
+        expect(secondMessages).toEqual(['two']);
+    });
+
+    it('delivers open, error, and close events with RN-compatible shapes', async () => {
+        const ws = new TorWebSocket('wss://a.example/x');
+        await flush();
+        const id = mockConnect.mock.calls[0][0];
+
+        const events: string[] = [];
+        let errorMessage: string | undefined;
+        ws.addEventListener('open', () => events.push('open'));
+        ws.addEventListener('error', (e) => {
+            events.push('error');
+            errorMessage = e.message;
+        });
+        ws.addEventListener('close', () => events.push('close'));
+
+        emitNative('TorWebSocketOpen', { id });
+        emitNative('TorWebSocketError', { id, message: 'boom' });
+        emitNative('TorWebSocketClose', { id });
+
+        expect(events).toEqual(['open', 'error', 'close']);
+        expect(errorMessage).toEqual('boom');
+    });
+
+    it('sends through the native module and stops after close', async () => {
+        const ws = new TorWebSocket('wss://a.example/x');
+        await flush();
+        const id = mockConnect.mock.calls[0][0];
+
+        ws.send('{"accept":true}');
+        expect(mockSend).toHaveBeenCalledWith(id, '{"accept":true}');
+
+        ws.close();
+        expect(mockClose).toHaveBeenCalledWith(id);
+
+        ws.send('late');
+        expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not connect when closed before Tor finished starting', async () => {
+        let resolveStart: () => void = () => {};
+        mockEnsureTorStarted.mockReturnValue(
+            new Promise<void>((resolve) => {
+                resolveStart = resolve;
+            })
+        );
+
+        const ws = new TorWebSocket('wss://a.example/x');
+        ws.close();
+        resolveStart();
+        await flush();
+
+        expect(mockConnect).not.toHaveBeenCalled();
+    });
+
+    it('fails closed with error + close when Tor cannot start', async () => {
+        mockEnsureTorStarted.mockRejectedValue(new Error('no tor'));
+
+        const ws = new TorWebSocket('wss://a.example/x');
+        const events: any[] = [];
+        ws.addEventListener('error', (e) => events.push(e.message));
+        ws.addEventListener('close', () => events.push('close'));
+
+        await flush();
+
+        expect(events).toEqual(['no tor', 'close']);
+        expect(mockConnect).not.toHaveBeenCalled();
+    });
+});

--- a/utils/TorWebSocket.ts
+++ b/utils/TorWebSocket.ts
@@ -1,0 +1,128 @@
+import { NativeEventEmitter, NativeModules } from 'react-native';
+
+import { ensureTorStarted, SOCKS_PORT } from './TorUtils';
+
+const { TorWebSocketModule } = NativeModules;
+
+type TorWebSocketEventType = 'open' | 'message' | 'error' | 'close';
+type TorWebSocketListener = (event: any) => void;
+
+let sharedEmitter: NativeEventEmitter | null = null;
+let nextSocketId = 0;
+
+const getEmitter = (): NativeEventEmitter => {
+    if (!sharedEmitter) {
+        sharedEmitter = new NativeEventEmitter(TorWebSocketModule);
+    }
+    return sharedEmitter;
+};
+
+/**
+ * A WebSocket routed through the Tor SOCKS proxy started by
+ * react-native-nitro-tor. React Native's global WebSocket has no proxy
+ * support, so a direct socket while Tor is enabled would leak the node
+ * host and the user's IP to network observers; this class is the
+ * Tor-honoring transport for the LND streaming endpoints.
+ *
+ * Implements the subset of the React Native WebSocket API the LND
+ * backend uses: addEventListener('open' | 'message' | 'error' |
+ * 'close'), send(), and close(). Event payload shapes match RN's
+ * (message events carry `data`, error events carry `message`).
+ *
+ * Fails closed by design: if the native transport is unavailable or Tor
+ * cannot start, the socket reports error + close and never falls back
+ * to a direct clearnet connection.
+ */
+export default class TorWebSocket {
+    private id = `tor-ws-${++nextSocketId}`;
+    private listeners: Partial<
+        Record<TorWebSocketEventType, TorWebSocketListener[]>
+    > = {};
+    private subscriptions: { remove: () => void }[] = [];
+    private closed = false;
+
+    constructor(url: string, headers: Record<string, string> = {}) {
+        if (!TorWebSocketModule) {
+            // fail closed: never fall back to a clearnet socket
+            setTimeout(() => {
+                this.dispatch('error', {
+                    message: 'Tor WebSocket native module unavailable'
+                });
+                this.dispatch('close', {});
+            }, 0);
+            return;
+        }
+
+        const emitter = getEmitter();
+        this.subscriptions = [
+            emitter.addListener('TorWebSocketOpen', (e) =>
+                this.route('open', e)
+            ),
+            emitter.addListener('TorWebSocketMessage', (e) =>
+                this.route('message', e)
+            ),
+            emitter.addListener('TorWebSocketError', (e) =>
+                this.route('error', e)
+            ),
+            emitter.addListener('TorWebSocketClose', (e) =>
+                this.route('close', e)
+            )
+        ];
+
+        ensureTorStarted()
+            .then(() => {
+                if (!this.closed) {
+                    TorWebSocketModule.connect(
+                        this.id,
+                        url,
+                        headers,
+                        SOCKS_PORT
+                    );
+                }
+            })
+            .catch((e: any) => {
+                this.dispatch('error', {
+                    message: e?.message ? e.message : String(e)
+                });
+                this.dispatch('close', {});
+                this.cleanup();
+            });
+    }
+
+    addEventListener(type: TorWebSocketEventType, cb: TorWebSocketListener) {
+        (this.listeners[type] = this.listeners[type] || []).push(cb);
+    }
+
+    send(data: string) {
+        if (TorWebSocketModule && !this.closed) {
+            TorWebSocketModule.send(this.id, data);
+        }
+    }
+
+    close() {
+        if (this.closed) return;
+        this.closed = true;
+        if (TorWebSocketModule) {
+            TorWebSocketModule.close(this.id);
+        }
+        this.cleanup();
+    }
+
+    private route(type: TorWebSocketEventType, event: any) {
+        if (!event || event.id !== this.id) return;
+        this.dispatch(type, event);
+        if (type === 'close') {
+            this.closed = true;
+            this.cleanup();
+        }
+    }
+
+    private dispatch(type: TorWebSocketEventType, event: any) {
+        (this.listeners[type] || []).forEach((cb) => cb(event));
+    }
+
+    private cleanup() {
+        this.subscriptions.forEach((s) => s.remove());
+        this.subscriptions = [];
+    }
+}


### PR DESCRIPTION
# Description

REST requests honor the Use Tor setting via `doTorRequest`, but the LND streaming paths — LSPS custom-message subscription, the zero-conf channel acceptor, and the PSBT/batch channel-open stream — constructed direct WebSockets with React Native's global `WebSocket`, which has no proxy support. With a clearnet remote LND host and Tor enabled, the custom-message and channel-acceptor sockets opened **on every wallet connect** (they're started unconditionally under `supportsFlowLSP`), leaking the node host (TLS SNI) and the user's IP to network observers despite the explicit Tor opt-in. Onion-only hosts silently failed for these streams.

**Approach (revised):** instead of failing closed and losing functionality, this wires the WebSockets through the SOCKS proxy `react-native-nitro-tor` already runs on `127.0.0.1:9056` — so all streaming features keep working over Tor, with no clearnet leak.

- **`TorWebSocketModule` (new native transport)**
  - Android: OkHttp WebSocket with a `Proxy.Type.SOCKS` proxy. OkHttp hands SOCKS proxies an *unresolved* hostname (`RouteSelector` uses `InetSocketAddress.createUnresolved`), so DNS resolves inside Tor and `.onion` hosts work.
  - iOS: `NSURLSessionWebSocketTask` with a SOCKS `connectionProxyDictionary` (literal `SOCKSEnable`/`SOCKSProxy`/`SOCKSPort` keys — the `kCFNetworkProxies*` symbols are macOS-only in the SDK headers but honored by CFNetwork on iOS; standard Tor integration approach).
  - TLS for `wss` URLs is negotiated end-to-end through the tunnel with standard certificate validation, matching the direct path's behavior (clearnet-over-Tor keeps strict TLS, same policy as `doTorRequest`).
- **`utils/TorWebSocket.ts`** wraps the native module in the RN WebSocket event-API subset the LND backend uses (`addEventListener` open/message/error/close, `send`, `close`), waits for Tor startup (`ensureTorStarted`) before connecting, and **fails closed** — error + close, never a clearnet fallback — if the native transport or Tor is unavailable.
- **`backends/LND.ts`** selects the transport per socket via a `createWebSocket` factory keyed on `settingsStore.enableTor`; the three streaming call sites are otherwise unchanged. The unused `wsReq` helper (which carried the same bypass, zero callers) is removed.

This also *fixes* previously broken behavior for Tor users: zero-conf LSP channel acceptance and PSBT/batch channel opens now work with onion/clearnet hosts over Tor instead of silently failing or leaking.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

New `utils/TorWebSocket.test.ts` (6 cases): SOCKS-port connect after Tor startup, per-socket event routing across concurrent sockets, RN-compatible event payload shapes, send/close lifecycle, close-before-Tor-ready races, and fail-closed when Tor cannot start.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Device tests pending (will update):
- Remote LND + Tor enabled, clearnet host: packet capture / node logs confirming streams arrive via Tor exit, no direct connection from device IP
- Remote LND + Tor enabled, onion host: custom-message subscription and channel acceptor connect (previously failed)
- Zero-conf LSP channel open over Tor end-to-end
- Tor disabled: regression check that all three streams use the direct path unchanged
- iOS specifically: verify NSURLSessionWebSocketTask honors the SOCKS dictionary on current iOS (known-good technique, but this is the load-bearing assumption on that platform)

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Only LND (REST) and LndHub (inherits the LND backend) construct these WebSockets; embedded LND uses native event streams and is unaffected.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

No new dependencies: Android uses the OkHttp already bundled with React Native; iOS uses Foundation only. Native app rebuild required (new native module on both platforms, pbxproj updated).

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding