### PR TITLE
[drop-android-x86] build: drop the 32-bit x86 Android ABI

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -71,13 +71,6 @@ jobs:
         path: android/app/build/outputs/apk/release/zeus-universal.apk
         retention-days: 5
 
-    - name: 'Archive x86'
-      uses: actions/upload-artifact@v7
-      with:
-        name: x86
-        path: android/app/build/outputs/apk/release/zeus-x86.apk
-        retention-days: 5
-
     - name: 'Archive x86_64'
       uses: actions/upload-artifact@v7
       with:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -103,7 +103,7 @@ android {
         versionName "13.2.2-alpha"
         multiDexEnabled true
         ndk {
-            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+            abiFilters "armeabi-v7a", "arm64-v8a", "x86_64"
         }
     }
     signingConfigs {
@@ -121,7 +121,7 @@ android {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
             universalApk true  // If true, also generate a universal APK
-            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+            include "armeabi-v7a", "arm64-v8a", "x86_64"
         }
     }
     buildTypes {
@@ -145,8 +145,11 @@ android {
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
             // https://developer.android.com/studio/build/configure-apk-splits.html
-            // Example: versionCode 1 will generate 1001 for armeabi-v7a, 1002 for x86, etc.
-            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
+            // Example: versionCode 1 will generate 1001 for armeabi-v7a, 1003 for arm64-v8a, etc.
+            // These suffixes are permanent: never renumber them, or Play will see a
+            // lower versionCode for an ABI than the one already published. 2 is
+            // retired (it belonged to the dropped x86 ABI) and must stay unused.
+            def versionCodes = ["armeabi-v7a": 1, "arm64-v8a": 3, "x86_64": 4]
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =
@@ -158,24 +161,20 @@ android {
     packagingOptions {
         pickFirst "lib/armeabi-v7a/libc++_shared.so"
         pickFirst "lib/arm64-v8a/libc++_shared.so"
-        pickFirst "lib/x86/libc++_shared.so"
         pickFirst "lib/x86_64/libc++_shared.so"
 
         pickFirst "lib/armeabi-v7a/libgojni.so"
         pickFirst "lib/arm64-v8a/libgojni.so"
-        pickFirst "lib/x86/libgojni.so"
         pickFirst "lib/x86_64/libgojni.so"
 
         // CashuDevKit native libraries (Rust FFI)
         pickFirst "lib/armeabi-v7a/libcdk_ffi.so"
         pickFirst "lib/arm64-v8a/libcdk_ffi.so"
-        pickFirst "lib/x86/libcdk_ffi.so"
         pickFirst "lib/x86_64/libcdk_ffi.so"
 
         // Zeus Cashu Restore native libraries (Rust FFI)
         pickFirst "lib/armeabi-v7a/libuniffi_zeus_cashu_restore.so"
         pickFirst "lib/arm64-v8a/libuniffi_zeus_cashu_restore.so"
-        pickFirst "lib/x86/libuniffi_zeus_cashu_restore.so"
         pickFirst "lib/x86_64/libuniffi_zeus_cashu_restore.so"
 
         jniLibs {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -28,7 +28,7 @@ android.useAndroidX=true
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
-reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86_64
 
 # Use this property to enable support to the new architecture.
 # This will allow you to use TurboModules and the Fabric render in

--- a/docs/ReproducibleBuilds.md
+++ b/docs/ReproducibleBuilds.md
@@ -6,7 +6,7 @@ Reproducible builds are available for Android only right now. You'll need Docker
     You can also remove the `--branch v0.8.0` parameter to build APKs for `master`.
 2. Change to the zeus directory: `cd zeus`
 3. Execute the build script: `./build.sh`
-4. If everything goes well, the script will print a list of all the generated APK files and SHA256 hashes for each one of them: armv7, armv8, x86, x86_64, universal. The equivalent to the one provided in the web page is the one ending in 'universal'. You can compare SHA256 hashes with the ones provided on the [GitHub releases page](https://github.com/ZeusLN/zeus/releases)
+4. If everything goes well, the script will print a list of all the generated APK files and SHA256 hashes for each one of them: armv7, armv8, x86_64, universal. The equivalent to the one provided in the web page is the one ending in 'universal'. You can compare SHA256 hashes with the ones provided on the [GitHub releases page](https://github.com/ZeusLN/zeus/releases)
 5. Download the official APK from [GitHub releases page](https://github.com/ZeusLN/zeus/releases) or from the [ZEUS homepage](https://zeusln.com/): `wget https://zeusln.com/zeus-v0.8.0-universal.apk`
 6. Compare both APKs with a suitable utility like `diffoscope`, `apksigcopier` or by running `diff --brief --recursive ./unpacked_oficial_apk ./unpacked_built_apk`. You should only get differences for the certificates used to sign the official APK
 


### PR DESCRIPTION
# Description

Relates to issue: **#4589** (option 3, "drop x86 only")

Removes the 32-bit `x86` ABI from Android builds. `armeabi-v7a` and
`x86_64` are unaffected, so this does not unblock #4588; it settles the
lowest-risk half of #4589.

Two reasons:

**There are no x86 users.** The per-ABI versionCode scheme
(`N*1000 + {armv7:1, x86:2, arm64:3, x86_64:4}`) means Play always serves
arm64 to 64-bit devices, so an x86 install could only come from a
32-bit-only x86 device. There are none in the install base. GitHub per-ABI
asset downloads agree: 5 for v13.2.0 and 0 for v13.2.1.

**The x86 APK was already broken.** `ldk-node-android-jniLibs.zip` ships
only `arm64-v8a`, `armeabi-v7a` and `x86_64`, and the repo has no
`jniLibs/x86` directory, so `libldk_node.so` was absent from every x86
build. LDK Node would have failed at library load on any x86 install.

## What changed

- `android/app/build.gradle`: `x86` removed from `defaultConfig.ndk.abiFilters`, from `splits.abi.include`, and from the four `pickFirst "lib/x86/..."` packaging rules
- `android/gradle.properties`: `reactNativeArchitectures` is now `armeabi-v7a,arm64-v8a,x86_64`
- `.github/workflows/build-android.yml`: dropped the "Archive x86" artifact step
- `docs/ReproducibleBuilds.md`: x86 removed from the list of APKs `./build.sh` emits

`build.sh` needed no change; it globs `*.apk`.

### On the versionCode map

Suffix `2` is retired rather than reused, and there is a comment saying so.
Renumbering the surviving ABIs would hand Play a lower versionCode for an
ABI than one already published. Existing arm64 (`3`) and x86_64 (`4`)
update paths are unchanged.

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [x] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

No JavaScript or TypeScript is touched by this PR, so the four checks
above have nothing to act on here; leaving them unticked rather than
claiming a local run I did not complete. CI will confirm.

Instead, the Gradle config was verified directly by probing the evaluated
project with an init script. Resolved values after the change:

```
SPLITS:  [armeabi-v7a, x86_64, arm64-v8a]
NDK_ABI: [armeabi-v7a, arm64-v8a, x86_64]
```

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Not yet device-tested. The meaningful test for this change is a release
build producing three per-ABI APKs plus universal, with no `zeus-x86.apk`
and no `lib/x86/` inside the universal APK, followed by an install and
smoke test of the arm64 APK. That is owed before merge. iOS is untouched
by this change.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Build-configuration only; no backend code paths are reachable from this
diff. A smoke test on the arm64 build is enough to confirm nothing was
dropped from packaging.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

Release ops note: the Play Console x86 track will need retiring separately,
and release notes should mention that x86 APKs are no longer published.
