### PR TITLE
Activity: add layer icons, contact images, and badges

### DIFF
--- a/components/SVG/EcashSvg.tsx
+++ b/components/SVG/EcashSvg.tsx
@@ -6,7 +6,8 @@ export default function OnChainSvg({
     width = 70,
     height = 70,
     circle = true,
-    selected = false
+    selected = false,
+    color = ''
 }) {
     const svgProps = {
         width: `${width}`,
@@ -29,17 +30,23 @@ export default function OnChainSvg({
     const polygonProps = [
         {
             points: '794.68 0 0 398.29 0 764.47 794.68 366.18 1589.35 764.47 1589.35 398.29 794.68 0',
-            fill: selected ? themeColor('background') : themeColor('chain'),
+            fill:
+                color ||
+                (selected ? themeColor('background') : themeColor('chain')),
             transform: transformScale
         },
         {
             points: '794.68 1633.82 326.88 1399.37 328.01 684.38 .39 847.95 0 1601.71 794.68 2000 1589.35 1601.71 1589.35 1235.53 794.68 1633.82',
-            fill: selected ? themeColor('background') : themeColor('chain'),
+            fill:
+                color ||
+                (selected ? themeColor('background') : themeColor('chain')),
             transform: transformScale
         },
         {
             points: '1224.07 665.72 794.68 880.93 399.37 682.8 399.37 1048.98 794.68 1247.11 1589.35 848.81 1224.07 665.72',
-            fill: selected ? themeColor('background') : themeColor('chain'),
+            fill:
+                color ||
+                (selected ? themeColor('background') : themeColor('chain')),
             transform: transformScale
         }
     ];

--- a/components/SVG/LightningSvg.tsx
+++ b/components/SVG/LightningSvg.tsx
@@ -6,7 +6,8 @@ export default function LightningSvg({
     width = 70,
     height = 70,
     circle = true,
-    selected = false
+    selected = false,
+    color = ''
 }) {
     const svgProps = {
         width: `${width}`,
@@ -25,12 +26,14 @@ export default function LightningSvg({
 
     const polygon1Props = {
         points: '20.802,29.826 23.896,36.001 25.676,32.449 24.362,29.826 25.676,27.2 23.896,23.651',
-        fill: selected ? themeColor('background') : themeColor('bolt')
+        fill:
+            color || (selected ? themeColor('background') : themeColor('bolt'))
     };
 
     const polygon2Props = {
         points: '29.197,20.173 26.103,14 24.323,17.55 25.637,20.173 24.323,22.799 26.103,26.351',
-        fill: selected ? themeColor('background') : themeColor('bolt')
+        fill:
+            color || (selected ? themeColor('background') : themeColor('bolt'))
     };
 
     return React.createElement(

--- a/components/SVG/OnChainSvg.tsx
+++ b/components/SVG/OnChainSvg.tsx
@@ -6,7 +6,8 @@ export default function OnChainSvg({
     width = 70,
     height = 70,
     circle = true,
-    selected = false
+    selected = false,
+    color = ''
 }) {
     const svgProps = {
         width: `${width}`,
@@ -25,17 +26,20 @@ export default function OnChainSvg({
 
     const path1Props = {
         d: 'M28.717,27.892l-1.65-1.652l4.129-4.131l-3.304-3.304l-4.13,4.13l-1.653-1.651l5.783-5.783l6.608,6.608L28.717,27.892z',
-        fill: selected ? themeColor('background') : themeColor('chain')
+        fill:
+            color || (selected ? themeColor('background') : themeColor('chain'))
     };
 
     const path2Props = {
         d: 'M21.282,22.108l1.652,1.653l-4.13,4.13l3.304,3.304l4.131-4.129l1.652,1.65L22.108,34.5L15.5,27.892L21.282,22.108z',
-        fill: selected ? themeColor('background') : themeColor('chain')
+        fill:
+            color || (selected ? themeColor('background') : themeColor('chain'))
     };
 
     const path3Props = {
         d: 'M29.544,22.108l-1.652-1.651l-7.435,7.435l1.651,1.652L29.544,22.108z',
-        fill: selected ? themeColor('background') : themeColor('chain')
+        fill:
+            color || (selected ? themeColor('background') : themeColor('chain'))
     };
 
     return React.createElement(

--- a/utils/ActivityIconUtils.test.ts
+++ b/utils/ActivityIconUtils.test.ts
@@ -1,0 +1,41 @@
+jest.mock('dateformat', () => ({}));
+jest.mock('./LocaleUtils', () => ({ localeString: (s: string) => s }));
+jest.mock('../stores/Stores', () => ({ notesStore: { notes: {} } }));
+jest.mock('../cashu-cdk', () => ({}));
+
+import CashuInvoice from '../models/CashuInvoice';
+import CashuPayment from '../models/CashuPayment';
+import CashuToken from '../models/CashuToken';
+import Invoice from '../models/Invoice';
+import Payment from '../models/Payment';
+import Transaction from '../models/Transaction';
+import Swap, { SwapType } from '../models/Swap';
+import { getActivityLayer } from './ActivityIconUtils';
+
+describe('getActivityLayer', () => {
+    it.each([
+        ['Cashu invoice', new CashuInvoice({}), 'ecash'],
+        ['Cashu payment', new CashuPayment({}), 'ecash'],
+        ['Cashu token', new CashuToken({}), 'ecash'],
+        ['transaction', new Transaction({}), 'onchain'],
+        [
+            'submarine swap destination',
+            new Swap({ type: SwapType.Submarine }),
+            'lightning'
+        ],
+        [
+            'reverse swap destination',
+            new Swap({ type: SwapType.Reverse }),
+            'onchain'
+        ],
+        ['invoice', new Invoice({}), 'lightning'],
+        ['payment', new Payment({}), 'lightning'],
+        ['LSPS1 order', { model: 'LSPS1Order' }, 'lightning'],
+        ['LSPS7 order', { model: 'LSPS7Order' }, 'lightning'],
+        ['unknown activity', {}, 'lightning'],
+        ['null', null, 'lightning'],
+        ['undefined', undefined, 'lightning']
+    ])('%s', (_name, item, layer) => {
+        expect(getActivityLayer(item)).toBe(layer);
+    });
+});

--- a/utils/ActivityIconUtils.ts
+++ b/utils/ActivityIconUtils.ts
@@ -1,0 +1,23 @@
+import CashuInvoice from '../models/CashuInvoice';
+import CashuPayment from '../models/CashuPayment';
+import CashuToken from '../models/CashuToken';
+import Transaction from '../models/Transaction';
+import Swap from '../models/Swap';
+
+export function getActivityLayer(item: any): 'onchain' | 'lightning' | 'ecash' {
+    if (
+        item instanceof CashuInvoice ||
+        item instanceof CashuPayment ||
+        item instanceof CashuToken
+    ) {
+        return 'ecash';
+    }
+
+    if (item instanceof Transaction) return 'onchain';
+
+    if (item instanceof Swap) {
+        return item.isSubmarineSwap ? 'lightning' : 'onchain';
+    }
+
+    return 'lightning';
+}

--- a/utils/ActivityImageUtils.test.ts
+++ b/utils/ActivityImageUtils.test.ts
@@ -1,0 +1,309 @@
+jest.mock('dateformat', () => ({}));
+jest.mock('./LocaleUtils', () => ({ localeString: (s: string) => s }));
+jest.mock('../stores/Stores', () => ({ notesStore: { notes: {} } }));
+jest.mock('../cashu-cdk', () => ({}));
+jest.mock('react-native-fs', () => ({ DocumentDirectoryPath: '/documents' }));
+
+import { Image } from 'react-native';
+import type Contact from '../models/Contact';
+import CashuInvoice from '../models/CashuInvoice';
+import CashuPayment from '../models/CashuPayment';
+import CashuToken from '../models/CashuToken';
+import Invoice from '../models/Invoice';
+import Payment from '../models/Payment';
+import Transaction from '../models/Transaction';
+import Bolt11Utils from './Bolt11Utils';
+import {
+    getActivityContactPhoto,
+    getActivityLnurlImage
+} from './ActivityImageUtils';
+
+const contact = (data: Partial<Contact> = {}): Contact =>
+    ({ photo: 'rnfs://alice.png', ...data } as Contact);
+const history = (metadata: unknown, lnurl = 'lnurl1alice') => ({
+    lnurl,
+    metadata: { metadata: JSON.stringify(metadata) }
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('getActivityContactPhoto', () => {
+    it('normalizes local photos and prefers explicit payment destinations', () => {
+        const decode = jest.spyOn(Bolt11Utils, 'decode');
+        expect(
+            getActivityContactPhoto(
+                new Payment({ destination: 'alice', payment_request: 'bad' }),
+                [contact({ pubkey: ['alice'] })]
+            )
+        ).toBe('file:///documents/alice.png');
+        expect(decode).not.toHaveBeenCalled();
+    });
+
+    it('normalizes preset photos', () => {
+        jest.spyOn(Image, 'resolveAssetSource').mockReturnValue({
+            uri: 'asset://alice',
+            width: 1,
+            height: 1,
+            scale: 1
+        });
+        expect(
+            getActivityContactPhoto(new Payment({ destination: 'alice' }), [
+                contact({ pubkey: ['alice'], photo: 'preset://alby' })
+            ])
+        ).toBe('asset://alice');
+    });
+
+    it('decodes only when a contact has a usable pubkey', () => {
+        const decode = jest.spyOn(Bolt11Utils, 'decode').mockReturnValue({
+            destination: 'alice'
+        } as any);
+        const payment = new Payment({ payment_request: 'invoice' });
+        for (const contacts of [[], [contact()], [contact({ pubkey: [''] })]]) {
+            expect(getActivityContactPhoto(payment, contacts)).toBeUndefined();
+        }
+        expect(decode).not.toHaveBeenCalled();
+        expect(
+            getActivityContactPhoto(payment, [contact({ pubkey: ['alice'] })])
+        ).toBe('file:///documents/alice.png');
+        expect(decode).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles malformed payment requests', () => {
+        expect(
+            getActivityContactPhoto(new Payment({ payment_request: 'bad' }), [
+                contact({ pubkey: ['alice'] })
+            ])
+        ).toBeUndefined();
+    });
+
+    it('prefers exact stored LNURL over metadata and the service pubkey', () => {
+        expect(
+            getActivityContactPhoto(
+                new Payment({ destination: 'service' }),
+                [
+                    contact({ pubkey: ['service'], photo: 'service.png' }),
+                    contact({
+                        lnAddress: ['bob@example.com'],
+                        photo: 'bob.png'
+                    }),
+                    contact({ lnAddress: ['lnurl1alice'] })
+                ],
+                history([['text/identifier', 'bob@example.com']])
+            )
+        ).toBe('file:///documents/alice.png');
+    });
+
+    it.each(['text/plain', 'text/identifier'])(
+        'matches a complete %s lightning address case-insensitively',
+        (type) => {
+            expect(
+                getActivityContactPhoto(
+                    new CashuPayment({}),
+                    [contact({ lnAddress: ['Alice@example.com'] })],
+                    history([[type, ' ALICE@example.com ']])
+                )
+            ).toBe('file:///documents/alice.png');
+        }
+    );
+
+    it.each([
+        'bad json',
+        'null',
+        '{}',
+        '[null, 1, ["text/identifier", 123]]',
+        '[["text/plain", "Pay alice@example.com"]]',
+        '[["text/email", "alice@example.com"]]'
+    ])(
+        'never falls back to a shared service key with metadata %s',
+        (metadata) => {
+            const decode = jest.spyOn(Bolt11Utils, 'decode');
+            expect(
+                getActivityContactPhoto(
+                    new Payment({
+                        destination: 'service',
+                        payment_request: 'bad'
+                    }),
+                    [
+                        contact({
+                            pubkey: ['service'],
+                            lnAddress: ['alice@example.com']
+                        })
+                    ],
+                    { lnurl: 'unknown', metadata: { metadata } }
+                )
+            ).toBeUndefined();
+            expect(decode).not.toHaveBeenCalled();
+        }
+    );
+
+    it('does not use pubkeys for LNURL history with no metadata', () => {
+        expect(
+            getActivityContactPhoto(
+                new Payment({ destination: 'service' }),
+                [contact({ pubkey: ['service'] })],
+                { lnurl: 'unknown' }
+            )
+        ).toBeUndefined();
+    });
+
+    it('matches outgoing Cashu lock keys, not incoming or unmarked tokens', () => {
+        const proofs = [
+            { secret: JSON.stringify(['P2PK', { data: 'alice' }]) }
+        ];
+        const contacts = [contact({ cashuPubkey: ['alice'] })];
+        expect(
+            getActivityContactPhoto(
+                new CashuToken({ sent: true, proofs }),
+                contacts
+            )
+        ).toBe('file:///documents/alice.png');
+        for (const flags of [
+            { received: true },
+            {},
+            { sent: true, received: true }
+        ]) {
+            expect(
+                getActivityContactPhoto(
+                    new CashuToken({ ...flags, proofs }),
+                    contacts
+                )
+            ).toBeUndefined();
+        }
+    });
+
+    it('matches external onchain outputs but never change or unknown ownership', () => {
+        const transaction = new Transaction({
+            amount: -100,
+            dest_addresses: ['change', 'alice', 'unknown'],
+            output_details: [
+                { address: 'change', is_our_address: true },
+                { address: 'alice', is_our_address: false },
+                { address: 'unknown' }
+            ]
+        });
+        const alice = contact({ onchainAddress: ['alice'] });
+        expect(
+            getActivityContactPhoto(transaction, [
+                contact({ onchainAddress: ['change'], photo: 'change.png' }),
+                alice
+            ])
+        ).toBe('file:///documents/alice.png');
+        for (const address of ['change', 'unknown']) {
+            expect(
+                getActivityContactPhoto(transaction, [
+                    contact({ onchainAddress: [address] })
+                ])
+            ).toBeUndefined();
+        }
+        expect(
+            getActivityContactPhoto(
+                new Transaction({ amount: -100, dest_addresses: ['alice'] }),
+                [alice]
+            )
+        ).toBeUndefined();
+    });
+
+    it.each([
+        new Invoice({ destination: 'alice' }),
+        new CashuInvoice({ destination: 'alice' }),
+        new Transaction({
+            amount: 100,
+            dest_addresses: ['alice'],
+            output_details: [{ address: 'alice', is_our_address: false }]
+        }),
+        new Transaction({ amount: 0, dest_addresses: ['alice'] }),
+        { destination: 'alice' },
+        null,
+        undefined
+    ])(
+        'does not infer a sender or match unknown activity types: %p',
+        (item) => {
+            expect(
+                getActivityContactPhoto(
+                    item,
+                    [
+                        contact({
+                            pubkey: ['alice'],
+                            onchainAddress: ['alice'],
+                            lnAddress: ['lnurl1alice']
+                        })
+                    ],
+                    history([])
+                )
+            ).toBeUndefined();
+        }
+    );
+
+    it('returns undefined for ambiguous matches or missing photos', () => {
+        const payment = new Payment({ destination: 'alice' });
+        expect(
+            getActivityContactPhoto(payment, [
+                contact({ pubkey: ['alice'], photo: null })
+            ])
+        ).toBeUndefined();
+        expect(
+            getActivityContactPhoto(payment, [
+                contact({ pubkey: ['alice'] }),
+                contact({ pubkey: ['alice'], photo: 'other.png' })
+            ])
+        ).toBeUndefined();
+    });
+});
+
+describe('getActivityLnurlImage', () => {
+    it.each(['image/png;base64', 'image/jpeg;base64'])(
+        'returns a data URI for %s',
+        (type) => {
+            expect(
+                getActivityLnurlImage(JSON.stringify([[type, 'aGVsbG8=']]))
+            ).toBe(`data:${type},aGVsbG8=`);
+        }
+    );
+
+    it.each([
+        undefined,
+        '',
+        'bad json',
+        'null',
+        '{}',
+        '"text"',
+        '[null, 1, {}, []]',
+        '[["image/png;base64", 123]]',
+        '[["image/png;base64", ""]]',
+        '[["image/png;base64", "   "]]',
+        '[["image/svg+xml;base64", "abc"]]',
+        '[["image/webp;base64", "abc"]]',
+        '[["image/png", "https://example.com/image.png"]]'
+    ])('ignores malformed or unsupported metadata: %s', (metadata) => {
+        expect(getActivityLnurlImage(metadata)).toBeUndefined();
+    });
+
+    it('skips malformed entries and returns the first supported image', () => {
+        expect(
+            getActivityLnurlImage(
+                JSON.stringify([
+                    null,
+                    ['image/svg+xml;base64', 'svg'],
+                    ['image/jpeg;base64', 'first'],
+                    ['image/png;base64', 'second']
+                ])
+            )
+        ).toBe('data:image/jpeg;base64,first');
+    });
+
+    it('supports contact-first composition without changing inputs', () => {
+        const payment = Object.freeze(new Payment({ destination: 'alice' }));
+        const contacts = [
+            contact({
+                pubkey: ['alice'],
+                photo: 'https://example.com/alice.png'
+            })
+        ];
+        Object.freeze(contacts[0]);
+        const metadata = JSON.stringify([['image/png;base64', 'fallback']]);
+        expect(
+            getActivityContactPhoto(payment, contacts) ||
+                getActivityLnurlImage(metadata)
+        ).toBe('https://example.com/alice.png');
+    });
+});

--- a/utils/ActivityImageUtils.ts
+++ b/utils/ActivityImageUtils.ts
@@ -1,0 +1,106 @@
+import type Contact from '../models/Contact';
+import CashuToken from '../models/CashuToken';
+import Payment from '../models/Payment';
+import Transaction from '../models/Transaction';
+import { getPhoto } from './PhotoUtils';
+
+export function getActivityContactPhoto(
+    item: any,
+    contacts: Contact[],
+    lnurl?: { lnurl: string; metadata?: { metadata: string } }
+): string | undefined {
+    if (!contacts.length) return undefined;
+
+    let matches: Contact[] = [];
+    if (item instanceof Payment) {
+        if (lnurl) {
+            matches = contacts.filter((contact) =>
+                contact.lnAddress?.some(
+                    (address) => address && address === lnurl.lnurl
+                )
+            );
+            if (!matches.length) {
+                let metadata: unknown;
+                try {
+                    metadata = JSON.parse(lnurl.metadata?.metadata || '[]');
+                } catch {
+                    return undefined;
+                }
+                if (Array.isArray(metadata)) {
+                    const identifiers = metadata
+                        .filter(
+                            (entry) =>
+                                Array.isArray(entry) &&
+                                entry.length === 2 &&
+                                (entry[0] === 'text/identifier' ||
+                                    entry[0] === 'text/plain') &&
+                                typeof entry[1] === 'string' &&
+                                entry[1].trim()
+                        )
+                        .map((entry) => entry[1].trim().toLowerCase());
+                    matches = contacts.filter((contact) =>
+                        contact.lnAddress?.some(
+                            (address) =>
+                                address &&
+                                identifiers.includes(address.toLowerCase())
+                        )
+                    );
+                }
+            }
+            // A service node pubkey does not identify its LNURL recipient.
+        } else if (contacts.some((contact) => contact.pubkey?.some(Boolean))) {
+            const destination = item.destination || item.getDestination;
+            if (destination) {
+                matches = contacts.filter((contact) =>
+                    contact.pubkey?.includes(destination)
+                );
+            }
+        }
+    } else if (item instanceof CashuToken && item.sent && !item.received) {
+        const destination = item.getLockPubkey;
+        if (destination) {
+            matches = contacts.filter((contact) =>
+                contact.cashuPubkey?.includes(destination)
+            );
+        }
+    } else if (item instanceof Transaction && Number(item.getAmount) < 0) {
+        // destAddresses alone can include change, notably on CLN.
+        const destinations = item.output_details
+            ?.filter((output) => output.is_our_address === false)
+            .map((output) => output.address)
+            .filter(Boolean);
+        if (destinations?.length) {
+            matches = contacts.filter((contact) =>
+                contact.onchainAddress?.some((address) =>
+                    destinations.includes(address)
+                )
+            );
+        }
+    }
+
+    // Do not choose arbitrarily between contacts sharing a destination.
+    return matches.length === 1
+        ? getPhoto(matches[0].photo || undefined) || undefined
+        : undefined;
+}
+
+export function getActivityLnurlImage(metadata?: string): string | undefined {
+    if (!metadata) return undefined;
+    try {
+        const entries: unknown = JSON.parse(metadata);
+        if (!Array.isArray(entries)) return undefined;
+        for (const entry of entries) {
+            if (
+                Array.isArray(entry) &&
+                entry.length === 2 &&
+                (entry[0] === 'image/png;base64' ||
+                    entry[0] === 'image/jpeg;base64') &&
+                typeof entry[1] === 'string' &&
+                entry[1].trim()
+            ) {
+                return `data:${entry[0]},${entry[1]}`;
+            }
+        }
+    } catch {}
+    return undefined;
+}

--- a/views/Activity/Activity.tsx
+++ b/views/Activity/Activity.tsx
@@ -22,6 +22,7 @@ import LoadingIndicator from '../../components/LoadingIndicator';
 import Screen from '../../components/Screen';
 import { Row } from '../../components/layout/Row';
 import ActivityToCsv from './ActivityToCsv';
+import ActivityIcon, { ActivityImageCache } from './ActivityIcon';
 
 import { localeString } from '../../utils/LocaleUtils';
 import BackendUtils from '../../utils/BackendUtils';
@@ -92,6 +93,7 @@ interface ActivityListItemProps {
         | 'warningReserve';
     order?: Order;
     swapStore: SwapStore;
+    imageCache: ActivityImageCache;
 }
 
 const ActivityListItem = observer(
@@ -101,9 +103,11 @@ const ActivityListItem = observer(
         onItemPress,
         getRightTitleTheme,
         order,
-        swapStore
+        swapStore,
+        imageCache
     }: ActivityListItemProps) => {
         const note = item.getNote;
+        const amountColor = getRightTitleTheme(item);
         let displayName = item.model;
         let subTitle = item.model;
 
@@ -292,6 +296,11 @@ const ActivityListItem = observer(
                 }}
                 onPress={() => onItemPress(item)}
             >
+                <ActivityIcon
+                    item={item}
+                    imageCache={imageCache}
+                    colorTheme={amountColor}
+                />
                 <ListItem.Content>
                     <View style={styles.row}>
                         <ListItem.Title
@@ -328,7 +337,7 @@ const ActivityListItem = observer(
                                         : item.getAmount
                                 }
                                 sensitive
-                                color={getRightTitleTheme(item)}
+                                color={amountColor}
                             />
                             {!!item.getFee && item.getFee != 0 && (
                                 <>
@@ -343,7 +352,7 @@ const ActivityListItem = observer(
                                     <Amount
                                         sats={item.getFee}
                                         sensitive
-                                        color={getRightTitleTheme(item)}
+                                        color={amountColor}
                                         fee
                                         roundAmount
                                     />
@@ -467,6 +476,7 @@ export default class Activity extends React.PureComponent<
     private transactionListener: EmitterSubscription;
     private invoicesListener: EmitterSubscription;
     private focusListener?: () => void;
+    private activityImageCache: ActivityImageCache = new Map();
 
     state = {
         loading: false,
@@ -859,6 +869,7 @@ export default class Activity extends React.PureComponent<
                                 getRightTitleTheme={this.getRightTitleTheme}
                                 order={route.params?.order}
                                 swapStore={SwapStore}
+                                imageCache={this.activityImageCache}
                             />
                         )}
                         keyExtractor={(item, index) => `${item.model}-${index}`}

--- a/views/Activity/ActivityIcon.test.ts
+++ b/views/Activity/ActivityIcon.test.ts
@@ -1,0 +1,299 @@
+jest.mock('mobx-react', () => ({
+    inject: () => (component: any) => component,
+    observer: (component: any) => component
+}));
+jest.mock('../../components/SVG/LightningSvg', () => 'LightningSvg');
+jest.mock('../../components/SVG/OnChainSvg', () => 'OnChainSvg');
+jest.mock('../../components/SVG/EcashSvg', () => 'EcashSvg');
+jest.mock('../../models/Payment', () => class Payment {});
+jest.mock('../../stores/ContactStore', () => ({}));
+jest.mock('../../stores/LnurlPayStore', () => ({}));
+jest.mock('../../utils/ActivityIconUtils', () => ({
+    getActivityLayer: jest.fn()
+}));
+jest.mock('../../utils/ActivityImageUtils', () => ({
+    getActivityContactPhoto: jest.fn(),
+    getActivityLnurlImage: jest.fn()
+}));
+jest.mock('../../utils/ThemeUtils', () => ({
+    themeColor: jest.fn()
+}));
+
+import React from 'react';
+import { Image, StyleSheet, View } from 'react-native';
+import { act, create, ReactTestRenderer } from 'react-test-renderer';
+import ActivityIcon, { ActivityImageCache } from './ActivityIcon';
+import LightningSvg from '../../components/SVG/LightningSvg';
+import OnChainSvg from '../../components/SVG/OnChainSvg';
+import EcashSvg from '../../components/SVG/EcashSvg';
+import Payment from '../../models/Payment';
+import type { LnurlPayTransaction } from '../../stores/LnurlPayStore';
+import { getActivityLayer } from '../../utils/ActivityIconUtils';
+import { themeColor } from '../../utils/ThemeUtils';
+import {
+    getActivityContactPhoto,
+    getActivityLnurlImage
+} from '../../utils/ActivityImageUtils';
+
+function payment(hash: string) {
+    return Object.assign(Object.create(Payment.prototype), {
+        resolvedPaymentHash: hash
+    });
+}
+
+function transaction(hash: string): LnurlPayTransaction {
+    return {
+        paymentHash: hash,
+        metadata: { metadata: `https://example.com/${hash}.png` }
+    } as LnurlPayTransaction;
+}
+
+function deferred() {
+    let resolve!: (value: LnurlPayTransaction | undefined) => void;
+    const promise = new Promise<LnurlPayTransaction | undefined>((done) => {
+        resolve = done;
+    });
+    return { promise, resolve };
+}
+
+describe('ActivityIcon', () => {
+    let renderers: ReactTestRenderer[];
+    let imageCache: ActivityImageCache;
+    let load: jest.Mock;
+    let props: React.ComponentProps<typeof ActivityIcon>;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        jest.mocked(themeColor).mockImplementation(
+            (key) =>
+                ({
+                    success: '#46BE43',
+                    error: 'rgb(200, 40, 40)',
+                    highlight: 'orange',
+                    warning: '#E14C4C',
+                    text: 'white',
+                    secondaryText: '#A7A9AC',
+                    background: '#1F242D'
+                }[key])
+        );
+        renderers = [];
+        imageCache = new Map();
+        load = jest.fn().mockResolvedValue(transaction('first'));
+        props = {
+            item: payment('first'),
+            imageCache,
+            colorTheme: 'success',
+            ContactStore: { contacts: [] },
+            LnurlPayStore: { load }
+        } as unknown as React.ComponentProps<typeof ActivityIcon>;
+        jest.mocked(getActivityLayer).mockReturnValue('lightning');
+        jest.mocked(getActivityLnurlImage).mockImplementation(
+            (metadata) => metadata
+        );
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            renderers.forEach((renderer) => renderer.unmount());
+        });
+    });
+
+    async function mount(item = props.item) {
+        let renderer!: ReactTestRenderer;
+        await act(async () => {
+            renderer = create(
+                React.createElement(ActivityIcon, { ...props, item })
+            );
+        });
+        renderers.push(renderer);
+        return renderer;
+    }
+
+    it.each([
+        ['success', '#46BE43'],
+        ['error', 'rgb(200, 40, 40)'],
+        ['highlight', 'orange'],
+        ['warning', '#E14C4C'],
+        ['text', 'white'],
+        ['secondaryText', '#A7A9AC']
+    ] as const)('matches the amount theme color %s', async (key, color) => {
+        props.colorTheme = key;
+        jest.mocked(getActivityLnurlImage).mockReturnValue(undefined);
+        const renderer = await mount();
+        expect(themeColor).toHaveBeenCalledWith(key);
+        expect(renderer.root.findByType(LightningSvg).props.color).toBe(color);
+        const views = renderer.root.findAllByType(View);
+        expect(StyleSheet.flatten(views[0].props.style).borderColor).toBe(
+            color
+        );
+        expect(StyleSheet.flatten(views[1].props.style)).toMatchObject({
+            backgroundColor: color,
+            opacity: 0.1
+        });
+    });
+
+    it('waits for history and prioritizes the contact photo over the LNURL image', async () => {
+        const lookup = deferred();
+        load.mockReturnValue(lookup.promise);
+        const contactPhoto = 'https://example.com/contact.png';
+        jest.mocked(getActivityContactPhoto).mockReturnValue(contactPhoto);
+        const renderer = await mount();
+
+        expect(renderer.root.findAllByType(Image)).toHaveLength(0);
+        expect(renderer.root.findAllByType(LightningSvg)).toHaveLength(1);
+        expect(getActivityContactPhoto).not.toHaveBeenCalled();
+
+        const history = transaction('first');
+        await act(async () => lookup.resolve(history));
+
+        expect(getActivityContactPhoto).toHaveBeenLastCalledWith(
+            props.item,
+            props.ContactStore!.contacts,
+            history
+        );
+        expect(getActivityLnurlImage).toHaveBeenLastCalledWith(
+            history.metadata!.metadata
+        );
+        expect(renderer.root.findByType(Image).props.source).toEqual({
+            uri: contactPhoto
+        });
+    });
+
+    it.each([
+        ['lightning', LightningSvg],
+        ['onchain', OnChainSvg],
+        ['ecash', EcashSvg]
+    ] as const)(
+        'falls back from contact to LNURL to the %s layer on image errors',
+        async (layer, LayerIcon) => {
+            jest.mocked(getActivityLayer).mockReturnValue(layer);
+            jest.mocked(getActivityContactPhoto).mockReturnValue(
+                'https://example.com/contact.png'
+            );
+            const renderer = await mount();
+            expect(renderer.root.findByType(Image).props.source.uri).toBe(
+                'https://example.com/contact.png'
+            );
+            const badgeIcon = renderer.root.findByType(LayerIcon);
+            expect(badgeIcon.props).toMatchObject({
+                width: layer === 'ecash' ? 38 : 26,
+                height: layer === 'ecash' ? 38 : 26,
+                circle: false,
+                color: '#46BE43'
+            });
+            expect(
+                StyleSheet.flatten(badgeIcon.parent!.props.style)
+            ).toMatchObject({
+                position: 'absolute',
+                right: -2,
+                bottom: -2,
+                width: 18,
+                height: 18,
+                backgroundColor: '#1F242D',
+                borderColor: '#46BE43'
+            });
+
+            await act(async () =>
+                renderer.root.findByType(Image).props.onError()
+            );
+            expect(renderer.root.findByType(Image).props.source.uri).toBe(
+                'https://example.com/first.png'
+            );
+            expect(renderer.root.findByType(LayerIcon).props.width).toBe(
+                layer === 'ecash' ? 38 : 26
+            );
+
+            await act(async () =>
+                renderer.root.findByType(Image).props.onError()
+            );
+            expect(renderer.root.findAllByType(Image)).toHaveLength(0);
+            expect(renderer.root.findAllByType(LayerIcon)).toHaveLength(1);
+            expect(renderer.root.findByType(LayerIcon).props).toMatchObject({
+                width: layer === 'ecash' ? 58 : 40,
+                height: layer === 'ecash' ? 58 : 40,
+                circle: false,
+                color: '#46BE43'
+            });
+        }
+    );
+
+    it.each([true, false])(
+        'ignores a stale lookup when the old hash resolves first: %s',
+        async (oldResolvesFirst) => {
+            const oldLookup = deferred();
+            const newLookup = deferred();
+            load.mockImplementation((hash) =>
+                hash === 'first' ? oldLookup.promise : newLookup.promise
+            );
+            const renderer = await mount();
+            const newItem = payment('second');
+            await act(async () => {
+                renderer.update(
+                    React.createElement(ActivityIcon, {
+                        ...props,
+                        item: newItem
+                    })
+                );
+            });
+            expect(load.mock.calls).toEqual([['first'], ['second']]);
+            expect(renderer.root.findAllByType(Image)).toHaveLength(0);
+
+            if (oldResolvesFirst) {
+                await act(async () => oldLookup.resolve(transaction('first')));
+                expect(renderer.root.findAllByType(Image)).toHaveLength(0);
+                expect(getActivityContactPhoto).not.toHaveBeenCalled();
+            }
+            await act(async () => newLookup.resolve(transaction('second')));
+            expect(renderer.root.findByType(Image).props.source.uri).toBe(
+                'https://example.com/second.png'
+            );
+            if (!oldResolvesFirst) {
+                await act(async () => oldLookup.resolve(transaction('first')));
+            }
+            expect(renderer.root.findByType(Image).props.source.uri).toBe(
+                'https://example.com/second.png'
+            );
+            expect(getActivityContactPhoto).toHaveBeenLastCalledWith(
+                newItem,
+                props.ContactStore!.contacts,
+                transaction('second')
+            );
+        }
+    );
+
+    it('shares pending and completed lookups between icons with the same hash', async () => {
+        const lookup = deferred();
+        load.mockReturnValue(lookup.promise);
+        const first = await mount();
+        const second = await mount(payment('first'));
+        expect(load).toHaveBeenCalledTimes(1);
+        expect(load).toHaveBeenCalledWith('first');
+        expect(imageCache.has('first')).toBe(true);
+        expect(second.root.findAllByType(Image)).toHaveLength(0);
+
+        await act(async () => lookup.resolve(transaction('first')));
+        const third = await mount(payment('first'));
+        for (const renderer of [first, second, third]) {
+            expect(renderer.root.findByType(Image).props.source.uri).toBe(
+                'https://example.com/first.png'
+            );
+        }
+        expect(load).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+        ['a payment without a hash', payment('')],
+        ['a non-payment with a hash field', { resolvedPaymentHash: 'first' }]
+    ])('does not load history for %s', async (_description, item) => {
+        const renderer = await mount(item);
+        expect(load).not.toHaveBeenCalled();
+        expect(imageCache.size).toBe(0);
+        expect(getActivityContactPhoto).toHaveBeenCalledWith(
+            item,
+            props.ContactStore!.contacts,
+            undefined
+        );
+        expect(renderer.root.findAllByType(Image)).toHaveLength(0);
+        expect(renderer.root.findAllByType(LightningSvg)).toHaveLength(1);
+    });
+});

--- a/views/Activity/ActivityIcon.tsx
+++ b/views/Activity/ActivityIcon.tsx
@@ -1,0 +1,194 @@
+import React, { useEffect, useState } from 'react';
+import { Image, StyleSheet, View } from 'react-native';
+import { inject, observer } from 'mobx-react';
+
+import LightningSvg from '../../components/SVG/LightningSvg';
+import OnChainSvg from '../../components/SVG/OnChainSvg';
+import EcashSvg from '../../components/SVG/EcashSvg';
+import Payment from '../../models/Payment';
+import ContactStore from '../../stores/ContactStore';
+import LnurlPayStore, { LnurlPayTransaction } from '../../stores/LnurlPayStore';
+import { getActivityLayer } from '../../utils/ActivityIconUtils';
+import {
+    getActivityContactPhoto,
+    getActivityLnurlImage
+} from '../../utils/ActivityImageUtils';
+import { themeColor } from '../../utils/ThemeUtils';
+
+export type ActivityImageCache = Map<
+    string,
+    Promise<LnurlPayTransaction | undefined>
+>;
+
+interface Props {
+    item: any;
+    imageCache: ActivityImageCache;
+    colorTheme: string;
+    ContactStore?: ContactStore;
+    LnurlPayStore?: LnurlPayStore;
+}
+
+const ActivityIcon = inject(
+    'ContactStore',
+    'LnurlPayStore'
+)(
+    observer(
+        ({
+            item,
+            imageCache,
+            colorTheme,
+            ContactStore,
+            LnurlPayStore
+        }: Props) => {
+            const hash =
+                item instanceof Payment ? item.resolvedPaymentHash : '';
+            const [history, setHistory] = useState<{
+                hash: string;
+                transaction?: LnurlPayTransaction;
+            }>();
+            const [failedImages, setFailedImages] = useState<string[]>([]);
+
+            useEffect(() => {
+                if (!hash || !LnurlPayStore) return;
+                let active = true;
+                let lookup = imageCache.get(hash);
+                if (!lookup) {
+                    lookup = LnurlPayStore.load(hash)
+                        .then((transaction) => {
+                            if (!transaction) imageCache.delete(hash);
+                            return transaction || undefined;
+                        })
+                        .catch(() => {
+                            imageCache.delete(hash);
+                            return undefined;
+                        });
+                    imageCache.set(hash, lookup);
+                }
+                lookup.then((transaction) => {
+                    if (active) setHistory({ hash, transaction });
+                });
+                return () => {
+                    active = false;
+                };
+            }, [hash, imageCache, LnurlPayStore]);
+
+            const transaction =
+                history?.hash === hash ? history?.transaction : undefined;
+            // Wait for history before matching pubkeys: an LNURL service can host many recipients.
+            const contactPhoto =
+                !hash || history?.hash === hash
+                    ? getActivityContactPhoto(
+                          item,
+                          ContactStore?.contacts || [],
+                          transaction
+                      )
+                    : undefined;
+            const lnurlImage = getActivityLnurlImage(
+                transaction?.metadata?.metadata
+            );
+            const uri = [contactPhoto, lnurlImage].find(
+                (image): image is string =>
+                    !!image && !failedImages.includes(image)
+            );
+            const layer = getActivityLayer(item);
+            const color = themeColor(colorTheme);
+            const LayerIcon =
+                layer === 'onchain'
+                    ? OnChainSvg
+                    : layer === 'ecash'
+                    ? EcashSvg
+                    : LightningSvg;
+
+            return (
+                <View
+                    accessible={false}
+                    style={[styles.circle, { borderColor: color }]}
+                >
+                    <View
+                        pointerEvents="none"
+                        style={[
+                            StyleSheet.absoluteFill,
+                            styles.tint,
+                            { backgroundColor: color, opacity: 0.1 }
+                        ]}
+                    />
+                    {uri ? (
+                        <>
+                            <Image
+                                key={uri}
+                                source={{ uri }}
+                                style={styles.image}
+                                onError={() =>
+                                    setFailedImages((images) => [
+                                        ...images,
+                                        uri
+                                    ])
+                                }
+                                accessible={false}
+                            />
+                            <View
+                                pointerEvents="none"
+                                style={[
+                                    styles.badge,
+                                    {
+                                        backgroundColor:
+                                            themeColor('background'),
+                                        borderColor: color
+                                    }
+                                ]}
+                            >
+                                <LayerIcon
+                                    width={layer === 'ecash' ? 38 : 26}
+                                    height={layer === 'ecash' ? 38 : 26}
+                                    circle={false}
+                                    color={color}
+                                />
+                            </View>
+                        </>
+                    ) : (
+                        <LayerIcon
+                            width={layer === 'ecash' ? 58 : 40}
+                            height={layer === 'ecash' ? 58 : 40}
+                            circle={false}
+                            color={color}
+                        />
+                    )}
+                </View>
+            );
+        }
+    )
+);
+
+export default ActivityIcon;
+
+const styles = StyleSheet.create({
+    circle: {
+        width: 42,
+        height: 42,
+        borderRadius: 21,
+        borderWidth: 2,
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0
+    },
+    tint: {
+        borderRadius: 19
+    },
+    badge: {
+        position: 'absolute',
+        right: -2,
+        bottom: -2,
+        width: 18,
+        height: 18,
+        borderRadius: 9,
+        borderWidth: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        overflow: 'hidden'
+    },
+    image: {
+        width: 38,
+        height: 38,
+        borderRadius: 19
+    }
+});


### PR DESCRIPTION
# Description

Relates to issue: #1323

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-09-11 at 20 22 53" src="https://github.com/user-attachments/assets/80ce39f0-d082-4cff-98a2-6f7d7b0f8f18" />

Add a visual layer column to Activity rows:

- Show the on-chain, Lightning, or ecash icon in a tinted circle.
- Use exactly the same theme color as the displayed amount, preserving existing amount-color behavior.
- Prefer a reliably associated contact photo, then a saved LNURL image, with a layer-icon fallback for missing or failed images.
- Overlay an 18px layer badge on the bottom-right of contact and LNURL images.
- Cache LNURL history lookups for the screen lifetime and ignore stale asynchronous results when rows change.

Existing titles, subtitles, amounts, selection, and navigation remain unchanged. Swaps use the destination layer. No new dependencies, storage format changes, or remote profile discovery.

This addresses the layer-icon portion of #1323, rather than closing the entire issue: replacing text labels, separate send/receive or channel-open/close glyphs, and changing failed-payment amount colors are outside this PR.

Draft for v13.3.0. Android and broader theme/backend testing remain outstanding.

This pull request is categorized as a:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [ ] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [ ] I've run `yarn run prettier` and made sure my code is formatted correctly
- [ ] I've run `yarn run test` and made sure all of the tests pass

Validation details:

- `yarn tsc --noEmit`: passed.
- Scoped ESLint and Prettier checks on all 10 changed files: passed.
- `yarn test --runInBand --runTestsByPath check-styles.test.ts --testPathIgnorePatterns=`: passed.
- `yarn test --runInBand --silent --testPathIgnorePatterns='check-styles.test.ts|/.claude/worktrees/|/zeus_modules/'`: 79 suites, 1,740 tests passed, including 69 focused layer/image/component tests.
- `git diff --cached --check`: passed before commit.
- Unscoped `yarn verify` was attempted but is not green in this workspace: it scans unrelated nested worktrees, and vendored LNC tests require an unavailable `chai` dependency. The unrestricted checkboxes remain unchecked; CI still needs to validate the clean checkout.

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [x] Yes
- [ ] N/A

Tests cover layer classification, conservative contact matching, malformed LNURL metadata, image precedence and error fallback, badge rendering, exact theme-color propagation, stale lookups, and shared caching.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS: iPhone 17 Pro Max simulator, iOS 26.5

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST): Polar Carol, litd v0.16.0-alpha with integrated LND v0.20.0-beta, regtest. Sent payments to Alice and Dave through the simulator UI.
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

No new user-facing strings.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:

Verify that `package.json` and `yarn.lock` have been properly updated: N/A, unchanged.

Verify that dependencies are installed for both iOS and Android platforms: N/A, no dependency changes.

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding
