### PR TITLE
fix(cashu): make Lock Settings Back cancel instead of dropping the lock

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2266,6 +2266,7 @@
     "cashu.lockTo": "Locked to",
     "cashu.locktime": "Locked until",
     "cashu.lock": "Lock",
+    "cashu.removeLock": "Remove lock",
     "cashu.noContactsWithCashuPubkey": "No contacts with Cashu pubkey",
     "cashu.noDuration": "no duration",
     "cashu.duration.1Day": "1 Day",

--- a/utils/CashuUtils.test.ts
+++ b/utils/CashuUtils.test.ts
@@ -12,7 +12,8 @@ import CashuDevKit from '../cashu-cdk';
 import CashuUtils, {
     cashuTokenPrefixes,
     CashuSeedOrigin,
-    classifyCashuSeedOrigin
+    classifyCashuSeedOrigin,
+    resolveLockTarget
 } from './CashuUtils';
 
 const mockIsValidToken = CashuDevKit.isValidToken as jest.Mock;
@@ -458,5 +459,45 @@ describe('CashuUtils', () => {
                 CashuSeedOrigin.DerivedFromWalletSeed
             );
         });
+    });
+});
+
+describe('resolveLockTarget', () => {
+    const locked = { pubkey: '02abc', contactName: 'Alice' };
+
+    it('drops the contact when the lock is removed (#4637)', () => {
+        // Lock Settings' Back used to send pubkey: '' without contactName, so
+        // the name survived and reopened Lock Settings with a chip but no pubkey
+        expect(resolveLockTarget({ pubkey: '' }, locked)).toEqual({
+            pubkey: '',
+            contactName: ''
+        });
+    });
+
+    it('keeps the existing lock when no lock fields are sent', () => {
+        expect(resolveLockTarget({}, locked)).toEqual(locked);
+    });
+
+    it('uses the contact sent with a newly saved lock', () => {
+        expect(
+            resolveLockTarget({ pubkey: '03def', contactName: 'Bob' }, locked)
+        ).toEqual({ pubkey: '03def', contactName: 'Bob' });
+    });
+
+    it('drops the old contact name when the pubkey changes without one', () => {
+        expect(resolveLockTarget({ pubkey: '03def' }, locked)).toEqual({
+            pubkey: '03def',
+            contactName: ''
+        });
+    });
+
+    it('keeps the contact name when the same pubkey is re-sent without one', () => {
+        expect(resolveLockTarget({ pubkey: '02abc' }, locked)).toEqual(locked);
+    });
+
+    it('clears a stale contact name left without a pubkey', () => {
+        expect(
+            resolveLockTarget({}, { pubkey: '', contactName: 'Alice' })
+        ).toEqual({ pubkey: '', contactName: '' });
     });
 });

--- a/utils/CashuUtils.ts
+++ b/utils/CashuUtils.ts
@@ -97,6 +97,25 @@ export const classifyCashuSeedOrigin = (
     return CashuSeedOrigin.Independent;
 };
 
+/**
+ * Resolves the lock target SendEcash keeps after returning from Lock
+ * Settings. A contact name only labels the pubkey it was chosen with, so it
+ * is dropped whenever the resolved pubkey is empty (the lock was removed) or
+ * changed without a new name. Otherwise Lock Settings reopens showing a
+ * contact chip with no pubkey behind it and LOCK disabled (#4637).
+ */
+export const resolveLockTarget = (
+    params: { pubkey?: string; contactName?: string },
+    current: { pubkey?: string; contactName?: string }
+): { pubkey: string; contactName: string } => {
+    const pubkey = params.pubkey ?? current.pubkey ?? '';
+    if (!pubkey) return { pubkey: '', contactName: '' };
+    const contactName =
+        params.contactName ??
+        (pubkey === current.pubkey ? current.contactName ?? '' : '');
+    return { pubkey, contactName };
+};
+
 // Limits to mitigate resource exhaustion from malicious P2PK secret payloads
 const MAX_P2PK_SECRET_LENGTH = 2048;
 const MAX_P2PK_SECRET_DEPTH = 10;

--- a/views/Cashu/CashuLockSettings.tsx
+++ b/views/Cashu/CashuLockSettings.tsx
@@ -33,8 +33,6 @@ export interface CashuLockSettingsParams extends SendEcashParams {
     // Forwarded through the contact-picker round trip (CashuLockSettings ->
     // Contacts/ContactDetails -> CashuLockSettings) since that hop pushes a
     // second instance whose own currentLockPubkey param is empty - without
-    // this, "Remove lock" would wrongly disappear on that instance (#4637
-    // follow-up flagged in review).
     hasExistingLock?: boolean;
 }
 interface CashuLockSettingsProps {
@@ -550,7 +548,8 @@ export default class CashuLockSettings extends React.Component<
                                     showCustomDuration,
                                     customDurationValue,
                                     customDurationUnit,
-                                    selectedDurationIndex
+                                    selectedDurationIndex,
+                                    hasExistingLock
                                 } = this.state;
                                 navigation.navigate('Contacts', {
                                     SendScreen: true,
@@ -563,7 +562,7 @@ export default class CashuLockSettings extends React.Component<
                                     customDurationValue,
                                     customDurationUnit,
                                     selectedDurationIndex,
-                                    hasExistingLock: this.state.hasExistingLock
+                                    hasExistingLock
                                 });
                             }}
                             style={{ position: 'absolute', right: 10 }}

--- a/views/Cashu/CashuLockSettings.tsx
+++ b/views/Cashu/CashuLockSettings.tsx
@@ -29,6 +29,13 @@ export interface CashuLockSettingsParams extends SendEcashParams {
     destination?: string | null;
     hasCashuPubkey?: boolean;
     selectedDurationIndex?: number;
+    // Whether the flow that opened this screen already had a saved lock.
+    // Forwarded through the contact-picker round trip (CashuLockSettings ->
+    // Contacts/ContactDetails -> CashuLockSettings) since that hop pushes a
+    // second instance whose own currentLockPubkey param is empty - without
+    // this, "Remove lock" would wrongly disappear on that instance (#4637
+    // follow-up flagged in review).
+    hasExistingLock?: boolean;
 }
 interface CashuLockSettingsProps {
     navigation: NativeStackNavigationProp<any, any>;
@@ -50,6 +57,7 @@ interface CashuLockSettingsState {
     hasClipboardContent: boolean;
     isPubkeyValid: boolean;
     selectedDurationIndex: number;
+    hasExistingLock: boolean;
 }
 
 const TIME_UNITS: string[] = [
@@ -87,7 +95,8 @@ export default class CashuLockSettings extends React.Component<
             customDurationValue,
             customDurationUnit,
             duration,
-            selectedDurationIndex
+            selectedDurationIndex,
+            hasExistingLock
         } = route.params || {};
 
         this.state = {
@@ -111,7 +120,11 @@ export default class CashuLockSettings extends React.Component<
                     ? selectedDurationIndex
                     : currentDuration
                     ? DURATION_OPTIONS.indexOf(currentDuration)
-                    : 0
+                    : 0,
+            // A lock exists either if this instance was opened with one
+            // directly (currentLockPubkey) or if the contact-picker round
+            // trip forwarded that an earlier instance had one.
+            hasExistingLock: !!currentLockPubkey || !!hasExistingLock
         };
         this.handleContactSelection = this.handleContactSelection.bind(this);
     }
@@ -363,12 +376,26 @@ export default class CashuLockSettings extends React.Component<
         return isPubkeyValid && selectedDurationIndex !== undefined;
     };
 
+    // Back cancels: return without params so SendEcash keeps whatever lock
+    // it already has, the same as the hardware/gesture back. popTo (rather
+    // than goBack) also unwinds a second Lock Settings screen pushed by the
+    // contact picker. Removing a lock is the explicit removeLock action.
     onBack = () => {
+        this.props.navigation.popTo('SendEcash');
+    };
+
+    // Clears every lock field, including contactName: leaving the name
+    // behind reopens Lock Settings with a contact chip but no pubkey, and
+    // LOCK disabled (#4637).
+    removeLock = () => {
         const params: SendEcashParams = {
             fromLockSettings: true,
             pubkey: '',
+            contactName: '',
             duration: '',
-            showCustomDuration: false
+            showCustomDuration: false,
+            customDurationValue: '',
+            customDurationUnit: ''
         };
         this.props.navigation.popTo('SendEcash', params);
     };
@@ -384,7 +411,8 @@ export default class CashuLockSettings extends React.Component<
             hasClipboardContent,
             isPubkeyValid,
             contactName,
-            selectedDurationIndex
+            selectedDurationIndex,
+            hasExistingLock
         } = this.state;
         const isFormValid = this.isFormValid();
 
@@ -534,7 +562,8 @@ export default class CashuLockSettings extends React.Component<
                                     showCustomDuration,
                                     customDurationValue,
                                     customDurationUnit,
-                                    selectedDurationIndex
+                                    selectedDurationIndex,
+                                    hasExistingLock: this.state.hasExistingLock
                                 });
                             }}
                             style={{ position: 'absolute', right: 10 }}
@@ -702,6 +731,14 @@ export default class CashuLockSettings extends React.Component<
                             disabled={!isFormValid}
                             title={localeString('cashu.lock')}
                         />
+                        {hasExistingLock && (
+                            <Button
+                                onPress={this.removeLock}
+                                containerStyle={styles.bottomButton}
+                                title={localeString('cashu.removeLock')}
+                                secondary
+                            />
+                        )}
                     </View>
                 </ScrollView>
             </Screen>

--- a/views/Cashu/SendEcash.tsx
+++ b/views/Cashu/SendEcash.tsx
@@ -22,6 +22,7 @@ import ContactStore from '../../stores/ContactStore';
 
 import { themeColor } from '../../utils/ThemeUtils';
 import { localeString } from '../../utils/LocaleUtils';
+import { resolveLockTarget } from '../../utils/CashuUtils';
 
 export interface SendEcashParams {
     amount?: string;
@@ -131,12 +132,16 @@ export default class SendEcash extends React.Component<
             // Restoring it from params here would instead reapply a stale
             // copy - captured back when the lock button was first pressed -
             // over whatever the user has since typed into the keypad.
+            const { pubkey, contactName } = resolveLockTarget(
+                params,
+                this.state
+            );
             const stateUpdate: Partial<SendEcashState> = {
-                pubkey: params.pubkey ?? this.state.pubkey,
+                pubkey,
                 duration: params.duration ?? this.state.duration,
                 locktime: this.convertDurationToSeconds(params.duration),
                 memo: params.memo ?? this.state.memo,
-                contactName: params.contactName ?? this.state.contactName,
+                contactName,
                 showCustomDuration:
                     params.showCustomDuration ?? this.state.showCustomDuration,
                 customDurationValue:

--- a/views/Settings/Contacts.tsx
+++ b/views/Settings/Contacts.tsx
@@ -122,7 +122,8 @@ export default class Contacts extends React.Component<
             showCustomDuration,
             customDurationValue,
             customDurationUnit,
-            selectedDurationIndex
+            selectedDurationIndex,
+            hasExistingLock
         } = route.params || {};
 
         const isCashuPubkeyAvailable =
@@ -155,7 +156,8 @@ export default class Contacts extends React.Component<
                                     showCustomDuration,
                                     customDurationValue,
                                     customDurationUnit,
-                                    selectedDurationIndex
+                                    selectedDurationIndex,
+                                    hasExistingLock
                                 }
                             });
                         } else {
@@ -172,7 +174,8 @@ export default class Contacts extends React.Component<
                                     showCustomDuration,
                                     customDurationValue,
                                     customDurationUnit,
-                                    selectedDurationIndex
+                                    selectedDurationIndex,
+                                    hasExistingLock
                                 }
                             );
                         }


### PR DESCRIPTION
# Description

Fixes #4637.

## Root cause

`CashuLockSettings.onBack` sent SendEcash `{ fromLockSettings: true, pubkey: '', duration: '', showCustomDuration: false }` — clearing the pubkey but never sending `contactName`. SendEcash's focus handler restores each field with `params.field ?? this.state.field`, so the explicit `''` wiped the pubkey while the omitted `contactName` fell through to the old value and survived.

Repro: lock a token to a contact, open Lock Settings again, tap the header Back button. SendEcash loses the lock (shows "Lock to Pubkey" again). Reopening Lock Settings shows the contact chip with no pubkey behind it, and LOCK stays disabled since it requires a valid pubkey — there was no way out of that state except restarting the flow.

The header Back also behaved differently from the hardware/gesture back, which left `route.params` alone and kept the lock.

## Fix

- `CashuLockSettings.onBack` now pops back to SendEcash with no params at all, so the existing lock (if any) is left untouched — the same behavior as the hardware/gesture back. `popTo` (not `goBack`) also correctly unwinds a second Lock Settings screen that the contact picker can push onto the stack.
- Removing a lock is now an explicit **Remove lock** button, shown only when Lock Settings opens with an existing lock (`hasExistingLock`). It clears every lock field, including `contactName`.
- SendEcash restores the lock through a new `resolveLockTarget` helper in `utils/CashuUtils.ts`, which never keeps a contact name without the pubkey it was chosen with. This closes the underlying invariant, not just this one code path, so the broken state can't come back through a different route later.

## Testing

`resolveLockTarget` is a pure function extracted specifically so this fix is unit-tested; `utils/CashuUtils.test.ts` covers it directly, including the exact case from #4637. Verified the regression tests fail against the old `??`-only logic and pass with the fix.

Manually verified: lock a token to a contact → reopen Lock Settings → header Back → the lock is still shown on SendEcash. Reopening Lock Settings again shows the same contact with LOCK enabled. Remove lock clears the contact chip and returns SendEcash to "Lock to Pubkey".




This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I’ve run `yarn run tsc` and made sure my code compiles correctly
- [x] I’ve run `yarn run lint` and made sure my code didn’t contain any problematic patterns
- [x] I’ve run `yarn run prettier` and made sure my code is formatted correctly
- [x] I’ve run `yarn run test` and made sure all of the tests pass

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I’m a fool
- [x] Yes
- [ ] N/A

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [x] Android
- [x] iOS

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [x] LDK Node
- [ ] Embedded LND

Remote
- [ ] LND (REST)
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [x] I’ve added new locale text that requires translations
- [ ] I’m aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:
    * verify that `package.json` and `yarn.lock` have been properly updated
    * verify that dependencies are installed for both iOS and Android platforms

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
