### PR TITLE
fix: report supportsTaproot as false for LDK Node

### DIFF
--- a/backends/LdkNode.ts
+++ b/backends/LdkNode.ts
@@ -2195,7 +2195,7 @@ export default class LdkNode {
     singleFeesEarnedTotal = () => false;
     supportsAddressTypeSelection = () => false;
     supportsNestedSegWit = () => false;
-    supportsTaproot = () => true;
+    supportsTaproot = () => false; // LDK Node's BDK wallet uses BIP-84 descriptors, so it can only hand out P2WPKH addresses
     supportsBumpFee = () => false;
     supportsFlowLSP = () => true;
     supportsNetworkInfo = () => true;


### PR DESCRIPTION
## Summary

`LdkNode` reports `supportsTaproot() => true`, but the LDK Node wallet cannot generate a taproot receive address.

ldk-node builds its BDK wallet from `Bip84` descriptors for both keychains ([`src/builder.rs`](https://github.com/lightningdevkit/ldk-node/blob/main/src/builder.rs)), so `newOnchainAddress()` only ever hands back P2WPKH. Our `getNewAddress` takes no address type argument and passes that address straight through.

## Impact

None today — the flag is inert. Both consumers sit behind `supportsAddressTypeSelection()`, which is already `false` for LDK Node:

- `views/Receive.tsx:1076` and `views/Settings/InvoicesSettings.tsx:137` — the P2TR entry in the address type picker
- `views/Receive.tsx:1064` and `views/Settings/InvoicesSettings.tsx:125` — the nested SegWit description variant (also gated by `supportsNestedSegWit()`, likewise `false`)

Worth correcting regardless so the capability map matches what the backend can actually do, and so nothing surprising surfaces if that gate ever changes.

## Testing

- `npx tsc --noEmit` — clean
- `npx prettier --check backends/LdkNode.ts` — clean