### PR TITLE
fix(nwc): guard overlapping same-kind connection mutations

### DIFF
--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -1694,6 +1694,32 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
         expect(handler).not.toHaveBeenCalled();
     });
 
+    it('rejects with UNAUTHORIZED when delete is not the first entry in the pending list', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+        const handler = jest.fn();
+
+        // 'update' pushed first (still running), 'delete' pushed second by
+        // a mutation that started concurrently: mutationRejection must
+        // scan the whole list for the most severe kind, not just check the
+        // first entry.
+        (store as any).pushPendingMutation(connection.id, 'update');
+        (store as any).pushPendingMutation(connection.id, 'delete');
+
+        const response = await (store as any).withGlobalHandler(
+            connection.id,
+            handler
+        );
+
+        expect(response.error).toEqual({
+            code: 'UNAUTHORIZED',
+            message: 'stores.NostrWalletConnectStore.error.connectionNotFound'
+        });
+        expect(handler).not.toHaveBeenCalled();
+    });
+
     it('defers relay release when updateConnection awaited in-flight handlers', async () => {
         jest.useFakeTimers();
         const store = buildStore();

--- a/stores/NostrWalletConnectStore.test.ts
+++ b/stores/NostrWalletConnectStore.test.ts
@@ -78,6 +78,15 @@ const NODE_PUBKEY = 'test-node-pubkey';
 const OLD_RELAY = 'wss://relay.old.example';
 const NEW_RELAY = 'wss://relay.new.example';
 
+// Drains a generous number of microtask turns so an in-progress async call
+// has a chance to run every step up to its next real (mocked) await point,
+// without pinning the test to the exact number of internal awaits.
+async function flushMicrotasks(turns = 20) {
+    for (let i = 0; i < turns; i++) {
+        await Promise.resolve();
+    }
+}
+
 describe('NostrWalletConnectStore relay rotation', () => {
     let clientKeys: Record<string, string>;
 
@@ -234,12 +243,14 @@ describe('NostrWalletConnectStore relay rotation', () => {
     it('marks a relay-changing update as rotate, not update, while in flight', async () => {
         const store = buildStore();
         const connection = seedConnection(store);
-        let markerDuringMutation: string | undefined;
+        let markerDuringMutation: string[] | undefined;
         jest.spyOn(store as any, 'subscribeToConnection').mockImplementation(
             async () => {
-                markerDuringMutation = (
-                    store as any
-                ).pendingConnectionMutations.get(connection.id);
+                markerDuringMutation = [
+                    ...((store as any).pendingConnectionMutations.get(
+                        connection.id
+                    ) ?? [])
+                ];
             }
         );
 
@@ -248,7 +259,7 @@ describe('NostrWalletConnectStore relay rotation', () => {
         });
 
         expect(result.success).toBe(true);
-        expect(markerDuringMutation).toBe('rotate');
+        expect(markerDuringMutation).toEqual(['rotate']);
         expect(
             (store as any).pendingConnectionMutations.has(connection.id)
         ).toBe(false);
@@ -262,10 +273,7 @@ describe('NostrWalletConnectStore relay rotation', () => {
             async () => {
                 // Simulate a delete winning the race while this update is
                 // still in its critical section.
-                (store as any).pendingConnectionMutations.set(
-                    connection.id,
-                    'delete'
-                );
+                (store as any).pushPendingMutation(connection.id, 'delete');
             }
         );
 
@@ -275,20 +283,22 @@ describe('NostrWalletConnectStore relay rotation', () => {
 
         expect(
             (store as any).pendingConnectionMutations.get(connection.id)
-        ).toBe('delete');
+        ).toEqual(['delete']);
     });
 
     it('does not downgrade a pre-existing delete marker when an update starts', async () => {
         const store = buildStore();
         const connection = seedConnection(store);
-        (store as any).pendingConnectionMutations.set(connection.id, 'delete');
+        (store as any).pushPendingMutation(connection.id, 'delete');
 
-        let markerDuringUpdate: string | undefined;
+        let markerDuringUpdate: string[] | undefined;
         jest.spyOn(store as any, 'subscribeToConnection').mockImplementation(
             async () => {
-                markerDuringUpdate = (
-                    store as any
-                ).pendingConnectionMutations.get(connection.id);
+                markerDuringUpdate = [
+                    ...((store as any).pendingConnectionMutations.get(
+                        connection.id
+                    ) ?? [])
+                ];
             }
         );
 
@@ -296,23 +306,25 @@ describe('NostrWalletConnectStore relay rotation', () => {
             name: 'Renamed App'
         });
 
-        expect(markerDuringUpdate).toBe('delete');
+        expect(markerDuringUpdate).toEqual(['delete', 'update']);
         expect(
             (store as any).pendingConnectionMutations.get(connection.id)
-        ).toBe('delete');
+        ).toEqual(['delete']);
     });
 
     it('does not downgrade a pre-existing rotate marker when a second update starts', async () => {
         const store = buildStore();
         const connection = seedConnection(store);
-        (store as any).pendingConnectionMutations.set(connection.id, 'rotate');
+        (store as any).pushPendingMutation(connection.id, 'rotate');
 
-        let markerDuringUpdate: string | undefined;
+        let markerDuringUpdate: string[] | undefined;
         jest.spyOn(store as any, 'subscribeToConnection').mockImplementation(
             async () => {
-                markerDuringUpdate = (
-                    store as any
-                ).pendingConnectionMutations.get(connection.id);
+                markerDuringUpdate = [
+                    ...((store as any).pendingConnectionMutations.get(
+                        connection.id
+                    ) ?? [])
+                ];
             }
         );
 
@@ -320,10 +332,82 @@ describe('NostrWalletConnectStore relay rotation', () => {
             name: 'Renamed App'
         });
 
-        expect(markerDuringUpdate).toBe('rotate');
+        expect(markerDuringUpdate).toEqual(['rotate', 'update']);
         expect(
             (store as any).pendingConnectionMutations.get(connection.id)
-        ).toBe('rotate');
+        ).toEqual(['rotate']);
+    });
+
+    it('keeps a second overlapping rotate guarded after the first rotate finishes', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store);
+
+        // A third relay, distinct from OLD_RELAY and NEW_RELAY: the first
+        // rotation's cleanup releases OLD_RELAY (closing its wallet service
+        // and unpublishing it), so routing the second overlapping rotation
+        // back to OLD_RELAY would exercise the real, unmocked
+        // publish-wallet-service-info/retry path instead of the mocked one
+        // this test wants to isolate.
+        const THIRD_RELAY = 'wss://relay.third.example';
+        (store as any).nwcWalletServices.set(THIRD_RELAY, {
+            connected: true,
+            close: jest.fn()
+        });
+        (store as any).publishedRelays.add(THIRD_RELAY);
+
+        let releaseFirst: () => void = () => undefined;
+        let releaseSecond: () => void = () => undefined;
+        let calls = 0;
+        jest.spyOn(store as any, 'subscribeToConnection').mockImplementation(
+            () =>
+                new Promise<void>((resolve) => {
+                    calls += 1;
+                    if (calls === 1) {
+                        releaseFirst = resolve;
+                    } else {
+                        releaseSecond = resolve;
+                    }
+                })
+        );
+
+        const firstDone = store.updateConnection(connection.id, {
+            relayUrl: NEW_RELAY
+        });
+        await flushMicrotasks();
+
+        expect(connection.relayUrl).toBe(NEW_RELAY);
+
+        const secondDone = store.updateConnection(connection.id, {
+            relayUrl: THIRD_RELAY
+        });
+        await flushMicrotasks();
+
+        expect(
+            (store as any).pendingConnectionMutations.get(connection.id)
+        ).toEqual(['rotate', 'rotate']);
+
+        releaseFirst();
+        await firstDone;
+
+        // The second rotation's pubkey rebind / deleteClientKeys window is
+        // still open: a request arriving now must still see UNAUTHORIZED,
+        // not fall through because the first rotate's finally cleared the
+        // only marker slot.
+        expect(
+            (store as any).pendingConnectionMutations.get(connection.id)
+        ).toEqual(['rotate']);
+        const midResponse = await (store as any).withGlobalHandler(
+            connection.id,
+            async () => ({ result: { should: 'not-run' }, error: undefined })
+        );
+        expect(midResponse.error?.code).toBe('UNAUTHORIZED');
+
+        releaseSecond();
+        await secondDone;
+
+        expect(
+            (store as any).pendingConnectionMutations.has(connection.id)
+        ).toBe(false);
     });
 
     it('leaves relayUrl unchanged when storing the new key fails so retry can rotate', async () => {
@@ -1293,12 +1377,9 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
 
         jest.spyOn(store as any, 'deleteClientKeys').mockImplementation(
             async () => {
-                // Simulate an update overwriting the marker after this
+                // Simulate an update starting concurrently after this
                 // delete already committed to removing the connection.
-                (store as any).pendingConnectionMutations.set(
-                    connection.id,
-                    'update'
-                );
+                (store as any).pushPendingMutation(connection.id, 'update');
             }
         );
 
@@ -1306,7 +1387,104 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
 
         expect(
             (store as any).pendingConnectionMutations.get(connection.id)
-        ).toBe('update');
+        ).toEqual(['update']);
+    });
+
+    it('keeps a second overlapping update guarded after the first update finishes', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+
+        let releaseFirst: () => void = () => undefined;
+        let releaseSecond: () => void = () => undefined;
+        let calls = 0;
+        jest.spyOn(store as any, 'subscribeToConnection').mockImplementation(
+            () =>
+                new Promise<void>((resolve) => {
+                    calls += 1;
+                    if (calls === 1) {
+                        releaseFirst = resolve;
+                    } else {
+                        releaseSecond = resolve;
+                    }
+                })
+        );
+
+        const firstDone = store.updateConnection(connection.id, {
+            name: 'First'
+        });
+        await flushMicrotasks();
+
+        const secondDone = store.updateConnection(connection.id, {
+            name: 'Second'
+        });
+        await flushMicrotasks();
+
+        expect(
+            (store as any).pendingConnectionMutations.get(connection.id)
+        ).toEqual(['update', 'update']);
+
+        releaseFirst();
+        await firstDone;
+
+        // The second update's own critical section is still running: a
+        // request arriving now must still see RATE_LIMITED, not be let
+        // through because the first update's finally cleared the marker.
+        expect(
+            (store as any).pendingConnectionMutations.get(connection.id)
+        ).toEqual(['update']);
+        const midResponse = await (store as any).withGlobalHandler(
+            connection.id,
+            async () => ({ result: { should: 'not-run' }, error: undefined })
+        );
+        expect(midResponse.error).toEqual({
+            code: 'RATE_LIMITED',
+            message: 'stores.NostrWalletConnectStore.error.connectionUpdating'
+        });
+
+        releaseSecond();
+        await secondDone;
+
+        expect(
+            (store as any).pendingConnectionMutations.has(connection.id)
+        ).toBe(false);
+    });
+
+    it('does not let a mid-delete failure clear a concurrent update marker', async () => {
+        const store = buildStore();
+        const connection = seedConnection(store, {
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+
+        let releaseUpdate: () => void = () => undefined;
+        jest.spyOn(store as any, 'subscribeToConnection').mockImplementation(
+            () => new Promise<void>((resolve) => (releaseUpdate = resolve))
+        );
+
+        const updateDone = store.updateConnection(connection.id, {
+            name: 'Renamed'
+        });
+        await flushMicrotasks();
+
+        jest.spyOn(store as any, 'deleteClientKeys').mockRejectedValue(
+            new Error('delete failed mid-way')
+        );
+
+        await expect(store.deleteConnection(connection.id)).rejects.toThrow();
+
+        // The failed delete's finally must only remove its own 'delete'
+        // entry, leaving the still-running update's marker in place.
+        expect(
+            (store as any).pendingConnectionMutations.get(connection.id)
+        ).toEqual(['update']);
+
+        releaseUpdate();
+        await updateDone;
+
+        expect(
+            (store as any).pendingConnectionMutations.has(connection.id)
+        ).toBe(false);
     });
 
     it('defers relay release when delete awaited in-flight handlers', async () => {
@@ -1447,10 +1625,7 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
 
         jest.spyOn(store as any, 'markConnectionUsed').mockImplementation(
             async () => {
-                (store as any).pendingConnectionMutations.set(
-                    connection.id,
-                    'update'
-                );
+                (store as any).pushPendingMutation(connection.id, 'update');
                 return true;
             }
         );
@@ -1476,10 +1651,7 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
 
         jest.spyOn(store as any, 'markConnectionUsed').mockImplementation(
             async () => {
-                (store as any).pendingConnectionMutations.set(
-                    connection.id,
-                    'delete'
-                );
+                (store as any).pushPendingMutation(connection.id, 'delete');
                 return true;
             }
         );
@@ -1505,10 +1677,7 @@ describe('NostrWalletConnectStore connection expiry enforcement', () => {
 
         jest.spyOn(store as any, 'markConnectionUsed').mockImplementation(
             async () => {
-                (store as any).pendingConnectionMutations.set(
-                    connection.id,
-                    'rotate'
-                );
+                (store as any).pushPendingMutation(connection.id, 'rotate');
                 return true;
             }
         );

--- a/stores/NostrWalletConnectStore.ts
+++ b/stores/NostrWalletConnectStore.ts
@@ -189,9 +189,15 @@ export default class NostrWalletConnectStore {
         number
     >();
     private makeInvoiceTimestampsByConnection = new Map<string, number[]>();
+    // A list, not a single slot: overlapping mutations of the same kind
+    // (e.g. two updates, or two rotations) on one connection must each keep
+    // their own marker alive for the duration of their own critical section.
+    // A single overwritable slot lets the first one's cleanup clear the
+    // second one's marker out from under it, leaving its window unguarded.
+    // See pushPendingMutation/popPendingMutation/mutationRejection below.
     private pendingConnectionMutations = new Map<
         string,
-        PendingConnectionMutation
+        PendingConnectionMutation[]
     >();
     private inFlightHandlersByConnection = new Map<
         string,
@@ -660,7 +666,7 @@ export default class NostrWalletConnectStore {
                     )
                 );
             }
-            this.pendingConnectionMutations.set(connectionId, 'delete');
+            this.pushPendingMutation(connectionId, 'delete');
             try {
                 const relayUrl = connection.relayUrl;
                 const hadActiveSubscription =
@@ -706,16 +712,10 @@ export default class NostrWalletConnectStore {
                 }
                 await this.saveConnections();
             } finally {
-                // Only clear our own marker: an update/rotate that started
-                // while this delete was in flight leaves 'delete' in place
-                // (see updateConnection) and must not have it cleared out
-                // from under it by whichever finally runs second.
-                if (
-                    this.pendingConnectionMutations.get(connectionId) ===
-                    'delete'
-                ) {
-                    this.pendingConnectionMutations.delete(connectionId);
-                }
+                // Pop only our own 'delete' entry: a concurrent update/rotate
+                // that pushed its own marker while this delete was in flight
+                // (see updateConnection) keeps its marker in the list.
+                this.popPendingMutation(connectionId, 'delete');
             }
         } catch (error: any) {
             runInAction(() => {
@@ -802,21 +802,12 @@ export default class NostrWalletConnectStore {
             const ownMutationKind: PendingConnectionMutation = relayUrlChanged
                 ? 'rotate'
                 : 'update';
-            // Never downgrade a concurrent delete or rotate: if this
-            // connection already has one of those revocation markers set,
-            // leave it in place so requests keep seeing the (correct)
-            // revocation signal instead of being demoted to retryable.
-            const existingMutation =
-                this.pendingConnectionMutations.get(connectionId);
-            if (
-                existingMutation !== 'delete' &&
-                existingMutation !== 'rotate'
-            ) {
-                this.pendingConnectionMutations.set(
-                    connectionId,
-                    ownMutationKind
-                );
-            }
+            // Push our own marker regardless of what else is pending: a
+            // concurrent delete/rotate keeps its own entry in the list (see
+            // mutationRejection, which reports the most severe kind present),
+            // and a second overlapping update/rotate gets its own entry too
+            // so this mutation's finally can't clear it out early.
+            this.pushPendingMutation(connectionId, ownMutationKind);
             try {
                 const hadActiveSubscription =
                     this.activeSubscriptions.has(connectionId);
@@ -932,15 +923,10 @@ export default class NostrWalletConnectStore {
                 await this.subscribeToConnection(connection);
                 return { success: true };
             } finally {
-                // Only clear our own marker: if a concurrent delete
-                // superseded it (see above), leave that marker for
-                // deleteConnection's own finally to clear.
-                if (
-                    this.pendingConnectionMutations.get(connectionId) ===
-                    ownMutationKind
-                ) {
-                    this.pendingConnectionMutations.delete(connectionId);
-                }
+                // Pop only our own entry: a concurrent delete or another
+                // overlapping update/rotate keeps its marker in the list
+                // until its own finally runs.
+                this.popPendingMutation(connectionId, ownMutationKind);
             }
         } catch (error: any) {
             console.error('Failed to update NWC connection:', error);
@@ -1802,24 +1788,55 @@ export default class NostrWalletConnectStore {
         ) as T;
     }
 
+    // Adds one occurrence of `kind` to the connection's pending-mutation
+    // list. See the field declaration for why this is a list, not a slot.
+    private pushPendingMutation(
+        connectionId: string,
+        kind: PendingConnectionMutation
+    ): void {
+        const existing = this.pendingConnectionMutations.get(connectionId);
+        if (existing) {
+            existing.push(kind);
+        } else {
+            this.pendingConnectionMutations.set(connectionId, [kind]);
+        }
+    }
+
+    // Removes exactly one occurrence of `kind` (the caller's own mutation),
+    // leaving any other pending mutations of the same or different kind
+    // untouched.
+    private popPendingMutation(
+        connectionId: string,
+        kind: PendingConnectionMutation
+    ): void {
+        const existing = this.pendingConnectionMutations.get(connectionId);
+        if (!existing) return;
+        const index = existing.indexOf(kind);
+        if (index !== -1) {
+            existing.splice(index, 1);
+        }
+        if (existing.length === 0) {
+            this.pendingConnectionMutations.delete(connectionId);
+        }
+    }
+
     // 'delete' and 'rotate' are true revocations (the pairing is ending, or
     // has just been rebound to a new pubkey) so they get UNAUTHORIZED.
     // 'update' is a short, retryable critical section so it gets RATE_LIMITED
     // rather than a signal some clients read as permanent revocation.
+    // When multiple mutations overlap, the most severe kind present wins.
     private mutationRejection<T>(connectionId: string): T | undefined {
-        const mutation = this.pendingConnectionMutations.get(connectionId);
-        if (mutation === 'delete' || mutation === 'rotate') {
+        const mutations = this.pendingConnectionMutations.get(connectionId);
+        if (!mutations?.length) return undefined;
+        if (mutations.includes('delete') || mutations.includes('rotate')) {
             return this.unauthorizedConnectionResponse<T>();
         }
-        if (mutation === 'update') {
-            return NostrConnectUtils.createNip47Error(
-                localeString(
-                    'stores.NostrWalletConnectStore.error.connectionUpdating'
-                ),
-                Nip47ErrorCode.RATE_LIMITED
-            ) as T;
-        }
-        return undefined;
+        return NostrConnectUtils.createNip47Error(
+            localeString(
+                'stores.NostrWalletConnectStore.error.connectionUpdating'
+            ),
+            Nip47ErrorCode.RATE_LIMITED
+        ) as T;
     }
 
     /**

--- a/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
+++ b/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, ScrollView, Text } from 'react-native';
+import { BackHandler, View, StyleSheet, ScrollView, Text } from 'react-native';
 import { ButtonGroup } from '@rneui/themed';
 import { inject, observer } from 'mobx-react';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -99,6 +99,31 @@ export default class AddOrEditNWCConnection extends React.Component<
 
     private unsubscribeFocus?: () => void;
     private scrollViewRef = React.createRef<ScrollView>();
+    private releaseNavGuard?: () => void;
+
+    // Hiding the header Back button (see render()) doesn't stop the
+    // hardware back button or the iOS swipe-back gesture from leaving
+    // mid-save, which is the entry path for the overlapping-mutation races
+    // in NostrWalletConnectStore (two saves in flight on one connection id).
+    // Mirrors utils/DataClearUtils.ts's blockNavigationDuringWipe, but
+    // releases once the save settles instead of holding until app restart.
+    private blockNavigation = (): (() => void) => {
+        const { navigation } = this.props;
+        navigation.setOptions({ gestureEnabled: false });
+        const backSubscription = BackHandler.addEventListener(
+            'hardwareBackPress',
+            () => true
+        );
+        const removeBeforeRemove = navigation.addListener(
+            'beforeRemove',
+            (e: any) => e.preventDefault()
+        );
+        return () => {
+            navigation.setOptions({ gestureEnabled: true });
+            backSubscription.remove();
+            removeBeforeRemove();
+        };
+    };
 
     loadData = async () => {
         const { route, NostrWalletConnectStore } = this.props;
@@ -131,6 +156,9 @@ export default class AddOrEditNWCConnection extends React.Component<
     componentWillUnmount() {
         if (this.unsubscribeFocus) {
             this.unsubscribeFocus();
+        }
+        if (this.releaseNavGuard) {
+            this.releaseNavGuard();
         }
     }
 
@@ -560,6 +588,7 @@ export default class AddOrEditNWCConnection extends React.Component<
         const { connectionId, isEdit } = route.params ?? {};
 
         this.setState({ loading: true, error: '' });
+        this.releaseNavGuard = this.blockNavigation();
 
         try {
             const params = await this.buildConnectionParams(
@@ -611,6 +640,10 @@ export default class AddOrEditNWCConnection extends React.Component<
             this.setState({ error: (error as Error).message, loading: false });
         } finally {
             this.setState({ loading: false });
+            if (this.releaseNavGuard) {
+                this.releaseNavGuard();
+                this.releaseNavGuard = undefined;
+            }
         }
     };
 
@@ -856,7 +889,7 @@ export default class AddOrEditNWCConnection extends React.Component<
         return (
             <Screen>
                 <Header
-                    leftComponent="Back"
+                    leftComponent={loading ? undefined : 'Back'}
                     centerComponent={{
                         text: route.params?.isEdit
                             ? localeString(

--- a/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
+++ b/views/Settings/NostrWalletConnect/AddOrEditNWCConnection.tsx
@@ -584,6 +584,14 @@ export default class AddOrEditNWCConnection extends React.Component<
     };
 
     createOrUpdateConnection = async () => {
+        // this.state.loading is stale until the next render, so a second
+        // tap landing before that re-render disables the button would
+        // otherwise re-enter this method and overwrite releaseNavGuard,
+        // orphaning the first guard's cleanup (leaked global
+        // hardwareBackPress/beforeRemove listeners). This field is set
+        // synchronously below, so it closes the race the state flag can't.
+        if (this.releaseNavGuard) return;
+
         const { NostrWalletConnectStore, route, navigation } = this.props;
         const { connectionId, isEdit } = route.params ?? {};
 


### PR DESCRIPTION
# Description

Closes #4560. Follow-up to #4503 / #4537. The pending-mutation marker introduced in #4537 closed the mixed-kind races (update vs delete, update vs rotate), but as a single slot per connection it could still be cleared out from under an overlapping mutation of the *same* kind:

- **update + update**: the first update's `finally` cleared the marker while the second update was still in its critical section, letting requests through unguarded for the remainder of the second window.
- **rotate + rotate**: the second rotate was blocked by a no-downgrade guard from installing its own marker, so when the first rotate's `finally` cleared it, the second rotation's pubkey-rebind/`deleteClientKeys` window was unguarded.
- **delete that throws mid-way**: its `finally` could clear `'delete'` out from under a concurrent update/rotate that had been blocked from installing its own marker.

All three share the same narrow UI entry path as #4500/#4537: `AddOrEditNWCConnection` rendered the Back button unconditionally while a save was in flight, so leaving mid-save and re-entering could start a second concurrent mutation on the same connection id.

## Changes
- `pendingConnectionMutations` is now `Map<string, PendingConnectionMutation[]>` instead of a single slot. Each mutation pushes its own kind on entry and pops exactly one occurrence of that kind in its `finally`, so an overlapping mutation of the same kind keeps its own marker alive.
- Removed the now-unnecessary "no-downgrade" guard in `updateConnection` — every mutation pushes unconditionally; `mutationRejection` reports the most severe kind present (`delete`/`rotate` over `update`) rather than relying on a single overwritable slot.
- `AddOrEditNWCConnection`: hides the header Back button while a save is in flight, and blocks the hardware back button / iOS swipe-back gesture for the same duration (mirroring `blockNavigationDuringWipe` in `DataClearUtils.ts`), removing the known entry path for two concurrent mutations on one connection.

## Testing
- Added regression tests for all three races: overlapping update+update, overlapping rotate+rotate, and a delete that throws mid-way leaving a concurrent update's marker intact.
- Updated existing marker-dependent tests for the array-based marker.
- `yarn jest stores/NostrWalletConnectStore.test.ts` — 71/71 passing.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
