### PR TITLE
fix(cashu): clear route params with replaceParams

### DIFF
--- a/views/Cashu/CashuLockSettings.tsx
+++ b/views/Cashu/CashuLockSettings.tsx
@@ -156,7 +156,12 @@ export default class CashuLockSettings extends React.Component<
                 error: ''
             });
         }
-        this.props.navigation.setParams({} as SendEcashParams);
+        // Clear all route params: the constructor and componentDidMount read
+        // theirs on mount, and the block above reads what the contact picker
+        // sends back. `setParams({})` merged into the existing params and left
+        // `destination` in place, so this restore re-ran on every later focus
+        // and brought back a contact the user had already cleared.
+        this.props.navigation.replaceParams({});
     };
 
     handleContactSelection(pubkey: string) {

--- a/views/Cashu/SendEcash.tsx
+++ b/views/Cashu/SendEcash.tsx
@@ -215,8 +215,10 @@ export default class SendEcash extends React.Component<
             customDurationUnit: ''
         });
 
-        // Reset all params at once
-        this.props.navigation.setParams({} as SendEcashParams);
+        // Reset all params at once. This has to be `replaceParams`:
+        // `setParams` merges into the existing params, so passing `{}` to it
+        // cleared nothing and the pre-mint values stayed on the route.
+        this.props.navigation.replaceParams({});
     }
 
     handleLockSettingsPress = () => {


### PR DESCRIPTION
# Description

Relates to issue: #4633, #4634

Both screens tried to clear their route params with `setParams({})`. In React Navigation 7, `setParams` merges the new params into the existing ones, so passing `{}` changes nothing. `replaceParams` replaces the whole params object, so both calls now use it.

- `CashuLockSettings` (#4633). The focus handler restores the contact from `params.destination` and then clears the params. Because the clear did nothing, `destination` stayed on the route, and every later focus restored the contact again, including one the user had already removed with the X on the chip.
- `SendEcash` (#4634). `resetForm()` runs after a token is minted and clears the params. Before this change `amount`, `pubkey`, `duration` and the rest stayed on the route. Nothing reads them after mount today, so there is no visible effect, but the code expected them to be gone.

The issue for #4633 says the repro was not confirmed on a device yet, so I ran it on Android before and after the change: pick a contact in Lock Settings, clear the chip with X, open the QR scanner from the header, go back. Before, the cleared contact comes back and LOCK is enabled again. After, the field stays empty. Screenshots in a comment below.

#4634 has nothing to see on screen, so I only checked that the mint path still works with the change: locked 1 sat to a contact for 1 week on the Testnut mint, sent it, went back. The form was reset, Lock Settings opened empty with the default duration, and there were no JS errors in logcat.

### What this does not cover

`SendEcash.handleLockSettingsPress` still spreads the current route params into the Lock Settings route, so a `duration` from an earlier round trip can reach the Lock Settings constructor, where it wins over `currentDuration`. I did not find a visible effect: that screen shows and saves `selectedDurationIndex`, and its `state.duration` is only passed through the contact picker. After this PR the params are empty after a mint, so old values no longer survive it. I left the spread as it is to keep this PR small.

Closes #4633
Closes #4634

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

Only view code changed, and there are no component tests for these screens.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [ ] iOS

Pixel 9 Pro emulator, x86_64, Android 16.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

LDK Node wallet with Cashu on the Testnut mint. The change is in the Cashu views and does not depend on the backend.

### Locales
- [ ] I've added new locale text that requires translations
- [ ] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:
