### PR TITLE
fix: never persist a wallet-less settings blob over a populated one

### DIFF
--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -317,6 +317,53 @@ describe('SettingsStore write guards', () => {
         expect(store.settingsLoadFailed).toEqual(false);
     });
 
+    it('keeps writing when the legacy read fails on a fresh install', async () => {
+        // EncryptedStorage rejects persistently when its Android
+        // keystore-backed store cannot initialize, so refusing writes
+        // here would block onboarding forever.
+        const EncryptedStorage = require('react-native-encrypted-storage');
+        EncryptedStorage.getItem.mockRejectedValueOnce(
+            new Error('Could not initialize SharedPreferences')
+        );
+        const store = new SettingsStore();
+
+        const result = await store.updateSettings({ fiat: 'EUR' });
+
+        expect(result.fiat).toEqual('EUR');
+        expect(persistedSettings().fiat).toEqual('EUR');
+        expect(store.settingsLoadFailed).toEqual(false);
+    });
+
+    it('loads the settings blob even when a pre-read migration throws', async () => {
+        seedSettings({ nodes: [nodeA, nodeB], fiat: 'USD' });
+        const MigrationUtils = require('../utils/MigrationUtils');
+        MigrationUtils.purgeRescueKeyFiles.mockRejectedValueOnce(
+            new Error('EncryptedStorage unavailable')
+        );
+        const store = new SettingsStore();
+
+        const result = await store.updateSettings({ fiat: 'EUR' });
+
+        // The blob lives in the keychain and is still readable: a failed
+        // migration flag lookup must not strand the store on defaults.
+        expect(result.nodes).toHaveLength(2);
+        expect(persistedSettings().nodes).toHaveLength(2);
+        expect(persistedSettings().fiat).toEqual('EUR');
+    });
+
+    it('persists an update whose updater mutates settings in place', async () => {
+        seedSettings({ nodes: [nodeA], fiat: 'USD' });
+        const store = new SettingsStore();
+        await store.getSettings();
+
+        await store.updateSettings((currentSettings: any) => {
+            currentSettings.nodes[0].macaroonHex = 'cccc';
+            return { nodes: currentSettings.nodes };
+        });
+
+        expect(persistedSettings().nodes[0].macaroonHex).toEqual('cccc');
+    });
+
     it('skips the write when nothing changed', async () => {
         seedSettings({ nodes: [nodeA], fiat: 'USD' });
         const store = new SettingsStore();

--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -32,8 +32,11 @@ jest.mock('../utils/LocaleUtils', () => ({
 jest.mock('../utils/MigrationUtils', () => ({
     keychainCloudSyncMigration: jest.fn().mockResolvedValue(undefined),
     purgeRescueKeyFiles: jest.fn().mockResolvedValue(undefined),
-    migrateRgsDefaultToZeus: jest.fn().mockResolvedValue(undefined),
+    migrateRgsDefaultsToV2: jest.fn().mockResolvedValue(undefined),
+    migrateSwapHostsToBoltz: jest.fn().mockResolvedValue(undefined),
+    migrateRetiredSwapHosts: jest.fn().mockResolvedValue(undefined),
     migrateInvoiceExpiryDisplay: jest.fn().mockResolvedValue(undefined),
+    migrateOlympusHostsToZeusLsp: jest.fn().mockResolvedValue(undefined),
     legacySettingsMigrations: jest.fn().mockResolvedValue({}),
     storageMigrationV2: jest.fn().mockResolvedValue(undefined)
 }));
@@ -81,16 +84,22 @@ const seedSettings = (settings: any) => {
 const persistedSettings = () => JSON.parse(StorageMock._backing[STORAGE_KEY]);
 
 let logSpy: jest.SpyInstance;
+let warnSpy: jest.SpyInstance;
+let errorSpy: jest.SpyInstance;
 
 beforeEach(() => {
     for (const key of Object.keys(StorageMock._backing)) {
         delete StorageMock._backing[key];
     }
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 });
 
 afterEach(() => {
     logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
 });
 
 describe('SettingsStore.updateSettings', () => {
@@ -201,5 +210,123 @@ describe('SettingsStore.updateSettings', () => {
         expect(result.fiat).toEqual('CAD');
         expect(persistedSettings().fiat).toEqual('CAD');
         expect(store.settingsUpdateInProgress).toEqual(false);
+    });
+});
+
+// Regression coverage for #4612: a settings read that FAILS is not the
+// same as a user with no wallets, but getSettings returned the store's
+// defaults for both, and the very next write (the launch-time biometry
+// refresh) merged onto those defaults and persisted a wallet-less blob
+// over the real one. On iOS that write is a delete-then-add of a single
+// keychain item, so the wallet list was gone with no prior copy left.
+describe('SettingsStore write guards', () => {
+    const nodeA = {
+        implementation: 'lnd',
+        host: 'a.example.com',
+        macaroonHex: 'aaaa'
+    };
+    const nodeB = {
+        implementation: 'lnd',
+        host: 'b.example.com',
+        macaroonHex: 'bbbb'
+    };
+
+    it('does not persist defaults over the wallet list when the read fails', async () => {
+        seedSettings({ nodes: [nodeA, nodeB], selectedNode: 0, fiat: 'USD' });
+        // Fresh store, as on app launch: `settings` is still the default
+        // object, which has no `nodes`.
+        const store = new SettingsStore();
+        StorageMock.getItem.mockRejectedValueOnce(
+            new Error('errSecInteractionNotAllowed')
+        );
+
+        const result = await store.updateSettings({
+            supportedBiometryType: 'FaceID'
+        });
+
+        expect(persistedSettings().nodes).toHaveLength(2);
+        expect(persistedSettings().fiat).toEqual('USD');
+        expect(result.supportedBiometryType).toBeUndefined();
+        expect(store.settings.nodes).toBeUndefined();
+        expect(store.settingsLoadFailed).toEqual(true);
+    });
+
+    it('does not persist over a corrupt settings blob', async () => {
+        StorageMock._backing[STORAGE_KEY] = '{"nodes":[{"host":"a.exa';
+        const store = new SettingsStore();
+
+        await store.updateSettings({ fiat: 'EUR' });
+
+        expect(StorageMock._backing[STORAGE_KEY]).toEqual(
+            '{"nodes":[{"host":"a.exa'
+        );
+        expect(store.settingsLoadFailed).toEqual(true);
+    });
+
+    it('resumes writing once a later load succeeds', async () => {
+        seedSettings({ nodes: [nodeA], fiat: 'USD' });
+        const store = new SettingsStore();
+        StorageMock.getItem.mockRejectedValueOnce(
+            new Error('errSecInteractionNotAllowed')
+        );
+
+        await store.updateSettings({ fiat: 'EUR' });
+        expect(persistedSettings().fiat).toEqual('USD');
+
+        const result = await store.updateSettings({ fiat: 'CAD' });
+
+        expect(result.fiat).toEqual('CAD');
+        expect(persistedSettings().fiat).toEqual('CAD');
+        expect(persistedSettings().nodes).toHaveLength(1);
+        expect(store.settingsLoadFailed).toEqual(false);
+    });
+
+    it('refuses to persist an empty wallet list over an existing one', async () => {
+        seedSettings({ nodes: [nodeA, nodeB], selectedNode: 0 });
+        const store = new SettingsStore();
+        await store.getSettings();
+
+        const result = await store.updateSettings({ nodes: [] });
+
+        expect(persistedSettings().nodes).toHaveLength(2);
+        expect(store.settings.nodes).toHaveLength(2);
+        expect(result.nodes).toHaveLength(2);
+    });
+
+    it('lets the last wallet be deleted with allowEmptyNodes', async () => {
+        seedSettings({ nodes: [nodeA], selectedNode: 0 });
+        const store = new SettingsStore();
+        await store.getSettings();
+
+        await store.updateSettings(
+            { nodes: [], selectedNode: 0, justDeletedWallet: true },
+            { allowEmptyNodes: true }
+        );
+
+        expect(persistedSettings().nodes).toHaveLength(0);
+        expect(StorageMock._backing[STORAGE_KEY]).not.toContain('aaaa');
+    });
+
+    it('still persists on a fresh install with no wallets', async () => {
+        const store = new SettingsStore();
+
+        const result = await store.updateSettings({ fiat: 'EUR' });
+
+        expect(result.fiat).toEqual('EUR');
+        expect(persistedSettings().fiat).toEqual('EUR');
+        expect(store.settingsLoadFailed).toEqual(false);
+    });
+
+    it('skips the write when nothing changed', async () => {
+        seedSettings({ nodes: [nodeA], fiat: 'USD' });
+        const store = new SettingsStore();
+        await store.getSettings();
+        StorageMock.setItem.mockClear();
+
+        const result = await store.updateSettings({ fiat: 'USD' });
+
+        expect(StorageMock.setItem).not.toHaveBeenCalled();
+        expect(result.fiat).toEqual('USD');
+        expect(store.triggerSettingsRefresh).toEqual(false);
     });
 });

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1978,8 +1978,21 @@ export default class SettingsStore {
     public getSettings = async (silentUpdate: boolean = false) => {
         if (!silentUpdate) this.loading = true;
         try {
-            await MigrationsUtils.keychainCloudSyncMigration();
-            await MigrationsUtils.purgeRescueKeyFiles();
+            try {
+                await MigrationsUtils.keychainCloudSyncMigration();
+                await MigrationsUtils.purgeRescueKeyFiles();
+            } catch (error) {
+                // These run before the settings are read and depend on
+                // EncryptedStorage (migration flags) and the filesystem.
+                // EncryptedStorage rejects persistently on Android when
+                // its keystore-backed store cannot initialize, and
+                // purgeRescueKeyFiles has no error handling of its own,
+                // so letting the throw escape would abort the load
+                // before the keychain is ever read and leave the store
+                // on its defaults - the exact state that then gets
+                // persisted over the user's wallet list.
+                console.error('Could not complete pre-load migrations', error);
+            }
 
             let modernSettings: any;
             try {
@@ -2027,15 +2040,21 @@ export default class SettingsStore {
                 console.log('attempting to load legacy settings');
 
                 // Retrieve the settings
-                let settings: string | null;
+                let settings: string | null = null;
                 try {
                     settings = await EncryptedStorage.getItem(
                         LEGACY_STORAGE_KEY
                     );
                 } catch (error) {
-                    this.settingsLoadFailed = true;
+                    // Reaching this branch means the modern read
+                    // succeeded and found nothing, so no populated blob
+                    // exists for a later write to clobber. Latching here
+                    // would refuse every settings write for as long as
+                    // the legacy read keeps failing, which on a device
+                    // whose EncryptedStorage cannot initialize is
+                    // forever - it would block onboarding on a fresh
+                    // install. Treat it as "no legacy data".
                     console.error('Could not read legacy settings', error);
-                    return this.settings;
                 }
                 this.settingsLoadFailed = false;
                 if (settings) {
@@ -2145,6 +2164,13 @@ export default class SettingsStore {
         this.settingsUpdateInProgress = true;
         try {
             const existingSettings = await this.getSettings();
+            // Snapshot before the updater runs. `existingSettings` is the
+            // live `this.settings` object, so an updater that mutates
+            // nested state in place (rather than copying it) would
+            // otherwise compare equal to its own result below and have
+            // its write silently skipped. Comparing serialized forms can
+            // only cost a redundant write, never drop one.
+            const existingSnapshot = JSON.stringify(existingSettings);
             // Functional updates read the settings inside the critical
             // section, so callers whose new value depends on the current
             // one (delete node X from the array) cannot act on a snapshot
@@ -2170,7 +2196,7 @@ export default class SettingsStore {
             // is not free - it destroys and recreates the user's wallet
             // list for nothing. The launch-time biometry refresh in
             // views/Wallet/Wallet.tsx is the common case.
-            if (isEqual(existingSettings, newSettings)) {
+            if (JSON.stringify(newSettings) === existingSnapshot) {
                 return existingSettings;
             }
 

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1484,6 +1484,17 @@ export const DEFAULT_NEUTRINO_PEERS_TESTNET = [
 
 export const DEFAULT_SLIDE_TO_PAY_THRESHOLD = 10000;
 
+export interface SettingsWriteOptions {
+    // Permits persisting a settings blob with no wallets over one that
+    // has them. Deleting the last wallet is the only caller that
+    // legitimately needs this; every other empty `nodes` is a settings
+    // load that failed or a merge onto the store's defaults.
+    allowEmptyNodes?: boolean;
+}
+
+const hasNodes = (settings: any): boolean =>
+    Array.isArray(settings?.nodes) && settings.nodes.length > 0;
+
 export default class SettingsStore {
     @observable settings: Settings = {
         privacy: {
@@ -1638,6 +1649,11 @@ export default class SettingsStore {
     @observable public posWasEnabled: boolean = false;
     @observable public loading = false;
     @observable public isMigrating = false;
+    // Set when the persisted settings blob could not be read or parsed,
+    // as opposed to genuinely not existing. `this.settings` then still
+    // holds the defaults, which carry no `nodes`, so writes are refused
+    // until a later load succeeds. See setSettings.
+    @observable public settingsLoadFailed = false;
     @observable public settingsUpdateInProgress: boolean = false;
     @observable btcPayError: string | null;
     @observable sponsorsError: string | null;
@@ -1965,11 +1981,37 @@ export default class SettingsStore {
             await MigrationsUtils.keychainCloudSyncMigration();
             await MigrationsUtils.purgeRescueKeyFiles();
 
-            const modernSettings: any = await Storage.getItem(STORAGE_KEY);
+            let modernSettings: any;
+            try {
+                modernSettings = await Storage.getItem(STORAGE_KEY);
+            } catch (error) {
+                // A read that FAILED is not a user with no wallets. The
+                // keychain rejects for anything other than "not found"
+                // (locked item, missing entitlement, Android decryption
+                // failure), and `this.settings` is still the default
+                // object, which has no `nodes`. Latch writes off so the
+                // caller that follows cannot merge onto those defaults
+                // and persist a wallet-less blob over the real one.
+                this.settingsLoadFailed = true;
+                console.error('Could not read settings', error);
+                return this.settings;
+            }
 
             if (modernSettings) {
                 console.log('attempting to load modern settings');
-                const parsedSettings = JSON.parse(modernSettings);
+                let parsedSettings: any;
+                try {
+                    parsedSettings = JSON.parse(modernSettings);
+                } catch (error) {
+                    // Same reasoning as a failed read: a truncated or
+                    // corrupt blob is not an empty wallet list, and
+                    // overwriting it destroys the only copy of the
+                    // user's wallet configurations.
+                    this.settingsLoadFailed = true;
+                    console.error('Could not parse settings', error);
+                    return this.settings;
+                }
+                this.settingsLoadFailed = false;
                 this.settings = parsedSettings;
                 await MigrationsUtils.migrateRgsDefaultsToV2(parsedSettings);
                 await MigrationsUtils.migrateSwapHostsToBoltz(parsedSettings);
@@ -1985,9 +2027,17 @@ export default class SettingsStore {
                 console.log('attempting to load legacy settings');
 
                 // Retrieve the settings
-                const settings = await EncryptedStorage.getItem(
-                    LEGACY_STORAGE_KEY
-                );
+                let settings: string | null;
+                try {
+                    settings = await EncryptedStorage.getItem(
+                        LEGACY_STORAGE_KEY
+                    );
+                } catch (error) {
+                    this.settingsLoadFailed = true;
+                    console.error('Could not read legacy settings', error);
+                    return this.settings;
+                }
+                this.settingsLoadFailed = false;
                 if (settings) {
                     const newSettings =
                         await MigrationsUtils.legacySettingsMigrations(
@@ -2020,7 +2070,44 @@ export default class SettingsStore {
     // call itself is typed `false | Result`); in-memory settings only
     // update when the write landed, so a blocked write cannot leave the
     // store advertising state that will not survive the imminent restart.
-    public async setSettings(settings: any): Promise<boolean> {
+    //
+    // Two further refusals protect the persisted wallet list from being
+    // replaced by state the app never actually read:
+    //
+    // 1. `settingsLoadFailed` - the last load threw, so the in-memory
+    //    settings are the defaults rather than the user's. Writing them
+    //    would persist a wallet-less blob over the real one. The latch
+    //    clears on the next successful load, and every updateSettings
+    //    re-reads first, so this self-heals as soon as the keychain
+    //    recovers.
+    // 2. Empty wallet list - a blob with no `nodes` must never overwrite
+    //    one that has them. Deleting the last wallet is the only
+    //    legitimate way to get there and opts in with `allowEmptyNodes`.
+    //    `this.settings` is the comparison base rather than a fresh read:
+    //    it tracks the last successful load or write, and refetching here
+    //    would add a keychain round trip to every write.
+    public async setSettings(
+        settings: any,
+        options?: SettingsWriteOptions
+    ): Promise<boolean> {
+        if (this.settingsLoadFailed) {
+            console.warn(
+                '[SettingsStore] refusing to persist settings: the last load failed'
+            );
+            return false;
+        }
+
+        if (
+            !options?.allowEmptyNodes &&
+            !hasNodes(settings) &&
+            hasNodes(this.settings)
+        ) {
+            console.warn(
+                '[SettingsStore] refusing to persist an empty wallet list over an existing one'
+            );
+            return false;
+        }
+
         this.loading = true;
         const persisted =
             (await Storage.setItem(STORAGE_KEY, settings)) !== false;
@@ -2039,10 +2126,11 @@ export default class SettingsStore {
     private updateSettingsQueue: Promise<unknown> = Promise.resolve();
 
     public updateSettings = (
-        newSetting: any | ((currentSettings: Settings) => any)
+        newSetting: any | ((currentSettings: Settings) => any),
+        options?: SettingsWriteOptions
     ): Promise<Settings> => {
         const task = this.updateSettingsQueue.then(() =>
-            this.applySettingsUpdate(newSetting)
+            this.applySettingsUpdate(newSetting, options)
         );
         // Keep the queue alive after a rejected update; the caller still
         // sees the rejection through `task`.
@@ -2051,7 +2139,8 @@ export default class SettingsStore {
     };
 
     private applySettingsUpdate = async (
-        newSetting: any | ((currentSettings: Settings) => any)
+        newSetting: any | ((currentSettings: Settings) => any),
+        options?: SettingsWriteOptions
     ) => {
         this.settingsUpdateInProgress = true;
         try {
@@ -2076,11 +2165,22 @@ export default class SettingsStore {
                 this.posWasEnabled = true;
             }
 
-            const persisted = await this.setSettings(newSettings);
+            // Nothing changed: skip the write. Persisting the blob is a
+            // delete-then-add of a single keychain item, so a no-op write
+            // is not free - it destroys and recreates the user's wallet
+            // list for nothing. The launch-time biometry refresh in
+            // views/Wallet/Wallet.tsx is the common case.
+            if (isEqual(existingSettings, newSettings)) {
+                return existingSettings;
+            }
+
+            const persisted = await this.setSettings(newSettings, options);
             if (!persisted) {
-                // Write latch engaged (data wipe in progress): nothing was
-                // persisted or kept in memory, so skip the derived-state
-                // updates that would advertise the unsaved settings.
+                // Write refused (data wipe in progress, a failed settings
+                // load, or an empty wallet list over a populated one):
+                // nothing was persisted or kept in memory, so skip the
+                // derived-state updates that would advertise the unsaved
+                // settings.
                 return this.settings;
             }
             this.triggerSettingsRefresh = true;

--- a/views/Settings/WalletConfiguration.tsx
+++ b/views/Settings/WalletConfiguration.tsx
@@ -895,7 +895,11 @@ export default class WalletConfiguration extends React.Component<
                         ),
                         justDeletedWallet: active
                     };
-                }
+                },
+                // Deleting the last wallet legitimately leaves `nodes`
+                // empty; every other empty write is refused so a failed
+                // settings load cannot wipe the wallet list.
+                { allowEmptyNodes: true }
             );
             const remainingNodes = newSettings?.nodes || [];
 

--- a/views/Wallet/Wallet.tsx
+++ b/views/Wallet/Wallet.tsx
@@ -324,13 +324,22 @@ export default class Wallet extends React.Component<WalletProps, WalletState> {
             this.handleAppStateChange
         );
 
-        const {
-            SettingsStore: { updateSettings }
-        } = this.props;
+        const { SettingsStore } = this.props;
+        const { updateSettings } = SettingsStore;
 
         const supportedBiometryType = await getSupportedBiometryType();
 
-        await updateSettings({ supportedBiometryType });
+        // updateSettings is a read-merge-write of the whole settings blob,
+        // which on iOS is a delete-then-add of one keychain item. This runs
+        // on every launch, so skip it unless the value actually changed.
+        // applySettingsUpdate short-circuits equal writes too; this check
+        // also avoids the read when the settings are already loaded.
+        if (
+            SettingsStore.settings?.supportedBiometryType !==
+            supportedBiometryType
+        ) {
+            await updateSettings({ supportedBiometryType });
+        }
 
         this.handleFocus();
     }


### PR DESCRIPTION
# Description

Relates to issue: **#4612** (surfaced while investigating #4610)

## Problem

`getSettings` could not distinguish a settings read that **failed** from a user who has **no** settings. On iOS `getInternetCredentials` resolves `false` only for `errSecItemNotFound`; every other `OSStatus` (locked item, missing entitlement, auth failure) rejects, and Android throws on decryption failures. A truncated or corrupt blob fails the same way in `JSON.parse`. All of those landed in the one `catch`, which only logged, so `getSettings` returned `this.settings`: the store's default object, which has no `nodes`.

The next write then persisted it. `Wallet.componentDidMount` refreshed `supportedBiometryType` through `updateSettings` on **every launch**, before anything had checked whether the settings actually loaded, so one transient read failure at startup was enough to replace the user's wallet list with the defaults. `Storage.setItem` is a delete-then-add of a single keychain item, so the previous blob is not retained, and while #4403 / #4385 are unfixed that item is synchronizable, which propagates the loss to the user's other devices.

Nothing here depends on iCloud: the same sequence loses the wallet list on Android. The iCloud bug is what turns a one-device loss into an all-device loss.

## Fix

Four guards, all in the write path:

1. **Distinguish error from absence.** `getSettings` latches `settingsLoadFailed` when the modern `Storage.getItem`, the `JSON.parse`, or the legacy `EncryptedStorage.getItem` throws, and clears it on the next successful load. `Storage.getItem` returning `false` still means "no settings" and takes the legacy / fresh-install path unchanged.
2. **Refuse writes while latched.** `setSettings` returns `false` without writing. Every `updateSettings` re-reads first, so this self-heals as soon as storage recovers; `applySettingsUpdate` already skips its derived-state updates when a write is refused.
3. **Never drop the wallet list.** `setSettings` refuses to persist a blob with no `nodes` over one that has them. `this.settings` is the comparison base rather than a fresh read, so no extra keychain round trip per write. Deleting the last wallet is the only legitimate caller and opts in via the new `SettingsWriteOptions.allowEmptyNodes`, threaded through `updateSettings`.
4. **Stop the unconditional launch write.** `applySettingsUpdate` skips the write entirely when the merged result deep-equals what is loaded, and `Wallet.componentDidMount` only calls `updateSettings` when `supportedBiometryType` actually changed. That removes one full read-merge-write of the blob from every cold start (helps #4470, and on iOS removes one delete-then-add of the shared keychain item per launch).

## Call-site audit for the empty-`nodes` guard

- `views/Settings/WalletConfiguration.tsx` deletion path: passes `{ allowEmptyNodes: true }` (the only opt-in).
- Duress/lockout wipe: no longer writes settings at all, it goes through `clearAllData()` + restart, so it is unaffected.
- `views/Settings/Wallets.tsx:78` `nodes: []` is component state, not a settings write.
- `CustodialWalletWarning`, the `EmbeddedNode/*` server pickers, and the import flow all write a non-empty `nodes` array.
- `MigrationUtils` writes go through `setSettings` with the loaded blob (non-empty when the user has wallets) or `Storage.setItem` directly, which is unchanged.

## Audit for the equality short-circuit

Skipping equal writes is only safe if no caller mutates settings in place and relies on the write. Checked: only `utils/MigrationUtils.ts` mutates in place, and it calls `setSettings` directly, which has no short-circuit. The `EmbeddedNode/*` pickers copy both the array and the node object. No caller uses `updateSettings` purely to trigger a refresh (`views/Lockscreen.tsx` and `views/Settings/SeedRecovery.tsx` set `triggerSettingsRefresh` directly).

## Migration plan

There is none to run, and that is deliberate:

- **No new persisted keys**, no change to the `zeus-settings-v2` shape, no `MOD_KEY` flag. Nothing to register in `STORAGE_KEYS` / `OTHER_KEYS` / `migrationKeys`.
- **Cohorts.** Fresh install: no persisted blob, `Storage.getItem` returns `false`, latch stays clear, writes proceed (covered by a test). Legacy blob user: unchanged path, plus the legacy read now latches instead of silently returning defaults. Modern v2 user: unchanged unless the read or parse fails, which previously destroyed the wallet list and now does nothing. User whose blob is already corrupt: writes are refused rather than overwriting it, which keeps the data available to the Keychain Recovery tool.
- **Idempotency / crash safety.** The latch is in-memory only and re-derived on every load, so a crash cannot leave it stuck.
- **Revert story.** Revert-safe. Nothing is written, deleted, or re-keyed by this change; reverting restores the old (unguarded) write behavior with no counter-migration.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

7 new tests in `stores/SettingsStore.test.ts` (`SettingsStore write guards`): failed read does not persist defaults over the wallet list, corrupt blob is not overwritten, writes resume after a later successful load, empty wallet list is refused over an existing one, the deletion opt-in still works, a fresh install with no wallets still persists, and an unchanged update performs no write. 6 of the 7 fail against the unmodified store; the seventh is the opt-in path, whose behavior is unchanged by design.

Full suite: 72 suites / 1581 tests pass, plus tsc, lint and prettier. The `MigrationUtils` mock in that file was also completed (`migrateRgsDefaultsToV2`, `migrateSwapHostsToBoltz`, `migrateRetiredSwapHosts`, `migrateOlympusHostsToZeusLsp`) so `getSettings` exercises its real path instead of throwing on an undefined mock.

Manual device matrix (pending, to be filled before merge):

- [ ] Fresh install: onboarding works, settings persist
- [ ] Upgrade from a release build with several wallets: all wallets intact, settings still writable
- [ ] Legacy blob upgrade
- [ ] Delete a wallet, and delete the last remaining wallet (the `allowEmptyNodes` path)
- [ ] Simulated read failure at launch: wallet list survives and writes resume on the next launch
- [ ] Corrupt blob: app does not overwrite it and the Keychain Recovery tool still sees the data

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Settings-layer change; applies to all backends. Device matrix above.

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

No new user-facing strings; the refusals log to the console only.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
