### PR TITLE
fix: stage channel backup exports in swept cache, not iOS Documents

### DIFF
--- a/stores/SettingsStore.test.ts
+++ b/stores/SettingsStore.test.ts
@@ -32,6 +32,7 @@ jest.mock('../utils/LocaleUtils', () => ({
 jest.mock('../utils/MigrationUtils', () => ({
     keychainCloudSyncMigration: jest.fn().mockResolvedValue(undefined),
     purgeRescueKeyFiles: jest.fn().mockResolvedValue(undefined),
+    purgeChannelExportFiles: jest.fn().mockResolvedValue(undefined),
     migrateRgsDefaultToZeus: jest.fn().mockResolvedValue(undefined),
     migrateInvoiceExpiryDisplay: jest.fn().mockResolvedValue(undefined),
     legacySettingsMigrations: jest.fn().mockResolvedValue({}),

--- a/stores/SettingsStore.ts
+++ b/stores/SettingsStore.ts
@@ -1964,6 +1964,7 @@ export default class SettingsStore {
         try {
             await MigrationsUtils.keychainCloudSyncMigration();
             await MigrationsUtils.purgeRescueKeyFiles();
+            await MigrationsUtils.purgeChannelExportFiles();
 
             const modernSettings: any = await Storage.getItem(STORAGE_KEY);
 

--- a/utils/ChannelExportStagingUtils.test.ts
+++ b/utils/ChannelExportStagingUtils.test.ts
@@ -1,0 +1,173 @@
+const mockPlatform = { OS: 'ios' };
+
+// Read through a getter: jest hoists this factory above the `const` above
+// it, so a direct reference captures the value while it is still in TDZ
+jest.mock('react-native', () => ({
+    get Platform() {
+        return mockPlatform;
+    }
+}));
+
+jest.mock('react-native-fs', () => ({
+    CachesDirectoryPath: '/cache',
+    DocumentDirectoryPath: '/documents',
+    exists: jest.fn(),
+    unlink: jest.fn(),
+    readDir: jest.fn()
+}));
+
+import RNFS from 'react-native-fs';
+
+import {
+    CHANNEL_EXPORT_STAGING_DIR,
+    channelExportStagingPath,
+    purgeChannelExportStaging,
+    purgeLegacyChannelExports,
+    LEGACY_CHANNEL_EXPORT_REGEX
+} from './ChannelExportStagingUtils';
+
+const file = (name: string) => ({
+    name,
+    path: `/documents/${name}`,
+    isFile: () => true,
+    isDirectory: () => false
+});
+
+describe('ChannelExportStagingUtils', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockPlatform.OS = 'ios';
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('channelExportStagingPath', () => {
+        it('sits in app-private cache, never in Documents', () => {
+            expect(channelExportStagingPath()).toBe(
+                `/cache/${CHANNEL_EXPORT_STAGING_DIR}`
+            );
+        });
+    });
+
+    describe('purgeChannelExportStaging', () => {
+        it('removes the staging directory when it exists', async () => {
+            (RNFS.exists as jest.Mock).mockResolvedValue(true);
+
+            await purgeChannelExportStaging();
+
+            expect(RNFS.unlink).toHaveBeenCalledWith(
+                `/cache/${CHANNEL_EXPORT_STAGING_DIR}`
+            );
+        });
+
+        it('is a no-op when the staging directory is absent', async () => {
+            (RNFS.exists as jest.Mock).mockResolvedValue(false);
+
+            await purgeChannelExportStaging();
+
+            expect(RNFS.unlink).not.toHaveBeenCalled();
+        });
+
+        it('swallows unlink failures', async () => {
+            (RNFS.exists as jest.Mock).mockResolvedValue(true);
+            (RNFS.unlink as jest.Mock).mockRejectedValue(new Error('EPERM'));
+
+            await expect(purgeChannelExportStaging()).resolves.toBeUndefined();
+        });
+    });
+
+    describe('LEGACY_CHANNEL_EXPORT_REGEX', () => {
+        it.each([
+            'zeus-lnd-mainnet-1736899200000.zip',
+            'zeus-lnd-testnet-1736899200000.zip'
+        ])('matches the shape released builds generated: %s', (name) => {
+            expect(LEGACY_CHANNEL_EXPORT_REGEX.test(name)).toBe(true);
+        });
+
+        it.each([
+            // networks exportChannelDb never names
+            'zeus-lnd-regtest-1736899200000.zip',
+            'zeus-lnd-signet-1736899200000.zip',
+            // not a timestamp
+            'zeus-lnd-mainnet-abc.zip',
+            'zeus-lnd-mainnet-.zip',
+            // user files that merely share the prefix
+            'my-zeus-lnd-mainnet-1736899200000.zip',
+            'zeus-lnd-mainnet-1736899200000.zip.bak',
+            'zeus-lnd-mainnet-1736899200000 (1).zip',
+            // unrelated ZEUS exports
+            'zeus_20250212_140719_onchain.csv'
+        ])('leaves %s alone', (name) => {
+            expect(LEGACY_CHANNEL_EXPORT_REGEX.test(name)).toBe(false);
+        });
+    });
+
+    describe('purgeLegacyChannelExports', () => {
+        it('does nothing on Android, which never staged in Documents', async () => {
+            mockPlatform.OS = 'android';
+
+            await purgeLegacyChannelExports();
+
+            expect(RNFS.readDir).not.toHaveBeenCalled();
+            expect(RNFS.unlink).not.toHaveBeenCalled();
+        });
+
+        it('deletes only matching files from iOS Documents', async () => {
+            (RNFS.readDir as jest.Mock).mockResolvedValue([
+                file('zeus-lnd-mainnet-1736899200000.zip'),
+                file('zeus-lnd-testnet-1736899200001.zip'),
+                file('holiday-photos.zip'),
+                file('zeus-lnd-mainnet-notatimestamp.zip')
+            ]);
+
+            await purgeLegacyChannelExports();
+
+            expect(RNFS.readDir).toHaveBeenCalledWith('/documents');
+            expect(RNFS.unlink).toHaveBeenCalledTimes(2);
+            expect(RNFS.unlink).toHaveBeenCalledWith(
+                '/documents/zeus-lnd-mainnet-1736899200000.zip'
+            );
+            expect(RNFS.unlink).toHaveBeenCalledWith(
+                '/documents/zeus-lnd-testnet-1736899200001.zip'
+            );
+        });
+
+        it('skips directories whose name would otherwise match', async () => {
+            (RNFS.readDir as jest.Mock).mockResolvedValue([
+                {
+                    name: 'zeus-lnd-mainnet-1736899200000.zip',
+                    path: '/documents/zeus-lnd-mainnet-1736899200000.zip',
+                    isFile: () => false,
+                    isDirectory: () => true
+                }
+            ]);
+
+            await purgeLegacyChannelExports();
+
+            expect(RNFS.unlink).not.toHaveBeenCalled();
+        });
+
+        it('keeps going after a failed unlink', async () => {
+            (RNFS.readDir as jest.Mock).mockResolvedValue([
+                file('zeus-lnd-mainnet-1736899200000.zip'),
+                file('zeus-lnd-testnet-1736899200001.zip')
+            ]);
+            (RNFS.unlink as jest.Mock)
+                .mockRejectedValueOnce(new Error('EPERM'))
+                .mockResolvedValueOnce(undefined);
+
+            await expect(purgeLegacyChannelExports()).resolves.toBeUndefined();
+            expect(RNFS.unlink).toHaveBeenCalledTimes(2);
+        });
+
+        it('swallows a readDir failure', async () => {
+            (RNFS.readDir as jest.Mock).mockRejectedValue(new Error('ENOENT'));
+
+            await expect(purgeLegacyChannelExports()).resolves.toBeUndefined();
+        });
+    });
+});

--- a/utils/ChannelExportStagingUtils.ts
+++ b/utils/ChannelExportStagingUtils.ts
@@ -1,0 +1,67 @@
+import { Platform } from 'react-native';
+import RNFS from 'react-native-fs';
+
+// Staging for the channel backup export, kept in a module of its own so the
+// sweeps can be reached from MigrationUtils and DataClearUtils without
+// pulling in ChannelMigrationUtils, which imports ChannelBackupStore ->
+// SettingsStore (a cycle, since SettingsStore reaches MigrationUtils) along
+// with the react-native-share and react-native-restart native modules.
+
+export const CHANNEL_EXPORT_STAGING_DIR = 'channel-export-staging';
+
+export const channelExportStagingPath = (): string =>
+    `${RNFS.CachesDirectoryPath}/${CHANNEL_EXPORT_STAGING_DIR}`;
+
+// Removes the staging directory. The staged zip cannot be unlinked as soon
+// as Share.open settles: on iOS the completion handler can fire while an
+// activity extension is still loading the NSItemProvider, so an immediate
+// unlink hands the receiver a dead file while the export reports success -
+// for a channel database, where a silently empty backup means channels that
+// cannot be recovered. Instead each export sweeps the previous attempt,
+// export failures sweep immediately (nothing was handed off at that point,
+// which also covers a partially written zip), app launch sweeps whatever
+// the post-export restart left behind, and clearAllData sweeps it on wipe.
+export const purgeChannelExportStaging = async (): Promise<void> => {
+    try {
+        const dir = channelExportStagingPath();
+        if (await RNFS.exists(dir)) await RNFS.unlink(dir);
+    } catch (e) {
+        console.warn('Error purging channel export staging:', e);
+    }
+};
+
+// exportChannelDb names its zip `zeus-lnd-<network>-<Date.now()>.zip`, and
+// only mainnet and testnet reach it (embedded LND has no other networks).
+// Anchored to exactly that shape so a user file that merely starts with the
+// same prefix - a renamed copy of an old export, say - is not swept up.
+export const LEGACY_CHANNEL_EXPORT_REGEX =
+    /^zeus-lnd-(mainnet|testnet)-\d+\.zip$/;
+
+// Best-effort removal of channel backups older builds left in shared
+// storage. Those staged the zip in the Files-visible iOS Documents
+// directory and only unlinked it once the share settled, so an export
+// interrupted before then (app killed, crash) left the backup there
+// indefinitely, swept into iCloud/iTunes backups, with nothing to clean it
+// up. Android is not affected: it has always staged in Caches, and its copy
+// in Downloads is deliberate and user-visible.
+export const purgeLegacyChannelExports = async (): Promise<void> => {
+    if (Platform.OS !== 'ios') return;
+    try {
+        const entries = await RNFS.readDir(RNFS.DocumentDirectoryPath);
+        for (const entry of entries) {
+            if (
+                entry.isFile() &&
+                LEGACY_CHANNEL_EXPORT_REGEX.test(entry.name)
+            ) {
+                try {
+                    await RNFS.unlink(entry.path);
+                    console.log('Legacy channel export deleted:', entry.path);
+                } catch (e) {
+                    console.warn('Error deleting legacy channel export:', e);
+                }
+            }
+        }
+    } catch (e) {
+        console.warn('Error purging legacy channel exports:', e);
+    }
+};

--- a/utils/ChannelMigrationUtils.test.ts
+++ b/utils/ChannelMigrationUtils.test.ts
@@ -40,6 +40,14 @@ jest.mock('react-native-blob-util', () => ({
 }));
 
 jest.mock('react-native-share', () => ({ open: jest.fn() }));
+
+const mockPurgeChannelExportStaging = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('./ChannelExportStagingUtils', () => ({
+    channelExportStagingPath: () => '/cache/channel-export-staging',
+    purgeChannelExportStaging: () => mockPurgeChannelExportStaging()
+}));
+
 jest.mock('react-native-restart', () => ({ Restart: jest.fn() }));
 jest.mock('./LocaleUtils', () => ({
     localeString: (key: string) => key
@@ -67,15 +75,33 @@ jest.mock('../storage', () => ({
     getItem: jest.fn().mockResolvedValue(null)
 }));
 
+// Mutable so the export tests can exercise both platforms. Read through a
+// getter: jest hoists this factory above the `const`, so a direct reference
+// captures the value while it is still in TDZ.
+const mockPlatform = {
+    OS: 'android',
+    select: (opts: any) => opts[mockPlatform.OS]
+};
+
 jest.mock('react-native', () => ({
     Alert: { alert: jest.fn() },
-    Platform: { OS: 'android', select: (opts: any) => opts.android }
+    get Platform() {
+        return mockPlatform;
+    }
 }));
+
+import { Alert } from 'react-native';
+import Share from 'react-native-share';
 
 import {
     validateChannelBackupFile,
-    importChannelDb
+    importChannelDb,
+    exportChannelDb
 } from './ChannelMigrationUtils';
+
+const STAGING_DIR = '/cache/channel-export-staging';
+const shareOpen = Share.open as jest.Mock;
+const alert = Alert.alert as jest.Mock;
 
 describe('ChannelMigrationUtils', () => {
     beforeEach(() => {
@@ -83,6 +109,9 @@ describe('ChannelMigrationUtils', () => {
         mockExists.mockResolvedValue(true);
         mockStat.mockResolvedValue({ size: 1024 });
         mockReadDir.mockResolvedValue([]);
+        mockZipFolder.mockResolvedValue(undefined);
+        mockPurgeChannelExportStaging.mockResolvedValue(undefined);
+        mockPlatform.OS = 'android';
     });
 
     describe('validateChannelBackupFile', () => {
@@ -236,6 +265,203 @@ describe('ChannelMigrationUtils', () => {
                 '/input.enc',
                 '/output.zip',
                 'my seed phrase'
+            );
+        });
+    });
+
+    describe('exportChannelDb', () => {
+        const stagedPath = () => mockZipFolder.mock.calls[0][1];
+
+        describe('staging', () => {
+            it.each(['android', 'ios'])(
+                'zips into a swept app-private cache dir on %s',
+                async (os) => {
+                    mockPlatform.OS = os;
+                    shareOpen.mockResolvedValue({ success: true });
+
+                    await exportChannelDb('lnd', false);
+
+                    expect(mockPurgeChannelExportStaging).toHaveBeenCalled();
+                    expect(mockMkdir).toHaveBeenCalledWith(STAGING_DIR);
+                    expect(stagedPath()).toMatch(
+                        /^\/cache\/channel-export-staging\/zeus-lnd-mainnet-\d+\.zip$/
+                    );
+                }
+            );
+
+            it('never stages in the Files-visible iOS Documents dir', async () => {
+                mockPlatform.OS = 'ios';
+                shareOpen.mockResolvedValue({ success: true });
+
+                await exportChannelDb('lnd', false);
+
+                expect(stagedPath()).not.toContain(
+                    '/data/user/0/app.zeusln.zeus/files'
+                );
+            });
+
+            it('names testnet exports for the network', async () => {
+                mockPlatform.OS = 'ios';
+                shareOpen.mockResolvedValue({ success: true });
+
+                await exportChannelDb('lnd', true);
+
+                expect(stagedPath()).toContain('zeus-lnd-testnet-');
+            });
+        });
+
+        describe('android', () => {
+            beforeEach(() => {
+                mockPlatform.OS = 'android';
+            });
+
+            it('copies to Downloads and sweeps the staged copy', async () => {
+                await exportChannelDb('lnd', false);
+
+                const staged = stagedPath();
+                expect(mockCopyFile).toHaveBeenCalledWith(
+                    staged,
+                    `/downloads/${staged.split('/').pop()}`
+                );
+                // copyFile has finished reading by the time it resolves, so
+                // unlike the share sheet this sweep is safe immediately
+                expect(mockPurgeChannelExportStaging).toHaveBeenCalledTimes(2);
+                expect(shareOpen).not.toHaveBeenCalled();
+                expect(alert).toHaveBeenCalledWith(
+                    'views.Tools.migration.export.success',
+                    'views.Tools.migration.export.success.text.android',
+                    expect.anything(),
+                    expect.anything()
+                );
+            });
+
+            it('sweeps a partial zip when zipping fails', async () => {
+                mockZipFolder.mockRejectedValue(new Error('disk full'));
+
+                await exportChannelDb('lnd', false);
+
+                expect(mockPurgeChannelExportStaging).toHaveBeenCalledTimes(2);
+                expect(alert).toHaveBeenCalledWith(
+                    'general.error',
+                    undefined,
+                    expect.anything(),
+                    expect.anything()
+                );
+            });
+        });
+
+        describe('ios share sheet', () => {
+            beforeEach(() => {
+                mockPlatform.OS = 'ios';
+            });
+
+            it('hands the staged file to Share.open', async () => {
+                shareOpen.mockResolvedValue({ success: true });
+
+                await exportChannelDb('lnd', false);
+
+                expect(shareOpen).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        url: `file://${stagedPath()}`,
+                        type: 'application/octet-stream',
+                        failOnCancel: false
+                    })
+                );
+            });
+
+            // The bug this suite exists for: Share.open can settle while an
+            // activity extension is still loading the NSItemProvider, so
+            // unlinking here hands the receiver a dead file while the user
+            // is told the export succeeded
+            it('does not unlink the staged file after a successful share', async () => {
+                shareOpen.mockResolvedValue({ success: true });
+
+                await exportChannelDb('lnd', false);
+
+                expect(mockUnlink).not.toHaveBeenCalled();
+                expect(mockPurgeChannelExportStaging).toHaveBeenCalledTimes(1);
+                expect(alert).toHaveBeenCalledWith(
+                    'views.Tools.migration.export.success',
+                    'views.Tools.migration.export.success.text',
+                    expect.anything(),
+                    expect.anything()
+                );
+            });
+
+            it.each([
+                ['dismissedAction', { dismissedAction: true }],
+                ['success: false', { success: false }]
+            ])(
+                'does not unlink the staged file after %s',
+                async (_label, result) => {
+                    shareOpen.mockResolvedValue(result);
+
+                    await exportChannelDb('lnd', false);
+
+                    expect(mockUnlink).not.toHaveBeenCalled();
+                    expect(mockPurgeChannelExportStaging).toHaveBeenCalledTimes(
+                        1
+                    );
+                    expect(alert).toHaveBeenCalledWith(
+                        'views.Tools.migration.export.cancelled',
+                        'views.Tools.migration.export.cancelled.text',
+                        expect.anything(),
+                        expect.anything()
+                    );
+                }
+            );
+
+            it('reports cancellation when Share.open rejects with a cancel', async () => {
+                shareOpen.mockRejectedValue(new Error('User did not share'));
+
+                await exportChannelDb('lnd', false);
+
+                expect(alert).toHaveBeenCalledWith(
+                    'views.Tools.migration.export.cancelled',
+                    'views.Tools.migration.export.cancelled.text',
+                    expect.anything(),
+                    expect.anything()
+                );
+            });
+
+            // Conservative: once the file is handed to the share sheet we
+            // cannot know a receiver is not reading it, so even a rejection
+            // leaves it for the launch sweep rather than unlinking here
+            it('leaves the staged file alone when Share.open rejects', async () => {
+                shareOpen.mockRejectedValue(new Error('kaboom'));
+
+                await exportChannelDb('lnd', false);
+
+                expect(mockUnlink).not.toHaveBeenCalled();
+                expect(mockPurgeChannelExportStaging).toHaveBeenCalledTimes(1);
+                expect(alert).toHaveBeenCalledWith(
+                    'general.error',
+                    undefined,
+                    expect.anything(),
+                    expect.anything()
+                );
+            });
+
+            it('sweeps a partial zip when zipping fails, before any handoff', async () => {
+                mockZipFolder.mockRejectedValue(new Error('disk full'));
+
+                await exportChannelDb('lnd', false);
+
+                expect(shareOpen).not.toHaveBeenCalled();
+                expect(mockPurgeChannelExportStaging).toHaveBeenCalledTimes(2);
+            });
+        });
+
+        it('bails out before staging when the graph dir is missing', async () => {
+            mockExists.mockResolvedValue(false);
+
+            await exportChannelDb('lnd', false);
+
+            expect(mockPurgeChannelExportStaging).not.toHaveBeenCalled();
+            expect(mockZipFolder).not.toHaveBeenCalled();
+            expect(alert).toHaveBeenCalledWith(
+                'general.error',
+                'views.Tools.migration.databaseNotFound'
             );
         });
     });

--- a/utils/ChannelMigrationUtils.ts
+++ b/utils/ChannelMigrationUtils.ts
@@ -11,6 +11,10 @@ import { signMessageNodePubkey } from '../lndmobile/wallet';
 import Base64Utils from './Base64Utils';
 import { sleep } from './SleepUtils';
 import { zipFolder, unzipFile, encryptFile, decryptFile } from './ZipUtils';
+import {
+    channelExportStagingPath,
+    purgeChannelExportStaging
+} from './ChannelExportStagingUtils';
 
 import { BACKUPS_HOST } from '../stores/ChannelBackupStore';
 
@@ -617,6 +621,7 @@ export const exportChannelDb = async (
     isTestnet: boolean,
     setStatus?: (message: string | null) => void
 ) => {
+    let handedOff = false;
     try {
         const graphDir = getGraphDir(lndDir, isTestnet);
 
@@ -646,15 +651,15 @@ export const exportChannelDb = async (
         const network = isTestnet ? 'testnet' : 'mainnet';
         const backupFileName = `zeus-lnd-${network}-${Date.now()}.zip`;
 
-        const stagingDir =
-            Platform.OS === 'android'
-                ? RNFS.CachesDirectoryPath
-                : RNFS.DocumentDirectoryPath;
+        // Stage in app-private cache on both platforms, sweeping whatever the
+        // previous attempt left behind rather than unlinking per file. iOS
+        // used to stage in the Files-visible Documents directory, where the
+        // backup was swept into iCloud/iTunes backups and outlived an
+        // interrupted export forever.
+        await purgeChannelExportStaging();
+        const stagingDir = channelExportStagingPath();
+        await RNFS.mkdir(stagingDir);
         const stagingPath = `${stagingDir}/${backupFileName}`;
-
-        if (await RNFS.exists(stagingPath)) {
-            await RNFS.unlink(stagingPath);
-        }
 
         if (setStatus)
             setStatus(
@@ -691,10 +696,16 @@ export const exportChannelDb = async (
         if (Platform.OS === 'android') {
             const downloadPath = `${RNFS.DownloadDirectoryPath}/${backupFileName}`;
             await RNFS.copyFile(stagingPath, downloadPath);
-            await RNFS.unlink(stagingPath);
+            // Not the share race: copyFile has finished reading by the time
+            // it resolves, so the staged copy is safe to drop here
+            await purgeChannelExportStaging();
             await finishExport();
             return;
         }
+
+        // From here the file is out of our hands: a receiving app may read
+        // it after Share.open settles, so the outer catch must not sweep it
+        handedOff = true;
 
         try {
             const shareResult = await Share.open({
@@ -709,7 +720,6 @@ export const exportChannelDb = async (
                 shareResult.dismissedAction || shareResult.success === false;
 
             if (isDismissed) {
-                await RNFS.unlink(stagingPath);
                 Alert.alert(
                     localeString('views.Tools.migration.export.cancelled'),
                     localeString('views.Tools.migration.export.cancelled.text'),
@@ -724,13 +734,8 @@ export const exportChannelDb = async (
                 return;
             }
 
-            await RNFS.unlink(stagingPath);
             await finishExport();
         } catch (err: any) {
-            if (await RNFS.exists(stagingPath)) {
-                await RNFS.unlink(stagingPath);
-            }
-
             const errorMsg = err?.message || String(err);
             if (
                 errorMsg.includes('User did not share') ||
@@ -754,6 +759,9 @@ export const exportChannelDb = async (
         }
     } catch (error) {
         console.error('Export Failed:', error);
+        // Covers a failed or partial zip; skipped once the file has been
+        // handed to the share sheet, where a receiver may still be reading
+        if (!handedOff) await purgeChannelExportStaging();
         if (setStatus) setStatus(null);
         Alert.alert(
             localeString('general.error'),

--- a/utils/DataClearUtils.test.ts
+++ b/utils/DataClearUtils.test.ts
@@ -123,6 +123,10 @@ jest.mock('../utils/SwapUtils', () => ({
     purgeLegacyRescueKeyFiles: jest.fn().mockResolvedValue(undefined),
     unlinkRescueKeyStagingFile: jest.fn().mockResolvedValue(undefined)
 }));
+jest.mock('../utils/ChannelExportStagingUtils', () => ({
+    purgeChannelExportStaging: jest.fn().mockResolvedValue(undefined),
+    purgeLegacyChannelExports: jest.fn().mockResolvedValue(undefined)
+}));
 jest.mock('../stores/NostrWalletConnectStore', () => ({
     NWC_CONNECTIONS_KEY: 'zeus-nwc-connections',
     NWC_CLIENT_KEYS: 'zeus-nwc-client-keys',
@@ -194,6 +198,28 @@ const settingsWithNodes = (nodes: any[]) => ({
         key === 'zeus-settings-v2'
             ? Promise.resolve(JSON.stringify({ nodes }))
             : Promise.resolve(null)
+});
+
+describe('clearAllData export artifact sweep', () => {
+    const {
+        purgeChannelExportStaging,
+        purgeLegacyChannelExports
+    } = require('../utils/ChannelExportStagingUtils');
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedStorageGetItem.mockResolvedValue(null);
+    });
+
+    // A channel backup names every peer and balance, so a panic/duress wipe
+    // must not leave one staged in cache or sitting in iOS Documents from an
+    // older build
+    it('sweeps staged and legacy channel backups', async () => {
+        await clearAllData();
+
+        expect(purgeChannelExportStaging).toHaveBeenCalled();
+        expect(purgeLegacyChannelExports).toHaveBeenCalled();
+    });
 });
 
 describe('clearAllData node data directory wipe (KEY-005 regression)', () => {

--- a/utils/DataClearUtils.ts
+++ b/utils/DataClearUtils.ts
@@ -57,6 +57,10 @@ import {
     unlinkRescueKeyStagingFile
 } from '../utils/SwapUtils';
 import {
+    purgeChannelExportStaging,
+    purgeLegacyChannelExports
+} from '../utils/ChannelExportStagingUtils';
+import {
     NWC_CONNECTIONS_KEY,
     NWC_CLIENT_KEYS,
     NWC_SERVICE_KEYS,
@@ -678,6 +682,13 @@ export async function clearAllData(): Promise<void> {
     // nothing else in this flow touches either.
     await purgeLegacyRescueKeyFiles();
     await unlinkRescueKeyStagingFile();
+
+    // 2e. Delete any exported channel backups still in app cache, plus the
+    // zips older builds left in the Files-visible iOS Documents directory. A
+    // panic/duress wipe must not leave a channel database - which names every
+    // peer and balance - sitting on the device.
+    await purgeChannelExportStaging();
+    await purgeLegacyChannelExports();
 
     // 3. Clear all known storage keys
     console.log('[ClearData] Clearing known storage keys...');

--- a/utils/MigrationUtils.test.ts
+++ b/utils/MigrationUtils.test.ts
@@ -5,7 +5,8 @@ jest.mock('react-native-fs', () => ({
     CachesDirectoryPath: '/cache',
     exists: jest.fn().mockResolvedValue(false),
     unlink: jest.fn().mockResolvedValue(undefined),
-    writeFile: jest.fn().mockResolvedValue(undefined)
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    readDir: jest.fn().mockResolvedValue([])
 }));
 jest.mock('@react-native-documents/picker', () => ({
     saveDocuments: jest.fn()
@@ -894,6 +895,84 @@ describe('MigrationUtils', () => {
 
             expect(RNFS.unlink).not.toHaveBeenCalledWith(LEGACY_PATH);
             expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('purgeChannelExportFiles', () => {
+        const RNFS = require('react-native-fs');
+        const EncryptedStorage = require('react-native-encrypted-storage');
+        // Platform.OS is 'ios' under the RN jest preset, so the legacy zips
+        // are in the Documents dir. Staging is the cache dir on both.
+        const STAGING_DIR = '/cache/channel-export-staging';
+        const LEGACY_ZIP = '/docs/zeus-lnd-mainnet-1736899200000.zip';
+
+        const stagingUnlinks = () =>
+            RNFS.unlink.mock.calls.filter(
+                (call: any[]) => call[0] === STAGING_DIR
+            );
+
+        beforeEach(() => {
+            RNFS.exists.mockReset().mockResolvedValue(true);
+            RNFS.unlink.mockReset().mockResolvedValue(undefined);
+            RNFS.readDir.mockReset().mockResolvedValue([
+                {
+                    name: 'zeus-lnd-mainnet-1736899200000.zip',
+                    path: LEGACY_ZIP,
+                    isFile: () => true
+                }
+            ]);
+            EncryptedStorage.getItem.mockReset();
+            EncryptedStorage.setItem.mockReset();
+        });
+
+        it('sweeps the staging dir at most once per process', async () => {
+            // Same hazard as the rescue key staging file: getSettings() runs
+            // on every transition to the background, and the iOS share sheet
+            // backgrounds the app while the staged zip must stay readable.
+            EncryptedStorage.getItem.mockResolvedValue('true');
+
+            await MigrationUtils.purgeChannelExportFiles();
+            await MigrationUtils.purgeChannelExportFiles();
+            await MigrationUtils.purgeChannelExportFiles();
+
+            expect(stagingUnlinks()).toHaveLength(1);
+        });
+
+        it('purges legacy Documents zips once and sets the flag', async () => {
+            EncryptedStorage.getItem.mockResolvedValue(null);
+
+            await MigrationUtils.purgeChannelExportFiles();
+
+            expect(RNFS.unlink).toHaveBeenCalledWith(LEGACY_ZIP);
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'channel-export-file-cleanup',
+                'true'
+            );
+        });
+
+        it('skips the legacy purge when the flag is already set', async () => {
+            EncryptedStorage.getItem.mockResolvedValue('true');
+
+            await MigrationUtils.purgeChannelExportFiles();
+
+            expect(RNFS.readDir).not.toHaveBeenCalled();
+            expect(RNFS.unlink).not.toHaveBeenCalledWith(LEGACY_ZIP);
+            expect(EncryptedStorage.setItem).not.toHaveBeenCalled();
+        });
+
+        it('sets the flag even when the legacy unlink fails', async () => {
+            // A failed unlink can never succeed on a later retry, so a
+            // one-shot that retried forever would just burn a keystore read
+            // and a readDir on every launch
+            EncryptedStorage.getItem.mockResolvedValue(null);
+            RNFS.unlink.mockRejectedValue(new Error('EPERM'));
+
+            await MigrationUtils.purgeChannelExportFiles();
+
+            expect(EncryptedStorage.setItem).toHaveBeenCalledWith(
+                'channel-export-file-cleanup',
+                'true'
+            );
         });
     });
 

--- a/utils/MigrationUtils.ts
+++ b/utils/MigrationUtils.ts
@@ -81,6 +81,11 @@ import {
 } from '../utils/SwapUtils';
 
 import {
+    purgeChannelExportStaging,
+    purgeLegacyChannelExports
+} from '../utils/ChannelExportStagingUtils';
+
+import {
     TimePeriod,
     displayFromExpirySeconds,
     expirySecondsFromInput
@@ -734,6 +739,45 @@ class MigrationsUtils {
         await purgeLegacyRescueKeyFiles();
 
         await EncryptedStorage.setItem(MOD_KEY_RESCUE_FILE, 'true');
+    }
+
+    // Channel backup export file cleanup, same two-part shape as
+    // purgeRescueKeyFiles above.
+    //
+    // Staging dir: the export hands its zip to the iOS share sheet and
+    // deliberately does not unlink it afterwards, because a receiving app may
+    // still be reading. Sweeping at the next export is not enough here the
+    // way it is for CSVs: exportChannelDb force-restarts the app on every
+    // outcome and locks the wallet, so the user has usually migrated away and
+    // never exports again. This launch sweep is what that restart runs into.
+    // Latched to at most once per process for the same reason as the rescue
+    // key staging file: getSettings() also runs on every transition to the
+    // background, and the share sheet backgrounds the app while the staged
+    // zip still has to be readable.
+    //
+    // Legacy shared-storage files: older builds staged the zip in the
+    // Files-visible iOS Documents directory, where an export interrupted
+    // before the share settled left the channel backup indefinitely, swept
+    // into iCloud/iTunes backups. One-shot best-effort cleanup; the flag is
+    // set regardless of outcome because a failed unlink can never succeed on
+    // a later retry.
+    private channelExportStagingPurged = false;
+
+    public async purgeChannelExportFiles() {
+        if (!this.channelExportStagingPurged) {
+            this.channelExportStagingPurged = true;
+            await purgeChannelExportStaging();
+        }
+
+        const MOD_KEY_CHANNEL_EXPORT = 'channel-export-file-cleanup';
+        const modChannelExport = await EncryptedStorage.getItem(
+            MOD_KEY_CHANNEL_EXPORT
+        );
+        if (modChannelExport) return;
+
+        await purgeLegacyChannelExports();
+
+        await EncryptedStorage.setItem(MOD_KEY_CHANNEL_EXPORT, 'true');
     }
 
     public async storageMigrationV2(settings: any) {


### PR DESCRIPTION
# Description

Relates to issue: https://github.com/ZeusLN/zeus/issues/4624

- [ ] New feature
- [X] Bug fix
- [X] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [ ] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [ ] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [ ] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
