### PR TITLE
fix(cashu): omit zero-valued NUT-11 tags so P2PK tokens are redeemable

### DIFF
--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -59,28 +59,48 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         val data = json.optJSONObject("data") ?: return null
         val pubkeyHex = data.optString("pubkey").takeIf { it.isNotEmpty() } ?: return null
 
-        val locktime = if (data.has("locktime") && !data.isNull("locktime")) {
-            data.optLong("locktime").toULong()
-        } else {
-            0UL
-        }
+        // NUT-11 tags must be omitted entirely when they don't apply. Emitting
+        // them with a value of 0 (["locktime", "0"], ["n_sigs", "0"],
+        // ["n_sigs_refund", "0"]) produces tokens that mints such as CDK refuse
+        // to redeem, and a zero locktime marks the lock as already expired.
+        val locktime = optionalPositiveULong(data, "locktime")
+        val numSigs = optionalPositiveULong(data, "num_sigs")
+        val numSigsRefund = optionalPositiveULong(data, "num_sigs_refund")
+
+        val pubkeys = data.optJSONArray("pubkeys")?.let { arr ->
+            (0 until arr.length()).mapNotNull { i ->
+                arr.optString(i).takeIf { it.isNotEmpty() }
+            }
+        } ?: emptyList()
+
         val refundKeys = data.optJSONArray("refund_keys")?.let { arr ->
             (0 until arr.length()).mapNotNull { i ->
                 arr.optString(i).takeIf { it.isNotEmpty() }
             }
         } ?: emptyList()
 
+        val sigFlag: UByte = if (data.optString("sig_flag") == "SigAll") 1.toUByte() else 0.toUByte()
+
         return SpendingConditions.P2pk(
             pubkey = pubkeyHex,
             conditions = Conditions(
                 locktime = locktime,
-                pubkeys = emptyList(),
+                pubkeys = pubkeys,
                 refundKeys = refundKeys,
-                numSigs = 0UL,
-                sigFlag = 0.toUByte(),
-                numSigsRefund = 0UL
+                numSigs = numSigs,
+                sigFlag = sigFlag,
+                numSigsRefund = numSigsRefund
             )
         )
+    }
+
+    /**
+     * Returns the value at [key] only when it is a positive integer, so that
+     * optional NUT-11 tags stay absent instead of being serialized as 0.
+     */
+    private fun optionalPositiveULong(json: JSONObject, key: String): ULong? {
+        if (!json.has(key) || json.isNull(key)) return null
+        return readPositiveLong(json, key).takeIf { it > 0L }?.toULong()
     }
 
     private fun readPositiveLong(json: JSONObject, key: String): Long {

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -81,6 +81,21 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
         val sigFlag: UByte = if (data.optString("sig_flag") == "SigAll") 1.toUByte() else 0.toUByte()
 
+        // NUT-11: "If n_sigs or n_sigs_refund ... exceeds the total number of
+        // keys in its pathway, the P2PK secret is malformed and the Proof
+        // MUST be rejected as unspendable." The mint only enforces this at
+        // redemption time, so an out-of-range value here would otherwise
+        // silently mint a token nobody can ever fully sign for. Main pathway
+        // has `1 (pubkey) + pubkeys.size` possible signers; refund pathway
+        // has `refundKeys.size`.
+        val maxMainSigs = 1 + pubkeys.size
+        require(numSigs == null || numSigs.toInt() <= maxMainSigs) {
+            "num_sigs ($numSigs) exceeds the number of available pubkeys ($maxMainSigs)"
+        }
+        require(numSigsRefund == null || numSigsRefund.toInt() <= refundKeys.size) {
+            "num_sigs_refund ($numSigsRefund) exceeds the number of available refund_keys (${refundKeys.size})"
+        }
+
         return SpendingConditions.P2pk(
             pubkey = pubkeyHex,
             conditions = Conditions(
@@ -956,11 +971,15 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
 
         scope.launch {
             try {
-                // Parse spending conditions if provided
+                // Parse spending conditions if provided. Only tolerate a
+                // malformed JSON *blob* silently (treat as "no conditions");
+                // a validation failure inside well-formed conditions (e.g. an
+                // impossible num_sigs) must fail loudly instead of quietly
+                // minting an unlocked proof the caller never asked for.
                 val conditions = conditionsJson?.let { json ->
-                    runCatching {
-                        parseP2PKConditions(JSONObject(json))
-                    }.getOrNull()
+                    val parsed = runCatching { JSONObject(json) }.getOrNull()
+                        ?: return@let null
+                    parseP2PKConditions(parsed)
                 }
                 val wallet = getWallet(mintUrl)
                 val proofs = wallet.mint(

--- a/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
+++ b/android/app/src/main/java/com/zeus/cashudevkit/CashuDevKitModule.kt
@@ -87,12 +87,15 @@ class CashuDevKitModule(private val reactContext: ReactApplicationContext) :
         // redemption time, so an out-of-range value here would otherwise
         // silently mint a token nobody can ever fully sign for. Main pathway
         // has `1 (pubkey) + pubkeys.size` possible signers; refund pathway
-        // has `refundKeys.size`.
+        // has `refundKeys.size`. Compared in the unsigned domain rather than
+        // via toInt(), which truncates to the low 32 bits (e.g. 4294967296
+        // -> 0) and could let a huge num_sigs wrap into a small, passing
+        // value instead of being rejected.
         val maxMainSigs = 1 + pubkeys.size
-        require(numSigs == null || numSigs.toInt() <= maxMainSigs) {
+        require(numSigs == null || numSigs <= maxMainSigs.toULong()) {
             "num_sigs ($numSigs) exceeds the number of available pubkeys ($maxMainSigs)"
         }
-        require(numSigsRefund == null || numSigsRefund.toInt() <= refundKeys.size) {
+        require(numSigsRefund == null || numSigsRefund <= refundKeys.size.toULong()) {
             "num_sigs_refund ($numSigsRefund) exceeds the number of available refund_keys (${refundKeys.size})"
         }
 

--- a/cashu-cdk/types.ts
+++ b/cashu-cdk/types.ts
@@ -120,9 +120,16 @@ export interface CDKSpendingConditions {
 
 export interface CDKP2PKCondition {
     pubkey: string;
+    /**
+     * Optional NUT-11 tags. Leave them undefined when they don't apply - a
+     * value of 0 is serialized as a tag (e.g. ["n_sigs", "0"]) that mints
+     * reject.
+     */
     locktime?: number;
+    pubkeys?: string[];
     refund_keys?: string[];
     num_sigs?: number;
+    num_sigs_refund?: number;
     sig_flag?: 'SigInputs' | 'SigAll';
 }
 

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -42,39 +42,57 @@ class CashuDevKitModule: RCTEventEmitter {
 
     /// Parse P2PK spending conditions from JSON dictionary
     private func parseP2PKConditions(from json: [String: Any]) -> SpendingConditions? {
-       guard let kind = json["kind"] as? String,
-          kind == "P2PK",
-          let condData = json["data"] as? [String: Any],
-          let pubkey = condData["pubkey"] as? String,
-          !pubkey.isEmpty else {
-        return nil
+        guard let kind = json["kind"] as? String,
+              kind == "P2PK",
+              let condData = json["data"] as? [String: Any],
+              let pubkey = condData["pubkey"] as? String,
+              !pubkey.isEmpty else {
+            return nil
+        }
+
+        // NUT-11 tags must be omitted entirely when they don't apply. Emitting
+        // them with a value of 0 (`["locktime", "0"]`, `["n_sigs", "0"]`,
+        // `["n_sigs_refund", "0"]`) produces tokens that mints such as CDK
+        // refuse to redeem, and a zero locktime marks the lock as already
+        // expired.
+        let locktime = optionalPositiveUInt64(from: condData, key: "locktime")
+        let numSigs = optionalPositiveUInt64(from: condData, key: "num_sigs")
+        let numSigsRefund = optionalPositiveUInt64(from: condData, key: "num_sigs_refund")
+
+        let pubkeys: [String] = {
+            if let keys = condData["pubkeys"] as? [String] {
+                return keys.filter { !$0.isEmpty }
+            }
+            return []
+        }()
+
+        let refundKeys: [String] = {
+            if let keys = condData["refund_keys"] as? [String] {
+                return keys.filter { !$0.isEmpty }
+            }
+            return []
+        }()
+
+        let sigFlag: UInt8 = (condData["sig_flag"] as? String) == "SigAll" ? 1 : 0
+
+        let conditions = Conditions(
+            locktime: locktime,
+            pubkeys: pubkeys,
+            refundKeys: refundKeys,
+            numSigs: numSigs,
+            sigFlag: sigFlag,
+            numSigsRefund: numSigsRefund
+        )
+
+        return .p2pk(pubkey: pubkey, conditions: conditions)
     }
 
-      let locktime: UInt64 = {
-        if let lt = condData["locktime"] as? NSNumber {
-            return lt.uint64Value
-        }
-        return 0
-    }()
-
-    let refundKeys: [String] = {
-        if let keys = condData["refund_keys"] as? [String] {
-            return keys.filter { !$0.isEmpty }
-        }
-        return []
-    }()
-
-    let conditions = Conditions(
-        locktime: locktime,
-        pubkeys: [],
-        refundKeys: refundKeys,
-        numSigs: 0,
-        sigFlag: 0,
-        numSigsRefund: 0
-    )
-
-    return .p2pk(pubkey: pubkey, conditions: conditions)
-  }
+    /// Returns the value at `key` only when it is a positive integer, so that
+    /// optional NUT-11 tags stay absent instead of being serialized as 0.
+    private func optionalPositiveUInt64(from json: [String: Any], key: String) -> UInt64? {
+        let value = readPositiveUInt64(from: json, key: key)
+        return value > 0 ? value : nil
+    }
 
     private func readPositiveUInt64(from json: [String: Any], key: String) -> UInt64 {
         guard let raw = json[key] else {

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -41,7 +41,7 @@ class CashuDevKitModule: RCTEventEmitter {
     // MARK: - Helper Methods
 
     /// Parse P2PK spending conditions from JSON dictionary
-    private func parseP2PKConditions(from json: [String: Any]) -> SpendingConditions? {
+    private func parseP2PKConditions(from json: [String: Any]) throws -> SpendingConditions? {
         guard let kind = json["kind"] as? String,
               kind == "P2PK",
               let condData = json["data"] as? [String: Any],
@@ -59,21 +59,45 @@ class CashuDevKitModule: RCTEventEmitter {
         let numSigs = optionalPositiveUInt64(from: condData, key: "num_sigs")
         let numSigsRefund = optionalPositiveUInt64(from: condData, key: "num_sigs_refund")
 
+        // Parse element-wise rather than casting the whole array to
+        // `[String]`: if the bridge delivers even one non-string entry
+        // (e.g. NSNull from a malformed caller payload), a whole-array cast
+        // fails to nil and silently drops every pubkey instead of just the
+        // bad one.
         let pubkeys: [String] = {
-            if let keys = condData["pubkeys"] as? [String] {
-                return keys.filter { !$0.isEmpty }
+            if let keys = condData["pubkeys"] as? [Any] {
+                return keys.compactMap { $0 as? String }.filter { !$0.isEmpty }
             }
             return []
         }()
 
         let refundKeys: [String] = {
-            if let keys = condData["refund_keys"] as? [String] {
-                return keys.filter { !$0.isEmpty }
+            if let keys = condData["refund_keys"] as? [Any] {
+                return keys.compactMap { $0 as? String }.filter { !$0.isEmpty }
             }
             return []
         }()
 
         let sigFlag: UInt8 = (condData["sig_flag"] as? String) == "SigAll" ? 1 : 0
+
+        // NUT-11: "If n_sigs or n_sigs_refund ... exceeds the total number of
+        // keys in its pathway, the P2PK secret is malformed and the Proof
+        // MUST be rejected as unspendable." The mint only enforces this at
+        // redemption time, so an out-of-range value here would otherwise
+        // silently mint a token nobody can ever fully sign for. Main pathway
+        // has `1 (pubkey) + pubkeys.count` possible signers; refund pathway
+        // has `refundKeys.count`.
+        let maxMainSigs = 1 + pubkeys.count
+        if let numSigs, Int(numSigs) > maxMainSigs {
+            throw makeP2PKValidationError(
+                "num_sigs (\(numSigs)) exceeds the number of available pubkeys (\(maxMainSigs))"
+            )
+        }
+        if let numSigsRefund, Int(numSigsRefund) > refundKeys.count {
+            throw makeP2PKValidationError(
+                "num_sigs_refund (\(numSigsRefund)) exceeds the number of available refund_keys (\(refundKeys.count))"
+            )
+        }
 
         let conditions = Conditions(
             locktime: locktime,
@@ -85,6 +109,14 @@ class CashuDevKitModule: RCTEventEmitter {
         )
 
         return .p2pk(pubkey: pubkey, conditions: conditions)
+    }
+
+    private func makeP2PKValidationError(_ message: String) -> NSError {
+        NSError(
+            domain: "CashuDevKitModule.P2PK",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
     }
 
     /// Returns the value at `key` only when it is a positive integer, so that
@@ -958,7 +990,7 @@ class CashuDevKitModule: RCTEventEmitter {
                 if let json = conditionsJson,
                    let data = json.data(using: .utf8),
                    let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                   conditions = parseP2PKConditions(from: parsed)
+                   conditions = try parseP2PKConditions(from: parsed)
                 }
 
                 let wallet = try await getWallet(mintUrl)
@@ -1128,7 +1160,7 @@ class CashuDevKitModule: RCTEventEmitter {
                         includeFee = fee
                     }
                     if let cond = parsed["conditions"] as? [String: Any] {
-                    spendingConditions = parseP2PKConditions(from: cond)
+                    spendingConditions = try parseP2PKConditions(from: cond)
                     }
                     if let kindStr = parsed["send_kind"] as? String {
                         let tolerance = (parsed["tolerance"] as? NSNumber).map { Amount(value: $0.uint64Value) } ?? Amount(value: 0)

--- a/ios/CashuDevKit/CashuDevKitModule.swift
+++ b/ios/CashuDevKit/CashuDevKitModule.swift
@@ -86,14 +86,18 @@ class CashuDevKitModule: RCTEventEmitter {
         // redemption time, so an out-of-range value here would otherwise
         // silently mint a token nobody can ever fully sign for. Main pathway
         // has `1 (pubkey) + pubkeys.count` possible signers; refund pathway
-        // has `refundKeys.count`.
+        // has `refundKeys.count`. Compared in the unsigned domain rather
+        // than via Int(numSigs), which traps at runtime when numSigs
+        // exceeds Int64.max - reachable through readPositiveUInt64's
+        // string-parsing path - turning a malformed payload into a crash
+        // instead of a rejected promise.
         let maxMainSigs = 1 + pubkeys.count
-        if let numSigs, Int(numSigs) > maxMainSigs {
+        if let numSigs, numSigs > UInt64(maxMainSigs) {
             throw makeP2PKValidationError(
                 "num_sigs (\(numSigs)) exceeds the number of available pubkeys (\(maxMainSigs))"
             )
         }
-        if let numSigsRefund, Int(numSigsRefund) > refundKeys.count {
+        if let numSigsRefund, numSigsRefund > UInt64(refundKeys.count) {
             throw makeP2PKValidationError(
                 "num_sigs_refund (\(numSigsRefund)) exceeds the number of available refund_keys (\(refundKeys.count))"
             )

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -1631,7 +1631,9 @@ export default class CashuStore {
             const conditionData: CDKP2PKCondition = {
                 pubkey: p2pkPubkey.trim()
             };
-            if (locktime !== undefined && locktime !== null) {
+            // Only forward a locktime that is actually set: a `["locktime", "0"]`
+            // tag marks the lock as already expired and is rejected by mints.
+            if (locktime !== undefined && locktime !== null && locktime > 0) {
                 conditionData.locktime = locktime;
             }
             conditions = {

--- a/stores/CashuStore.ts
+++ b/stores/CashuStore.ts
@@ -5296,11 +5296,7 @@ export default class CashuStore {
                     errorMessage: localeString('stores.CashuStore.alreadySpent')
                 };
             }
-            if (
-                typeof e?.message === 'string' &&
-                e.message.toLowerCase().includes('witness is missing') &&
-                e.message.toLowerCase().includes('p2pk')
-            ) {
+            if (CashuUtils.isTokenLockedError(e)) {
                 this.loading = false;
                 return {
                     success: false,

--- a/utils/CashuUtils.test.ts
+++ b/utils/CashuUtils.test.ts
@@ -349,6 +349,50 @@ describe('CashuUtils', () => {
         });
     });
 
+    describe('isTokenLockedError', () => {
+        it('detects CDK\'s older "witness is missing" wording', () => {
+            expect(
+                CashuUtils.isTokenLockedError(
+                    new Error('Witness is missing signatures required for P2PK')
+                )
+            ).toBe(true);
+        });
+
+        it('detects CDK\'s newer "signatures not provided" wording', () => {
+            expect(
+                CashuUtils.isTokenLockedError(
+                    new Error(
+                        'Witness signatures not provided. P2PK signatures are required but not provided'
+                    )
+                )
+            ).toBe(true);
+        });
+
+        it('is case-insensitive', () => {
+            expect(
+                CashuUtils.isTokenLockedError(
+                    new Error('witness SIGNATURE missing for P2PK')
+                )
+            ).toBe(true);
+        });
+
+        it('returns false for unrelated errors', () => {
+            expect(
+                CashuUtils.isTokenLockedError(new Error('Token already spent'))
+            ).toBe(false);
+            expect(
+                CashuUtils.isTokenLockedError(new Error('Network error'))
+            ).toBe(false);
+        });
+
+        it('returns false for non-error values', () => {
+            expect(CashuUtils.isTokenLockedError(undefined)).toBe(false);
+            expect(CashuUtils.isTokenLockedError(null)).toBe(false);
+            expect(CashuUtils.isTokenLockedError('a plain string')).toBe(false);
+            expect(CashuUtils.isTokenLockedError({})).toBe(false);
+        });
+    });
+
     describe('classifyCashuSeedOrigin', () => {
         const ldk12 =
             'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';

--- a/utils/CashuUtils.test.ts
+++ b/utils/CashuUtils.test.ts
@@ -376,6 +376,14 @@ describe('CashuUtils', () => {
             ).toBe(true);
         });
 
+        it('detects CDK 0.18\'s "Signature missing or invalid" wording, which carries no "p2pk" substring', () => {
+            expect(
+                CashuUtils.isTokenLockedError(
+                    new Error('Signature missing or invalid')
+                )
+            ).toBe(true);
+        });
+
         it('returns false for unrelated errors', () => {
             expect(
                 CashuUtils.isTokenLockedError(new Error('Token already spent'))

--- a/utils/CashuUtils.ts
+++ b/utils/CashuUtils.ts
@@ -277,6 +277,33 @@ class CashuUtils {
         }
         return undefined;
     };
+
+    /**
+     * True when a CDK claim/receive error means "you don't hold the private
+     * key this token is P2PK-locked to" (as opposed to e.g. already-spent,
+     * network, or mint errors). CDK's exact wording for this varies by
+     * version/code path - e.g. "Witness is missing ... for P2PK" or
+     * "Witness signatures not provided. P2PK signatures are required but
+     * not provided" - so this matches on the P2PK + missing-signature
+     * combination rather than one exact phrase.
+     */
+    isTokenLockedError = (error: unknown): boolean => {
+        const message =
+            error &&
+            typeof error === 'object' &&
+            'message' in error &&
+            typeof (error as { message?: unknown }).message === 'string'
+                ? (error as { message: string }).message.toLowerCase()
+                : '';
+
+        return (
+            message.includes('p2pk') &&
+            message.includes('signature') &&
+            (message.includes('missing') ||
+                message.includes('not provided') ||
+                message.includes('required'))
+        );
+    };
 }
 
 const cashuUtils = new CashuUtils();

--- a/utils/CashuUtils.ts
+++ b/utils/CashuUtils.ts
@@ -297,11 +297,14 @@ class CashuUtils {
                 : '';
 
         return (
-            message.includes('p2pk') &&
-            message.includes('signature') &&
-            (message.includes('missing') ||
-                message.includes('not provided') ||
-                message.includes('required'))
+            // CDK 0.18's wallet-side NUT-11 error (SignatureMissingOrInvalid)
+            // is exactly this phrase, with no "p2pk" substring at all.
+            message.includes('signature missing or invalid') ||
+            (message.includes('p2pk') &&
+                message.includes('signature') &&
+                (message.includes('missing') ||
+                    message.includes('not provided') ||
+                    message.includes('required')))
         );
     };
 }


### PR DESCRIPTION

# Description

Fixes #4627 — P2PK-locked Cashu tokens could not be redeemed against a CDK mint.

## Root cause

`parseP2PKConditions` on both native bridges hardcoded `numSigs`/`numSigsRefund` to `0` and defaulted `locktime` to `0` when unset. NUT-11 requires these optional tags to be *absent* when they don't apply — a mint receiving `["n_sigs", "0"]` or `["n_sigs_refund", "0"]` rejects the token outright (validation fails fast), and `["locktime", "0"]` marks the lock as already expired.

- `ios/CashuDevKit/CashuDevKitModule.swift`, `android/.../CashuDevKitModule.kt`: only emit `locktime`/`num_sigs`/`num_sigs_refund` when positive; also stop silently dropping `pubkeys` and always-`SigInputs` `sig_flag`.
- `cashu-cdk/types.ts`: extend `CDKP2PKCondition` with `pubkeys`/`num_sigs_refund`.
- `stores/CashuStore.ts`: never forward `locktime: 0` from the send flow.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
