### PR TITLE
LNURL: prevent toggling payment history into an empty panel

### DIFF
--- a/views/LnurlPay/Historical.test.ts
+++ b/views/LnurlPay/Historical.test.ts
@@ -1,0 +1,136 @@
+jest.mock('@rneui/themed', () => ({ Icon: 'Icon' }));
+jest.mock('../../utils/ThemeUtils', () => ({ themeColor: () => '#ffffff' }));
+jest.mock('../../utils/LocaleUtils', () => ({
+    localeString: (key: string) => key
+}));
+jest.mock('js-lnurl/lib/helpers', () => ({
+    decipherAES: () => 'Decrypted receipt'
+}));
+
+import React from 'react';
+import { Image, TouchableOpacity } from 'react-native';
+import { act, create, ReactTestRenderer } from 'react-test-renderer';
+import Historical from './Historical';
+import Metadata from './Metadata';
+import Success from './Success';
+
+describe('LNURL historical metadata toggle', () => {
+    let renderer: ReactTestRenderer;
+    let props: React.ComponentProps<typeof Historical>;
+
+    beforeEach(() => {
+        props = {
+            navigation: { navigate: jest.fn() },
+            preimage: '00'.repeat(32),
+            lnurlpaytx: {
+                lnurl: '',
+                domain: '',
+                successAction: { tag: 'noop' },
+                metadata: {
+                    metadata: JSON.stringify([
+                        ['text/plain', 'Polar Cafe'],
+                        [
+                            'image/png;base64',
+                            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jRZkAAAAASUVORK5CYII='
+                        ]
+                    ])
+                }
+            }
+        } as unknown as React.ComponentProps<typeof Historical>;
+    });
+
+    afterEach(async () => {
+        if (renderer) await act(async () => renderer.unmount());
+    });
+
+    async function mount() {
+        await act(async () => {
+            renderer = create(React.createElement(Historical, props));
+        });
+    }
+
+    it.each([undefined, null, { tag: 'noop' }, { tag: 'unsupported' }])(
+        'does not offer an empty details panel for %j',
+        async (successAction) => {
+            props.lnurlpaytx.successAction = successAction as any;
+            await mount();
+
+            expect(
+                renderer.root.findByType(TouchableOpacity).props.disabled
+            ).toBe(true);
+            expect(renderer.root.findByType(Metadata).props.showArrow).toBe(
+                false
+            );
+            expect(renderer.root.findAllByType(Image)).toHaveLength(1);
+            expect(renderer.root.findAllByType(Success)).toHaveLength(0);
+        }
+    );
+
+    it.each([
+        ['cafe.example', { tag: 'noop' }],
+        ['cafe.example', undefined],
+        ['', { tag: 'message', message: 'Thank you' }],
+        [
+            '',
+            {
+                tag: 'url',
+                description: 'Receipt',
+                url: 'https://cafe.example/receipt'
+            }
+        ],
+        [
+            '',
+            {
+                tag: 'aes',
+                description: 'Receipt',
+                ciphertext: 'ciphertext',
+                iv: 'iv'
+            }
+        ]
+    ])(
+        'toggles both ways with domain %s and action %j',
+        async (domain, successAction) => {
+            props.lnurlpaytx.domain = domain as string;
+            props.lnurlpaytx.successAction = successAction as any;
+            await mount();
+
+            expect(renderer.root.findByType(Metadata).props.showArrow).toBe(
+                true
+            );
+            const toggle = renderer.root.findAllByType(TouchableOpacity)[0];
+            expect(toggle.props.disabled).toBe(false);
+            await act(async () => toggle.props.onPress());
+            expect(renderer.root.findAllByType(Image)).toHaveLength(0);
+            expect(renderer.root.findAllByType(Success)).toHaveLength(1);
+            expect(
+                renderer.root.findByType(Success).children.length
+            ).toBeGreaterThan(0);
+
+            await act(async () => toggle.props.onPress());
+            expect(renderer.root.findAllByType(Image)).toHaveLength(1);
+            expect(renderer.root.findAllByType(Success)).toHaveLength(0);
+        }
+    );
+
+    it('returns to metadata if displayed success details disappear', async () => {
+        props.lnurlpaytx.domain = 'cafe.example';
+        await mount();
+        await act(async () =>
+            renderer.root.findByType(TouchableOpacity).props.onPress()
+        );
+        expect(renderer.root.findAllByType(Success)).toHaveLength(1);
+
+        await act(async () => {
+            renderer.update(
+                React.createElement(Historical, {
+                    ...props,
+                    lnurlpaytx: { ...props.lnurlpaytx, domain: '' }
+                })
+            );
+        });
+        expect(renderer.root.findAllByType(Image)).toHaveLength(1);
+        expect(renderer.root.findByType(TouchableOpacity).props.disabled).toBe(
+            true
+        );
+    });
+});

--- a/views/LnurlPay/Historical.tsx
+++ b/views/LnurlPay/Historical.tsx
@@ -29,6 +29,11 @@ export default class LnurlPayHistorical extends React.Component<
         const { navigation, lnurlpaytx, preimage } = this.props;
         const { showLnurlSuccess } = this.state;
         const { lnurl, domain, successAction } = lnurlpaytx;
+        // Do not collapse metadata into an empty, untappable success panel.
+        const hasSuccessDetails = Boolean(
+            domain ||
+                ['message', 'url', 'aes'].includes(successAction?.tag || '')
+        );
         const metadata =
             (lnurlpaytx.metadata && lnurlpaytx.metadata.metadata) ||
             'No metadata available';
@@ -54,20 +59,24 @@ export default class LnurlPayHistorical extends React.Component<
                     </TouchableOpacity>
                 )}
                 <TouchableOpacity
+                    disabled={!hasSuccessDetails}
                     onPress={() => {
-                        this.setState({
+                        this.setState(({ showLnurlSuccess }) => ({
                             showLnurlSuccess: !showLnurlSuccess
-                        });
+                        }));
                     }}
                 >
-                    {showLnurlSuccess ? (
+                    {showLnurlSuccess && hasSuccessDetails ? (
                         <LnurlPaySuccess
                             domain={domain}
                             successAction={successAction}
                             preimage={preimage}
                         />
                     ) : (
-                        <LnurlPayMetadata metadata={metadata} />
+                        <LnurlPayMetadata
+                            metadata={metadata}
+                            showArrow={hasSuccessDetails}
+                        />
                     )}
                 </TouchableOpacity>
             </View>


### PR DESCRIPTION
# Description

|Before|After|
|-|-|
|https://github.com/user-attachments/assets/e61a2e66-bac7-4537-8c5f-331814b33e3b|https://github.com/user-attachments/assets/2b8a4dc3-e12f-4b13-9674-aff9946d2c1b|

Found while testing #4642; this fix is independent of that Activity-icons feature and targets **v13.2.2**.

LNURL payment history always allowed tapping its image/metadata to switch to the success panel. When the saved transaction has neither a domain nor a supported success action, `LnurlPaySuccess` renders nothing. The image disappears along with the visible toggle target, leaving no way back without leaving and reopening the payment.

This occurs naturally with Lightning-address payments whose payRequest has no `domain` field and whose callback has no success action. No data corruption or synthetic history mutation is needed to reproduce it.

- Keep metadata visible and disable the toggle when no success details can render.
- Hide the down arrow in that case instead of advertising an empty panel.
- Preserve two-way toggling for domain-only details and message, URL, and AES actions.
- Defensively fall back to metadata if details disappear while expanded. As noted in review, this transition is not reachable through current usage, since `lnurlpaytx` is loaded once on mount and never updated; the guard and its test are forward-looking hardening.
- Add 10 regression/control tests against the historical, metadata, and success components.

The change is limited to the shared historical display and tests. It covers both Lightning and Cashu payment detail consumers without changing payment execution, storage, or LNURL validation.

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Configuration change
- [ ] Locales update
- [ ] Quality assurance
- [ ] Other

## Checklist
- [x] I've run `yarn run tsc` and made sure my code compiles correctly
- [x] I've run `yarn run lint` and made sure my code didn't contain any problematic patterns
- [x] I've run `yarn run prettier` and made sure my code is formatted correctly
- [x] I've run `yarn run test` and made sure all of the tests pass

Validation:

- `yarn tsc --noEmit`: passed.
- Scoped ESLint and Prettier for both changed files: passed.
- `yarn test --runInBand --runTestsByPath check-styles.test.ts --testPathIgnorePatterns=`: passed.
- `yarn test --runInBand --silent --testPathIgnorePatterns='check-styles.test.ts|/.claude/worktrees/|/zeus_modules/'`: 77 suites, 1,681 tests passed.
- `git diff --check`: passed.
- The new regression tests failed before the fix and pass with it. The before recording was made with `Historical.tsx` restored to the unchanged base version; the after recording uses the fix.
- Unrestricted workspace checks are not claimed green: the earlier `yarn verify` attempt encountered unrelated nested-worktree failures and vendored LNC tests requiring unavailable `chai`. Clean-checkout CI remains the full gate.

## Testing

If you modified or added a utility file, did you add new unit tests?

- [ ] No, I'm a fool
- [ ] Yes
- [x] N/A

No utility changes. Added `views/LnurlPay/Historical.test.ts` covering missing/null/noop/unsupported actions, domain-only details, message/URL/AES controls, round-trip toggling, and details disappearing while expanded (the last case is defensive coverage for a currently unreachable prop update).

Adversarial review compared the predicate with the actual success renderer; no blocking mismatch found. Nested URL navigation and Android native touch behavior are not covered by this manual test. AES decryption is mocked in the rendering tests.

I have tested this PR on the following platforms (please specify OS version and phone model/VM):

- [ ] Android
- [x] iOS: iPhone 17 Pro Max simulator, iOS 26.5. Reproduced the bug, verified the fix after repeated taps/reopening, and verified a separate domain-bearing LNURL payment still toggles both ways.

Android testing remains required before merge.

I have tested this PR with the following types of nodes (please specify node version and API version where appropriate):

On-device
- [ ] LDK Node
- [ ] Embedded LND

Remote
- [x] LND (REST): Polar Carol, litd v0.16.0-alpha with integrated LND v0.20.0-beta, regtest; recipient Dave.
- [ ] LND (Lightning Node Connect)
- [ ] Core Lightning (CLNRest)
- [ ] Nostr Wallet Connect
- [ ] LndHub

### Locales
- [ ] I've added new locale text that requires translations
- [x] I'm aware that new translations should be made on the ZEUS [Transfix page](https://app.transifex.com/ZeusLN/zeus/) and not directly to this repo

No new user-facing strings.

### Third Party Dependencies and Packages

- [ ] Contributors will need to run `yarn` after this PR is merged in
- [ ] 3rd party dependencies have been modified:

Verify that `package.json` and `yarn.lock` have been properly updated: N/A, unchanged.

Verify that dependencies are installed for both iOS and Android platforms: N/A, no dependency changes.

### Other:

- [ ] Changes were made that require an update to the README
- [ ] Changes were made that require an update to onboarding

