### PR TITLE
backends: type the CLN responses CLNRest reads

### DIFF
--- a/backends/CoreLightningRequestHandler.test.ts
+++ b/backends/CoreLightningRequestHandler.test.ts
@@ -1,4 +1,5 @@
 const mockPostRequest = jest.fn();
+const mockGetNode = jest.fn();
 
 // the handler constructs its CLNRest instance at import time, so postRequest
 // has to resolve the mock lazily
@@ -8,13 +9,21 @@ jest.mock('./CLNRest', () => ({
         postRequest(...args: Array<any>) {
             return mockPostRequest(...args);
         }
+        getNode(...args: Array<any>) {
+            return mockGetNode(...args);
+        }
     }
 }));
 // only used by getChainTransactions, but importing it pulls in the whole
 // store graph
 jest.mock('../utils/AddressUtils', () => ({ __esModule: true, default: {} }));
 
-import { getUTXOs } from './CoreLightningRequestHandler';
+import {
+    getUTXOs,
+    listClosedChannels,
+    listPeerChannels,
+    listPeers
+} from './CoreLightningRequestHandler';
 
 const listfunds = (outputs: Array<any>) => ({ outputs, channels: [] });
 
@@ -103,5 +112,193 @@ describe('CoreLightningRequestHandler.getUTXOs', () => {
         );
 
         await expect(getUTXOs()).rejects.toThrow('listfunds failed');
+    });
+});
+
+describe('CoreLightningRequestHandler.listPeerChannels', () => {
+    const channel = (overrides: any = {}): any => ({
+        state: 'CHANNELD_NORMAL',
+        peer_connected: true,
+        peer_id: 'peer-1',
+        ...overrides
+    });
+
+    beforeEach(() => {
+        mockGetNode.mockReset();
+        mockGetNode.mockResolvedValue({ nodes: [] });
+    });
+
+    it('reports 0 sats for a channel that carries no amounts yet', async () => {
+        // CLN sends the msat fields only once the channel is funded, and
+        // OPENINGD is not one of the states this mapper filters out, so the
+        // arithmetic used to produce "NaN" for every amount on the row
+        const { channels } = await listPeerChannels({
+            channels: [channel({ state: 'OPENINGD' })]
+        });
+
+        expect(channels[0]).toMatchObject({
+            capacity: '0',
+            local_balance: '0',
+            remote_balance: '0',
+            total_satoshis_sent: '0',
+            total_satoshis_received: '0',
+            num_updates: '0',
+            local_chan_reserve_sat: '0',
+            remote_chan_reserve_sat: '0'
+        });
+    });
+
+    it('converts msat amounts to sats', async () => {
+        const { channels } = await listPeerChannels({
+            channels: [
+                channel({
+                    total_msat: 1000000,
+                    to_us_msat: 400000,
+                    out_fulfilled_msat: 20000,
+                    in_fulfilled_msat: 5000
+                })
+            ]
+        });
+
+        expect(channels[0]).toMatchObject({
+            capacity: '1000',
+            local_balance: '400',
+            remote_balance: '600',
+            total_satoshis_sent: '20',
+            total_satoshis_received: '5'
+        });
+    });
+
+    it('drops channels that are closed or not yet locked in', async () => {
+        const { channels } = await listPeerChannels({
+            channels: [
+                channel({ state: 'ONCHAIN' }),
+                channel({ state: 'CHANNELD_AWAITING_LOCKIN' }),
+                channel({ state: 'CHANNELD_NORMAL' })
+            ]
+        });
+
+        expect(channels).toHaveLength(1);
+        expect(channels[0].active).toBe(true);
+    });
+
+    it('attaches the peer alias when the node is known', async () => {
+        mockGetNode.mockResolvedValue({ nodes: [{ alias: 'ACINQ' }] });
+
+        const { channels } = await listPeerChannels({
+            channels: [channel()]
+        });
+
+        expect(channels[0].alias).toBe('ACINQ');
+    });
+});
+
+describe('CoreLightningRequestHandler.listClosedChannels', () => {
+    const closed = (overrides: any = {}): any => ({
+        channel_id: 'chan-1',
+        opener: 'local',
+        private: false,
+        funding_txid: 'txid-1',
+        total_msat: 1000000,
+        final_to_us_msat: 400000,
+        min_to_us_msat: 300000,
+        max_to_us_msat: 900000,
+        total_htlcs_sent: 7,
+        close_cause: 'user',
+        ...overrides
+    });
+
+    it('reports 0 sats when no commitment fee was recorded', () => {
+        // last_commitment_fee_msat is the fee on last_commitment_txid, and
+        // neither is present for a channel that never had a commitment tx
+        const { channels } = listClosedChannels({
+            closedchannels: [closed()]
+        });
+
+        expect(channels[0].last_commitment_fee_satoshis).toBe('0');
+    });
+
+    it('maps a fully populated closed channel', () => {
+        const { channels } = listClosedChannels({
+            closedchannels: [
+                closed({
+                    peer_id: 'peer-1',
+                    short_channel_id: '122x1x1',
+                    last_commitment_txid: 'commit-1',
+                    last_commitment_fee_msat: 2895000,
+                    closer: 'remote',
+                    channel_type: {
+                        bits: [12],
+                        names: ['static_remotekey/even']
+                    }
+                })
+            ]
+        });
+
+        expect(channels[0]).toMatchObject({
+            remote_pubkey: 'peer-1',
+            short_channel_id: '122x1x1',
+            capacity: '1000',
+            closing_txid: 'commit-1',
+            last_commitment_fee_satoshis: '2895',
+            opener: 'local',
+            closer: 'remote',
+            close_cause: 'user',
+            channel_type: ['static_remotekey/even'],
+            total_htlcs_sent: '7',
+            to_us_msat: '400000'
+        });
+    });
+
+    it('reports no channel type when the node did not send one', () => {
+        // channel_type only became a required field in CLN v26.06
+        const { channels } = listClosedChannels({
+            closedchannels: [closed()]
+        });
+
+        expect(channels[0].channel_type).toEqual([]);
+    });
+});
+
+describe('CoreLightningRequestHandler.listPeers', () => {
+    beforeEach(() => {
+        mockGetNode.mockReset();
+        mockGetNode.mockResolvedValue({ nodes: [] });
+    });
+
+    it('maps a disconnected peer that carries no address or features', () => {
+        // the schema requires netaddr and features only while connected
+        return listPeers({
+            peers: [{ id: 'peer-1', connected: false, num_channels: 0 }]
+        }).then(({ peersWithAliases }) => {
+            expect(peersWithAliases[0]).toMatchObject({
+                id: 'peer-1',
+                connected: false,
+                num_channels: 0,
+                alias: ''
+            });
+        });
+    });
+
+    it('attaches the peer alias when the node is known', async () => {
+        mockGetNode.mockResolvedValue({ nodes: [{ alias: 'ACINQ' }] });
+
+        const { peersWithAliases } = await listPeers({
+            peers: [
+                {
+                    id: 'peer-1',
+                    connected: true,
+                    num_channels: 2,
+                    netaddr: ['1.2.3.4:9735'],
+                    features: '08a0000a0a69a2'
+                }
+            ]
+        });
+
+        expect(peersWithAliases[0]).toMatchObject({
+            alias: 'ACINQ',
+            netaddr: ['1.2.3.4:9735'],
+            features: '08a0000a0a69a2'
+        });
     });
 });

--- a/backends/CoreLightningRequestHandler.ts
+++ b/backends/CoreLightningRequestHandler.ts
@@ -1,6 +1,88 @@
 import CLNRest from './CLNRest';
 import AddressUtils from '../utils/AddressUtils';
 
+// Response shapes for the Core Lightning RPCs this module consumes.
+//
+// Typed from the schemas shipped with CLN (doc/schemas), cross-checked between
+// v24.11 - the oldest release CLNRest.supports() gates on - and v26.06.7. A
+// field is only non-optional here when the schema marks it required in both,
+// so anything optional below really can be missing from a node Zeus supports.
+// `*_msat` values arrive as plain JSON numbers, not "1234msat" strings.
+//
+// These describe what the handlers below read, not the full CLN response.
+
+export interface IClnChannelType {
+    bits: number[];
+    names: string[];
+}
+
+// lightning-listpeerchannels
+export interface IClnPeerChannel {
+    // one of the 14 values in the schema's `state` enum, e.g. CHANNELD_NORMAL
+    state: string;
+    peer_connected: boolean;
+    peer_id: string;
+    // A channel that is not funded yet carries no balances, no funding txid
+    // and no ids, so everything below can be absent.
+    funding_txid?: string;
+    channel_id?: string;
+    short_channel_id?: string;
+    total_msat?: number;
+    to_us_msat?: number;
+    out_fulfilled_msat?: number;
+    in_fulfilled_msat?: number;
+    in_payments_offered?: number;
+    out_payments_offered?: number;
+    our_to_self_delay?: number;
+    private?: boolean;
+    our_reserve_msat?: number;
+    their_reserve_msat?: number;
+    // only when a close address was negotiated
+    close_to_addr?: string;
+}
+
+// lightning-listclosedchannels
+export interface IClnClosedChannel {
+    channel_id: string;
+    opener: 'local' | 'remote';
+    private: boolean;
+    funding_txid: string;
+    total_msat: number;
+    final_to_us_msat: number;
+    min_to_us_msat: number;
+    max_to_us_msat: number;
+    total_htlcs_sent: number;
+    close_cause:
+        | 'unknown'
+        | 'local'
+        | 'user'
+        | 'remote'
+        | 'protocol'
+        | 'onchain';
+    // "can be missing with pre-v23.05 closes", per the schema
+    peer_id?: string;
+    short_channel_id?: string;
+    // absent for channels that never had a commitment tx, and the fee below
+    // is the fee on that same tx
+    last_commitment_txid?: string;
+    last_commitment_fee_msat?: number;
+    // only present if the channel was closed by one of the two sides
+    closer?: 'local' | 'remote';
+    // required from v26.06 on, absent on older nodes
+    channel_type?: IClnChannelType;
+    last_stable_connection?: number;
+}
+
+// lightning-listpeers
+export interface IClnPeer {
+    id: string;
+    connected: boolean;
+    num_channels: number;
+    // the schema requires these only while `connected` is true
+    netaddr?: string[];
+    features?: string;
+}
+
 const api = new CLNRest();
 
 // Returns onchain balance of core-lightning node
@@ -70,9 +152,11 @@ export const getOffchainBalance = (data: any) => {
 };
 
 // Get your peers and the channel info for core lightning node
-export const listPeerChannels = async (data: any) => {
+export const listPeerChannels = async (data: {
+    channels: IClnPeerChannel[];
+}) => {
     const formattedChannels = data.channels
-        .map((peer: any) => {
+        .map((peer: IClnPeerChannel) => {
             if (
                 peer.state === 'ONCHAIN' ||
                 peer.state === 'CLOSED' ||
@@ -87,27 +171,31 @@ export const listPeerChannels = async (data: any) => {
                 channel_point: peer.funding_txid,
                 chan_id: peer.channel_id,
                 short_channel_id: peer.short_channel_id,
-                capacity: Number(peer.total_msat / 1000).toString(),
-                local_balance: Number(peer.to_us_msat / 1000).toString(),
+                // These are absent until the channel is funded, and this
+                // mapper is reached in states where that is still true, so
+                // fall back to 0 rather than reporting "NaN" sats.
+                capacity: Number((peer.total_msat ?? 0) / 1000).toString(),
+                local_balance: Number((peer.to_us_msat ?? 0) / 1000).toString(),
                 remote_balance: Number(
-                    (peer.total_msat - peer.to_us_msat) / 1000
+                    ((peer.total_msat ?? 0) - (peer.to_us_msat ?? 0)) / 1000
                 ).toString(),
                 total_satoshis_sent: Number(
-                    peer.out_fulfilled_msat / 1000
+                    (peer.out_fulfilled_msat ?? 0) / 1000
                 ).toString(),
                 total_satoshis_received: Number(
-                    peer.in_fulfilled_msat / 1000
+                    (peer.in_fulfilled_msat ?? 0) / 1000
                 ).toString(),
                 num_updates: (
-                    peer.in_payments_offered + peer.out_payments_offered
+                    (peer.in_payments_offered ?? 0) +
+                    (peer.out_payments_offered ?? 0)
                 ).toString(),
                 csv_delay: peer.our_to_self_delay,
                 private: peer.private,
                 local_chan_reserve_sat: Number(
-                    peer.our_reserve_msat / 1000
+                    (peer.our_reserve_msat ?? 0) / 1000
                 ).toString(),
                 remote_chan_reserve_sat: Number(
-                    peer.their_reserve_msat / 1000
+                    (peer.their_reserve_msat ?? 0) / 1000
                 ).toString(),
                 close_address: peer.close_to_addr
             };
@@ -132,8 +220,10 @@ export const listPeerChannels = async (data: any) => {
 };
 
 // Returns a list of closed Lightning Network channels
-export const listClosedChannels = (data: any) => {
-    const formattedClosedChannels = data.closedchannels.map((channel: any) => ({
+export const listClosedChannels = (data: {
+    closedchannels: IClnClosedChannel[];
+}) => {
+    const formattedClosedChannels = data.closedchannels.map((channel) => ({
         remote_pubkey: channel.peer_id,
         capacity: Number(channel.total_msat / 1000).toString(),
         channel_id: channel.channel_id,
@@ -150,8 +240,9 @@ export const listClosedChannels = (data: any) => {
         max_to_us_satoshis: Number(channel.max_to_us_msat / 1000).toString(),
         total_htlcs_sent: channel.total_htlcs_sent.toString(),
         close_cause: channel.close_cause,
+        // absent when the channel had no commitment tx to pay a fee on
         last_commitment_fee_satoshis: Number(
-            channel.last_commitment_fee_msat / 1000
+            (channel.last_commitment_fee_msat ?? 0) / 1000
         ).toString(),
         last_stable_connection: channel.last_stable_connection
     }));
@@ -159,8 +250,8 @@ export const listClosedChannels = (data: any) => {
     return { channels: formattedClosedChannels };
 };
 
-export const listPeers = async (data: any) => {
-    const formattedPeers = data.peers.map((peer: any) => {
+export const listPeers = async (data: { peers: IClnPeer[] }) => {
+    const formattedPeers = data.peers.map((peer) => {
         return {
             id: peer.id,
             connected: peer.connected,


### PR DESCRIPTION
# Description

Relates to issue: #3925

`listPeerChannels`, `listClosedChannels` and `listPeers` took `any` and read fields straight off it. This adds interfaces for the three Core Lightning responses this handler consumes.

The types are not guessed. They come from the schemas shipped with CLN in `doc/schemas`, cross-checked between **v24.11** - the oldest release `CLNRest.supports()` gates on - and **v26.06.7**. A field is only non-optional here when both schemas mark it required, so everything optional in the interfaces can really be missing from a node ZEUS supports. `*_msat` values are typed as numbers because that is what the schemas' own recorded examples show on the wire, and because the mapper already does arithmetic on them.

## What the types found

Making the optional fields optional turned eleven reads into type errors. Every one of them was arithmetic on a value CLN may not send, and every one produced the string `NaN`:

- peer channels: `capacity`, `local_balance`, `remote_balance`, `total_satoshis_sent`, `total_satoshis_received`, `num_updates`, `local_chan_reserve_sat`, `remote_chan_reserve_sat`
- closed channels: `last_commitment_fee_satoshis`

They now fall back to 0. The peer-channel ones are reachable in practice: `OPENINGD` is not among the three states the mapper filters out, and a channel in that state carries no amounts yet.

## Left alone, for you to judge

Three things the schemas show that I did not change, because they are behaviour on a backend path rather than typing:

- The mapper skips `state === 'CLOSED'`, but `CLOSED` is not one of the 14 values in the `state` enum in either v24.11 or v26.06.7, so that branch looks unreachable. I typed `state` as `string` rather than the enum so the check still compiles.
- On closed channels `peer_id` is optional ("can be missing with pre-v23.05 closes", per the schema) and so is `last_commitment_txid`. Those are the two fields #3924 mapped to `remote_pubkey` and `closing_txid` to get the peer name and the close-tx link into the UI, so on an old close both quietly fall back.
- `last_commitment_fee_satoshis` is written here and read nowhere else in the repo.

## Scope

The issue asks for interfaces for the CLN API response, so that is what this covers. The `any` on the other side of the mappers - the LND-shaped objects the handlers return - is untouched.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [x] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

Nine new cases in `backends/CoreLightningRequestHandler.test.ts`, extending the harness already there: the absent-amount cases on both channel mappers, the msat-to-sats conversion, the state filter, the alias lookup, and a disconnected peer that carries neither `netaddr` nor `features`. Both absent-amount cases fail without the fallbacks in the first commit; I checked by removing them.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

Neither. The changed code path only runs against a Core Lightning node, which I do not have, so a device pass would not have exercised any of it. What the change does is type-level plus the 0 fallbacks above, and that part is covered by the unit tests.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

None. I could not test against a CLN node. The field-by-field basis for the types is CLN's published schemas at the two versions named above rather than one node's output, which also covers the states a single node would not have shown me.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
