### PR TITLE
views: use sending capacity for payment selection

### DIFF
--- a/components/LayerBalances/PaymentMethodList.tsx
+++ b/components/LayerBalances/PaymentMethodList.tsx
@@ -35,6 +35,9 @@ interface PaymentMethodListProps {
     lnurlParams?: LNURLWithdrawParams | undefined;
     lightningBalance?: number | string;
     lightningBalanceLabel?: string;
+    // Balance the lightning rows are judged against, when it differs from the
+    // one displayed (e.g. capacity locked in a momentarily offline channel).
+    lightningEligibilityBalance?: number | string;
     onchainBalance?: number | string;
     ecashBalance?: number | string;
     accounts?: Array<{
@@ -55,6 +58,9 @@ type DataRow = {
     disabled?: boolean;
     balance?: number | string;
     balanceLabel?: string;
+    // Defaults to `balance`. Set when the row should be judged against a
+    // different figure than the one it shows.
+    eligibilityBalance?: number | string;
     account?: string;
     hidden?: boolean;
     satAmount?: number;
@@ -94,10 +100,15 @@ const hasInsufficientBalance = (
     Number(balance) === 0 ||
     (satAmount !== undefined && satAmount > Number(balance));
 
+const isRowInsufficient = (item: DataRow) =>
+    !item.isWithdraw &&
+    hasInsufficientBalance(
+        item.eligibilityBalance ?? item.balance,
+        item.satAmount
+    );
+
 const Row = ({ item }: { item: DataRow }) => {
-    const insufficient =
-        !item.isWithdraw &&
-        hasInsufficientBalance(item.balance, item.satAmount);
+    const insufficient = isRowInsufficient(item);
     const layerLabel = LAYER_LOCALE_MAP[item.layer]
         ? localeString(LAYER_LOCALE_MAP[item.layer])
         : item.layer;
@@ -205,9 +216,7 @@ const SwipeableRow = ({
     clinkNoffer?: string;
     lnurlParams?: LNURLWithdrawParams | undefined;
 }) => {
-    const insufficient =
-        !item.isWithdraw &&
-        hasInsufficientBalance(item.balance, item.satAmount);
+    const insufficient = isRowInsufficient(item);
     const rowDisabled = item.disabled || insufficient;
     if (item.layer === 'Lightning') {
         return (
@@ -312,11 +321,15 @@ export default class PaymentMethodList extends Component<
             clinkNoffer,
             lnurlParams,
             lightningBalance,
+            lightningEligibilityBalance,
             onchainBalance,
             ecashBalance,
             accounts
         } = this.props;
         let DATA: DataRow[] = [];
+
+        const lightningEligibility =
+            lightningEligibilityBalance ?? lightningBalance;
 
         const isWithdraw = lnurlParams?.tag === 'withdrawRequest';
         const subtitle = isWithdraw
@@ -329,6 +342,7 @@ export default class PaymentMethodList extends Component<
                 subtitle,
                 balance: lightningBalance,
                 balanceLabel: this.props.lightningBalanceLabel,
+                eligibilityBalance: lightningEligibility,
                 disabled: false,
                 isWithdraw,
                 satAmount
@@ -355,6 +369,7 @@ export default class PaymentMethodList extends Component<
                 subtitle: lightningAddress,
                 balance: lightningBalance,
                 balanceLabel: this.props.lightningBalanceLabel,
+                eligibilityBalance: lightningEligibility,
                 disabled: false,
                 satAmount
             });
@@ -367,6 +382,7 @@ export default class PaymentMethodList extends Component<
                 disabled: !nodeInfoStore.supportsOffers,
                 balance: lightningBalance,
                 balanceLabel: this.props.lightningBalanceLabel,
+                eligibilityBalance: lightningEligibility,
                 satAmount
             });
         }
@@ -431,14 +447,19 @@ export default class PaymentMethodList extends Component<
                 Number(lightningBalance ?? 0),
                 ecashAvailable ? Number(ecashBalance ?? 0) : 0
             );
+            const clinkEligibility = Math.max(
+                Number(lightningEligibility ?? 0),
+                ecashAvailable ? Number(ecashBalance ?? 0) : 0
+            );
             DATA.push({
                 layer: 'CLINK',
                 subtitle: clinkNoffer,
                 // No funds in either bucket means no path to pay,
                 // regardless of the noffer's pricing type.
-                disabled: clinkBalance === 0,
+                disabled: clinkEligibility === 0,
                 ...(embeddedAmount !== undefined && {
                     balance: clinkBalance,
+                    eligibilityBalance: clinkEligibility,
                     // Compare against the noffer's embedded price (the
                     // amount that will actually be paid) rather than any
                     // BIP21 `amount=` that may have come in separately.

--- a/components/LayerBalances/PaymentMethodList.tsx
+++ b/components/LayerBalances/PaymentMethodList.tsx
@@ -34,6 +34,7 @@ interface PaymentMethodListProps {
     clinkNoffer?: string;
     lnurlParams?: LNURLWithdrawParams | undefined;
     lightningBalance?: number | string;
+    lightningBalanceLabel?: string;
     onchainBalance?: number | string;
     ecashBalance?: number | string;
     accounts?: Array<{
@@ -53,6 +54,7 @@ type DataRow = {
     subtitle?: string;
     disabled?: boolean;
     balance?: number | string;
+    balanceLabel?: string;
     account?: string;
     hidden?: boolean;
     satAmount?: number;
@@ -158,6 +160,20 @@ const Row = ({ item }: { item: DataRow }) => {
                                     : themeColor('buttonText')
                             }
                         />
+                        {item.balanceLabel && (
+                            <Text
+                                style={[
+                                    styles.balanceLabel,
+                                    {
+                                        color:
+                                            themeColor('buttonTextSecondary') ||
+                                            themeColor('secondaryText')
+                                    }
+                                ]}
+                            >
+                                {item.balanceLabel}
+                            </Text>
+                        )}
                     </View>
                 )}
             </LinearGradient>
@@ -312,6 +328,7 @@ export default class PaymentMethodList extends Component<
                 layer: 'Lightning',
                 subtitle,
                 balance: lightningBalance,
+                balanceLabel: this.props.lightningBalanceLabel,
                 disabled: false,
                 isWithdraw,
                 satAmount
@@ -337,6 +354,7 @@ export default class PaymentMethodList extends Component<
                 layer: 'Lightning address',
                 subtitle: lightningAddress,
                 balance: lightningBalance,
+                balanceLabel: this.props.lightningBalanceLabel,
                 disabled: false,
                 satAmount
             });
@@ -348,6 +366,7 @@ export default class PaymentMethodList extends Component<
                 subtitle: offer,
                 disabled: !nodeInfoStore.supportsOffers,
                 balance: lightningBalance,
+                balanceLabel: this.props.lightningBalanceLabel,
                 satAmount
             });
         }
@@ -508,6 +527,12 @@ const styles = StyleSheet.create({
         flexShrink: 0,
         marginLeft: 10,
         maxWidth: '40%'
+    },
+    balanceLabel: {
+        fontSize: 12,
+        fontFamily: 'PPNeueMontreal-Medium',
+        textAlign: 'right',
+        marginTop: 2
     },
     separator: {
         backgroundColor: 'transparent',

--- a/locales/en.json
+++ b/locales/en.json
@@ -308,6 +308,7 @@
     "views.Accounts.fetchTxFees": "Fetch on-chain transaction fees",
     "views.ChoosePaymentMethod.selectReceiveMethod": "Select receive method",
     "views.ChoosePaymentMethod.availableToSend": "Available to send",
+    "views.ChoosePaymentMethod.channelsOffline": "Some channels are offline. This payment may fail until they reconnect.",
     "views.EditFee.title": "Edit network fee",
     "views.EditFee.titleDisplayOnly": "Transaction fees",
     "views.LnurlPay.LnurlPay.amount": "Amount to pay",

--- a/locales/en.json
+++ b/locales/en.json
@@ -307,6 +307,7 @@
     "views.Accounts.select": "Select payment method",
     "views.Accounts.fetchTxFees": "Fetch on-chain transaction fees",
     "views.ChoosePaymentMethod.selectReceiveMethod": "Select receive method",
+    "views.ChoosePaymentMethod.availableToSend": "Available to send",
     "views.EditFee.title": "Edit network fee",
     "views.EditFee.titleDisplayOnly": "Transaction fees",
     "views.LnurlPay.LnurlPay.amount": "Amount to pay",

--- a/stores/ChannelsStore.test.ts
+++ b/stores/ChannelsStore.test.ts
@@ -1,0 +1,151 @@
+jest.mock('react-native-randombytes', () => ({
+    randomBytes: () => Buffer.alloc(32)
+}));
+jest.mock('../utils/BackendUtils', () => ({
+    getChannels: jest.fn(),
+    getNodeInfo: jest.fn(() => Promise.resolve(null)),
+    supportsClosedChannels: () => false,
+    supportsPendingChannels: () => false,
+    isLNDBased: () => false
+}));
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+jest.mock('../utils/ErrorUtils', () => ({
+    errorToUserFriendly: (e: any) => String(e)
+}));
+
+import { autorun } from 'mobx';
+
+import ChannelsStore from './ChannelsStore';
+import BackendUtils from '../utils/BackendUtils';
+
+const channel = (
+    localBalance: number,
+    remoteBalance: number,
+    active: boolean
+) => ({
+    active,
+    local_balance: String(localBalance),
+    remote_balance: String(remoteBalance),
+    remote_pubkey: `pubkey-${localBalance}-${remoteBalance}`,
+    channel_id: `chan-${localBalance}-${remoteBalance}`
+});
+
+// cln-rest short-circuits the node-info enrichment reaction, which would
+// otherwise leave its 10s lookup timeout pending after each test. The balance
+// accounting under test is implementation independent.
+const makeStore = () =>
+    new ChannelsStore(
+        { implementation: 'cln-rest' } as any,
+        { setPendingCloseBalance: jest.fn() } as any
+    );
+
+describe('ChannelsStore.getChannels', () => {
+    let store: ChannelsStore;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        store = makeStore();
+    });
+
+    it('splits local balance by channel activity', async () => {
+        jest.mocked(BackendUtils.getChannels).mockResolvedValue({
+            channels: [channel(11243, 5000, true), channel(4000, 1000, false)]
+        } as any);
+
+        await store.getChannels();
+
+        expect(store.hasChannelData).toBe(true);
+        expect(store.totalOutbound).toBe(11243);
+        expect(store.totalInbound).toBe(5000);
+        // the offline channel's local balance is tracked apart from its
+        // total capacity, so callers can tell it from an empty wallet
+        expect(store.totalOutboundOffline).toBe(4000);
+        expect(store.totalOffline).toBe(5000);
+    });
+
+    it('reports no capacity, not stale capacity, when every channel is offline', async () => {
+        jest.mocked(BackendUtils.getChannels).mockResolvedValue({
+            channels: [channel(11243, 5000, false)]
+        } as any);
+
+        await store.getChannels();
+
+        expect(store.totalOutbound).toBe(0);
+        expect(store.totalOutboundOffline).toBe(11243);
+    });
+
+    it('keeps the previous totals visible while a refresh is in flight', async () => {
+        jest.mocked(BackendUtils.getChannels).mockResolvedValue({
+            channels: [channel(11243, 5000, true)]
+        } as any);
+        await store.getChannels();
+
+        let release: (value: any) => void = () => {};
+        jest.mocked(BackendUtils.getChannels).mockReturnValue(
+            new Promise((resolve) => {
+                release = resolve;
+            }) as any
+        );
+
+        const refresh = store.getChannels();
+
+        // Observers such as ChoosePaymentMethod read these synchronously while
+        // the fetch is outstanding. Zeroing them here is what let a 12,000 sat
+        // payment be offered against 11,243 sats of real capacity.
+        expect(store.hasChannelData).toBe(true);
+        expect(store.totalOutbound).toBe(11243);
+        expect(store.channels.length).toBe(1);
+
+        release({ channels: [channel(9000, 5000, true)] });
+        await refresh;
+
+        expect(store.totalOutbound).toBe(9000);
+    });
+
+    it('never publishes the data flag ahead of the totals', async () => {
+        jest.mocked(BackendUtils.getChannels).mockResolvedValue({
+            channels: [channel(11243, 5000, true)]
+        } as any);
+        await store.getChannels();
+
+        // an observer of the store sees every intermediate state, the way
+        // ChoosePaymentMethod does
+        const seen: Array<{ flag: boolean; outbound: number }> = [];
+        const dispose = autorun(() =>
+            seen.push({
+                flag: store.hasChannelData,
+                outbound: store.totalOutbound + store.totalOutboundOffline
+            })
+        );
+
+        await store.getChannels();
+        await store.getChannels();
+        dispose();
+
+        // the flag reading true against zeroed totals is the state that
+        // renders "not enough funds" for a wallet that has the funds
+        expect(seen.some((s) => s.flag && s.outbound === 0)).toBe(false);
+    });
+
+    it('clears the totals and the data flag when the fetch fails', async () => {
+        jest.mocked(BackendUtils.getChannels).mockResolvedValue({
+            channels: [channel(11243, 5000, true)]
+        } as any);
+        await store.getChannels();
+
+        jest.mocked(BackendUtils.getChannels).mockRejectedValue(
+            new Error('offline')
+        );
+        await store.getChannels();
+
+        expect(store.hasChannelData).toBe(false);
+        expect(store.totalOutbound).toBe(0);
+        expect(store.totalOutboundOffline).toBe(0);
+        expect(store.totalInbound).toBe(0);
+        expect(store.totalOffline).toBe(0);
+        expect(store.channels).toEqual([]);
+        expect(store.error).toBe(true);
+    });
+});

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -83,7 +83,15 @@ export default class ChannelsStore {
     // redesign
     @observable public largestChannelSats = 0;
     @observable public totalOutbound = 0;
-    @observable public hasSendingCapacity = false;
+    // Local balance sitting in channels that are currently inactive. These
+    // sats cannot be routed right now but are not lost: the peer may be
+    // momentarily disconnected. Tracked separately so callers can tell
+    // "no money" apart from "money you cannot reach at this instant".
+    @observable public totalOutboundOffline = 0;
+    // Whether a channel fetch has ever succeeded for this node. Callers use
+    // it to decide if the totals above are meaningful; it says nothing about
+    // whether there is any capacity.
+    @observable public hasChannelData = false;
     @observable public totalInbound = 0;
     @observable public totalOffline = 0;
     @observable public chanInfo: ChannelInfoIndex = {};
@@ -199,7 +207,7 @@ export default class ChannelsStore {
     @action
     public reset = () => {
         this.resetOpenChannel();
-        this.hasSendingCapacity = false;
+        this.hasChannelData = false;
         this.haveAnnouncedChannels = false;
         this.nodes = {};
         this.channels = [];
@@ -214,6 +222,7 @@ export default class ChannelsStore {
         this.filteredPeers = [];
         this.largestChannelSats = 0;
         this.totalOutbound = 0;
+        this.totalOutboundOffline = 0;
         this.totalInbound = 0;
         this.totalOffline = 0;
         this.channelsType = ChannelsType.Open;
@@ -504,8 +513,13 @@ export default class ChannelsStore {
 
     @action
     private getChannelsError = () => {
-        this.hasSendingCapacity = false;
+        this.hasChannelData = false;
         this.channels = [];
+        this.largestChannelSats = 0;
+        this.totalOutbound = 0;
+        this.totalOutboundOffline = 0;
+        this.totalInbound = 0;
+        this.totalOffline = 0;
         this.error = true;
         this.loading = false;
         this.closingChannel = false;
@@ -513,19 +527,23 @@ export default class ChannelsStore {
 
     @action
     public getChannels = () => {
-        this.hasSendingCapacity = false;
         this.loading = true;
-        this.channels = [];
-        this.largestChannelSats = 0;
-        this.totalOutbound = 0;
-        this.totalInbound = 0;
-        this.totalOffline = 0;
 
         const loadPromises = [
+            // The channel list and its totals are accumulated into locals and
+            // published in one go once the fetch succeeds. Zeroing them up
+            // front would make every refresh briefly report an empty wallet to
+            // observers (payment method selection, Receive's inbound checks,
+            // the channels header), and refreshes are frequent.
             BackendUtils.getChannels().then((data: any) => {
                 const channels = data.channels.map(
                     (channel: any) => new Channel(channel)
                 );
+                let largestChannelSats = new BigNumber(0);
+                let totalInbound = new BigNumber(0);
+                let totalOutbound = new BigNumber(0);
+                let totalOutboundOffline = new BigNumber(0);
+                let totalOffline = new BigNumber(0);
                 channels.forEach((channel: Channel) => {
                     const channelRemoteBalance = new BigNumber(
                         channel.receivingCapacity
@@ -535,23 +553,26 @@ export default class ChannelsStore {
                     );
                     const channelTotal =
                         channelRemoteBalance.plus(channelLocalBalance);
-                    if (channelTotal.gt(this.largestChannelSats))
-                        this.largestChannelSats = channelTotal.toNumber();
+                    if (channelTotal.gt(largestChannelSats))
+                        largestChannelSats = channelTotal;
                     if (!channel.isActive) {
-                        this.totalOffline = new BigNumber(this.totalOffline)
-                            .plus(channelTotal)
-                            .toNumber();
+                        totalOffline = totalOffline.plus(channelTotal);
+                        totalOutboundOffline =
+                            totalOutboundOffline.plus(channelLocalBalance);
                     } else {
-                        this.totalInbound = new BigNumber(this.totalInbound)
-                            .plus(channelRemoteBalance)
-                            .toNumber();
-                        this.totalOutbound = new BigNumber(this.totalOutbound)
-                            .plus(channelLocalBalance)
-                            .toNumber();
+                        totalInbound = totalInbound.plus(channelRemoteBalance);
+                        totalOutbound = totalOutbound.plus(channelLocalBalance);
                     }
                 });
-                this.channels = channels;
-                this.hasSendingCapacity = true;
+                runInAction(() => {
+                    this.largestChannelSats = largestChannelSats.toNumber();
+                    this.totalInbound = totalInbound.toNumber();
+                    this.totalOutbound = totalOutbound.toNumber();
+                    this.totalOutboundOffline = totalOutboundOffline.toNumber();
+                    this.totalOffline = totalOffline.toNumber();
+                    this.channels = channels;
+                    this.hasChannelData = true;
+                });
             })
         ];
 

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -83,6 +83,7 @@ export default class ChannelsStore {
     // redesign
     @observable public largestChannelSats = 0;
     @observable public totalOutbound = 0;
+    @observable public hasSendingCapacity = false;
     @observable public totalInbound = 0;
     @observable public totalOffline = 0;
     @observable public chanInfo: ChannelInfoIndex = {};
@@ -198,6 +199,7 @@ export default class ChannelsStore {
     @action
     public reset = () => {
         this.resetOpenChannel();
+        this.hasSendingCapacity = false;
         this.haveAnnouncedChannels = false;
         this.nodes = {};
         this.channels = [];
@@ -502,6 +504,7 @@ export default class ChannelsStore {
 
     @action
     private getChannelsError = () => {
+        this.hasSendingCapacity = false;
         this.channels = [];
         this.error = true;
         this.loading = false;
@@ -510,6 +513,7 @@ export default class ChannelsStore {
 
     @action
     public getChannels = () => {
+        this.hasSendingCapacity = false;
         this.loading = true;
         this.channels = [];
         this.largestChannelSats = 0;
@@ -547,6 +551,7 @@ export default class ChannelsStore {
                     }
                 });
                 this.channels = channels;
+                this.hasSendingCapacity = true;
             })
         ];
 

--- a/views/ChoosePaymentMethod.test.ts
+++ b/views/ChoosePaymentMethod.test.ts
@@ -1,0 +1,150 @@
+jest.mock('mobx-react', () => ({
+    inject: () => (component: any) => component,
+    observer: (component: any) => component
+}));
+jest.mock('../stores/Stores', () => ({
+    feeStore: {},
+    settingsStore: {}
+}));
+jest.mock('../utils/BackendUtils', () => ({
+    supportsChannelManagement: jest.fn(),
+    supportsOnchainReceiving: () => false,
+    supportsCashuWallet: () => false
+}));
+jest.mock('../utils/Bolt11Utils', () => ({}));
+jest.mock('../models/Invoice', () => ({}));
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+jest.mock('../utils/ThemeUtils', () => ({
+    themeColor: () => '#000000'
+}));
+jest.mock('../components/Header', () => 'Header');
+jest.mock(
+    '../components/LayerBalances/PaymentMethodList',
+    () => 'PaymentMethodList'
+);
+jest.mock('../components/Screen', () => 'Screen');
+jest.mock('../components/Amount', () => 'Amount');
+jest.mock('../components/SuccessErrorMessage', () => ({
+    ErrorMessage: 'ErrorMessage'
+}));
+jest.mock('../components/SyncingStatus', () => 'SyncingStatus');
+jest.mock('../components/RecoveryStatus', () => 'RecoveryStatus');
+jest.mock('../components/RescanStatus', () => 'RescanStatus');
+jest.mock('../components/FeeEstimate', () => 'FeeEstimate');
+
+import * as React from 'react';
+import ChoosePaymentMethod from './ChoosePaymentMethod';
+import PaymentMethodList from '../components/LayerBalances/PaymentMethodList';
+import BackendUtils from '../utils/BackendUtils';
+
+function expectLightningBalance(
+    view: ChoosePaymentMethod,
+    balance: number,
+    usesCapacity: boolean
+) {
+    expect(view.lightningPaymentBalance).toBe(balance);
+    expect(view.usesSendingCapacity).toBe(usesCapacity);
+    const list = React.Children.toArray(view.render().props.children).find(
+        (child) =>
+            React.isValidElement(child) && child.type === PaymentMethodList
+    ) as React.ReactElement<React.ComponentProps<typeof PaymentMethodList>>;
+    expect(list).toBeDefined();
+    expect(list.props.lightningBalance).toBe(balance);
+    expect(list.props.lightningBalanceLabel).toBe(
+        usesCapacity ? 'views.ChoosePaymentMethod.availableToSend' : undefined
+    );
+}
+
+describe('ChoosePaymentMethod sending capacity', () => {
+    let view: ChoosePaymentMethod;
+    let balances: { lightningBalance: number; totalBlockchainBalance: number };
+    let channels: { hasSendingCapacity: boolean; totalOutbound: number };
+
+    beforeEach(() => {
+        jest.mocked(BackendUtils.supportsChannelManagement).mockReturnValue(
+            true
+        );
+        balances = { lightningBalance: 12291, totalBlockchainBalance: 0 };
+        channels = { hasSendingCapacity: true, totalOutbound: 11243 };
+        view = new ChoosePaymentMethod({
+            navigation: {},
+            route: { params: {} },
+            BalanceStore: balances,
+            ChannelsStore: channels,
+            CashuStore: { totalBalanceSats: 0 },
+            UTXOsStore: { accounts: [] }
+        } as unknown as React.ComponentProps<typeof ChoosePaymentMethod>);
+        // Set state directly without mounting or triggering fee/network requests.
+        view.state = {
+            ...view.state,
+            lightning: 'invoice',
+            satAmount: '12000'
+        };
+    });
+
+    it.each([
+        { amount: 12000, capacity: 11243, insufficient: true },
+        { amount: 11243, capacity: 11243, insufficient: false },
+        { amount: 11000, capacity: 11243, insufficient: false },
+        { amount: 1, capacity: 0, insufficient: true }
+    ])(
+        'uses capacity $capacity for payment $amount (insufficient: $insufficient)',
+        ({ amount, capacity, insufficient }) => {
+            channels.totalOutbound = capacity;
+            view.state.satAmount = String(amount);
+
+            expect(view.hasInsufficientFunds()).toBe(insufficient);
+            expectLightningBalance(view, capacity, true);
+        }
+    );
+
+    it.each(['unavailable', 'missing', 'unsupported'])(
+        'falls back to the balance when channel data is %s',
+        (scenario) => {
+            if (scenario === 'unavailable') channels.hasSendingCapacity = false;
+            if (scenario === 'missing') {
+                const state = view.state;
+                view = new ChoosePaymentMethod({
+                    ...view.props,
+                    ChannelsStore: undefined
+                });
+                view.state = state;
+            }
+            if (scenario === 'unsupported') {
+                jest.mocked(
+                    BackendUtils.supportsChannelManagement
+                ).mockReturnValue(false);
+            }
+
+            expect(view.hasInsufficientFunds()).toBe(false);
+            expectLightningBalance(view, 12291, false);
+            view.state.satAmount = '12292';
+            expect(view.hasInsufficientFunds()).toBe(true);
+        }
+    );
+
+    it.each([12291, 0])(
+        'keeps the original balance %i and never reports insufficient funds for LNURL withdraw',
+        (balance) => {
+            balances.lightningBalance = balance;
+            view.state = {
+                ...view.state,
+                satAmount: '20000',
+                lnurlParams: {
+                    tag: 'withdrawRequest',
+                    domain: 'example.com',
+                    callback: 'https://example.com/withdraw',
+                    k1: 'challenge',
+                    defaultDescription: 'withdraw',
+                    minWithdrawable: 20000000,
+                    maxWithdrawable: 20000000
+                }
+            };
+
+            expect(view.hasInsufficientFunds()).toBe(false);
+            expectLightningBalance(view, balance, false);
+        }
+    );
+});

--- a/views/ChoosePaymentMethod.test.ts
+++ b/views/ChoosePaymentMethod.test.ts
@@ -60,14 +60,22 @@ function expectLightningBalance(
 describe('ChoosePaymentMethod sending capacity', () => {
     let view: ChoosePaymentMethod;
     let balances: { lightningBalance: number; totalBlockchainBalance: number };
-    let channels: { hasSendingCapacity: boolean; totalOutbound: number };
+    let channels: {
+        hasChannelData: boolean;
+        totalOutbound: number;
+        totalOutboundOffline: number;
+    };
 
     beforeEach(() => {
         jest.mocked(BackendUtils.supportsChannelManagement).mockReturnValue(
             true
         );
         balances = { lightningBalance: 12291, totalBlockchainBalance: 0 };
-        channels = { hasSendingCapacity: true, totalOutbound: 11243 };
+        channels = {
+            hasChannelData: true,
+            totalOutbound: 11243,
+            totalOutboundOffline: 0
+        };
         view = new ChoosePaymentMethod({
             navigation: {},
             route: { params: {} },
@@ -103,7 +111,7 @@ describe('ChoosePaymentMethod sending capacity', () => {
     it.each(['unavailable', 'missing', 'unsupported'])(
         'falls back to the balance when channel data is %s',
         (scenario) => {
-            if (scenario === 'unavailable') channels.hasSendingCapacity = false;
+            if (scenario === 'unavailable') channels.hasChannelData = false;
             if (scenario === 'missing') {
                 const state = view.state;
                 view = new ChoosePaymentMethod({
@@ -124,6 +132,68 @@ describe('ChoosePaymentMethod sending capacity', () => {
             expect(view.hasInsufficientFunds()).toBe(true);
         }
     );
+
+    describe('with channels whose peer is offline', () => {
+        // A disconnected peer is routine for the first seconds after
+        // foregrounding. That capacity is unreachable right now but the
+        // wallet is not out of money, so it must not read as
+        // "not enough funds".
+        it('does not report insufficient funds when offline capacity covers the payment', () => {
+            channels.totalOutbound = 0;
+            channels.totalOutboundOffline = 11243;
+            view.state.satAmount = '11000';
+
+            expect(view.hasInsufficientFunds()).toBe(false);
+            expect(view.hasOfflineCapacityGap).toBe(true);
+        });
+
+        it('still reports insufficient funds when even the offline capacity falls short', () => {
+            channels.totalOutbound = 0;
+            channels.totalOutboundOffline = 11243;
+            view.state.satAmount = '12000';
+
+            expect(view.hasInsufficientFunds()).toBe(true);
+        });
+
+        it('flags the gap when the payment exceeds only the active capacity', () => {
+            channels.totalOutbound = 5000;
+            channels.totalOutboundOffline = 7000;
+            view.state.satAmount = '11000';
+
+            expect(view.hasInsufficientFunds()).toBe(false);
+            expect(view.hasOfflineCapacityGap).toBe(true);
+            // the row still shows what is actually spendable right now
+            expectLightningBalance(view, 5000, true);
+            expect(view.lightningSpendableBalance).toBe(12000);
+        });
+
+        it('does not flag a gap when the active capacity already covers it', () => {
+            channels.totalOutbound = 11243;
+            channels.totalOutboundOffline = 7000;
+            view.state.satAmount = '11000';
+
+            expect(view.hasInsufficientFunds()).toBe(false);
+            expect(view.hasOfflineCapacityGap).toBe(false);
+        });
+
+        it('passes the offline-inclusive figure to the list for eligibility only', () => {
+            channels.totalOutbound = 0;
+            channels.totalOutboundOffline = 11243;
+            view.state.satAmount = '11000';
+
+            const list = React.Children.toArray(
+                view.render().props.children
+            ).find(
+                (child) =>
+                    React.isValidElement(child) &&
+                    child.type === PaymentMethodList
+            ) as React.ReactElement<
+                React.ComponentProps<typeof PaymentMethodList>
+            >;
+            expect(list.props.lightningBalance).toBe(0);
+            expect(list.props.lightningEligibilityBalance).toBe(11243);
+        });
+    });
 
     it.each([12291, 0])(
         'keeps the original balance %i and never reports insufficient funds for LNURL withdraw',

--- a/views/ChoosePaymentMethod.tsx
+++ b/views/ChoosePaymentMethod.tsx
@@ -17,6 +17,7 @@ import RescanStatus from '../components/RescanStatus';
 import FeeEstimate from '../components/FeeEstimate';
 
 import BalanceStore from '../stores/BalanceStore';
+import ChannelsStore from '../stores/ChannelsStore';
 import CashuStore from '../stores/CashuStore';
 import UTXOsStore from '../stores/UTXOsStore';
 import InvoicesStore from '../stores/InvoicesStore';
@@ -42,6 +43,7 @@ interface ChoosePaymentMethodProps {
     navigation: NativeStackNavigationProp<any, any>;
     route: Route<'ChoosePaymentMethod', RouteParams>;
     BalanceStore?: BalanceStore;
+    ChannelsStore?: ChannelsStore;
     CashuStore?: CashuStore;
     UTXOsStore?: UTXOsStore;
     InvoicesStore?: InvoicesStore;
@@ -58,7 +60,13 @@ interface ChoosePaymentMethodState {
     feeRate: string;
 }
 
-@inject('BalanceStore', 'CashuStore', 'UTXOsStore', 'InvoicesStore')
+@inject(
+    'BalanceStore',
+    'ChannelsStore',
+    'CashuStore',
+    'UTXOsStore',
+    'InvoicesStore'
+)
 @observer
 export default class ChoosePaymentMethod extends React.Component<
     ChoosePaymentMethodProps,
@@ -176,9 +184,23 @@ export default class ChoosePaymentMethod extends React.Component<
         await Promise.all(tasks);
     };
 
+    get usesSendingCapacity() {
+        return (
+            this.state.lnurlParams?.tag !== 'withdrawRequest' &&
+            BackendUtils.supportsChannelManagement() &&
+            !!this.props.ChannelsStore?.hasSendingCapacity
+        );
+    }
+
+    get lightningPaymentBalance() {
+        return this.usesSendingCapacity
+            ? this.props.ChannelsStore!.totalOutbound
+            : this.props.BalanceStore!.lightningBalance;
+    }
+
     hasInsufficientFunds = () => {
         const { BalanceStore, CashuStore } = this.props;
-        const { totalBlockchainBalance, lightningBalance } = BalanceStore!;
+        const { totalBlockchainBalance } = BalanceStore!;
         const { totalBalanceSats: ecashBalance } = CashuStore!;
         const {
             value,
@@ -196,7 +218,7 @@ export default class ChoosePaymentMethod extends React.Component<
         const satAmount = Number(this.state.satAmount);
 
         const onchain = Number(totalBlockchainBalance);
-        const lightning_ = Number(lightningBalance);
+        const lightning_ = Number(this.lightningPaymentBalance);
         const ecash = Number(ecashBalance);
         const total = onchain + lightning_ + ecash;
 
@@ -245,7 +267,7 @@ export default class ChoosePaymentMethod extends React.Component<
         } = this.state;
 
         const { accounts } = UTXOsStore!;
-        const { totalBlockchainBalance, lightningBalance } = BalanceStore!;
+        const { totalBlockchainBalance } = BalanceStore!;
         const { totalBalanceSats } = CashuStore!;
 
         const isWithdraw = lnurlParams?.tag === 'withdrawRequest';
@@ -339,7 +361,14 @@ export default class ChoosePaymentMethod extends React.Component<
                     clinkNoffer={clinkNoffer}
                     lnurlParams={lnurlParams}
                     // balance data
-                    lightningBalance={lightningBalance}
+                    lightningBalance={this.lightningPaymentBalance}
+                    lightningBalanceLabel={
+                        this.usesSendingCapacity
+                            ? localeString(
+                                  'views.ChoosePaymentMethod.availableToSend'
+                              )
+                            : undefined
+                    }
                     onchainBalance={totalBlockchainBalance}
                     ecashBalance={totalBalanceSats}
                     accounts={accounts}

--- a/views/ChoosePaymentMethod.tsx
+++ b/views/ChoosePaymentMethod.tsx
@@ -10,7 +10,10 @@ import Header from '../components/Header';
 import PaymentMethodList from '../components/LayerBalances/PaymentMethodList';
 import Screen from '../components/Screen';
 import Amount from '../components/Amount';
-import { ErrorMessage } from '../components/SuccessErrorMessage';
+import {
+    ErrorMessage,
+    WarningMessage
+} from '../components/SuccessErrorMessage';
 import SyncingStatus from '../components/SyncingStatus';
 import RecoveryStatus from '../components/RecoveryStatus';
 import RescanStatus from '../components/RescanStatus';
@@ -188,14 +191,48 @@ export default class ChoosePaymentMethod extends React.Component<
         return (
             this.state.lnurlParams?.tag !== 'withdrawRequest' &&
             BackendUtils.supportsChannelManagement() &&
-            !!this.props.ChannelsStore?.hasSendingCapacity
+            !!this.props.ChannelsStore?.hasChannelData
         );
     }
 
+    /**
+     * What the wallet can route right now, and what gets displayed under the
+     * "Available to send" label. Excludes channels whose peer is currently
+     * disconnected.
+     */
     get lightningPaymentBalance() {
         return this.usesSendingCapacity
             ? this.props.ChannelsStore!.totalOutbound
             : this.props.BalanceStore!.lightningBalance;
+    }
+
+    /**
+     * What the wallet could route once every channel is connected. Used for
+     * eligibility rather than display: a peer that is offline for a few
+     * seconds after foregrounding should not turn into "not enough funds"
+     * for a payment the wallet can actually afford.
+     */
+    get lightningSpendableBalance() {
+        if (!this.usesSendingCapacity)
+            return this.props.BalanceStore!.lightningBalance;
+        const { totalOutbound, totalOutboundOffline } =
+            this.props.ChannelsStore!;
+        return totalOutbound + totalOutboundOffline;
+    }
+
+    /**
+     * True when the payment only fits if offline channels come back. The row
+     * stays selectable in that case, but the user is told why the payment may
+     * not go through yet.
+     */
+    get hasOfflineCapacityGap() {
+        if (!this.usesSendingCapacity) return false;
+        const { totalOutbound, totalOutboundOffline } =
+            this.props.ChannelsStore!;
+        if (totalOutboundOffline <= 0) return false;
+        if (totalOutbound === 0) return true;
+        const satAmount = Number(this.state.satAmount);
+        return !isNaN(satAmount) && satAmount > totalOutbound;
     }
 
     hasInsufficientFunds = () => {
@@ -218,7 +255,7 @@ export default class ChoosePaymentMethod extends React.Component<
         const satAmount = Number(this.state.satAmount);
 
         const onchain = Number(totalBlockchainBalance);
-        const lightning_ = Number(this.lightningPaymentBalance);
+        const lightning_ = Number(this.lightningSpendableBalance);
         const ecash = Number(ecashBalance);
         const total = onchain + lightning_ + ecash;
 
@@ -348,6 +385,15 @@ export default class ChoosePaymentMethod extends React.Component<
                         />
                     </View>
                 )}
+                {!hasInsufficientFunds && this.hasOfflineCapacityGap && (
+                    <View style={styles.errorSection}>
+                        <WarningMessage
+                            message={localeString(
+                                'views.ChoosePaymentMethod.channelsOffline'
+                            )}
+                        />
+                    </View>
+                )}
 
                 <PaymentMethodList
                     navigation={navigation}
@@ -362,6 +408,7 @@ export default class ChoosePaymentMethod extends React.Component<
                     lnurlParams={lnurlParams}
                     // balance data
                     lightningBalance={this.lightningPaymentBalance}
+                    lightningEligibilityBalance={this.lightningSpendableBalance}
                     lightningBalanceLabel={
                         this.usesSendingCapacity
                             ? localeString(


### PR DESCRIPTION
# Description

|Before|After|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-06 at 10 50 33" src="https://github.com/user-attachments/assets/955c1d7f-1604-4677-9cad-f0202cbf5f55" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-09-06 at 10 49 54" src="https://github.com/user-attachments/assets/514a1763-9811-440b-9d52-15a410d0589f" />|


Keep the Home/BalancePane Lightning balance unchanged, but show reserve-adjusted sending capacity on Select Payment Method when channel data is available. For example, a wallet with 12,291 sats and 11,243 sats outbound should not offer a 12,000-sat Lightning payment based on its headline balance.

- Display sending capacity with an "Available to send" label for Lightning, Lightning address, and Offer rows.
- Use the same amount for insufficient-funds checks and payment-row eligibility, including the Lightning contribution to CLINK eligibility.
- Track channel-capacity availability separately from zero capacity; fall back to the reported balance when channel data is unavailable or unsupported.
- Preserve LNURL-withdraw behavior and leave Home balances unchanged.
- Add nine regression cases covering the reserve gap, capacity boundaries, zero capacity, fallback behavior, withdrawals, and the balance/label passed to the payment list.

Capacity is before routing fees and is not a guarantee of route availability. Screenshots and hands-on iOS/Android testing are pending; this PR is a draft.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [x] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I have run `yarn run tsc` and made sure my code compiles correctly
- [x] I have run `yarn run lint` and made sure my code did not contain any problematic patterns
- [x] I have run `yarn run prettier` and made sure my code is formatted correctly
- [x] I have run `yarn run test` and made sure all of the tests pass

## Testing

All 71 Jest suites pass (1,549 tests), including nine new regression cases. TypeScript passes. The initial `yarn verify` found one formatting issue; after fixing it, both `yarn lint` (including the stylesheet test) and `yarn prettier` passed. `git diff --check` also passed.

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I am a fool
- [ ] Yes
- [x] N/A

No utility files changed. Regression tests were added in `views/ChoosePaymentMethod.test.ts`.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Manual platform/backend testing and screenshots remain pending. Unit tests use mocked component and backend boundaries.

### Locales
- [x] I have added new locale text that requires translations
- [x] I am aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

Only `locales/en.json` was changed: "Available to send".

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:

No dependencies changed. Dependency checks, if applicable: verify that `package.json` and `yarn.lock` have been properly updated; verify that dependencies are installed for both iOS and Android platforms.

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding