### PR TITLE
fix: NaN amount when scanning a BIP21 QR from inside the Send view

### DIFF
--- a/utils/AmountUtils.test.ts
+++ b/utils/AmountUtils.test.ts
@@ -2,6 +2,7 @@ import {
     processSatsAmount,
     shouldHideMillisatoshiAmounts,
     getUnformattedAmount,
+    getRawAmountFromSats,
     getAmountFromSats,
     getFormattedAmount,
     getFeePercentage,
@@ -1052,8 +1053,10 @@ describe('AmountUtils', () => {
     // Regression: a BIP21 amount handed to Send/ClinkPay is fed into
     // AmountInput's `amount` prop, which parses it back into sats with
     // getSatAmount. getAmountFromSats returns a *display* string, so using it
-    // there rendered '12,618 sats sats' and a NaN conversion.
-    describe('AmountInput round-trip', () => {
+    // there rendered '12,618 sats sats' and a NaN conversion. Both views now
+    // go through getRawAmountFromSats, so its output must survive the round
+    // trip in every unit mode.
+    describe('AmountInput round-trip (getRawAmountFromSats)', () => {
         beforeEach(() => {
             (settingsStore as any).settings = {
                 fiat: 'USD',
@@ -1072,17 +1075,38 @@ describe('AmountUtils', () => {
             ];
         });
 
-        it('round-trips getUnformattedAmount output in sats', () => {
+        it('round-trips in sats', () => {
             (unitsStore as any).units = 'sats';
-            const { amount } = getUnformattedAmount({ sats: 12618 });
-            expect(amount).toBe('12618');
-            expect(getSatAmount(amount)).toBe(12618);
+            expect(getRawAmountFromSats(12618)).toBe('12618');
+            expect(getSatAmount(getRawAmountFromSats(12618))).toBe(12618);
+            // route params deliver satAmount as a string
+            expect(getSatAmount(getRawAmountFromSats('12618'))).toBe(12618);
         });
 
-        it('round-trips getUnformattedAmount output in BTC', () => {
+        it('round-trips in BTC', () => {
             (unitsStore as any).units = 'BTC';
-            const { amount } = getUnformattedAmount({ sats: 12618 });
-            expect(getSatAmount(amount)).toBe(12618);
+            expect(getRawAmountFromSats(12618)).toBe('0.00012618');
+            expect(getSatAmount(getRawAmountFromSats(12618))).toBe(12618);
+        });
+
+        it('round-trips in fiat when the rate divides evenly', () => {
+            (unitsStore as any).units = 'fiat';
+            // 12,000 sats at 50,000 USD/BTC is exactly $6.00
+            expect(getRawAmountFromSats(12000)).toBe('6.00');
+            expect(getSatAmount(getRawAmountFromSats(12000))).toBe(12000);
+        });
+
+        it('round-trips in fiat to cent precision otherwise', () => {
+            (unitsStore as any).units = 'fiat';
+            // 12,618 sats is $6.309, which displays as $6.31 = 12,620 sats.
+            // Lossy by design (cent rounding), but parseable - never NaN.
+            expect(getRawAmountFromSats(12618)).toBe('6.31');
+            expect(getSatAmount(getRawAmountFromSats(12618))).toBe(12620);
+        });
+
+        it('respects fixedUnits over the active unit', () => {
+            (unitsStore as any).units = 'fiat';
+            expect(getRawAmountFromSats(12618, 'sats')).toBe('12618');
         });
 
         it('getAmountFromSats output is display-only and does not round-trip', () => {
@@ -1092,9 +1116,13 @@ describe('AmountUtils', () => {
             expect(getSatAmount(getAmountFromSats(12618)!)).toBe(0);
         });
 
-        it('returns 0 rather than NaN for unparseable input', () => {
+        it('getSatAmount returns 0 rather than NaN for unparseable input', () => {
             (unitsStore as any).units = 'sats';
             expect(getSatAmount('12,618 sats')).toBe(0);
+            // AmountInput used to write the literal string 'NaN' back into
+            // Send's satAmount, slipping past every `<= 0` proceed guard
+            expect(getSatAmount('NaN')).toBe(0);
+            expect(getSatAmount('abc')).toBe(0);
             (unitsStore as any).units = 'BTC';
             expect(getSatAmount('\u20bf0.00012618')).toBe(0);
         });

--- a/utils/AmountUtils.test.ts
+++ b/utils/AmountUtils.test.ts
@@ -1048,4 +1048,55 @@ describe('AmountUtils', () => {
             expect(getFeePercentage(1, 1000000)).toBe('0%');
         });
     });
+
+    // Regression: a BIP21 amount handed to Send/ClinkPay is fed into
+    // AmountInput's `amount` prop, which parses it back into sats with
+    // getSatAmount. getAmountFromSats returns a *display* string, so using it
+    // there rendered '12,618 sats sats' and a NaN conversion.
+    describe('AmountInput round-trip', () => {
+        beforeEach(() => {
+            (settingsStore as any).settings = {
+                fiat: 'USD',
+                display: {
+                    removeDecimalSpaces: false,
+                    showAllDecimalPlaces: false
+                }
+            };
+            (fiatStore as any).fiatRates = [
+                {
+                    code: 'USD',
+                    rate: 50000,
+                    cryptoCode: 'BTC',
+                    currencyPair: 'USD/BTC'
+                }
+            ];
+        });
+
+        it('round-trips getUnformattedAmount output in sats', () => {
+            (unitsStore as any).units = 'sats';
+            const { amount } = getUnformattedAmount({ sats: 12618 });
+            expect(amount).toBe('12618');
+            expect(getSatAmount(amount)).toBe(12618);
+        });
+
+        it('round-trips getUnformattedAmount output in BTC', () => {
+            (unitsStore as any).units = 'BTC';
+            const { amount } = getUnformattedAmount({ sats: 12618 });
+            expect(getSatAmount(amount)).toBe(12618);
+        });
+
+        it('getAmountFromSats output is display-only and does not round-trip', () => {
+            (unitsStore as any).units = 'sats';
+            expect(getAmountFromSats(12618)).toBe('12,618 sats');
+            // guarded to 0 rather than NaN so amount checks still reject it
+            expect(getSatAmount(getAmountFromSats(12618)!)).toBe(0);
+        });
+
+        it('returns 0 rather than NaN for unparseable input', () => {
+            (unitsStore as any).units = 'sats';
+            expect(getSatAmount('12,618 sats')).toBe(0);
+            (unitsStore as any).units = 'BTC';
+            expect(getSatAmount('\u20bf0.00012618')).toBe(0);
+        });
+    });
 });

--- a/utils/AmountUtils.ts
+++ b/utils/AmountUtils.ts
@@ -404,5 +404,7 @@ export function getSatAmount(
             break;
     }
 
-    return satAmount;
+    // never hand back NaN - it is falsy in some checks and truthy once
+    // stringified, which lets unparseable input slip past amount guards
+    return isNaN(satAmount) ? 0 : satAmount;
 }

--- a/utils/AmountUtils.ts
+++ b/utils/AmountUtils.ts
@@ -194,6 +194,22 @@ export function getUnformattedAmount({
 }
 
 /**
+ * Converts satoshis to the raw, unformatted amount string in the active unit,
+ * fit for editable inputs like AmountInput's `amount` prop. That prop is
+ * parsed back into satoshis with getSatAmount, so it must never receive a
+ * display-formatted string from getAmountFromSats (e.g. '12,618 sats').
+ * @param sats - The amount in satoshis (string or number)
+ * @param fixedUnits - Optional unit override ('sats', 'BTC', or 'fiat')
+ * @returns Raw amount string like "0.00012618", "12618", or "6.31"
+ */
+export function getRawAmountFromSats(
+    sats: string | number,
+    fixedUnits?: string
+): string {
+    return getUnformattedAmount({ sats, fixedUnits }).amount || sats.toString();
+}
+
+/**
  * Converts satoshi amounts to formatted display strings
  * @param value - The amount in satoshis (string or number)
  * @param fixedUnits - Optional unit override ('sats', 'BTC', or 'fiat')

--- a/views/ClinkPay/ClinkPay.tsx
+++ b/views/ClinkPay/ClinkPay.tsx
@@ -23,7 +23,7 @@ import { errorToUserFriendly } from '../../utils/ErrorUtils';
 import handleAnything from '../../utils/handleAnything';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
-import { getAmountFromSats } from '../../utils/AmountUtils';
+import { getUnformattedAmount } from '../../utils/AmountUtils';
 
 interface ClinkPayProps {
     navigation: NativeStackNavigationProp<any, any>;
@@ -115,8 +115,9 @@ export default class ClinkPay extends React.Component<
             ) {
                 satAmount = nofferData.price.toString();
                 amount =
-                    getAmountFromSats(nofferData.price.toString()) ||
-                    nofferData.price.toString();
+                    getUnformattedAmount({
+                        sats: nofferData.price.toString()
+                    }).amount || nofferData.price.toString();
             }
         } catch (err: any) {
             Alert.alert(

--- a/views/ClinkPay/ClinkPay.tsx
+++ b/views/ClinkPay/ClinkPay.tsx
@@ -23,7 +23,7 @@ import { errorToUserFriendly } from '../../utils/ErrorUtils';
 import handleAnything from '../../utils/handleAnything';
 import { localeString } from '../../utils/LocaleUtils';
 import { themeColor } from '../../utils/ThemeUtils';
-import { getUnformattedAmount } from '../../utils/AmountUtils';
+import { getRawAmountFromSats } from '../../utils/AmountUtils';
 
 interface ClinkPayProps {
     navigation: NativeStackNavigationProp<any, any>;
@@ -114,10 +114,7 @@ export default class ClinkPay extends React.Component<
                 nofferData.price
             ) {
                 satAmount = nofferData.price.toString();
-                amount =
-                    getUnformattedAmount({
-                        sats: nofferData.price.toString()
-                    }).amount || nofferData.price.toString();
+                amount = getRawAmountFromSats(satAmount);
             }
         } catch (err: any) {
             Alert.alert(

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -49,7 +49,7 @@ import { errorToUserFriendly } from '../utils/ErrorUtils';
 import { scanNfcTag } from '../utils/NFCUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
-import { getUnformattedAmount, getAmountFromSats } from '../utils/AmountUtils';
+import { getUnformattedAmount } from '../utils/AmountUtils';
 import { clearPendingPaymentData } from '../utils/GraphSyncUtils';
 
 import NFC from '../assets/images/SVG/NFC-alt.svg';
@@ -215,7 +215,13 @@ export default class Send extends React.Component<SendProps, SendState> {
             };
 
             if (satAmount) {
-                const amount = getAmountFromSats(satAmount) || satAmount;
+                // must be the raw, unformatted value in the active unit -
+                // AmountInput's `amount` prop is parsed back into sats, so a
+                // display-formatted string (eg '12,618 sats') yields NaN
+                const amount =
+                    getUnformattedAmount({
+                        sats: satAmount
+                    }).amount || satAmount;
                 stateUpdate.amount = amount;
                 stateUpdate.satAmount = satAmount;
             }

--- a/views/Send.tsx
+++ b/views/Send.tsx
@@ -49,7 +49,7 @@ import { errorToUserFriendly } from '../utils/ErrorUtils';
 import { scanNfcTag } from '../utils/NFCUtils';
 import { localeString } from '../utils/LocaleUtils';
 import { themeColor } from '../utils/ThemeUtils';
-import { getUnformattedAmount } from '../utils/AmountUtils';
+import { getRawAmountFromSats } from '../utils/AmountUtils';
 import { clearPendingPaymentData } from '../utils/GraphSyncUtils';
 
 import NFC from '../assets/images/SVG/NFC-alt.svg';
@@ -152,10 +152,7 @@ export default class Send extends React.Component<SendProps, SendState> {
 
         let amount;
         if (satAmount) {
-            amount =
-                getUnformattedAmount({
-                    sats: satAmount
-                }).amount || satAmount;
+            amount = getRawAmountFromSats(satAmount);
         }
 
         this.state = {
@@ -218,11 +215,7 @@ export default class Send extends React.Component<SendProps, SendState> {
                 // must be the raw, unformatted value in the active unit -
                 // AmountInput's `amount` prop is parsed back into sats, so a
                 // display-formatted string (eg '12,618 sats') yields NaN
-                const amount =
-                    getUnformattedAmount({
-                        sats: satAmount
-                    }).amount || satAmount;
-                stateUpdate.amount = amount;
+                stateUpdate.amount = getRawAmountFromSats(satAmount);
                 stateUpdate.satAmount = satAmount;
             }
             if (fee) {


### PR DESCRIPTION
# Description

Fixes the [user report from leito on nostr](https://damus.io/nevent1qqsqqqzwv0qt8ylan9rlfw0a2e76tvuq9a40xw4x73ydwm7erykc42c8quu0z): scanning a BTCPay Server on-chain QR shows `12,618 sats sats` in the amount field and `₿NaN` in the conversion line beneath it. Reported on v13.2.1.

<img width="400" src="https://blossom.primal.net/c4955554c35814e7994b0d3d18583b956f810bccebeefa05f21439d0503a6daa.jpg" />

## Root cause

`Send`'s constructor converts the incoming `satAmount` route param with `getUnformattedAmount({ sats })`, which returns a raw value (`"12618"`). `componentDidUpdate` instead used `getAmountFromSats()`, which is a **display** formatter and returns `"12,618 sats"`.

`AmountInput`'s `amount` prop must be a raw value in the active unit, so that string:

1. renders as `numberWithCommas("12,618 sats") + " sats"` → `12,618 sats sats`
2. is parsed back with `getSatAmount()` → `Number("12.618 sats")` → `NaN` → `₿NaN`

## Why it looked intermittent

The reporter later said they couldn't replicate it. It depends on **where the scanner was opened from**, not on the QR:

- Wallet → scan → `Send` is pushed fresh → constructor runs → fine
- `Send` → scan button → `HandleAnythingQRScanner` does `goBack(); navigate('Send', props)`. `Send` is already in the native stack, so v7 merges params instead of remounting → `componentDidUpdate` → broken

Paste-from-clipboard and the contacts picker on `Send` go through `validateAddress` → `navigate('Send', ...)` and hit the same path.

## Not just cosmetic

The On-chain `AmountInput` only mounts once `transactionType` flips to `'On-chain'`, and its constructor calls `onAmountChange(amount, getSatAmount(amount).toString())` — writing the **string `"NaN"`** back over `Send`'s correct `satAmount`. `"NaN"` is truthy and `Number("NaN") <= 0` is false, so every Proceed-button guard passed and the user could continue to `VerifyOnChain` with a garbage amount.

`getSatAmount` now returns `0` instead of `NaN` so unparseable input can't slip past those guards.

## Also fixed

`views/ClinkPay/ClinkPay.tsx` made the same display-vs-raw mix-up, so a fixed-price noffer showed `1,000 sats sats`.

## Regression window

Introduced in 8c8245a877e38d108f832d349d659220f6c957da (*refactor: specify amount as sats wherever possible*, May 2025), which fixed the constructor but left `UNSAFE_componentWillReceiveProps` on the old helper. fdad118ed4a72cd3824863638f668215c01c3b85 carried it over verbatim into `componentDidUpdate`. Present in every release since v0.11.0, including v13.2.1.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

`views/Send.tsx` and `views/ClinkPay/ClinkPay.tsx` now route through a new `getRawAmountFromSats()` helper in `utils/AmountUtils.ts`: views have no test harness, so the shared expression was extracted so that the exact code the views run is the unit under test. 7 regression tests in `utils/AmountUtils.test.ts` cover the `AmountInput` round-trip invariant (whatever is handed to `AmountInput`'s `amount` prop must survive `getSatAmount()`) in all three unit modes, plus the `fixedUnits` override and the `NaN` guard, including the literal `'NaN'` string that `AmountInput` used to write back over `satAmount`.

Values on master vs this branch (USD rate 50,000, as in the test mocks):

| Call | Active unit | master | this PR |
|---|---|---|---|
| `getUnformattedAmount({ sats: 12618 }).amount` | sats | `'12618'` | `'12618'` |
| `getAmountFromSats(12618)` (display-only) | sats | `'12,618 sats'` | `'12,618 sats'` |
| `getRawAmountFromSats(12618)` | sats | n/a (new) | `'12618'` |
| `getRawAmountFromSats(12618)` | BTC | n/a (new) | `'0.00012618'` |
| `getRawAmountFromSats(12618)` | fiat | n/a (new) | `'6.31'` |
| `getSatAmount('12,618 sats')` | sats | `NaN` | `0` |
| `getSatAmount('NaN')` | sats | `NaN` | `0` |
| `getSatAmount('₿0.00012618')` | BTC | `NaN` | `0` |

What the user sees when scanning a BIP21 with `amount=0.00012618` from inside Send, in sats mode:

| Step | master | this PR |
|---|---|---|
| `componentDidUpdate` computes `amount` | `'12,618 sats'` (display string) | `'12618'` (raw) |
| Amount field renders | `12,618 sats sats` | `12,618 sats` |
| Conversion line | `₿NaN` | `₿0.00012618` |
| `satAmount` written back by `AmountInput` | `'NaN'` (passes the `<= 0` guards) | `'12618'` |

Note the fiat path is lossy to cent precision by design (12,618 sats displays as $6.31, which parses back to 12,620 sats) but is always parseable, never `NaN`.

Failing-test-first check: run against master's `AmountUtils.ts` (or with the `isNaN` guard reverted), the guard tests fail with `Received: NaN`; all 113 tests in the file pass with the fix.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

**Not yet device-tested — draft pending manual verification.** Suggested manual repro: open Send, tap the in-view scan button, scan a BTCPay on-chain BIP21 with an `amount=`. Before this change the field reads `... sats sats` with `₿NaN`; after, it reads the correct amount. Worth checking in all three unit modes (sats/BTC/fiat) and the ClinkPay fixed-price noffer path.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

The change is in view/util code above the backend dispatch layer, so it is backend-independent.

### Locales
- [ ] I’ve added new locale text that requires translations
- [x] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

---

The reporter also mentioned "LN payments are not working for me either" against the same BTCPay instance. That is unconfirmed and not addressed here — a BOLT11 scan routes to `PaymentRequest`, not through this code.

