### PR TITLE
components: Restore automatic percentage fee limits

### DIFF
--- a/components/FeeLimit.test.tsx
+++ b/components/FeeLimit.test.tsx
@@ -1,0 +1,178 @@
+jest.mock('react-native', () => ({
+    StyleSheet: { create: (styles: unknown) => styles },
+    Text: 'Text',
+    View: 'View'
+}));
+jest.mock('mobx-react', () => ({
+    inject: () => (component: unknown) => component,
+    observer: (component: unknown) => component
+}));
+jest.mock('./Amount', () => 'Amount');
+jest.mock('./TextInput', () => 'FeeInput');
+jest.mock('./layout/Row', () => ({ Row: 'Row' }));
+jest.mock('../utils/BackendUtils', () => ({
+    __esModule: true,
+    default: { supportsCustomFeeLimit: () => true }
+}));
+jest.mock('../utils/LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+jest.mock('../utils/ThemeUtils', () => ({ themeColor: () => 'black' }));
+
+import * as React from 'react';
+import { act, create, ReactTestRenderer } from 'react-test-renderer';
+import { FeeLimit } from './FeeLimit';
+
+type Props = React.ComponentProps<typeof FeeLimit>;
+const settings = {
+    payments: { defaultFeeFixed: '20', defaultFeePercentage: '0.5' }
+};
+const deferredSettings = () => {
+    let resolve!: (value: typeof settings) => void;
+    const promise = new Promise<typeof settings>((done) => {
+        resolve = done;
+    });
+    return { promise, resolve };
+};
+
+describe('FeeLimit mode synchronization', () => {
+    let root: ReactTestRenderer;
+    const actEnvironment = globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+    const previousActEnvironment = actEnvironment.IS_REACT_ACT_ENVIRONMENT;
+
+    beforeAll(() => {
+        actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    });
+
+    afterAll(() => {
+        actEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    });
+
+    afterEach(async () => {
+        if (root) await act(async () => root.unmount());
+    });
+
+    it.each(['child-first', 'parent-first', 'together'])(
+        'uses percentage when the parent selects it after mount (%s)',
+        async (order) => {
+            const childSettings = deferredSettings();
+            const parentSettings = deferredSettings();
+            const caps = jest.fn();
+            // PaymentRequest renders the already-decoded LNURL invoice with
+            // fixed mode, then selects percent after its own settings await.
+            class PaymentScreen extends React.Component {
+                state = { feeOption: 'fixed', feeLimitSat: '1000' };
+                async componentDidMount() {
+                    await parentSettings.promise;
+                    this.setState({ feeOption: 'percent' });
+                    this.setState({ feeLimitSat: '20' });
+                }
+                render() {
+                    return (
+                        <FeeLimit
+                            satAmount={100000}
+                            feeOption={this.state.feeOption}
+                            SettingsStore={
+                                {
+                                    getSettings: () => childSettings.promise
+                                } as unknown as Props['SettingsStore']
+                            }
+                            onFeeLimitSatChange={(feeLimitSat) => {
+                                caps(feeLimitSat);
+                                this.setState({ feeLimitSat });
+                            }}
+                        />
+                    );
+                }
+            }
+            await act(async () => {
+                root = create(<PaymentScreen />);
+            });
+            if (order === 'together') {
+                await act(async () => {
+                    childSettings.resolve(settings);
+                    parentSettings.resolve(settings);
+                });
+            } else {
+                const first =
+                    order === 'child-first' ? childSettings : parentSettings;
+                const second =
+                    order === 'child-first' ? parentSettings : childSettings;
+                await act(async () => first.resolve(settings));
+                await act(async () => second.resolve(settings));
+            }
+            expect(caps).toHaveBeenLastCalledWith('500');
+            expect(
+                root.root.findByType(PaymentScreen).instance.state.feeLimitSat
+            ).toBe('500');
+        }
+    );
+
+    it('handles mode and amount changing together in both directions', async () => {
+        const caps = jest.fn();
+        const props: Props = {
+            satAmount: 1000,
+            feeOption: 'fixed',
+            SettingsStore: {
+                getSettings: async () => settings
+            } as unknown as Props['SettingsStore'],
+            onFeeLimitSatChange: caps
+        };
+        await act(async () => {
+            root = create(<FeeLimit {...props} />);
+        });
+        expect(caps).toHaveBeenLastCalledWith('20');
+        await act(async () => {
+            root.update(
+                <FeeLimit {...props} satAmount={1001} feeOption="percent" />
+            );
+        });
+        expect(caps).toHaveBeenLastCalledWith('5');
+        await act(async () => {
+            root.update(<FeeLimit {...props} satAmount={999} />);
+        });
+        expect(caps).toHaveBeenLastCalledWith('20');
+    });
+
+    it('preserves a manual selection on amount changes and unrelated renders', async () => {
+        const caps = jest.fn();
+        const props: Props = {
+            satAmount: 100000,
+            feeOption: 'percent',
+            SettingsStore: {
+                getSettings: async () => settings
+            } as unknown as Props['SettingsStore'],
+            onFeeLimitSatChange: caps
+        };
+        await act(async () => {
+            root = create(<FeeLimit {...props} />);
+        });
+        expect(caps).toHaveBeenLastCalledWith('500');
+        // Some callers do not supply onFeeOptionChange. An unchanged prop
+        // must not override the local selection on the next amount update.
+        const inputs = () =>
+            root.root.findAll(
+                (node) => node.type === ('FeeInput' as React.ElementType)
+            );
+        await act(async () => inputs()[0].props.onPressIn());
+        expect(caps).toHaveBeenLastCalledWith('20');
+        await act(async () => {
+            root.update(<FeeLimit {...props} satAmount={200000} />);
+        });
+        expect(caps).toHaveBeenLastCalledWith('20');
+        await act(async () => {
+            root.update(
+                <FeeLimit
+                    {...props}
+                    satAmount={200000}
+                    displayFeeRecommendation={false}
+                />
+            );
+        });
+        expect(caps).toHaveBeenLastCalledWith('20');
+        await act(async () => inputs()[1].props.onPressIn());
+        expect(caps).toHaveBeenLastCalledWith('1000');
+    });
+});

--- a/components/FeeLimit.tsx
+++ b/components/FeeLimit.tsx
@@ -56,10 +56,10 @@ export default class FeeLimit extends React.Component<
     }
 
     async componentDidMount(): Promise<void> {
-        const { SettingsStore, feeOption, satAmount, onFeeLimitSatChange } =
-            this.props;
+        const { SettingsStore } = this.props;
         const { getSettings } = SettingsStore;
         const settings = await getSettings();
+        const { satAmount, onFeeLimitSatChange } = this.props;
 
         const feeLimitSat = settings?.payments?.defaultFeeFixed || '100';
 
@@ -76,6 +76,7 @@ export default class FeeLimit extends React.Component<
                     percentAmount
                 });
 
+                const feeOption = this.props.feeOption;
                 if (feeOption) {
                     this.setState(
                         {
@@ -106,7 +107,21 @@ export default class FeeLimit extends React.Component<
         const { satAmount, onFeeLimitSatChange } = this.props;
         const { feeLimitSat, feeOption } = this.state;
 
-        if (satAmount !== prevProps.satAmount) {
+        const feeOptionChanged =
+            this.props.feeOption !== prevProps.feeOption &&
+            !!this.props.feeOption;
+        if (feeOptionChanged) {
+            const nextFeeOption = this.props.feeOption!;
+            const percentAmount = this.calculatePercentAmount(satAmount);
+            this.setState({ feeOption: nextFeeOption, percentAmount }, () => {
+                onFeeLimitSatChange(
+                    BackendUtils.supportsCustomFeeLimit() &&
+                        nextFeeOption === 'percent'
+                        ? percentAmount
+                        : this.state.feeLimitSat
+                );
+            });
+        } else if (satAmount !== prevProps.satAmount) {
             const percentAmount = this.calculatePercentAmount(satAmount);
             const percentUpdated = percentAmount !== this.state.percentAmount;
 


### PR DESCRIPTION
# Description

Follow-up to #4390, specifically [the acknowledged fee-mode synchronization issue](https://github.com/ZeusLN/zeus/pull/4390#issuecomment-5268396230).

When an already-decoded invoice opens `PaymentRequest`, `FeeLimit` mounts with the initial fixed mode. The parent selects percentage mode above 1,000 sats after loading settings, but the child captures the old prop before its own await and never handles mode updates. With 20 sats / 0.5% configured, a 100,000-sat payment therefore keeps a 20-sat cap until the percentage field is tapped; it should calculate 500 sats.

Read the current mode during initialization and synchronize subsequent mode prop changes, emitting the corresponding satoshi cap. Only changed mode props override local selection, preserving manual selection for callers without `onFeeOptionChange`. The existing threshold, rounding and backend cap mapping remain unchanged.

Credit to the reviewer and maintainer discussion in #4390, which identified this synchronization issue and left restoration of the automatic default for follow-up. This PR proposes that focused restoration.

**Draft: device validation and full repository checks remain outstanding.** No screenshot/video of the fix is available yet. The original behavior and manual-tap workaround were observed on ZEUS v13.2.1, iPhone 17 Pro / iOS 26.6.1, connected over LAN to CLN v26.06.7 with 20 sats / 0.5% defaults. That is the reported environment, not a claim that this patch has been tested on that device.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

Added `components/FeeLimit.test.tsx` with five React-renderer regression tests: parent/child settings resolution in both orders and together; simultaneous amount/mode updates; and manual mode selection surviving amount changes and unrelated renders.

Local targeted Jest run: **5 passed with the fix; 4 failed / 1 passed against the original source**, including `expected "500", received "20"`. Tests ran with isolated Jest 29.7.0, React/test-renderer 19.2.8 and TypeScript 5.7.3, with native views/MobX wrappers mocked and a TypeScript transpilation-only Jest transform. This was not the repository's React Native preset or full suite, and does not claim type checking. Intended repository command: `yarn test components/FeeLimit.test.tsx --runInBand`.

Prettier 2.4.1 passed for both changed files; `git diff --check` passed. Full `yarn tsc`, `yarn lint`, repository-wide Prettier and the complete test suite were not run locally. No dependency or lockfile changes are included.

Device follow-up: confirm automatic percentage selection above 1,000 sats and fixed selection at/below it; verify manual overrides; confirm CLN receives the displayed cap. No live payment was sent during automated testing.

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
