### PR TITLE
stores: fix crash opening a channel with a missing routing policy

### DIFF
--- a/models/ChannelInfo.ts
+++ b/models/ChannelInfo.ts
@@ -10,7 +10,7 @@ export interface RoutingPolicy {
     inbound_fee_rate_milli_msat?: string;
     disabled: boolean;
     max_htlc_msat: string;
-    last_update: number;
+    last_update?: number;
 }
 
 export default class ChannelInfo extends BaseModel {

--- a/stores/ChannelsStore.test.ts
+++ b/stores/ChannelsStore.test.ts
@@ -19,6 +19,7 @@ import { autorun } from 'mobx';
 
 import ChannelsStore from './ChannelsStore';
 import BackendUtils from '../utils/BackendUtils';
+import ChannelInfo from '../models/ChannelInfo';
 
 const channel = (
     localBalance: number,
@@ -147,5 +148,52 @@ describe('ChannelsStore.getChannels', () => {
         expect(store.totalOffline).toBe(0);
         expect(store.channels).toEqual([]);
         expect(store.error).toBe(true);
+    });
+});
+
+describe('ChannelsStore.getNodePolicy', () => {
+    it('returns undefined for LND-shaped channel info missing CLNRest fields (issue #4591)', () => {
+        const store = makeStore();
+        // lnd getChanInfo response for a channel where neither side's
+        // policy is in the graph yet: policies are null, and none of the
+        // CLNRest fields (delay, htlc_minimum_msat, ...) exist
+        store.chanInfo['123x456x0'] = new ChannelInfo({
+            channel_id: '123x456x0',
+            node1_pub: 'node1',
+            node2_pub: 'node2',
+            node1_policy: null,
+            node2_policy: null
+        });
+
+        expect(store.getNodePolicy('123x456x0')).toBeUndefined();
+    });
+
+    it('returns undefined when channel info is missing entirely', () => {
+        const store = makeStore();
+
+        expect(store.getNodePolicy('unknown')).toBeUndefined();
+    });
+
+    it('builds a policy from CLNRest-shaped channel info', () => {
+        const store = makeStore();
+        store.chanInfo['456'] = new ChannelInfo({
+            short_channel_id: '456',
+            delay: 34,
+            htlc_minimum_msat: 1000,
+            htlc_maximum_msat: 990000000,
+            base_fee_millisatoshi: 1000,
+            fee_per_millionth: 10,
+            last_update: 1700000000
+        });
+
+        expect(store.getNodePolicy('456')).toEqual({
+            time_lock_delta: 34,
+            min_htlc: '1000',
+            fee_base_msat: '1000',
+            fee_rate_milli_msat: '10',
+            disabled: false,
+            max_htlc_msat: '990000000',
+            last_update: 1700000000
+        });
     });
 });

--- a/stores/ChannelsStore.test.ts
+++ b/stores/ChannelsStore.test.ts
@@ -196,4 +196,18 @@ describe('ChannelsStore.getNodePolicy', () => {
             last_update: 1700000000
         });
     });
+
+    it('leaves last_update undefined instead of NaN when absent', () => {
+        const store = makeStore();
+        store.chanInfo['789'] = new ChannelInfo({
+            short_channel_id: '789',
+            delay: 34,
+            htlc_minimum_msat: 1000,
+            htlc_maximum_msat: 990000000,
+            base_fee_millisatoshi: 1000,
+            fee_per_millionth: 10
+        });
+
+        expect(store.getNodePolicy('789')?.last_update).toBeUndefined();
+    });
 });

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -1313,17 +1313,28 @@ export default class ChannelsStore {
     };
 
     // for CLNRest nodes, because the backend does not return the node policy.
-    public getNodePolicy = (chanId: string): RoutingPolicy => {
+    // Other backends (e.g. LND) can also land here when one side of a
+    // channel has no policy in the graph yet, so bail out unless the
+    // CLNRest-shaped fields are actually present.
+    public getNodePolicy = (chanId: string): RoutingPolicy | undefined => {
+        const chanInfo = this.chanInfo[chanId];
+        if (
+            chanInfo?.delay == null ||
+            chanInfo.htlc_minimum_msat == null ||
+            chanInfo.base_fee_millisatoshi == null ||
+            chanInfo.fee_per_millionth == null ||
+            chanInfo.htlc_maximum_msat == null
+        ) {
+            return undefined;
+        }
         return {
-            time_lock_delta: this.chanInfo[chanId].delay,
-            min_htlc: this.chanInfo[chanId].htlc_minimum_msat.toString(),
-            fee_base_msat:
-                this.chanInfo[chanId].base_fee_millisatoshi.toString(),
-            fee_rate_milli_msat:
-                this.chanInfo[chanId].fee_per_millionth.toString(),
+            time_lock_delta: chanInfo.delay,
+            min_htlc: chanInfo.htlc_minimum_msat.toString(),
+            fee_base_msat: chanInfo.base_fee_millisatoshi.toString(),
+            fee_rate_milli_msat: chanInfo.fee_per_millionth.toString(),
             disabled: false,
-            max_htlc_msat: this.chanInfo[chanId].htlc_maximum_msat.toString(),
-            last_update: Number(this.chanInfo[chanId].last_update?.toString())
+            max_htlc_msat: chanInfo.htlc_maximum_msat.toString(),
+            last_update: Number(chanInfo.last_update?.toString())
         };
     };
 

--- a/stores/ChannelsStore.ts
+++ b/stores/ChannelsStore.ts
@@ -1334,7 +1334,10 @@ export default class ChannelsStore {
             fee_rate_milli_msat: chanInfo.fee_per_millionth.toString(),
             disabled: false,
             max_htlc_msat: chanInfo.htlc_maximum_msat.toString(),
-            last_update: Number(chanInfo.last_update?.toString())
+            last_update:
+                chanInfo.last_update != null
+                    ? Number(chanInfo.last_update)
+                    : undefined
         };
     };
 

--- a/utils/DateTimeUtils.test.ts
+++ b/utils/DateTimeUtils.test.ts
@@ -1,5 +1,10 @@
 import DateTimeUtils from './DateTimeUtils';
 
+jest.mock('./LocaleUtils', () => ({
+    localeString: (key: string) =>
+        key === 'general.notAvailable' ? 'N/A' : key
+}));
+
 describe('listDate', () => {
     it('returns date for timestamp as number', () => {
         const date = new Date(2024, 11, 26, 21, 21);

--- a/utils/DateTimeUtils.test.ts
+++ b/utils/DateTimeUtils.test.ts
@@ -41,6 +41,14 @@ describe('listFormattedDate', () => {
 
         expect(result).toMatch(/^Thu, Dec 26 '24, 21:21/);
     });
+
+    it('falls back to N/A if timestamp is undefined', () => {
+        const result = DateTimeUtils.listFormattedDate(
+            undefined as unknown as string
+        );
+
+        expect(result).toEqual('N/A');
+    });
 });
 
 describe('listFormattedDateShort', () => {

--- a/utils/DateTimeUtils.test.ts
+++ b/utils/DateTimeUtils.test.ts
@@ -43,9 +43,7 @@ describe('listFormattedDate', () => {
     });
 
     it('falls back to N/A if timestamp is undefined', () => {
-        const result = DateTimeUtils.listFormattedDate(
-            undefined as unknown as string
-        );
+        const result = DateTimeUtils.listFormattedDate(undefined);
 
         expect(result).toEqual('N/A');
     });

--- a/utils/DateTimeUtils.test.ts
+++ b/utils/DateTimeUtils.test.ts
@@ -49,6 +49,20 @@ describe('listFormattedDate', () => {
 
         expect(result).toEqual('N/A');
     });
+
+    it('returns the raw value if timestamp is not date-coercible', () => {
+        const result = DateTimeUtils.listFormattedDate('not-a-date');
+
+        expect(result).toEqual('not-a-date');
+    });
+
+    it('formats an empty string as the epoch rather than N/A', () => {
+        // Number('') is 0, so '' stays on the happy path as a valid date
+        const result = DateTimeUtils.listFormattedDate('');
+
+        expect(result).not.toEqual('N/A');
+        expect(result).toMatch(/'69|'70/);
+    });
 });
 
 describe('listFormattedDateShort', () => {

--- a/utils/DateTimeUtils.ts
+++ b/utils/DateTimeUtils.ts
@@ -1,5 +1,7 @@
 import dateFormat from 'dateformat';
 
+import { localeString } from './LocaleUtils';
+
 class DateTimeUtils {
     listDate = (timestamp: number | string | undefined) =>
         new Date(Number(timestamp) * 1000);
@@ -12,7 +14,9 @@ class DateTimeUtils {
             const date = this.listDate(timestamp);
             return dateFormat(date, format).toString();
         } catch (error) {
-            return timestamp?.toString() || 'N/A';
+            return (
+                timestamp?.toString() || localeString('general.notAvailable')
+            );
         }
     };
 

--- a/utils/DateTimeUtils.ts
+++ b/utils/DateTimeUtils.ts
@@ -12,7 +12,7 @@ class DateTimeUtils {
             const date = this.listDate(timestamp);
             return dateFormat(date, format).toString();
         } catch (error) {
-            return timestamp.toString() || 'N/A';
+            return timestamp?.toString() ?? 'N/A';
         }
     };
 

--- a/utils/DateTimeUtils.ts
+++ b/utils/DateTimeUtils.ts
@@ -12,7 +12,7 @@ class DateTimeUtils {
             const date = this.listDate(timestamp);
             return dateFormat(date, format).toString();
         } catch (error) {
-            return timestamp?.toString() ?? 'N/A';
+            return timestamp?.toString() || 'N/A';
         }
     };
 

--- a/utils/DateTimeUtils.ts
+++ b/utils/DateTimeUtils.ts
@@ -1,11 +1,11 @@
 import dateFormat from 'dateformat';
 
 class DateTimeUtils {
-    listDate = (timestamp: number | string) =>
+    listDate = (timestamp: number | string | undefined) =>
         new Date(Number(timestamp) * 1000);
 
     listFormattedDate = (
-        timestamp: number | string,
+        timestamp: number | string | undefined,
         format = "ddd, mmm d 'yy, HH:MM Z"
     ) => {
         try {


### PR DESCRIPTION
# Description

Relates to issue: **#4591**

Fixes #4591

Opening a channel's view crashed the app with `TypeError: Cannot read property 'toString' of undefined` in `FeeBreakdown` on LND (REST), reproducing every time for the affected channel.

Root cause: `ChannelsStore.getNodePolicy` was added as a CLNRest-only fallback that builds a routing policy from CLN `listchannels` fields, but `FeeBreakdown` falls back to it whenever a channel side's policy is falsy, on any backend. On LND, `getChanInfo` returns `node1_policy`/`node2_policy` as `null` when that side's `channel_update` is not in the graph yet (freshly opened channel, or a peer whose update was never received or was pruned). The fallback then ran against an LND-shaped `ChannelInfo` and crashed calling `.toString()` on the absent CLNRest fields (`htlc_minimum_msat`, etc.).

Changes:

* `getNodePolicy` now returns `undefined` unless the CLNRest-shaped fields are actually present. `FeeBreakdown` already renders gracefully when a policy is unavailable, so a channel with an unknown policy shows the rest of its details instead of crashing. Same crash path was also reachable from the RoutingEvent view.
* Hardened `DateTimeUtils.listFormattedDate`: `dateformat` throws on invalid dates, and the catch block called `timestamp.toString()`, which itself throws for undefined/null. The `|| 'N/A'` fallback was also unreachable. Now uses `timestamp?.toString() ?? 'N/A'`.
* Regression tests for both (`stores/ChannelsStore.test.ts`, `utils/DateTimeUtils.test.ts`). The new `getNodePolicy` test fails with the old code.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Device testing pending: repro is LND (REST) with a channel where one side's policy is missing from the graph (e.g. freshly opened channel before the peer's channel_update propagates).

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
