### PR TITLE
build: bump CashuDevKit (CDK) to 0.18.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -166,11 +166,13 @@ android {
         pickFirst "lib/x86/libgojni.so"
         pickFirst "lib/x86_64/libgojni.so"
 
-        // CashuDevKit native libraries (Rust FFI)
-        pickFirst "lib/armeabi-v7a/libcdk_ffi.so"
-        pickFirst "lib/arm64-v8a/libcdk_ffi.so"
-        pickFirst "lib/x86/libcdk_ffi.so"
-        pickFirst "lib/x86_64/libcdk_ffi.so"
+        // CashuDevKit native libraries (Rust FFI; renamed from libcdk_ffi.so
+        // in 0.18.0, which upstream currently only ships for arm64-v8a and
+        // x86_64)
+        pickFirst "lib/armeabi-v7a/libcdk_ffi_kotlin.so"
+        pickFirst "lib/arm64-v8a/libcdk_ffi_kotlin.so"
+        pickFirst "lib/x86/libcdk_ffi_kotlin.so"
+        pickFirst "lib/x86_64/libcdk_ffi_kotlin.so"
 
         // Zeus Cashu Restore native libraries (Rust FFI)
         pickFirst "lib/armeabi-v7a/libuniffi_zeus_cashu_restore.so"
@@ -204,10 +206,9 @@ dependencies {
 
     implementation fileTree(dir: "libs", include: ["*.jar", "*.aar"])
 
-    // CashuDevKit - native libs (cdk-android) + Kotlin bindings (cdk-jvm),
+    // CashuDevKit - native libs + Kotlin bindings in one aar (cdk-android),
     // vendored from Maven Central by fetch-libraries.sh
     implementation files("../cdk/cashudevkit.aar")
-    implementation files("../cdk/cdk-jvm.jar")
     // Zeus Cashu Restore - standalone NUT-13 restore for v1 legacy seeds
     implementation files("../zeus-restore/zeus-cashu-restore.aar")
     // CDK / LDK Node dependencies

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -222,6 +222,10 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                 legacyErrorCode(e.code, e.errorMessage) to e.errorMessage
             is FfiException.Internal ->
                 legacyErrorCode(null, e.errorMessage) to e.errorMessage
+            // 0.18.0 NUT-18 transport failure; unreachable until the bridge
+            // exposes preparePayRequest
+            is FfiException.PaymentRequestDeliveryFailed ->
+                "PAYMENT_FAILED" to e.errorMessage
         }
     }
 
@@ -303,14 +307,17 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         val mintUrl = token.mintUrl()
         val proofsArray = JSONArray()
         val currentRepo = repo
-        if (isInitialized && currentRepo != null) {
+        val currentDb = db
+        if (isInitialized && currentRepo != null && currentDb != null) {
             try {
                 // Only resolve proofs through a wallet the mint is already
                 // part of; decoding a foreign token must not add its mint or
-                // contact it
-                if (currentRepo.hasMint(MintUrl(normalizeMintUrl(mintUrl.url)))) {
-                    val wallet = getWallet(mintUrl.url)
-                    val keysets = wallet.getMintKeysets(KeysetFilter.ALL)
+                // contact it, so read the cached keysets straight from the
+                // database (0.18 removed Wallet.getMintKeysets)
+                val normalizedUrl = MintUrl(normalizeMintUrl(mintUrl.url))
+                if (currentRepo.hasMint(normalizedUrl)) {
+                    val keysets = currentDb.getMintKeysets(normalizedUrl)
+                        ?: emptyList()
                     val proofs = token.proofs(keysets)
                     proofs.forEach { proof ->
                         proofsArray.put(encodeProof(proof))
@@ -348,7 +355,7 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
             put("id", keyset.id.toString())
             put("unit", currencyUnitToString(keyset.unit))
             put("active", keyset.active)
-            put("input_fee_ppk", keyset.inputFeePpk ?: 0)
+            put("input_fee_ppk", keyset.inputFeePpk.toLong())
         }
     }
 
@@ -637,8 +644,12 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
         scope.launch {
             try {
-                val wallet = getWallet(mintUrl)
-                val keysets = wallet.getMintKeysets(KeysetFilter.ALL)
+                // Cached keysets from the database; the pre-0.18
+                // Wallet.getMintKeysets(KeysetFilter.ALL) was also a
+                // local-store read (network refresh was a separate call)
+                val keysets =
+                    db!!.getMintKeysets(MintUrl(normalizeMintUrl(mintUrl)))
+                        ?: emptyList()
 
                 val array = JSONArray()
                 keysets.forEach { keyset ->
@@ -842,6 +853,10 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
                     expiry = expiry.toLong().toULong(),
                     amountPaid = if (quoteState == QuoteState.PAID || quoteState == QuoteState.ISSUED) amt else zeroAmount,
                     amountIssued = if (quoteState == QuoteState.ISSUED) amt else zeroAmount,
+                    // Insert as oldest-possible so any later saga update
+                    // (which drops stale responses by timestamp) supersedes
+                    // this externally sourced row
+                    updatedAt = 0uL,
                     estimatedBlocks = null,
                     paymentMethod = PaymentMethod.Bolt11,
                     secretKey = storedSecretKey,

--- a/fetch-libraries-versions.json
+++ b/fetch-libraries-versions.json
@@ -10,11 +10,10 @@
         "iosSha256": "649c2c08ff6870220eb8c3871728c9791c40215040a0e9714963130dd0394d98"
     },
     "cdk": {
-        "version": "0.17.4",
-        "androidSha256": "9717f92f62ae9c9e044b5f40f5831a2bd0d9fc3bb9dd63739468500bfe70f4cd",
-        "androidBindingsSha256": "520bdd3ff49d7f0b5376b4313720665d7208634a1c463620d3959437484d8260",
-        "iosSha256": "0908c519ee72a0d80713dbb96d787fd5a3bd8ee1fb38074cc2e562b417911c96",
-        "iosBindingsSha256": "7ebcce2363c346daaae4c01c090d34a6d73bf168ddef0395a5eae9aab36bf53f"
+        "version": "0.18.0",
+        "androidSha256": "c96c3e40c279209796a451b51b2bafd9cbcade2369517e96e91c11becb3f1e7d",
+        "iosSha256": "09316331f8c57a08e2819b5764770686a6f8659147fe7b441866325ecb4305ca",
+        "iosBindingsSha256": "336d3fdf46539d8aefc54e76cf9d9192b6a8274d5559ac7a7cd1a815fdd973f1"
     },
     "zeus-cashu-restore": {
         "version": "0.1.0",

--- a/fetch-libraries.sh
+++ b/fetch-libraries.sh
@@ -10,7 +10,6 @@ LDK_NODE_ANDROID_SHA256=$(jq "['ldk-node']['androidSha256']")
 LDK_NODE_IOS_SHA256=$(jq "['ldk-node']['iosSha256']")
 CDK_VERSION=$(jq "['cdk']['version']")
 CDK_ANDROID_SHA256=$(jq "['cdk']['androidSha256']")
-CDK_ANDROID_BINDINGS_SHA256=$(jq "['cdk']['androidBindingsSha256']")
 CDK_IOS_SHA256=$(jq "['cdk']['iosSha256']")
 CDK_IOS_BINDINGS_SHA256=$(jq "['cdk']['iosBindingsSha256']")
 RESTORE_VERSION=$(jq "['zeus-cashu-restore']['version']")
@@ -24,7 +23,7 @@ RESTORE_IOS_BINDINGS_SHA256=$(jq "['zeus-cashu-restore']['iosBindingsSha256']")
 # blank hash would otherwise skip verification silently.
 for HASH in "$EMBEDDED_LND_ANDROID_SHA256" "$EMBEDDED_LND_IOS_SHA256" \
             "$LDK_NODE_ANDROID_SHA256" "$LDK_NODE_IOS_SHA256" \
-            "$CDK_ANDROID_SHA256" "$CDK_ANDROID_BINDINGS_SHA256" \
+            "$CDK_ANDROID_SHA256" \
             "$CDK_IOS_SHA256" "$CDK_IOS_BINDINGS_SHA256" \
             "$RESTORE_ANDROID_SHA256" "$RESTORE_IOS_SHA256" \
             "$RESTORE_ANDROID_BINDINGS_SHA256" "$RESTORE_IOS_BINDINGS_SHA256"; do
@@ -115,21 +114,24 @@ unzip ios/LndMobileLibZipFile/$EMBEDDED_LND_IOS_FILE.zip -d ios/LncMobile
 
 # Local filenames (what we save as)
 CDK_ANDROID_FILE=cashudevkit.aar
-CDK_ANDROID_BINDINGS_FILE=cdk-jvm.jar
 CDK_IOS_FILE=CashuDevKitFFI.xcframework
 
-# Since 0.17.x, cdk-kotlin is distributed via Maven Central and split in two:
-# cdk-android (only the per-ABI libcdk_ffi.so) + cdk-jvm (the compiled Kotlin
-# bindings). Both are vendored here with pinned hashes; JNA comes via gradle.
+# Since 0.18.0, cdk-android on Maven Central bundles the compiled Kotlin
+# bindings (classes.jar) alongside the per-ABI libcdk_ffi_kotlin.so again;
+# the separate cdk-jvm jar was discontinued after 0.17.5. JNA comes via
+# gradle.
 CDK_MAVEN_PATH=https://repo1.maven.org/maven2/org/cashudevkit
 CDK_IOS_PATH=https://github.com/cashubtc/cdk-swift/releases/download/v$CDK_VERSION/
 
 CDK_ANDROID_LINK=$CDK_MAVEN_PATH/cdk-android/$CDK_VERSION/cdk-android-$CDK_VERSION.aar
-CDK_ANDROID_BINDINGS_LINK=$CDK_MAVEN_PATH/cdk-jvm/$CDK_VERSION/cdk-jvm-$CDK_VERSION.jar
 CDK_IOS_LINK=$CDK_IOS_PATH$CDK_IOS_FILE.zip
 
 # Android CDK
 mkdir -p android/cdk
+
+# Remove the 0.17.x-era standalone bindings jar so stale copies of the old
+# API cannot shadow the bindings bundled in the aar
+rm -f android/cdk/cdk-jvm.jar
 
 if ! echo "$CDK_ANDROID_SHA256 android/cdk/$CDK_ANDROID_FILE" | sha256sum -c -; then
     echo "CDK Android library file missing or checksum failed" >&2
@@ -139,19 +141,6 @@ if ! echo "$CDK_ANDROID_SHA256 android/cdk/$CDK_ANDROID_FILE" | sha256sum -c -; 
 
     if ! echo "$CDK_ANDROID_SHA256 android/cdk/$CDK_ANDROID_FILE" | sha256sum -c -; then
         echo "CDK Android checksum failed" >&2
-        exit 1
-    fi
-fi
-
-# Android CDK Kotlin bindings (cdk-jvm)
-if ! echo "$CDK_ANDROID_BINDINGS_SHA256 android/cdk/$CDK_ANDROID_BINDINGS_FILE" | sha256sum -c -; then
-    echo "CDK Android bindings jar missing or checksum failed" >&2
-
-    rm -f android/cdk/$CDK_ANDROID_BINDINGS_FILE
-    curl -fL $CDK_ANDROID_BINDINGS_LINK > android/cdk/$CDK_ANDROID_BINDINGS_FILE
-
-    if ! echo "$CDK_ANDROID_BINDINGS_SHA256 android/cdk/$CDK_ANDROID_BINDINGS_FILE" | sha256sum -c -; then
-        echo "CDK Android bindings checksum failed" >&2
         exit 1
     fi
 fi

--- a/ios/CashuDevKit.podspec
+++ b/ios/CashuDevKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CashuDevKit'
-  s.version          = '0.17.4'
+  s.version          = '0.18.0'
   s.summary          = 'Cashu Development Kit - FFI bindings for iOS'
   s.description      = <<-DESC
     CashuDevKit provides Swift bindings to the Cashu Development Kit (CDK),

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -297,6 +297,10 @@ class CashuDevKitModule: RCTEventEmitter {
             return (legacyErrorCode(protocolCode: code, message: errorMessage), errorMessage)
         case let .Internal(errorMessage):
             return (legacyErrorCode(protocolCode: nil, message: errorMessage), errorMessage)
+        // 0.18.0 NUT-18 transport failure; unreachable until the bridge
+        // exposes preparePayRequest
+        case let .PaymentRequestDeliveryFailed(_, errorMessage):
+            return ("PAYMENT_FAILED", errorMessage)
         @unknown default:
             return ("UNKNOWN_ERROR", "Unknown error occurred")
         }
@@ -414,11 +418,17 @@ class CashuDevKitModule: RCTEventEmitter {
     ]
     do {
         // Only resolve proofs through a wallet the mint is already part
-        // of; decoding a foreign token must not add its mint or contact it
-        if let repo = walletQueue.sync(execute: { isInitialized ? self.repo : nil }) {
-            if await repo.hasMint(mintUrl: MintUrl(url: normalizeMintUrl(mintUrl.url))) {
-                let wallet = try await getWallet(mintUrl.url)
-                let keysets = try await wallet.getMintKeysets(filter: .all)
+        // of; decoding a foreign token must not add its mint or contact
+        // it, so read the cached keysets straight from the database
+        // (0.18 removed Wallet.getMintKeysets)
+        let handles: (WalletRepository, WalletSqliteDatabase)? = walletQueue.sync {
+            guard isInitialized, let repo = self.repo, let db = self.db else { return nil }
+            return (repo, db)
+        }
+        if let (repo, db) = handles {
+            let normalizedUrl = MintUrl(url: normalizeMintUrl(mintUrl.url))
+            if await repo.hasMint(mintUrl: normalizedUrl) {
+                let keysets = try await db.getMintKeysets(mintUrl: normalizedUrl) ?? []
                 let proofs = try token.proofs(mintKeysets: keysets)
                 result["proofs"] = proofs.map { encodeProof($0) }
             }
@@ -684,11 +694,18 @@ class CashuDevKitModule: RCTEventEmitter {
                         resolve: @escaping RCTPromiseResolveBlock,
                         reject: @escaping RCTPromiseRejectBlock) {
         guard getInitializedRepo(reject: reject) != nil else { return }
+        guard let db = walletQueue.sync(execute: { self.db }) else {
+            reject("NO_WALLET", "Wallet not initialized", nil)
+            return
+        }
 
         Task {
             do {
-                let wallet = try await getWallet(mintUrl)
-                let keysets = try await wallet.getMintKeysets(filter: .all)
+                // Cached keysets from the database; the pre-0.18
+                // Wallet.getMintKeysets(filter: .all) was also a local-store
+                // read (network refresh was a separate call)
+                let keysets = try await db.getMintKeysets(
+                    mintUrl: MintUrl(url: normalizeMintUrl(mintUrl))) ?? []
                 let encoded = keysets.map { encodeKeyset($0) }
                 resolve(encodeToJson(encoded))
             } catch let error as FfiError {
@@ -866,6 +883,10 @@ class CashuDevKitModule: RCTEventEmitter {
                         mintUrl: url,
                         amountIssued: quoteState == .issued ? amt : zeroAmount,
                         amountPaid: (quoteState == .paid || quoteState == .issued) ? amt : zeroAmount,
+                        // Insert as oldest-possible so any later saga update
+                        // (which drops stale responses by timestamp)
+                        // supersedes this externally sourced row
+                        updatedAt: 0,
                         estimatedBlocks: nil,
                         paymentMethod: .bolt11,
                         secretKey: storedSecretKey,


### PR DESCRIPTION
# Description

Relates to issue: **ZEUS-0000**

Bumps the vendored CashuDevKit (CDK) artifacts from 0.17.4 to 0.18.0.

**Android packaging rework (upstream):** the `cdk-jvm` bindings jar was discontinued after 0.17.5; the compiled Kotlin bindings now ship inside the `cdk-android` aar again (package unchanged: `org.cashudevkit`), and the native library was renamed from `libcdk_ffi.so` to `libcdk_ffi_kotlin.so`. `fetch-libraries.sh` drops the jar fetch (and removes stale local copies so an old-API jar cannot shadow the bundled bindings), and gradle drops the jar dependency and updates `packagingOptions`.

**API changes absorbed in the native bridges (both platforms kept in lockstep):**

* `Wallet.getMintKeysets(KeysetFilter)` was removed in favor of `keysets(policy:)`, which returns the new `KeySet` type. Both Zeus call sites (token decode and the `getMintKeysets` RN method) were local-store reads in 0.17.x, so they now read cached keysets straight from `WalletSqliteDatabase.getMintKeysets`, which still returns `[KeySetInfo]`. The token-decode path keeps its no-network guarantee for foreign tokens.
* `MintQuote` gained an `updatedAt` field. External quotes are inserted with 0 (oldest possible) so any later saga update, which drops stale responses by timestamp, supersedes the externally sourced row.
* `FfiException`/`FfiError` gained a `PaymentRequestDeliveryFailed` variant (NUT-18 transport failure). Mapped explicitly to `PAYMENT_FAILED`; the path is unreachable until the bridge exposes `preparePayRequest`.
* `KeySetInfo.inputFeePpk` is no longer optional on Android.

**Why draft:**

1. **32-bit Android is blocked upstream.** The 0.18.0 `cdk-android` aar only ships arm64-v8a and x86_64; armeabi-v7a and x86 were dropped by the rewritten publish pipeline (the pre-existing `pickFirst` entries for them are kept, renamed, so the build is ready either way). Restoration proposed in cashubtc/cdk#2489. Alternatively we may decide to retire our 32-bit release APKs; input welcome, discussion started on the upstream PR.
2. Device testing is pending (see below). Note for testers: **0.18.0 runs one-way wallet DB migrations automatically on open** (transaction status, quote timestamps, derivation counters). A build rolled back to 0.17.x cannot reopen a migrated Cashu DB, so test with a throwaway wallet or be ready to restore from seed. Upgrade-in-place with existing balance and history is the key scenario.
3. 0.18.0 adds default per-mint request pacing (persistent token bucket); multimint balance refresh timing should be sanity checked on device.

**Follow-up unlocked (not in this PR):** `Transaction` now carries `status` (pending/completed/failed), which #4493 can surface to drive pending/failed activity rows from CDK as the source of truth. New 0.18.0 surface worth exploring later: NUT-16 animated QR token encoding, `getOrCreateWallet`, cross-mint transfer quotes.

Verification done so far: `:app:compileDebugKotlin` compiles against the 0.18.0 bindings (the exhaustive-when check on `FfiException` is what surfaced the new error variant); `fetch-libraries.sh` runs end to end with all checksums verified; the 0.18.0 xcframework still needs and still passes the macOS-slice strip; `utils/DataClearUtils.test.ts` (which parses both native sources for the DB filename scheme) passes.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [x] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

Contributors will need to re-run `bash fetch-libraries.sh` after this PR is merged in (`package.json` and `yarn.lock` are untouched; the CDK artifacts and their pinned hashes changed).

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
