### PR TITLE
utils: match lnd on duplicate BOLT11 singleton tags

### DIFF
--- a/utils/Bolt11Utils.test.ts
+++ b/utils/Bolt11Utils.test.ts
@@ -1,3 +1,4 @@
+import { bech32 } from 'bech32';
 import * as secp from '@noble/secp256k1';
 
 import Bolt11Utils from './Bolt11Utils';
@@ -239,5 +240,143 @@ describe('lazy signature recovery', () => {
         expect(payeeDescriptor?.get).toBeUndefined();
         expect(sigDescriptor?.get).toBeDefined();
         expect(recoveryFlagDescriptor?.get).toBeDefined();
+    });
+});
+
+describe('duplicate singleton tags', () => {
+    // Attack shape from the `invoices` npm package bug (fixed there in
+    // 6.0.0, 2026-08-07): an invoice that repeats a singleton tag makes a
+    // last-wins reader track a different payment than the node, which
+    // settles on the first well-formed occurrence (lnd zpay32 behavior).
+    const HASH_A = 'aa'.repeat(32);
+    const HASH_B = 'bb'.repeat(32);
+    const PAYEE_A = '02' + 'ab'.repeat(32);
+    const PAYEE_B = '03' + 'cd'.repeat(32);
+
+    const hexToWords = (hex: string): number[] =>
+        bech32.toWords(
+            Uint8Array.from(
+                hex.match(/.{2}/g)!.map((byte) => parseInt(byte, 16))
+            )
+        );
+
+    const utf8ToWords = (text: string): number[] =>
+        bech32.toWords(Uint8Array.from(text, (char) => char.charCodeAt(0)));
+
+    const tag = (code: number, words: number[]): number[] => [
+        code,
+        words.length >> 5,
+        words.length & 31,
+        ...words
+    ];
+
+    // Timestamp of 1 (7 words) + tags + a zeroed 104-word signature block.
+    // The signature cannot recover, but recovery is lazy, so tests that
+    // never read destination/signature exercise only the tag loop.
+    const buildInvoice = (tags: number[][]): string => {
+        const words: number[] = [0, 0, 0, 0, 0, 0, 1];
+        for (const tagWords of tags) words.push(...tagWords);
+        words.push(...new Array(104).fill(0));
+        return bech32.encode('lnbcrt', words, Number.MAX_SAFE_INTEGER);
+    };
+
+    it('keeps the first payment_hash when the tag is duplicated', () => {
+        const decoded = Bolt11Utils.decode(
+            buildInvoice([
+                tag(1, hexToWords(HASH_A)),
+                tag(1, hexToWords(HASH_B))
+            ])
+        );
+
+        expect(decoded.payment_hash).toBe(HASH_A);
+    });
+
+    it('skips a wrong-length payment_hash tag like lnd does', () => {
+        // 20 bytes = 32 words: lnd's zpay32 ignores it entirely, so the
+        // valid second occurrence is the one the node settles on.
+        const decoded = Bolt11Utils.decode(
+            buildInvoice([
+                tag(1, hexToWords('cc'.repeat(20))),
+                tag(1, hexToWords(HASH_B))
+            ])
+        );
+
+        expect(decoded.payment_hash).toBe(HASH_B);
+    });
+
+    it('keeps the first payment_secret when the tag is duplicated', () => {
+        const decoded = Bolt11Utils.decode(
+            buildInvoice([
+                tag(1, hexToWords(HASH_A)),
+                tag(16, hexToWords(HASH_A)),
+                tag(16, hexToWords(HASH_B))
+            ])
+        );
+
+        expect(decoded.payment_secret).toBe(HASH_A);
+    });
+
+    it('keeps the first description_hash when the tag is duplicated', () => {
+        const decoded = Bolt11Utils.decode(
+            buildInvoice([
+                tag(23, hexToWords(HASH_A)),
+                tag(23, hexToWords(HASH_B))
+            ])
+        );
+
+        expect(decoded.description_hash).toBe(HASH_A);
+    });
+
+    it('keeps the first description when the tag is duplicated', () => {
+        const decoded = Bolt11Utils.decode(
+            buildInvoice([
+                tag(13, utf8ToWords('first memo')),
+                tag(13, utf8ToWords('second memo'))
+            ])
+        );
+
+        expect(decoded.description).toBe('first memo');
+    });
+
+    it('keeps the first expiry and derives timeExpireDate from it', () => {
+        // 3600 encoded big-endian in 5-bit words: 3*32^2 + 16*32 + 16
+        const decoded = Bolt11Utils.decode(
+            buildInvoice([
+                tag(1, hexToWords(HASH_A)),
+                tag(6, [3, 16, 16]),
+                tag(6, [1])
+            ])
+        );
+
+        expect(decoded.expiry).toBe(3600);
+        expect(decoded.timeExpireDate).toBe(decoded.timestamp + 3600);
+    });
+
+    it('keeps the first valid payee tag for destination', () => {
+        const decoded = Bolt11Utils.decode(
+            buildInvoice([
+                tag(19, hexToWords(PAYEE_A)),
+                tag(19, hexToWords(PAYEE_B))
+            ])
+        );
+
+        expect(decoded.destination).toBe(PAYEE_A);
+        expect(decoded.payeeNodeKey).toBe(PAYEE_A);
+    });
+
+    it('still records every occurrence in the sections array', () => {
+        const decoded = Bolt11Utils.decode(
+            buildInvoice([
+                tag(1, hexToWords(HASH_A)),
+                tag(1, hexToWords(HASH_B))
+            ])
+        );
+
+        const hashSections = decoded.sections.filter(
+            (s) => s.name === 'payment_hash'
+        );
+        expect(hashSections).toHaveLength(2);
+        expect(hashSections[0].value).toBe(HASH_A);
+        expect(hashSections[1].value).toBe(HASH_B);
     });
 });

--- a/utils/Bolt11Utils.test.ts
+++ b/utils/Bolt11Utils.test.ts
@@ -319,6 +319,7 @@ describe('duplicate singleton tags', () => {
     it('keeps the first description_hash when the tag is duplicated', () => {
         const decoded = Bolt11Utils.decode(
             buildInvoice([
+                tag(1, hexToWords(HASH_A)),
                 tag(23, hexToWords(HASH_A)),
                 tag(23, hexToWords(HASH_B))
             ])
@@ -330,6 +331,7 @@ describe('duplicate singleton tags', () => {
     it('keeps the first description when the tag is duplicated', () => {
         const decoded = Bolt11Utils.decode(
             buildInvoice([
+                tag(1, hexToWords(HASH_A)),
                 tag(13, utf8ToWords('first memo')),
                 tag(13, utf8ToWords('second memo'))
             ])
@@ -355,6 +357,7 @@ describe('duplicate singleton tags', () => {
     it('keeps the first valid payee tag for destination', () => {
         const decoded = Bolt11Utils.decode(
             buildInvoice([
+                tag(1, hexToWords(HASH_A)),
                 tag(19, hexToWords(PAYEE_A)),
                 tag(19, hexToWords(PAYEE_B))
             ])
@@ -362,6 +365,24 @@ describe('duplicate singleton tags', () => {
 
         expect(decoded.destination).toBe(PAYEE_A);
         expect(decoded.payeeNodeKey).toBe(PAYEE_A);
+    });
+
+    it('throws when no payment_hash tag is present', () => {
+        // lnd's zpay32 rejects such invoices outright; no node can
+        // settle them.
+        const action = () =>
+            Bolt11Utils.decode(buildInvoice([tag(13, utf8ToWords('memo'))]));
+
+        expect(action).toThrowError('No valid payment hash found');
+    });
+
+    it('throws when the only payment_hash tag has the wrong length', () => {
+        const action = () =>
+            Bolt11Utils.decode(
+                buildInvoice([tag(1, hexToWords('cc'.repeat(20)))])
+            );
+
+        expect(action).toThrowError('No valid payment hash found');
     });
 
     it('still records every occurrence in the sections array', () => {

--- a/utils/Bolt11Utils.ts
+++ b/utils/Bolt11Utils.ts
@@ -204,31 +204,65 @@ class Bolt11Utils {
             });
             letters = letters.slice(1 + 2 + tagLength);
 
+            // These are singleton tags per BOLT11, and the node settles on
+            // the first well-formed occurrence (lnd's zpay32 skips repeats
+            // and wrong-length fixed-size fields). The reader here must
+            // agree, or a crafted invoice that repeats a tag makes the app
+            // track a different payment_hash / payee than the node settles
+            // on. `sections` still records every occurrence.
             switch (tagName) {
                 case 'payment_hash':
-                    result.payment_hash = value;
+                    if (
+                        result.payment_hash === undefined &&
+                        tagWords.length === this.HASH_TAG_WORDS
+                    ) {
+                        result.payment_hash = value;
+                    }
                     break;
                 case 'payment_secret':
-                    result.payment_secret = value;
+                    if (
+                        result.payment_secret === undefined &&
+                        tagWords.length === this.HASH_TAG_WORDS
+                    ) {
+                        result.payment_secret = value;
+                    }
                     break;
                 case 'description':
-                    result.description = value;
+                    if (result.description === undefined) {
+                        result.description = value;
+                    }
                     break;
                 case 'description_hash':
-                    result.description_hash = value;
+                    if (
+                        result.description_hash === undefined &&
+                        tagWords.length === this.HASH_TAG_WORDS
+                    ) {
+                        result.description_hash = value;
+                    }
                     break;
                 case 'payee':
-                    result.destination = value;
-                    result.payeeNodeKey = value;
+                    if (
+                        result.destination === undefined &&
+                        tagWords.length === this.PAYEE_TAG_WORDS
+                    ) {
+                        result.destination = value;
+                        result.payeeNodeKey = value;
+                    }
                     break;
                 case 'expiry':
-                    result.expiry = value;
+                    if (result.expiry === undefined) {
+                        result.expiry = value;
+                    }
                     break;
                 case 'min_final_cltv_expiry':
-                    result.cltv_expiry = value;
+                    if (result.cltv_expiry === undefined) {
+                        result.cltv_expiry = value;
+                    }
                     break;
                 case 'metadata':
-                    result.metadata = value;
+                    if (result.metadata === undefined) {
+                        result.metadata = value;
+                    }
                     break;
             }
         }
@@ -402,6 +436,13 @@ class Bolt11Utils {
         fallback_address: 9,
         metadata: 27
     };
+
+    // Fixed-size singleton tags measured in 5-bit words: the 32-byte
+    // p / s / h fields span exactly 52 words, the 33-byte payee pubkey
+    // (n) spans 53. lnd's zpay32 skips occurrences of any other length,
+    // so the reader here must too.
+    private HASH_TAG_WORDS = 52;
+    private PAYEE_TAG_WORDS = 53;
 
     private TAGPARSERS: { [tagCode: string]: (words: number[]) => any } = {
         '1': (words: number[]) => this.wordsToHex(words),

--- a/utils/Bolt11Utils.ts
+++ b/utils/Bolt11Utils.ts
@@ -267,6 +267,13 @@ class Bolt11Utils {
             }
         }
 
+        // lnd's zpay32 rejects an invoice without a valid payment hash
+        // (no node can settle it), so fail loudly rather than return a
+        // result whose payment_hash is silently absent.
+        if (result.payment_hash === undefined) {
+            throw new Error('No valid payment hash found');
+        }
+
         if (result.expiry != null) {
             result.timeExpireDate = timestamp + result.expiry;
         }


### PR DESCRIPTION
# Description

`Bolt11Utils.decode` applied singleton tags last-wins: if an invoice carried a tag like `payment_hash` more than once, the last occurrence overwrote the earlier one. Lightning nodes read the opposite way. lnd's zpay32 takes the first well-formed occurrence of each singleton tag and skips fixed-size fields of the wrong length. A crafted invoice could therefore make ZEUS track, display, or verify a payment under an attacker-chosen payment hash, payee, description, or expiry while the node settles on a different one.

This is the same bug class that was recently used to double-collect payments from lnp2pBot via the `invoices` npm package (fixed there in 6.0.0 on 2026-08-07, silently, inside a Node 22 major bump). ZEUS does not depend on that package, but our vendored decoder had identical behavior.

The fix mirrors lnd's reader semantics:

* only the first occurrence of each singleton tag (`payment_hash`, `payment_secret`, `description`, `description_hash`, `payee`, `expiry`, `min_final_cltv_expiry`, `metadata`) populates the top-level decoded fields
* fixed-size fields must have the exact word length lnd enforces (52 words for the 32-byte p/s/h tags, 53 for the 33-byte payee pubkey); wrong-length occurrences are skipped so they also cannot block the real value
* the `sections` array is unchanged and still records every occurrence

First-wins alone would not be enough: lnd skips a wrong-length first `p` tag and settles on the next valid one, so a decoder that locked in the malformed first occurrence would still diverge from the node.

Review follow-up (second commit): decode now throws `No valid payment hash found` when no well-formed p tag is present, matching zpay32's validation, instead of returning a result whose `payment_hash` is silently `undefined`. The field was already optional and callers already guard it, but no node can settle such an invoice, so failing at decode time is strictly safer.

Includes 10 new unit tests that hand-assemble bech32 invoices with duplicated and malformed singleton tags. Verified by running the new suite against master's decoder (`git checkout master -- utils/Bolt11Utils.ts`) and against this PR:

| New test | Against master | Against this PR |
|---|---|---|
| keeps the first payment_hash when the tag is duplicated | fail | pass |
| skips a wrong-length payment_hash tag like lnd does | pass * | pass |
| keeps the first payment_secret when the tag is duplicated | fail | pass |
| keeps the first description_hash when the tag is duplicated | fail | pass |
| keeps the first description when the tag is duplicated | fail | pass |
| keeps the first expiry and derives timeExpireDate from it | fail | pass |
| keeps the first valid payee tag for destination | fail | pass |
| still records every occurrence in the sections array | pass * | pass |
| throws when no payment_hash tag is present | fail | pass |
| throws when the only payment_hash tag has the wrong length | fail | pass |

\* Passes on master coincidentally: the wrong-length case expects the second hash, which master's last-wins behavior also happens to produce, and the `sections` array has always recorded every occurrence. The 20 pre-existing tests pass unchanged on both.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [ ] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

Device testing pending. The change is confined to the pure decoder in `utils/Bolt11Utils.ts`; behavior for well-formed invoices is covered by the existing suite, which passes unchanged.

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding


